### PR TITLE
fix(txpool): harden fork-boundary revalidation

### DIFF
--- a/src/Nethermind/Nethermind.Api/INethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/INethermindApi.cs
@@ -20,6 +20,18 @@ namespace Nethermind.Api
 
     public static class NethermindApiExtensions
     {
+        /// <summary>
+        /// Registers the RPC decoder and transaction validator for a transaction type.
+        /// </summary>
+        /// <remarks>
+        /// A per-type validator may cover fewer rules than the default full validator. Chain plugins that register
+        /// one must ensure their <see cref="ISpecChangeTxValidator"/> validates any omitted fork-sensitive rules in
+        /// <see cref="ISpecChangeTxValidator.IsWellFormedAfterFullValidation"/>.
+        /// </remarks>
+        /// <typeparam name="T">The RPC transaction representation to register.</typeparam>
+        /// <param name="api">The Nethermind API receiving the registrations.</param>
+        /// <param name="decoder">The decoder for the transaction type.</param>
+        /// <param name="validator">The full validator for the transaction type.</param>
         public static void RegisterTxType<T>(this INethermindApi api, ITxDecoder decoder, ITxValidator validator) where T : TransactionForRpc, IFromTransaction<T>
         {
             ArgumentNullException.ThrowIfNull(api.TxValidator);

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -266,8 +266,8 @@ public class TxPoolSourceTests
     }
 
     [TestCase(1, true)]
-    [TestCase(25, true)]
-    [TestCase(26, false)]
+    [TestCase(10, true)]
+    [TestCase(11, false)]
     public void GetTransactions_should_bound_resolved_rejections(int invalidBlobCount, bool expectValidBlob)
     {
         TestSpecProvider specProvider = new(Osaka.Instance)

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -351,6 +351,67 @@ public class TxPoolSourceTests
         }
     }
 
+    [TestCase(25, true)]
+    [TestCase(26, false)]
+    public void GetTransactions_should_bound_light_rejections_without_resolving_them(int invalidBlobCount, bool expectValidBlob)
+    {
+        TestSpecProvider specProvider = new(Osaka.Instance)
+        {
+            NextForkSpec = Amsterdam.Instance,
+            ForkOnBlockNumber = 1
+        };
+        TransactionComparerProvider transactionComparerProvider = new(specProvider, Build.A.BlockTree().TestObject);
+        Transaction validBlob = Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Amsterdam.Instance)
+            .WithMaxFeePerGas(1.GWei)
+            .WithMaxPriorityFeePerGas(1.GWei)
+            .SignedAndResolved(TestItem.PrivateKeys[invalidBlobCount])
+            .TestObject;
+        Dictionary<AddressAsKey, Transaction[]> pendingBlobTransactions = new(invalidBlobCount + 1);
+        LightTransaction[] invalidBlobs = new LightTransaction[invalidBlobCount];
+        for (int i = 0; i < invalidBlobs.Length; i++)
+        {
+            LightTransaction invalidBlob = new(validBlob)
+            {
+                Hash = TestItem.Keccaks[i],
+                SenderAddress = TestItem.Addresses[i],
+                GasPrice = 2.GWei,
+                DecodedMaxFeePerGas = 2.GWei,
+                GasBottleneck = 2.GWei,
+                ProofVersion = ProofVersion.V0
+            };
+            invalidBlobs[i] = invalidBlob;
+            pendingBlobTransactions[new AddressAsKey(invalidBlob.SenderAddress)] = [invalidBlob];
+        }
+
+        pendingBlobTransactions[new AddressAsKey(validBlob.SenderAddress!)] = [new LightTransaction(validBlob)];
+        ITxPool txPool = Substitute.For<ITxPool>();
+        SetPendingForProduction(txPool, blobTransactions: pendingBlobTransactions);
+        txPool.TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = validBlob;
+                return true;
+            });
+        txPool.SupportsBlobs.Returns(true);
+        ITxFilterPipeline txFilterPipeline = Substitute.For<ITxFilterPipeline>();
+        txFilterPipeline.Execute(Arg.Any<Transaction>(), Arg.Any<BlockHeader>(), Arg.Any<IReleaseSpec>()).Returns(true);
+        TxPoolTxSource txSource = new(txPool, specProvider, transactionComparerProvider, LimboLogs.Instance,
+            txFilterPipeline, new BlocksConfig { BlockProductionBlobLimit = 1 }, CreateSpecChangeTxValidator(specProvider));
+        BlockHeader parent = Build.A.BlockHeader.WithNumber(0).WithExcessBlobGas(0).TestObject;
+        BlockHeader targetBlock = Build.A.BlockHeader.WithNumber(1).WithExcessBlobGas(0).TestObject;
+
+        Transaction[] result = txSource.GetTransactions(parent, targetBlock, long.MaxValue).ToArray();
+
+        Transaction[] expected = expectValidBlob ? [validBlob] : [];
+        Assert.That(result, Is.EqualTo(expected).UsingTransactionComparer());
+        txPool.Received(expectValidBlob ? 1 : 0).TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>());
+        for (int i = 0; i < invalidBlobs.Length; i++)
+        {
+            txPool.DidNotReceive().TryGetPendingBlobTransaction(invalidBlobs[i].Hash!, out Arg.Any<Transaction?>());
+        }
+    }
+
     [Test]
     public void GetTransactions_should_skip_full_fork_validation_when_pool_is_safe_for_target_block()
     {

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -252,21 +252,22 @@ public class TxPoolSourceTests
     }
 
     [Test]
-    public void Default_pending_view_does_not_expose_a_mutable_shared_dictionary()
+    public void Default_pending_view_is_empty()
     {
         PendingTransactionsView view = default;
-
-        Action mutate = () => view.Transactions.Add(TestItem.AddressA, []);
+        IReadOnlyDictionary<AddressAsKey, Transaction[]> transactions = view.Transactions;
+        IReadOnlyDictionary<AddressAsKey, Transaction[]> blobTransactions = view.BlobTransactions;
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(mutate, Throws.TypeOf<NotSupportedException>());
-            Assert.That(default(PendingTransactionsView).Transactions, Is.Empty);
+            Assert.That(transactions, Is.Empty);
+            Assert.That(blobTransactions, Is.Empty);
         }
     }
 
-    [Test]
-    public void GetTransactions_should_not_let_an_invalid_blob_displace_a_valid_blob()
+    [TestCase(1)]
+    [TestCase(6)]
+    public void GetTransactions_should_not_let_invalid_blobs_displace_a_valid_blob(int invalidBlobCount)
     {
         TestSpecProvider specProvider = new(Osaka.Instance)
         {
@@ -275,39 +276,46 @@ public class TxPoolSourceTests
         };
         TransactionComparerProvider transactionComparerProvider = new(specProvider, Build.A.BlockTree().TestObject);
 
-        Transaction invalidBlob = Build.A.Transaction
-            .WithShardBlobTxTypeAndFields(spec: Amsterdam.Instance)
-            .WithAccessList(BuildUnderGassedAccessList())
-            .WithGasLimit(UnderGassedTransactionGasLimit)
-            .WithMaxFeePerGas(2.GWei)
-            .WithMaxPriorityFeePerGas(2.GWei)
-            .SignedAndResolved(TestItem.PrivateKeyA)
-            .TestObject;
+        Transaction[] invalidBlobs = new Transaction[invalidBlobCount];
+        Dictionary<AddressAsKey, Transaction[]> pendingBlobTransactions = new(invalidBlobCount + 1);
+        Dictionary<ValueHash256, Transaction> fullBlobTransactions = new(invalidBlobCount + 1);
+        for (int i = 0; i < invalidBlobs.Length; i++)
+        {
+            UInt256 fee = 2.GWei + (UInt256)(invalidBlobCount - i);
+            Transaction invalidBlob = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(spec: Amsterdam.Instance)
+                .WithAccessList(BuildUnderGassedAccessList())
+                .WithGasLimit(UnderGassedTransactionGasLimit)
+                .WithMaxFeePerGas(fee)
+                .WithMaxPriorityFeePerGas(fee)
+                .SignedAndResolved(TestItem.PrivateKeys[i])
+                .TestObject;
+            invalidBlobs[i] = invalidBlob;
+            pendingBlobTransactions[new AddressAsKey(invalidBlob.SenderAddress!)] = [new LightTransaction(invalidBlob)];
+            fullBlobTransactions[invalidBlob.Hash!.ValueHash256] = invalidBlob;
+        }
+
         Transaction validBlob = Build.A.Transaction
             .WithShardBlobTxTypeAndFields(spec: Amsterdam.Instance)
             .WithAccessList(BuildUnderGassedAccessList())
             .WithGasLimit(100_000)
             .WithMaxFeePerGas(1.GWei)
             .WithMaxPriorityFeePerGas(1.GWei)
-            .SignedAndResolved(TestItem.PrivateKeyB)
+            .SignedAndResolved(TestItem.PrivateKeys[invalidBlobCount])
             .TestObject;
+        pendingBlobTransactions[new AddressAsKey(validBlob.SenderAddress!)] = [new LightTransaction(validBlob)];
+        fullBlobTransactions[validBlob.Hash!.ValueHash256] = validBlob;
+
         ITxPool txPool = Substitute.For<ITxPool>();
-        SetPendingForProduction(txPool, blobTransactions: new Dictionary<AddressAsKey, Transaction[]>
-        {
-            { new AddressAsKey(invalidBlob.SenderAddress!), [new LightTransaction(invalidBlob)] },
-            { new AddressAsKey(validBlob.SenderAddress!), [new LightTransaction(validBlob)] }
-        });
-        txPool.TryGetPendingBlobTransaction(Arg.Is<Hash256>(h => h == invalidBlob.Hash), out Arg.Any<Transaction?>())
-            .Returns(x =>
+        SetPendingForProduction(txPool, blobTransactions: pendingBlobTransactions);
+        txPool.TryGetPendingBlobTransaction(Arg.Any<Hash256>(), out Arg.Any<Transaction?>())
+            .Returns(callInfo =>
             {
-                x[1] = invalidBlob;
-                return true;
-            });
-        txPool.TryGetPendingBlobTransaction(Arg.Is<Hash256>(h => h == validBlob.Hash), out Arg.Any<Transaction?>())
-            .Returns(x =>
-            {
-                x[1] = validBlob;
-                return true;
+                bool found = fullBlobTransactions.TryGetValue(
+                    callInfo.ArgAt<Hash256>(0).ValueHash256,
+                    out Transaction? fullBlobTransaction);
+                callInfo[1] = fullBlobTransaction;
+                return found;
             });
         txPool.SupportsBlobs.Returns(true);
 
@@ -333,8 +341,13 @@ public class TxPoolSourceTests
         {
             Assert.That(result, Is.EqualTo(new[] { validBlob }).UsingTransactionComparer());
             txPool.Received(1).TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>());
-            txFilterPipeline.DidNotReceive().Execute(invalidBlob, parent, Amsterdam.Instance);
             txFilterPipeline.DidNotReceive().Execute(validBlob, parent, Amsterdam.Instance);
+        }
+
+        for (int i = 0; i < invalidBlobs.Length; i++)
+        {
+            txPool.Received(1).TryGetPendingBlobTransaction(invalidBlobs[i].Hash!, out Arg.Any<Transaction?>());
+            txFilterPipeline.DidNotReceive().Execute(invalidBlobs[i], parent, Amsterdam.Instance);
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -265,9 +265,10 @@ public class TxPoolSourceTests
         }
     }
 
-    [TestCase(1)]
-    [TestCase(6)]
-    public void GetTransactions_should_not_let_invalid_blobs_displace_a_valid_blob(int invalidBlobCount)
+    [TestCase(1, true)]
+    [TestCase(25, true)]
+    [TestCase(26, false)]
+    public void GetTransactions_should_bound_resolved_rejections(int invalidBlobCount, bool expectValidBlob)
     {
         TestSpecProvider specProvider = new(Osaka.Instance)
         {
@@ -337,10 +338,11 @@ public class TxPoolSourceTests
 
         Transaction[] result = txSource.GetTransactions(parent, targetBlock, long.MaxValue).ToArray();
 
+        Transaction[] expected = expectValidBlob ? [validBlob] : [];
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result, Is.EqualTo(new[] { validBlob }).UsingTransactionComparer());
-            txPool.Received(1).TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>());
+            Assert.That(result, Is.EqualTo(expected).UsingTransactionComparer());
+            txPool.Received(expectValidBlob ? 1 : 0).TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>());
             txFilterPipeline.DidNotReceive().Execute(validBlob, parent, Amsterdam.Instance);
         }
 
@@ -351,9 +353,8 @@ public class TxPoolSourceTests
         }
     }
 
-    [TestCase(25, true)]
-    [TestCase(26, false)]
-    public void GetTransactions_should_bound_light_rejections_without_resolving_them(int invalidBlobCount, bool expectValidBlob)
+    [TestCase(26)]
+    public void GetTransactions_should_skip_light_rejections_without_resolving_them(int invalidBlobCount)
     {
         TestSpecProvider specProvider = new(Osaka.Instance)
         {
@@ -403,9 +404,8 @@ public class TxPoolSourceTests
 
         Transaction[] result = txSource.GetTransactions(parent, targetBlock, long.MaxValue).ToArray();
 
-        Transaction[] expected = expectValidBlob ? [validBlob] : [];
-        Assert.That(result, Is.EqualTo(expected).UsingTransactionComparer());
-        txPool.Received(expectValidBlob ? 1 : 0).TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>());
+        Assert.That(result, Is.EqualTo(new[] { validBlob }).UsingTransactionComparer());
+        txPool.Received(1).TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>());
         for (int i = 0; i < invalidBlobs.Length; i++)
         {
             txPool.DidNotReceive().TryGetPendingBlobTransaction(invalidBlobs[i].Hash!, out Arg.Any<Transaction?>());

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -21,6 +21,7 @@ using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -496,6 +497,103 @@ public class TxValidatorTests
 
         Assert.That(() => result = txValidator.IsWellFormed(tx, Osaka.Instance).AsBool(), Throws.Nothing);
         Assert.That(result, Is.False);
+    }
+
+    private static IEnumerable<TestCaseData> SpecChangeValidationCases()
+    {
+        yield return new TestCaseData(
+                Berlin.Instance,
+                Build.A.Transaction
+                    .WithType(TxType.EIP1559)
+                    .WithAccessList(AccessList.Empty)
+                    .WithMaxFeePerGas(1)
+                    .WithMaxPriorityFeePerGas(1)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_release_activation_is_covered_by_full_and_delta_validation");
+
+        yield return new TestCaseData(
+                Cancun.Instance,
+                Build.A.Transaction
+                    .WithShardBlobTxTypeAndFields((int)Cancun.Instance.MaxBlobCount + 1, isMempoolTx: false)
+                    .WithMaxFeePerGas(1)
+                    .WithMaxPriorityFeePerGas(1)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_blob_count_is_covered_by_full_and_delta_validation");
+
+        yield return new TestCaseData(
+                Osaka.Instance,
+                Build.A.Transaction
+                    .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + 1)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_gas_limit_cap_is_covered_by_full_and_delta_validation");
+
+        yield return new TestCaseData(
+                Osaka.Instance,
+                Build.A.Transaction
+                    .WithShardBlobTxTypeAndFields(spec: Cancun.Instance)
+                    .WithMaxFeePerGas(1)
+                    .WithMaxPriorityFeePerGas(1)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_proof_version_is_covered_by_full_and_delta_validation");
+
+        yield return new TestCaseData(
+                Shanghai.Instance,
+                Build.A.Transaction
+                    .WithCode(new byte[(int)Shanghai.Instance.MaxInitCodeSize + 1])
+                    .WithGasLimit(int.MaxValue)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_contract_size_is_covered_by_full_and_delta_validation");
+
+        yield return new TestCaseData(
+                Prague.Instance,
+                Build.A.Transaction
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .TestObject)
+            .SetName("Spec_change_signature_is_covered_by_full_and_delta_validation");
+
+        yield return new TestCaseData(
+                Prague.Instance,
+                Build.A.Transaction
+                    .WithData([1])
+                    .WithGasLimit(Transaction.BaseTxGasCost)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_intrinsic_gas_is_covered_by_full_and_delta_validation");
+    }
+
+    [TestCaseSource(nameof(SpecChangeValidationCases))]
+    public void Full_and_delta_validation_cover_spec_change_validation(IReleaseSpec spec, Transaction transaction)
+    {
+        TxValidator fullValidator = new(TestBlockchainIds.ChainId);
+        SpecChangeTxValidator specChangeValidator = new(TestBlockchainIds.ChainId);
+        ValidationResult specChangeResult = specChangeValidator.IsWellFormed(transaction, spec);
+        ValidationResult admissionResult = fullValidator.IsWellFormed(
+            transaction,
+            spec,
+            blockGasLimit: 0,
+            TxValidationOptions.SkipBlobProofs);
+
+        if (admissionResult)
+        {
+            admissionResult = specChangeValidator.IsWellFormedAfterFullValidation(transaction, spec);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(specChangeResult.AsBool, Is.False, "test case must exercise a spec-change rejection");
+            Assert.That(admissionResult.AsBool, Is.False);
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -511,7 +511,7 @@ public class TxValidatorTests
                     .WithChainId(TestBlockchainIds.ChainId)
                     .SignedAndResolved()
                     .TestObject)
-            .SetName("Spec_change_release_activation_is_covered_by_full_and_delta_validation");
+            .SetName("Spec_change_release_activation_is_covered_by_full_validation");
 
         yield return new TestCaseData(
                 Cancun.Instance,
@@ -522,7 +522,7 @@ public class TxValidatorTests
                     .WithChainId(TestBlockchainIds.ChainId)
                     .SignedAndResolved()
                     .TestObject)
-            .SetName("Spec_change_blob_count_is_covered_by_full_and_delta_validation");
+            .SetName("Spec_change_blob_count_is_covered_by_full_validation");
 
         yield return new TestCaseData(
                 Osaka.Instance,
@@ -531,7 +531,7 @@ public class TxValidatorTests
                     .WithChainId(TestBlockchainIds.ChainId)
                     .SignedAndResolved()
                     .TestObject)
-            .SetName("Spec_change_gas_limit_cap_is_covered_by_full_and_delta_validation");
+            .SetName("Spec_change_gas_limit_cap_is_covered_by_full_validation");
 
         yield return new TestCaseData(
                 Osaka.Instance,
@@ -542,7 +542,7 @@ public class TxValidatorTests
                     .WithChainId(TestBlockchainIds.ChainId)
                     .SignedAndResolved()
                     .TestObject)
-            .SetName("Spec_change_proof_version_is_covered_by_full_and_delta_validation");
+            .SetName("Spec_change_proof_version_is_covered_by_full_validation");
 
         yield return new TestCaseData(
                 Shanghai.Instance,
@@ -552,14 +552,14 @@ public class TxValidatorTests
                     .WithChainId(TestBlockchainIds.ChainId)
                     .SignedAndResolved()
                     .TestObject)
-            .SetName("Spec_change_contract_size_is_covered_by_full_and_delta_validation");
+            .SetName("Spec_change_contract_size_is_covered_by_full_validation");
 
         yield return new TestCaseData(
                 Prague.Instance,
                 Build.A.Transaction
                     .WithChainId(TestBlockchainIds.ChainId)
                     .TestObject)
-            .SetName("Spec_change_signature_is_covered_by_full_and_delta_validation");
+            .SetName("Spec_change_signature_is_covered_by_full_validation");
 
         yield return new TestCaseData(
                 Prague.Instance,
@@ -569,30 +569,25 @@ public class TxValidatorTests
                     .WithChainId(TestBlockchainIds.ChainId)
                     .SignedAndResolved()
                     .TestObject)
-            .SetName("Spec_change_intrinsic_gas_is_covered_by_full_and_delta_validation");
+            .SetName("Spec_change_intrinsic_gas_is_covered_by_full_validation");
     }
 
     [TestCaseSource(nameof(SpecChangeValidationCases))]
-    public void Full_and_delta_validation_cover_spec_change_validation(IReleaseSpec spec, Transaction transaction)
+    public void Full_validation_covers_spec_change_validation(IReleaseSpec spec, Transaction transaction)
     {
         TxValidator fullValidator = new(TestBlockchainIds.ChainId);
         SpecChangeTxValidator specChangeValidator = new(TestBlockchainIds.ChainId);
         ValidationResult specChangeResult = specChangeValidator.IsWellFormed(transaction, spec);
-        ValidationResult admissionResult = fullValidator.IsWellFormed(
+        ValidationResult fullValidationResult = fullValidator.IsWellFormed(
             transaction,
             spec,
             blockGasLimit: 0,
             TxValidationOptions.SkipBlobProofs);
 
-        if (admissionResult)
-        {
-            admissionResult = specChangeValidator.IsWellFormedAfterFullValidation(transaction, spec);
-        }
-
         using (Assert.EnterMultipleScope())
         {
             Assert.That(specChangeResult.AsBool, Is.False, "test case must exercise a spec-change rejection");
-            Assert.That(admissionResult.AsBool, Is.False);
+            Assert.That(fullValidationResult.AsBool, Is.False);
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -12,7 +12,6 @@ using Nethermind.Consensus.AuRa.Contracts.DataStore;
 using Nethermind.Consensus.AuRa.Transactions;
 using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Transactions;
-using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Init.Steps;
 using Nethermind.Logging;
@@ -103,7 +102,7 @@ public class InitializeBlockchainAuRa(
             chainHeadInfoProvider,
             NethermindApi.Config<ITxPoolConfig>(),
             api.TxValidator!,
-            new SpecChangeTxValidator(api.SpecProvider.ChainId),
+            _specChangeTxValidator,
             api.LogManager,
             CreateTxPoolTxComparer(txPriorityContract, localDataSource),
             _txGossipPolicy,

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -42,7 +42,7 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit)
         {
             if (_logger.IsTrace)
             {

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -37,6 +37,9 @@ namespace Nethermind.Consensus.Producers
         [KeyFilter(ITxValidator.SpecChangeTxValidatorKey)] ITxValidator? specChangeTxValidator)
         : ITxSource
     {
+        private const ulong BlobConsiderationMultiplier = 5;
+        private const ulong RejectedBlobConsiderationMultiplier = 5;
+
         private readonly ITxPool _transactionPool = transactionPool ?? throw new ArgumentNullException(nameof(transactionPool));
         private readonly ITransactionComparerProvider _transactionComparerProvider = transactionComparerProvider ?? throw new ArgumentNullException(nameof(transactionComparerProvider));
         private readonly ITxFilterPipeline _txFilterPipeline = txFilterPipeline ?? throw new ArgumentNullException(nameof(txFilterPipeline));
@@ -68,13 +71,14 @@ namespace Nethermind.Consensus.Producers
                 : tx => filter(tx) && IsForkSensitiveStateValid(tx, spec);
 
             ulong maxBlobCount = spec.MaxProductionBlobCount(blocksConfig.BlockProductionBlobLimit);
+            // PendingTransactionsView preserves an IDictionary-compatible backing instance for this virtual API.
             IEnumerable<Transaction> transactions = GetOrderedTransactions(
                 (IDictionary<AddressAsKey, Transaction[]>)pendingTransactions,
                 comparer,
                 pendingTxFilter,
                 gasLimit);
             IEnumerable<(Transaction tx, ulong blobChain)> blobTransactions = GetOrderedBlobTransactions(
-                (IDictionary<AddressAsKey, Transaction[]>)pendingBlobTransactionsEquivalences,
+                pendingBlobTransactionsEquivalences,
                 comparer,
                 BlobFilter,
                 maxBlobCount);
@@ -171,13 +175,14 @@ namespace Nethermind.Consensus.Producers
             ulong maxBlobs,
             bool validateForkSensitiveState)
         {
-            ulong maxBlobsToConsider = maxBlobs * 5ul;
-            ulong maxRejectedBlobsToConsider = maxBlobsToConsider * 5ul;
+            ulong maxBlobsToConsider = maxBlobs * BlobConsiderationMultiplier;
+            ulong maxRejectedBlobsToConsider = maxBlobsToConsider * RejectedBlobConsiderationMultiplier;
             ulong countOfRemainingBlobs = 0UL;
             ulong consideredBlobCount = 0UL;
             ulong rejectedBlobCount = 0UL;
             Dictionary<Hash256, Transaction>? fullBlobTxs = null;
 
+            // A larger, separate rejection budget prevents invalid prefixes from consuming the valid-candidate budget while bounding sidecar reads.
             if (!TryUpdateFeePerBlobGas(parent, spec, out UInt256 feePerBlobGas))
             {
                 if (_logger.IsTrace) _logger.Trace($"Declining blobs, failed to calculate gas price.");
@@ -202,20 +207,10 @@ namespace Nethermind.Consensus.Producers
 
                 if (validateForkSensitiveState)
                 {
-                    if (blobTx is LightTransaction lightTransaction
-                        && _specChangeTxValidator is ILightTxValidator lightTxValidator
-                        && !lightTxValidator.IsWellFormedLight(lightTransaction, spec))
-                    {
-                        rejectedBlobCount += txBlobCount;
-                        if (rejectedBlobCount > maxRejectedBlobsToConsider)
-                        {
-                            break;
-                        }
-
-                        continue;
-                    }
-
-                    if (!TryResolveBlob(blobTx, spec, out Transaction? fullBlobTx)
+                    if ((blobTx is LightTransaction lightTransaction
+                            && _specChangeTxValidator is ILightTxValidator lightTxValidator
+                            && !lightTxValidator.IsWellFormedLight(lightTransaction, spec))
+                        || !TryResolveBlob(blobTx, spec, out Transaction? fullBlobTx)
                         || !IsForkSensitiveStateValid(fullBlobTx, spec))
                     {
                         rejectedBlobCount += txBlobCount;
@@ -490,17 +485,18 @@ namespace Nethermind.Consensus.Producers
         protected virtual IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
             Order(pendingTransactions, comparer, filter, gasLimit);
 
-        private static IEnumerable<(Transaction tx, ulong blobChain)> GetOrderedBlobTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong maxBlobs = 0ul) =>
-            OrderCore(pendingTransactions, comparer, static tx => (ulong)tx.GetBlobCount(), filter, maxBlobs, enforceSequentialNonces: true);
+        private static IEnumerable<(Transaction tx, ulong blobChain)> GetOrderedBlobTransactions(IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong maxBlobs = 0ul) =>
+            OrderCore(pendingTransactions, pendingTransactions.Count, comparer, static tx => (ulong)tx.GetBlobCount(), filter, maxBlobs, enforceSequentialNonces: true);
 
         protected virtual IComparer<Transaction> GetComparer(BlockHeader parent, BlockPreparationContext blockPreparationContext)
             => _transactionComparerProvider.GetDefaultProducerComparer(blockPreparationContext);
 
         internal static IEnumerable<Transaction> Order(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
-            OrderCore(pendingTransactions, comparer, static tx => tx.BlockGasUsed, filter, gasLimit, enforceSequentialNonces: false).Select(static tx => tx.tx);
+            OrderCore(pendingTransactions, pendingTransactions.Count, comparer, static tx => tx.BlockGasUsed, filter, gasLimit, enforceSequentialNonces: false).Select(static tx => tx.tx);
 
         private static IEnumerable<(Transaction tx, ulong resource)> OrderCore(
-            IDictionary<AddressAsKey, Transaction[]> pendingTransactions,
+            IEnumerable<KeyValuePair<AddressAsKey, Transaction[]>> pendingTransactions,
+            int pendingTransactionsCount,
             IComparer<Transaction> comparer,
             Func<Transaction, ulong> resourceSelector,
             Func<Transaction, bool> filter,
@@ -510,7 +506,7 @@ namespace Nethermind.Consensus.Producers
             using ArrayPoolList<IEnumerator<Transaction>> bySenderEnumerators = pendingTransactions
                 .Select<KeyValuePair<AddressAsKey, Transaction[]>, IEnumerable<Transaction>>(static g => g.Value)
                 .Select(static g => g.GetEnumerator())
-                .ToPooledList(pendingTransactions.Count);
+                .ToPooledList(pendingTransactionsCount);
 
             try
             {

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -175,6 +175,7 @@ namespace Nethermind.Consensus.Producers
             ulong maxBlobs,
             bool validateForkSensitiveState)
         {
+            // A larger, separate rejection budget prevents invalid prefixes from consuming the valid-candidate budget while bounding sidecar reads.
             ulong maxBlobsToConsider = maxBlobs * BlobConsiderationMultiplier;
             ulong maxRejectedBlobsToConsider = maxBlobsToConsider * RejectedBlobConsiderationMultiplier;
             ulong countOfRemainingBlobs = 0UL;
@@ -182,7 +183,6 @@ namespace Nethermind.Consensus.Producers
             ulong rejectedBlobCount = 0UL;
             Dictionary<Hash256, Transaction>? fullBlobTxs = null;
 
-            // A larger, separate rejection budget prevents invalid prefixes from consuming the valid-candidate budget while bounding sidecar reads.
             if (!TryUpdateFeePerBlobGas(parent, spec, out UInt256 feePerBlobGas))
             {
                 if (_logger.IsTrace) _logger.Trace($"Declining blobs, failed to calculate gas price.");

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Consensus.Producers
         : ITxSource
     {
         private const ulong BlobConsiderationMultiplier = 5;
-        private const ulong RejectedBlobReadMultiplier = 25;
+        private const ulong RejectedBlobReadMultiplier = 10;
 
         private readonly ITxPool _transactionPool = transactionPool ?? throw new ArgumentNullException(nameof(transactionPool));
         private readonly ITransactionComparerProvider _transactionComparerProvider = transactionComparerProvider ?? throw new ArgumentNullException(nameof(transactionComparerProvider));
@@ -71,9 +71,8 @@ namespace Nethermind.Consensus.Producers
                 : tx => filter(tx) && IsForkSensitiveStateValid(tx, spec);
 
             ulong maxBlobCount = spec.MaxProductionBlobCount(blocksConfig.BlockProductionBlobLimit);
-            // PendingTransactionsView preserves an IDictionary-compatible backing instance for this virtual API.
             IEnumerable<Transaction> transactions = GetOrderedTransactions(
-                (IDictionary<AddressAsKey, Transaction[]>)pendingTransactions,
+                pendingTransactions,
                 comparer,
                 pendingTxFilter,
                 gasLimit);
@@ -487,21 +486,20 @@ namespace Nethermind.Consensus.Producers
             return true;
         }
 
-        protected virtual IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
+        protected virtual IEnumerable<Transaction> GetOrderedTransactions(IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
             Order(pendingTransactions, comparer, filter, gasLimit);
 
         private static IEnumerable<(Transaction tx, ulong blobChain)> GetOrderedBlobTransactions(IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong maxBlobs = 0ul) =>
-            OrderCore(pendingTransactions, pendingTransactions.Count, comparer, static tx => (ulong)tx.GetBlobCount(), filter, maxBlobs, enforceSequentialNonces: true);
+            OrderCore(pendingTransactions, comparer, static tx => (ulong)tx.GetBlobCount(), filter, maxBlobs, enforceSequentialNonces: true);
 
         protected virtual IComparer<Transaction> GetComparer(BlockHeader parent, BlockPreparationContext blockPreparationContext)
             => _transactionComparerProvider.GetDefaultProducerComparer(blockPreparationContext);
 
-        internal static IEnumerable<Transaction> Order(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
-            OrderCore(pendingTransactions, pendingTransactions.Count, comparer, static tx => tx.BlockGasUsed, filter, gasLimit, enforceSequentialNonces: false).Select(static tx => tx.tx);
+        internal static IEnumerable<Transaction> Order(IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
+            OrderCore(pendingTransactions, comparer, static tx => tx.BlockGasUsed, filter, gasLimit, enforceSequentialNonces: false).Select(static tx => tx.tx);
 
         private static IEnumerable<(Transaction tx, ulong resource)> OrderCore(
-            IEnumerable<KeyValuePair<AddressAsKey, Transaction[]>> pendingTransactions,
-            int pendingTransactionsCount,
+            IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions,
             IComparer<Transaction> comparer,
             Func<Transaction, ulong> resourceSelector,
             Func<Transaction, bool> filter,
@@ -511,7 +509,7 @@ namespace Nethermind.Consensus.Producers
             using ArrayPoolList<IEnumerator<Transaction>> bySenderEnumerators = pendingTransactions
                 .Select<KeyValuePair<AddressAsKey, Transaction[]>, IEnumerable<Transaction>>(static g => g.Value)
                 .Select(static g => g.GetEnumerator())
-                .ToPooledList(pendingTransactionsCount);
+                .ToPooledList(pendingTransactions.Count);
 
             try
             {

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -55,8 +55,8 @@ namespace Nethermind.Consensus.Producers
             UInt256 baseFee = BaseFeeCalculator.Calculate(parent, spec);
             PendingTransactionsView pending = _transactionPool.GetPendingForProduction(targetBlock, filterSource, baseFee);
             bool isRevalidatedForTarget = pending.IsRevalidated;
-            IDictionary<AddressAsKey, Transaction[]> pendingTransactions = pending.Transactions;
-            IDictionary<AddressAsKey, Transaction[]> pendingBlobTransactionsEquivalences = pending.BlobTransactions;
+            IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions = pending.Transactions;
+            IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingBlobTransactionsEquivalences = pending.BlobTransactions;
             IComparer<Transaction> comparer = GetComparer(parent, new BlockPreparationContext(baseFee, targetBlock.Number))
                 .ThenBy(ByHashTxComparer.Instance); // in order to sort properly and not lose transactions we need to differentiate on their identity which provided comparer might not be doing
 
@@ -68,8 +68,16 @@ namespace Nethermind.Consensus.Producers
                 : tx => filter(tx) && IsForkSensitiveStateValid(tx, spec);
 
             ulong maxBlobCount = spec.MaxProductionBlobCount(blocksConfig.BlockProductionBlobLimit);
-            IEnumerable<Transaction> transactions = GetOrderedTransactions(pendingTransactions, comparer, pendingTxFilter, gasLimit);
-            IEnumerable<(Transaction tx, ulong blobChain)> blobTransactions = GetOrderedBlobTransactions(pendingBlobTransactionsEquivalences, comparer, BlobFilter, maxBlobCount);
+            IEnumerable<Transaction> transactions = GetOrderedTransactions(
+                (IDictionary<AddressAsKey, Transaction[]>)pendingTransactions,
+                comparer,
+                pendingTxFilter,
+                gasLimit);
+            IEnumerable<(Transaction tx, ulong blobChain)> blobTransactions = GetOrderedBlobTransactions(
+                (IDictionary<AddressAsKey, Transaction[]>)pendingBlobTransactionsEquivalences,
+                comparer,
+                BlobFilter,
+                maxBlobCount);
             if (_logger.IsTrace) _logger.Trace($"Collecting pending transactions at block gas limit {gasLimit}.");
 
             int checkedTransactions = 0;
@@ -164,8 +172,10 @@ namespace Nethermind.Consensus.Producers
             bool validateForkSensitiveState)
         {
             ulong maxBlobsToConsider = maxBlobs * 5ul;
+            ulong maxRejectedBlobsToConsider = maxBlobsToConsider * 5ul;
             ulong countOfRemainingBlobs = 0UL;
             ulong consideredBlobCount = 0UL;
+            ulong rejectedBlobCount = 0UL;
             Dictionary<Hash256, Transaction>? fullBlobTxs = null;
 
             if (!TryUpdateFeePerBlobGas(parent, spec, out UInt256 feePerBlobGas))
@@ -190,15 +200,26 @@ namespace Nethermind.Consensus.Producers
                     continue;
                 }
 
-                // Count before resolving sidecars so an invalid pool cannot make fork-transition validation unbounded.
-                consideredBlobCount += txBlobCount;
-                bool reachedConsiderationLimit = consideredBlobCount > maxBlobsToConsider;
                 if (validateForkSensitiveState)
                 {
+                    if (blobTx is LightTransaction lightTransaction
+                        && _specChangeTxValidator is ILightTxValidator lightTxValidator
+                        && !lightTxValidator.IsWellFormedLight(lightTransaction, spec))
+                    {
+                        rejectedBlobCount += txBlobCount;
+                        if (rejectedBlobCount > maxRejectedBlobsToConsider)
+                        {
+                            break;
+                        }
+
+                        continue;
+                    }
+
                     if (!TryResolveBlob(blobTx, spec, out Transaction? fullBlobTx)
                         || !IsForkSensitiveStateValid(fullBlobTx, spec))
                     {
-                        if (reachedConsiderationLimit)
+                        rejectedBlobCount += txBlobCount;
+                        if (rejectedBlobCount > maxRejectedBlobsToConsider)
                         {
                             break;
                         }
@@ -211,6 +232,9 @@ namespace Nethermind.Consensus.Producers
                         (fullBlobTxs ??= [])[hash] = fullBlobTx;
                     }
                 }
+
+                consideredBlobCount += txBlobCount;
+                bool reachedConsiderationLimit = consideredBlobCount > maxBlobsToConsider;
 
                 if (txBlobCount == 1UL && candidates is null)
                 {

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -38,7 +38,7 @@ namespace Nethermind.Consensus.Producers
         : ITxSource
     {
         private const ulong BlobConsiderationMultiplier = 5;
-        private const ulong RejectedBlobConsiderationMultiplier = 5;
+        private const ulong RejectedBlobReadMultiplier = 25;
 
         private readonly ITxPool _transactionPool = transactionPool ?? throw new ArgumentNullException(nameof(transactionPool));
         private readonly ITransactionComparerProvider _transactionComparerProvider = transactionComparerProvider ?? throw new ArgumentNullException(nameof(transactionComparerProvider));
@@ -175,9 +175,9 @@ namespace Nethermind.Consensus.Producers
             ulong maxBlobs,
             bool validateForkSensitiveState)
         {
-            // A larger, separate rejection budget prevents invalid prefixes from consuming the valid-candidate budget while bounding sidecar reads.
+            // Allow more rejected sidecar loads than valid candidates, but keep storage work bounded.
             ulong maxBlobsToConsider = maxBlobs * BlobConsiderationMultiplier;
-            ulong maxRejectedBlobsToConsider = maxBlobsToConsider * RejectedBlobConsiderationMultiplier;
+            ulong maxRejectedBlobsToConsider = maxBlobs * RejectedBlobReadMultiplier;
             ulong countOfRemainingBlobs = 0UL;
             ulong consideredBlobCount = 0UL;
             ulong rejectedBlobCount = 0UL;
@@ -207,10 +207,14 @@ namespace Nethermind.Consensus.Producers
 
                 if (validateForkSensitiveState)
                 {
-                    if ((blobTx is LightTransaction lightTransaction
-                            && _specChangeTxValidator is ILightTxValidator lightTxValidator
-                            && !lightTxValidator.IsWellFormedLight(lightTransaction, spec))
-                        || !TryResolveBlob(blobTx, spec, out Transaction? fullBlobTx)
+                    if (blobTx is LightTransaction lightTransaction
+                        && _specChangeTxValidator is ILightTxValidator lightTxValidator
+                        && !lightTxValidator.IsWellFormedLight(lightTransaction, spec))
+                    {
+                        continue;
+                    }
+
+                    if (!TryResolveBlob(blobTx, spec, out Transaction? fullBlobTx)
                         || !IsForkSensitiveStateValid(fullBlobTx, spec))
                     {
                         rejectedBlobCount += txBlobCount;

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -174,7 +174,8 @@ namespace Nethermind.Consensus.Producers
             ulong maxBlobs,
             bool validateForkSensitiveState)
         {
-            // Allow more rejected sidecar loads than valid candidates, but keep storage work bounded.
+            // Allow more rejected sidecar loads than valid candidates, but keep storage work bounded. Light-only
+            // rejections do no I/O and are bounded by the pool size instead, so they do not consume this budget.
             ulong maxBlobsToConsider = maxBlobs * BlobConsiderationMultiplier;
             ulong maxRejectedBlobsToConsider = maxBlobs * RejectedBlobReadMultiplier;
             ulong countOfRemainingBlobs = 0UL;

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -182,6 +182,7 @@ namespace Nethermind.Consensus.Producers
             ulong consideredBlobCount = 0UL;
             ulong rejectedBlobCount = 0UL;
             Dictionary<Hash256, Transaction>? fullBlobTxs = null;
+            ILightTxValidator? lightTxValidator = _specChangeTxValidator as ILightTxValidator;
 
             if (!TryUpdateFeePerBlobGas(parent, spec, out UInt256 feePerBlobGas))
             {
@@ -208,7 +209,7 @@ namespace Nethermind.Consensus.Producers
                 if (validateForkSensitiveState)
                 {
                     if (blobTx is LightTransaction lightTransaction
-                        && _specChangeTxValidator is ILightTxValidator lightTxValidator
+                        && lightTxValidator is not null
                         && !lightTxValidator.IsWellFormedLight(lightTransaction, spec))
                     {
                         continue;

--- a/src/Nethermind/Nethermind.Consensus/Validators/SpecChangeTxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/SpecChangeTxValidator.cs
@@ -25,6 +25,13 @@ public sealed class SpecChangeTxValidator(ulong chainId) :
     public string PersistenceFingerprint { get; } =
         FormattableString.Invariant($"2|{typeof(SpecChangeTxValidator).Module.ModuleVersionId:N}|{typeof(EthereumGasPolicy).Module.ModuleVersionId:N}|{chainId}");
 
+    /// <inheritdoc/>
+    /// <remarks>
+    /// This follows a successful <see cref="TxValidator"/> pass with blob proofs skipped. That pass already covers
+    /// release activation, gas caps, proof version, contract size, signatures, and intrinsic gas. The inexpensive
+    /// blob-count check is retained as the explicit fork-dependent admission guard. Any new rule added to this
+    /// validator must also be added here unless the full validator applies it for every affected transaction type.
+    /// </remarks>
     public ValidationResult IsWellFormedAfterFullValidation(Transaction transaction, IReleaseSpec releaseSpec) =>
         MaxBlobCountBlobTxValidator.Instance.IsWellFormed(transaction, releaseSpec);
 

--- a/src/Nethermind/Nethermind.Consensus/Validators/SpecChangeTxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/SpecChangeTxValidator.cs
@@ -4,6 +4,7 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.GasPolicy;
 using Nethermind.TxPool;
 
 namespace Nethermind.Consensus.Validators;
@@ -22,7 +23,10 @@ public sealed class SpecChangeTxValidator(ulong chainId) :
     private static readonly HeadTxValidator LightTxValidator = new();
 
     public string PersistenceFingerprint { get; } =
-        FormattableString.Invariant($"1|{typeof(SpecChangeTxValidator).Module.ModuleVersionId:N}|{chainId}");
+        FormattableString.Invariant($"2|{typeof(SpecChangeTxValidator).Module.ModuleVersionId:N}|{typeof(EthereumGasPolicy).Module.ModuleVersionId:N}|{chainId}");
+
+    public ValidationResult IsWellFormedAfterFullValidation(Transaction transaction, IReleaseSpec releaseSpec) =>
+        MaxBlobCountBlobTxValidator.Instance.IsWellFormed(transaction, releaseSpec);
 
     public ValidationResult IsWellFormedLight(LightTransaction transaction, IReleaseSpec releaseSpec) =>
         LightTxValidator.IsWellFormed(transaction, releaseSpec);

--- a/src/Nethermind/Nethermind.Consensus/Validators/SpecChangeTxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/SpecChangeTxValidator.cs
@@ -28,12 +28,11 @@ public sealed class SpecChangeTxValidator(ulong chainId) :
     /// <inheritdoc/>
     /// <remarks>
     /// This follows a successful <see cref="TxValidator"/> pass with blob proofs skipped. That pass already covers
-    /// release activation, gas caps, proof version, contract size, signatures, and intrinsic gas. The inexpensive
-    /// blob-count check is retained as the explicit fork-dependent admission guard. Any new rule added to this
-    /// validator must also be added here unless the full validator applies it for every affected transaction type.
+    /// every rule in this validator, including blob count. Chain-specific validators only need to override this
+    /// when a registered transaction type bypasses part of the full validator.
     /// </remarks>
     public ValidationResult IsWellFormedAfterFullValidation(Transaction transaction, IReleaseSpec releaseSpec) =>
-        MaxBlobCountBlobTxValidator.Instance.IsWellFormed(transaction, releaseSpec);
+        ValidationResult.Success;
 
     public ValidationResult IsWellFormedLight(LightTransaction transaction, IReleaseSpec releaseSpec) =>
         LightTxValidator.IsWellFormed(transaction, releaseSpec);

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismBlockValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismBlockValidatorTests.cs
@@ -6,8 +6,11 @@ using System.Collections.Generic;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
 using Nethermind.Logging;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Optimism.Test;
@@ -141,6 +144,40 @@ public class OptimismBlockValidatorTests(Fork fork)
         Assert.That(
             validator.ValidateSuggestedBlock(block, parentHeader, out string? error),
             Is.EqualTo(isValid.On(_timestamp)),
+            () => error!);
+    }
+
+    [Test]
+    public void ValidateSuggestedBlock_ValidatesLegacyTransactionGasLimitCap()
+    {
+        const ulong chainId = 10;
+        Transaction transaction = Build.A.Transaction
+            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + 1)
+            .SignedAndResolved(new EthereumEcdsa(chainId), TestItem.PrivateKeyA)
+            .TestObject;
+        (BlockHeader parentHeader, Block block) = BuildBlock(b => b
+            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap * 2)
+            .WithTransactions(transaction));
+        OptimismReleaseSpec spec = new()
+        {
+            IsEip1559Enabled = true,
+            IsEip7825Enabled = _timestamp >= Spec.KarstTimeStamp
+        };
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(block.Header).Returns(spec);
+        TxValidator txValidator = new(chainId);
+        txValidator.RegisterValidator(TxType.Legacy, new OptimismLegacyTxValidator(chainId));
+        OptimismBlockValidator validator = new(
+            txValidator,
+            Always.Valid,
+            Always.Valid,
+            specProvider,
+            Spec.Instance,
+            TestLogManager.Instance);
+
+        Assert.That(
+            validator.ValidateSuggestedBlock(block, parentHeader, out string? error),
+            Is.EqualTo(_timestamp < Spec.KarstTimeStamp),
             () => error!);
     }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
@@ -86,6 +86,7 @@ public class OptimismModuleTests
     [TestCase(TxType.Legacy, true, false, 1ul, true)]
     [TestCase(TxType.DepositTx, true, false, 1ul, true)]
     [TestCase(TxType.Legacy, false, true, 1ul, true)]
+    [TestCase(TxType.DepositTx, false, true, 1ul, false)]
     public void Full_and_delta_validation_respect_optimism_gas_limit_cap(
         TxType transactionType,
         bool isEip1559Enabled,
@@ -122,6 +123,30 @@ public class OptimismModuleTests
         {
             Assert.That(specChangeResult.AsBool, Is.EqualTo(expected));
             Assert.That(admissionResult.AsBool, Is.EqualTo(expected));
+        }
+    }
+
+    [TestCase(false, ulong.MaxValue, null)]
+    [TestCase(true, ulong.MaxValue - 1, null)]
+    [TestCase(true, ulong.MaxValue, TxErrorMessages.NonceTooHigh)]
+    public void Legacy_validation_respects_eip2681_nonce_cap_after_bedrock(
+        bool isEip1559Enabled,
+        ulong nonce,
+        string? expectedError)
+    {
+        const ulong chainId = 10;
+        OptimismReleaseSpec spec = new() { IsEip1559Enabled = isEip1559Enabled };
+        Transaction transaction = Build.A.Transaction
+            .WithNonce(nonce)
+            .SignedAndResolved(new EthereumEcdsa(chainId), TestItem.PrivateKeyA)
+            .TestObject;
+
+        ValidationResult result = new OptimismLegacyTxValidator(chainId).IsWellFormed(transaction, spec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.AsBool, Is.EqualTo(expectedError is null));
+            Assert.That(result.Error, Is.EqualTo(expectedError));
         }
     }
 

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
@@ -113,4 +113,21 @@ public class OptimismModuleTests
             Assert.That(admissionResult.AsBool, Is.False);
         }
     }
+
+    [Test]
+    public void Full_validation_prioritizes_sender_independent_errors_over_intrinsic_gas()
+    {
+        OptimismReleaseSpec spec = new() { IsEip1559Enabled = true };
+        Transaction transaction = Build.A.Transaction
+            .WithGasLimit(0)
+            .TestObject;
+
+        ValidationResult result = new OptimismLegacyTxValidator(10).IsWellFormed(transaction, spec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.AsBool, Is.False);
+            Assert.That(result.IsIntrinsicGasError, Is.False);
+        }
+    }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
@@ -78,8 +78,9 @@ public class OptimismModuleTests
         }
     }
 
-    [Test]
-    public void Full_and_delta_validation_cover_optimism_legacy_gas_limit_cap()
+    [TestCase(TxType.Legacy)]
+    [TestCase(TxType.DepositTx)]
+    public void Full_and_delta_validation_cover_optimism_gas_limit_cap(TxType transactionType)
     {
         const ulong chainId = 10;
         OptimismReleaseSpec spec = new()
@@ -87,11 +88,16 @@ public class OptimismModuleTests
             IsEip1559Enabled = true,
             IsEip7825Enabled = true
         };
-        Transaction transaction = Build.A.Transaction
+        TransactionBuilder<Transaction> transactionBuilder = Build.A.Transaction
+            .WithType(transactionType)
             .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + 1)
-            .SignedAndResolved(new EthereumEcdsa(chainId), TestItem.PrivateKeyA)
-            .TestObject;
-        OptimismLegacyTxValidator fullValidator = new(chainId);
+            .WithSenderAddress(TestItem.AddressA);
+        Transaction transaction = transactionType == TxType.Legacy
+            ? transactionBuilder.SignedAndResolved(new EthereumEcdsa(chainId), TestItem.PrivateKeyA).TestObject
+            : transactionBuilder.TestObject;
+        ITxValidator fullValidator = transactionType == TxType.DepositTx
+            ? Always.Valid
+            : new OptimismLegacyTxValidator(chainId);
         OptimismSpecChangeTxValidator specChangeValidator = new(chainId);
         ValidationResult specChangeResult = specChangeValidator.IsWellFormed(transaction, spec);
         ValidationResult admissionResult = fullValidator.IsWellFormed(transaction, spec);

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
@@ -66,11 +66,13 @@ public class OptimismModuleTests
         builder.RegisterInstance(specProvider).As<ISpecProvider>();
         using IContainer container = builder.Build();
         ITxValidator validator = container.ResolveKeyed<ITxValidator>(ITxValidator.SpecChangeTxValidatorKey);
+        string ethereumFingerprint = new SpecChangeTxValidator(chainId).PersistenceFingerprint;
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(validator, Is.TypeOf<OptimismSpecChangeTxValidator>());
             Assert.That(container.ResolveKeyed<ITxValidator>(ITxValidator.SpecChangeTxValidatorKey), Is.SameAs(validator));
+            Assert.That(((ISpecChangeTxValidator)validator).PersistenceFingerprint, Does.Contain(ethereumFingerprint));
             Assert.That(validator.IsWellFormed(transaction, preBedrock).AsBool(), Is.True);
             Assert.That(validator.IsWellFormed(transaction, postBedrock).AsBool(), Is.False);
         }

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
@@ -79,19 +79,29 @@ public class OptimismModuleTests
         }
     }
 
-    [TestCase(TxType.Legacy)]
-    [TestCase(TxType.DepositTx)]
-    public void Full_and_delta_validation_cover_optimism_gas_limit_cap(TxType transactionType)
+    [TestCase(TxType.Legacy, true, true, 1ul, false)]
+    [TestCase(TxType.DepositTx, true, true, 1ul, false)]
+    [TestCase(TxType.Legacy, true, true, 0ul, true)]
+    [TestCase(TxType.DepositTx, true, true, 0ul, true)]
+    [TestCase(TxType.Legacy, true, false, 1ul, true)]
+    [TestCase(TxType.DepositTx, true, false, 1ul, true)]
+    [TestCase(TxType.Legacy, false, true, 1ul, true)]
+    public void Full_and_delta_validation_respect_optimism_gas_limit_cap(
+        TxType transactionType,
+        bool isEip1559Enabled,
+        bool isEip7825Enabled,
+        ulong gasLimitAboveCap,
+        bool expected)
     {
         const ulong chainId = 10;
         OptimismReleaseSpec spec = new()
         {
-            IsEip1559Enabled = true,
-            IsEip7825Enabled = true
+            IsEip1559Enabled = isEip1559Enabled,
+            IsEip7825Enabled = isEip7825Enabled
         };
         TransactionBuilder<Transaction> transactionBuilder = Build.A.Transaction
             .WithType(transactionType)
-            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + 1)
+            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + gasLimitAboveCap)
             .WithSenderAddress(TestItem.AddressA);
         Transaction transaction = transactionType == TxType.Legacy
             ? transactionBuilder.SignedAndResolved(new EthereumEcdsa(chainId), TestItem.PrivateKeyA).TestObject
@@ -110,8 +120,8 @@ public class OptimismModuleTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(specChangeResult.AsBool, Is.False, "test case must exercise a spec-change rejection");
-            Assert.That(admissionResult.AsBool, Is.False);
+            Assert.That(specChangeResult.AsBool, Is.EqualTo(expected));
+            Assert.That(admissionResult.AsBool, Is.EqualTo(expected));
         }
     }
 

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
@@ -7,6 +7,7 @@ using Autofac;
 using Nethermind.Api.Steps;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
+using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
@@ -128,6 +129,7 @@ public class OptimismModuleTests
         {
             Assert.That(result.AsBool, Is.False);
             Assert.That(result.IsIntrinsicGasError, Is.False);
+            Assert.That(result.Error, Is.EqualTo(TxErrorMessages.InvalidTxSignature));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
@@ -77,4 +77,34 @@ public class OptimismModuleTests
             Assert.That(validator.IsWellFormed(transaction, postBedrock).AsBool(), Is.False);
         }
     }
+
+    [Test]
+    public void Full_and_delta_validation_cover_optimism_legacy_gas_limit_cap()
+    {
+        const ulong chainId = 10;
+        OptimismReleaseSpec spec = new()
+        {
+            IsEip1559Enabled = true,
+            IsEip7825Enabled = true
+        };
+        Transaction transaction = Build.A.Transaction
+            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + 1)
+            .SignedAndResolved(new EthereumEcdsa(chainId), TestItem.PrivateKeyA)
+            .TestObject;
+        OptimismLegacyTxValidator fullValidator = new(chainId);
+        OptimismSpecChangeTxValidator specChangeValidator = new(chainId);
+        ValidationResult specChangeResult = specChangeValidator.IsWellFormed(transaction, spec);
+        ValidationResult admissionResult = fullValidator.IsWellFormed(transaction, spec);
+
+        if (admissionResult)
+        {
+            admissionResult = specChangeValidator.IsWellFormedAfterFullValidation(transaction, spec);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(specChangeResult.AsBool, Is.False, "test case must exercise a spec-change rejection");
+            Assert.That(admissionResult.AsBool, Is.False);
+        }
+    }
 }

--- a/src/Nethermind/Nethermind.Optimism/Nethermind.Optimism.csproj
+++ b/src/Nethermind/Nethermind.Optimism/Nethermind.Optimism.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Nethermind.Optimism.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Nethermind.Libp2p" />
     <PackageReference Include="Nethermind.Libp2p.Protocols.PubsubPeerDiscovery" />
     <PackageReference Include="Google.Protobuf" />

--- a/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
@@ -28,12 +28,12 @@ public sealed class OptimismLegacyTxDecoder : LegacyTxDecoder<Transaction>
 public sealed class OptimismLegacyTxValidator(ulong chainId) : ITxValidator
 {
     private readonly ITxValidator _postBedrockValidator = new CompositeTxValidator([
-        GasLimitCapTxValidator.Instance,
-        IntrinsicGasTxValidator.Instance,
         new LegacySignatureTxValidator(chainId),
         ContractSizeTxValidator.Instance,
         NonBlobFieldsTxValidator.Instance,
-        NonSetCodeFieldsTxValidator.Instance
+        NonSetCodeFieldsTxValidator.Instance,
+        GasLimitCapTxValidator.Instance,
+        IntrinsicGasTxValidator.Instance
     ]);
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)

--- a/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Runtime.CompilerServices;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -10,8 +9,6 @@ using Nethermind.Core.Specs;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Serialization.Rlp.TxDecoders;
 using Nethermind.TxPool;
-
-[assembly: InternalsVisibleTo("Nethermind.Optimism.Test")]
 
 namespace Nethermind.Optimism;
 
@@ -55,17 +52,28 @@ public sealed class OptimismLegacyTxValidator(ulong chainId) : ITxValidator
     }
 }
 
-internal sealed class OptimismSpecChangeTxValidator(ulong chainId) : ITxValidator, ILightTxValidator, ISpecChangeTxValidator
+internal sealed class OptimismSpecChangeTxValidator : ITxValidator, ILightTxValidator, ISpecChangeTxValidator
 {
-    private readonly SpecChangeTxValidator _ethereumValidator = new(chainId);
+    private readonly SpecChangeTxValidator _ethereumValidator;
 
-    public string PersistenceFingerprint { get; } =
-        FormattableString.Invariant($"1|{typeof(OptimismSpecChangeTxValidator).Module.ModuleVersionId:N}|{chainId}");
+    public OptimismSpecChangeTxValidator(ulong chainId)
+    {
+        _ethereumValidator = new(chainId);
+        PersistenceFingerprint = FormattableString.Invariant(
+            $"2|{typeof(OptimismSpecChangeTxValidator).Module.ModuleVersionId:N}|{_ethereumValidator.PersistenceFingerprint}");
+    }
+
+    public string PersistenceFingerprint { get; }
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
         transaction.Type == TxType.Legacy && !releaseSpec.IsEip1559Enabled
             ? ValidationResult.Success
             : _ethereumValidator.IsWellFormed(transaction, releaseSpec);
+
+    public ValidationResult IsWellFormedAfterFullValidation(Transaction transaction, IReleaseSpec releaseSpec) =>
+        transaction.Type == TxType.Legacy && !releaseSpec.IsEip1559Enabled
+            ? ValidationResult.Success
+            : _ethereumValidator.IsWellFormedAfterFullValidation(transaction, releaseSpec);
 
     public ValidationResult IsWellFormedLight(LightTransaction transaction, IReleaseSpec releaseSpec) =>
         _ethereumValidator.IsWellFormedLight(transaction, releaseSpec);

--- a/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
@@ -28,6 +28,7 @@ public sealed class OptimismLegacyTxDecoder : LegacyTxDecoder<Transaction>
 public sealed class OptimismLegacyTxValidator(ulong chainId) : ITxValidator
 {
     private readonly ITxValidator _postBedrockValidator = new CompositeTxValidator([
+        NonceCapTxValidator.Instance,
         new LegacySignatureTxValidator(chainId),
         ContractSizeTxValidator.Instance,
         NonBlobFieldsTxValidator.Instance,

--- a/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
@@ -32,7 +32,8 @@ public sealed class OptimismLegacyTxValidator(ulong chainId) : ITxValidator
         new LegacySignatureTxValidator(chainId),
         ContractSizeTxValidator.Instance,
         NonBlobFieldsTxValidator.Instance,
-        NonSetCodeFieldsTxValidator.Instance
+        NonSetCodeFieldsTxValidator.Instance,
+        GasLimitCapTxValidator.Instance
     ]);
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)

--- a/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
@@ -28,12 +28,12 @@ public sealed class OptimismLegacyTxDecoder : LegacyTxDecoder<Transaction>
 public sealed class OptimismLegacyTxValidator(ulong chainId) : ITxValidator
 {
     private readonly ITxValidator _postBedrockValidator = new CompositeTxValidator([
+        GasLimitCapTxValidator.Instance,
         IntrinsicGasTxValidator.Instance,
         new LegacySignatureTxValidator(chainId),
         ContractSizeTxValidator.Instance,
         NonBlobFieldsTxValidator.Instance,
-        NonSetCodeFieldsTxValidator.Instance,
-        GasLimitCapTxValidator.Instance
+        NonSetCodeFieldsTxValidator.Instance
     ]);
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
@@ -72,9 +72,12 @@ internal sealed class OptimismSpecChangeTxValidator : ITxValidator, ILightTxVali
             : _ethereumValidator.IsWellFormed(transaction, releaseSpec);
 
     public ValidationResult IsWellFormedAfterFullValidation(Transaction transaction, IReleaseSpec releaseSpec) =>
-        transaction.Type == TxType.Legacy && !releaseSpec.IsEip1559Enabled
-            ? ValidationResult.Success
-            : _ethereumValidator.IsWellFormedAfterFullValidation(transaction, releaseSpec);
+        transaction.Type switch
+        {
+            TxType.Legacy when !releaseSpec.IsEip1559Enabled => ValidationResult.Success,
+            TxType.DepositTx => _ethereumValidator.IsWellFormed(transaction, releaseSpec),
+            _ => _ethereumValidator.IsWellFormedAfterFullValidation(transaction, releaseSpec)
+        };
 
     public ValidationResult IsWellFormedLight(LightTransaction transaction, IReleaseSpec releaseSpec) =>
         _ethereumValidator.IsWellFormedLight(transaction, releaseSpec);

--- a/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
@@ -225,6 +226,42 @@ public class BlobTxStorageTests
             Assert.That(blobTxStorage.TryGetWithoutBlobs(first.Hash, first.SenderAddress!, out _), Is.False);
             Assert.That(blobTxStorage.TryGetWithoutBlobs(second.Hash, second.SenderAddress!, out _), Is.False);
             Assert.That(blobTxStorage.GetAll(), Is.Empty);
+        }
+    }
+
+    [Test]
+    public void DeleteObsoleteFullBlobTransactions_should_skip_write_batches_for_live_entries()
+    {
+        const int transactionCount = 17;
+        TrackingColumnsDb columnsDb = new();
+        BlobTxStorage blobTxStorage = new(columnsDb);
+        Transaction[] transactions = new Transaction[transactionCount];
+        EthereumEcdsa ecdsa = new(BlockchainIds.Mainnet);
+        for (int i = 0; i < transactions.Length; i++)
+        {
+            transactions[i] = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields()
+                .WithNonce((ulong)i)
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .SignedAndResolved(ecdsa, TestItem.PrivateKeyA).TestObject;
+            blobTxStorage.Add(transactions[i]);
+        }
+
+        ((IBatchDeleteTxStorage)blobTxStorage).DeleteObsoleteFullBlobTransactions(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(columnsDb.StartedWriteBatchCount, Is.Zero);
+            for (int i = 0; i < transactions.Length; i++)
+            {
+                Transaction transaction = transactions[i];
+                Assert.That(blobTxStorage.TryGet(
+                    transaction.Hash,
+                    transaction.SenderAddress!,
+                    transaction.Timestamp,
+                    out _), Is.True);
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -384,6 +384,9 @@ namespace Nethermind.TxPool.Test
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
             await _txPool.DisposeAsync();
 
             storage.ResetFullReadCount();
@@ -749,6 +752,62 @@ namespace Nethermind.TxPool.Test
                 Assert.That(elidedTransactionPersisted, Is.True);
                 Assert.That(storage.GetAll(), Is.Not.Empty);
             }
+        }
+
+        [Test]
+        public async Task should_defer_obsolete_full_transaction_recovery_from_startup()
+        {
+            TestSpecProvider specProvider = new(Cancun.Instance);
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
+            UInt256 obsoleteTimestamp = transaction.Timestamp;
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            transaction.Timestamp += UInt256.One;
+            storage.Add(transaction);
+            storage.Delete(transaction.Hash, transaction.Timestamp);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                PersistentBlobStorageSize = 1
+            };
+            TaskCompletionSource recoveryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRecovery = new(false);
+            storage.BeforeObsoleteRecovery = () =>
+            {
+                recoveryStarted.TrySetResult();
+                Assert.That(
+                    releaseRecovery.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "Timed out waiting to release obsolete blob-body recovery.");
+            };
+
+            Task<TxPool> poolCreation = RunOnDedicatedThread(() => CreatePool(txPoolConfig, specProvider, txStorage: storage));
+            await recoveryStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            TxPool createdPool = null;
+            bool constructionCompletedBeforeRecovery = true;
+            try
+            {
+                createdPool = await poolCreation.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+            }
+            catch (TimeoutException)
+            {
+                constructionCompletedBeforeRecovery = false;
+            }
+            finally
+            {
+                releaseRecovery.Set();
+            }
+
+            _txPool = createdPool ?? await poolCreation.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.That(constructionCompletedBeforeRecovery, Is.True, "TxPool construction waited for the recovery scan.");
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+            Assert.That(
+                storage.TryGet(transaction.Hash, transaction.SenderAddress!, obsoleteTimestamp, out _),
+                Is.False);
         }
 
         [Test]
@@ -1864,6 +1923,8 @@ namespace Nethermind.TxPool.Test
 
             public bool FailNextFullTransactionDelete { get; set; }
 
+            public Action BeforeObsoleteRecovery { get; set; }
+
             public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
                 _storage.TryGet(hash, sender, timestamp, out transaction);
 
@@ -1918,8 +1979,11 @@ namespace Nethermind.TxPool.Test
                 ((IBatchDeleteTxStorage)_storage).DeleteFullBlobTransactions(keys);
             }
 
-            void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions() =>
+            void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions()
+            {
+                BeforeObsoleteRecovery?.Invoke();
                 ((IBatchDeleteTxStorage)_storage).DeleteObsoleteFullBlobTransactions();
+            }
         }
 
         private static void RemoveAllTransactions(

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Reflection;
 using CkzgLib;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
@@ -780,7 +779,7 @@ namespace Nethermind.TxPool.Test
             };
             TaskCompletionSource recoveryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
             using ManualResetEventSlim releaseRecovery = new(false);
-            storage.BeforeObsoleteRecovery = () =>
+            storage.BeforeObsoleteRecovery = _ =>
             {
                 if (storage.ObsoleteRecoveryCount != 1)
                 {
@@ -914,48 +913,37 @@ namespace Nethermind.TxPool.Test
 
         [Test]
         [NonParallelizable]
-        public async Task should_skip_obsolete_full_transaction_recovery_during_shutdown()
+        public async Task should_cancel_obsolete_full_transaction_recovery_during_shutdown()
         {
-            int testThreadId = Environment.CurrentManagedThreadId;
-            TaskCompletionSource recoveryCheckReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            TaskCompletionSource<bool> recoveryCheckReleased = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            using ManualResetEventSlim releaseRecoveryCheck = new(false);
-            ITxPoolConfig txPoolConfig = Substitute.For<ITxPoolConfig>();
-            txPoolConfig.Size.Returns(1);
-            txPoolConfig.PersistentBlobStorageSize.Returns(1);
-            txPoolConfig.BlobCacheSize.Returns(1);
-            txPoolConfig.BlobsSupport.Returns(_ =>
-            {
-                if (Environment.CurrentManagedThreadId != testThreadId)
-                {
-                    recoveryCheckReached.TrySetResult();
-                    recoveryCheckReleased.TrySetResult(releaseRecoveryCheck.Wait(TimeSpan.FromSeconds(10)));
-                }
-
-                return BlobsSupportMode.Storage;
-            });
+            TaskCompletionSource recoveryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> recoveryReleasedAfterCancellation = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRecovery = new(false);
             FailingBatchDeleteBlobTxStorage storage = new();
-            _txPool = CreatePool(txPoolConfig, GetCancunSpecProvider(), txStorage: storage);
-            await recoveryCheckReached.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            storage.BeforeObsoleteRecovery = cancellationToken =>
+            {
+                recoveryStarted.TrySetResult();
+                bool released = releaseRecovery.Wait(TimeSpan.FromSeconds(10));
+                recoveryReleasedAfterCancellation.TrySetResult(released && cancellationToken.IsCancellationRequested);
+            };
+            _txPool = CreatePool(
+                new TxPoolConfig
+                {
+                    BlobsSupport = BlobsSupportMode.Storage,
+                    PersistentBlobStorageSize = 1
+                },
+                GetCancunSpecProvider(),
+                txStorage: storage);
+            await recoveryStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
-            CancellationTokenSource cancellation = (CancellationTokenSource)typeof(TxPool)
-                .GetField("_cts", BindingFlags.Instance | BindingFlags.NonPublic)!
-                .GetValue(_txPool)!;
             ValueTask disposal = _txPool.DisposeAsync();
-            try
-            {
-                Assert.That(cancellation.IsCancellationRequested, Is.True);
-            }
-            finally
-            {
-                releaseRecoveryCheck.Set();
-            }
+            releaseRecovery.Set();
 
             await disposal.AsTask().WaitAsync(TimeSpan.FromSeconds(10));
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(await recoveryCheckReleased.Task.WaitAsync(TimeSpan.FromSeconds(10)), Is.True);
-                Assert.That(storage.ObsoleteRecoveryCount, Is.Zero);
+                Assert.That(await recoveryReleasedAfterCancellation.Task.WaitAsync(TimeSpan.FromSeconds(10)), Is.True);
+                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(1));
+                Assert.That(storage.ObsoleteRecoveryCancellationCount, Is.EqualTo(1));
             }
         }
 
@@ -2064,6 +2052,7 @@ namespace Nethermind.TxPool.Test
         {
             private readonly BlobTxStorage _storage = new();
             private int _obsoleteRecoveryCount;
+            private int _obsoleteRecoveryCancellationCount;
 
             public List<int> DeleteBatchSizes { get; } = [];
 
@@ -2073,9 +2062,11 @@ namespace Nethermind.TxPool.Test
 
             public bool FailNextFullTransactionDelete { get; set; }
 
-            public Action BeforeObsoleteRecovery { get; set; }
+            public Action<CancellationToken> BeforeObsoleteRecovery { get; set; }
 
             public int ObsoleteRecoveryCount => Volatile.Read(ref _obsoleteRecoveryCount);
+
+            public int ObsoleteRecoveryCancellationCount => Volatile.Read(ref _obsoleteRecoveryCancellationCount);
 
             public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
                 _storage.TryGet(hash, sender, timestamp, out transaction);
@@ -2131,11 +2122,19 @@ namespace Nethermind.TxPool.Test
                 ((IBatchDeleteTxStorage)_storage).DeleteFullBlobTransactions(keys);
             }
 
-            void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions()
+            void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken)
             {
                 Interlocked.Increment(ref _obsoleteRecoveryCount);
-                BeforeObsoleteRecovery?.Invoke();
-                ((IBatchDeleteTxStorage)_storage).DeleteObsoleteFullBlobTransactions();
+                BeforeObsoleteRecovery?.Invoke(cancellationToken);
+                try
+                {
+                    ((IBatchDeleteTxStorage)_storage).DeleteObsoleteFullBlobTransactions(cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    Interlocked.Increment(ref _obsoleteRecoveryCancellationCount);
+                    throw;
+                }
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -841,6 +841,76 @@ namespace Nethermind.TxPool.Test
                 Is.False);
         }
 
+        [TestCase(BlobsSupportMode.Disabled)]
+        [TestCase(BlobsSupportMode.InMemory)]
+        public async Task should_not_recover_obsolete_full_transactions_for_non_persistent_blob_pool(BlobsSupportMode blobsSupport)
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider specProvider = new(Prague.Instance)
+            {
+                NextForkSpec = Osaka.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            FailingBatchDeleteBlobTxStorage storage = new();
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = blobsSupport };
+            _txPool = CreatePool(txPoolConfig, specProvider, txStorage: storage);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            Transaction transaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+
+            Assert.That(storage.ObsoleteRecoveryCount, Is.Zero);
+        }
+
+        [Test]
+        public async Task should_recover_obsolete_full_transactions_before_revalidation_walk()
+        {
+            TestSpecProvider specProvider = new(Cancun.Instance);
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                PersistentBlobStorageSize = 1
+            };
+            TaskCompletionSource revalidationStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRevalidation = new(false);
+            ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
+            specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(_ =>
+            {
+                revalidationStarted.TrySetResult();
+                Assert.That(
+                    releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "Timed out waiting to release fork revalidation.");
+                return ValidationResult.Success;
+            });
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            _txPool = CreatePool(
+                txPoolConfig,
+                specProvider,
+                txStorage: storage,
+                specChangeTxValidator: specChangeTxValidator);
+            await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            try
+            {
+                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                releaseRevalidation.Set();
+            }
+
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+        }
+
         [Test]
         public void should_load_full_sidecar_from_db_when_getting_blob_tx_after_cache_eviction()
         {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -595,6 +595,10 @@ namespace Nethermind.TxPool.Test
             };
             FailingBatchDeleteBlobTxStorage storage = new() { DeleteManyFailuresRemaining = 2 };
             _txPool = CreatePool(txPoolConfig, provider, txStorage: storage);
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+            int recoveryCountBeforeFork = storage.ObsoleteRecoveryCount;
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
@@ -615,6 +619,7 @@ namespace Nethermind.TxPool.Test
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1, 1 }));
+                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(recoveryCountBeforeFork + 1));
                 Assert.That(storage.GetAll(), Is.Empty);
                 Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
             }
@@ -774,11 +779,17 @@ namespace Nethermind.TxPool.Test
             using ManualResetEventSlim releaseRecovery = new(false);
             storage.BeforeObsoleteRecovery = () =>
             {
+                if (storage.ObsoleteRecoveryCount != 1)
+                {
+                    return;
+                }
+
                 recoveryStarted.TrySetResult();
                 Assert.That(
                     releaseRecovery.Wait(TimeSpan.FromSeconds(10)),
                     Is.True,
                     "Timed out waiting to release obsolete blob-body recovery.");
+                throw new InvalidOperationException("Simulated interrupted obsolete blob-body recovery.");
             };
 
             Task<TxPool> poolCreation = RunOnDedicatedThread(() => CreatePool(txPoolConfig, specProvider, txStorage: storage));
@@ -788,7 +799,9 @@ namespace Nethermind.TxPool.Test
             try
             {
                 createdPool = await poolCreation.WaitAsync(TimeSpan.FromSeconds(5));
+                _txPool = createdPool;
                 Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+                await AddEmptyBlock();
             }
             catch (TimeoutException)
             {
@@ -802,6 +815,7 @@ namespace Nethermind.TxPool.Test
             _txPool = createdPool ?? await poolCreation.WaitAsync(TimeSpan.FromSeconds(10));
 
             Assert.That(constructionCompletedBeforeRecovery, Is.True, "TxPool construction waited for the recovery scan.");
+            Assert.That(() => storage.ObsoleteRecoveryCount, Is.EqualTo(2).After(Timeout, 10));
             Assert.That(
                 () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
                 Is.Not.Null.After(Timeout, 10));
@@ -1914,6 +1928,7 @@ namespace Nethermind.TxPool.Test
         private sealed class FailingBatchDeleteBlobTxStorage : IBlobTxStorage, IBatchDeleteTxStorage, ISpecChangeValidationStorage
         {
             private readonly BlobTxStorage _storage = new();
+            private int _obsoleteRecoveryCount;
 
             public List<int> DeleteBatchSizes { get; } = [];
 
@@ -1924,6 +1939,8 @@ namespace Nethermind.TxPool.Test
             public bool FailNextFullTransactionDelete { get; set; }
 
             public Action BeforeObsoleteRecovery { get; set; }
+
+            public int ObsoleteRecoveryCount => Volatile.Read(ref _obsoleteRecoveryCount);
 
             public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
                 _storage.TryGet(hash, sender, timestamp, out transaction);
@@ -1981,6 +1998,7 @@ namespace Nethermind.TxPool.Test
 
             void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions()
             {
+                Interlocked.Increment(ref _obsoleteRecoveryCount);
                 BeforeObsoleteRecovery?.Invoke();
                 ((IBatchDeleteTxStorage)_storage).DeleteObsoleteFullBlobTransactions();
             }
@@ -3603,18 +3621,35 @@ namespace Nethermind.TxPool.Test
             Task<BlobCellMergeResult> merge = RunOnDedicatedThread(() =>
                 blobPool.MergeCells(sparseTx.Hash!.ValueHash256, updateMask, updateCells));
             Assert.That(storage.WaitForBlockedRead(TimeSpan.FromSeconds(5)), Is.True);
+            using ManualResetEventSlim lookupCompleted = new();
             Task<bool> concurrentLookup = RunOnDedicatedThread(() =>
-                blobPool.TryGetValue(cacheEvictor.Hash!.ValueHash256, out _));
+            {
+                try
+                {
+                    return blobPool.TryGetValue(cacheEvictor.Hash!.ValueHash256, out _);
+                }
+                finally
+                {
+                    lookupCompleted.Set();
+                }
+            });
+            bool lookupCompletedBeforeRelease;
             try
             {
-                Assert.That(await concurrentLookup.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+                lookupCompletedBeforeRelease = lookupCompleted.Wait(TimeSpan.FromSeconds(5));
             }
             finally
             {
                 storage.ReleaseBlockedRead();
             }
 
-            Assert.That(await merge, Is.EqualTo(BlobCellMergeResult.Accepted));
+            await Task.WhenAll(merge, concurrentLookup);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(lookupCompletedBeforeRelease, Is.True);
+                Assert.That(await concurrentLookup, Is.True);
+                Assert.That(await merge, Is.EqualTo(BlobCellMergeResult.Accepted));
+            }
         }
 
         [TestCase(false)]

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -570,6 +570,45 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public async Task should_flush_failed_revalidation_deletes_before_publishing_marker()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            (ChainSpecBasedSpecProvider provider, _) = TestSpecHelper.LoadChainSpec(new ChainSpecJson
+            {
+                Params = new ChainSpecParamsJson
+                {
+                    Eip4844TransitionTimestamp = head.Timestamp,
+                    Eip7594TransitionTimestamp = head.Timestamp + 1,
+                }
+            });
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                PersistentBlobStorageSize = 1
+            };
+            FailingBatchDeleteBlobTxStorage storage = new();
+            _txPool = CreatePool(txPoolConfig, provider, txStorage: storage);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
+            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            await AddEmptyBlock();
+            await AddEmptyBlock();
+
+            await _txPool.DisposeAsync();
+            _txPool = CreatePool(txPoolConfig, provider, txStorage: storage);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1 }));
+                Assert.That(storage.GetAll(), Is.Empty);
+                Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Not.Null);
+                Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
+            }
+        }
+
+        [Test]
         public void should_retry_batched_revalidation_deletes_after_storage_failure()
         {
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
@@ -1707,7 +1746,7 @@ namespace Nethermind.TxPool.Test
             public void ResetFullReadCount() => FullReadCount = 0;
         }
 
-        private sealed class FailingBatchDeleteBlobTxStorage : ITxStorage, IBatchDeleteTxStorage
+        private sealed class FailingBatchDeleteBlobTxStorage : IBlobTxStorage, IBatchDeleteTxStorage, ISpecChangeValidationStorage
         {
             private readonly BlobTxStorage _storage = new();
 
@@ -1724,6 +1763,21 @@ namespace Nethermind.TxPool.Test
             public void Add(Transaction transaction) => _storage.Add(transaction);
 
             public void Delete(in ValueHash256 hash, in UInt256 timestamp) => _storage.Delete(hash, timestamp);
+
+            public bool TryGetBlobTransactionsFromBlock(ulong blockNumber, out Transaction[] blockBlobTransactions) =>
+                _storage.TryGetBlobTransactionsFromBlock(blockNumber, out blockBlobTransactions);
+
+            public void AddBlobTransactionsFromBlock(ulong blockNumber, in ArrayPoolListRef<Transaction> blockBlobTransactions) =>
+                _storage.AddBlobTransactionsFromBlock(blockNumber, blockBlobTransactions);
+
+            public void DeleteBlobTransactionsFromBlock(ulong blockNumber) =>
+                _storage.DeleteBlobTransactionsFromBlock(blockNumber);
+
+            string ISpecChangeValidationStorage.GetSpecChangeValidationMarker() =>
+                ((ISpecChangeValidationStorage)_storage).GetSpecChangeValidationMarker();
+
+            void ISpecChangeValidationStorage.SetSpecChangeValidationMarker(string marker) =>
+                ((ISpecChangeValidationStorage)_storage).SetSpecChangeValidationMarker(marker);
 
             void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
             {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -278,6 +278,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
         }
@@ -318,6 +319,7 @@ namespace Nethermind.TxPool.Test
             storage.DeletePersistedTransaction(transaction);
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             bool found = _txPool.TryGetPendingBlobTransaction(transaction.Hash!, out Transaction pendingTransaction);
             BlobCellMask pendingMask = found
@@ -552,6 +554,7 @@ namespace Nethermind.TxPool.Test
 
             EnsureSenderBalance(TestItem.AddressA, UInt256.Zero);
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
 
@@ -587,23 +590,29 @@ namespace Nethermind.TxPool.Test
                 BlobsSupport = BlobsSupportMode.Storage,
                 PersistentBlobStorageSize = 1
             };
-            FailingBatchDeleteBlobTxStorage storage = new();
+            FailingBatchDeleteBlobTxStorage storage = new() { DeleteManyFailuresRemaining = 2 };
             _txPool = CreatePool(txPoolConfig, provider, txStorage: storage);
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
-            await AddEmptyBlock();
+            Assert.That(() => storage.DeleteBatchSizes.Count, Is.EqualTo(1).After(Timeout, 10));
+            Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
 
-            await _txPool.DisposeAsync();
-            _txPool = CreatePool(txPoolConfig, provider, txStorage: storage);
+            await AddEmptyBlock();
+            Assert.That(() => storage.DeleteBatchSizes.Count, Is.EqualTo(2).After(Timeout, 10));
+            Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+
+            await AddEmptyBlock();
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1 }));
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1, 1 }));
                 Assert.That(storage.GetAll(), Is.Empty);
-                Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Not.Null);
                 Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
             }
         }
@@ -675,6 +684,68 @@ namespace Nethermind.TxPool.Test
                 Assert.That(storage.FullTransactionDeleteBatchSizes, Is.EqualTo(changeTimestamp ? new[] { 1 } : Array.Empty<int>()));
                 Assert.That(persisted, Is.True);
                 Assert.That(obsoleteTransactionPersisted, Is.EqualTo(!changeTimestamp));
+                Assert.That(elidedTransactionPersisted, Is.True);
+                Assert.That(storage.GetAll(), Is.Not.Empty);
+            }
+        }
+
+        [Test]
+        public async Task should_remove_obsolete_full_transaction_after_failed_delete_and_restart()
+        {
+            TestSpecProvider specProvider = new(Cancun.Instance);
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
+            UInt256 originalTimestamp = transaction.Timestamp;
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            IComparer<Transaction> comparer = new TransactionComparerProvider(specProvider, _blockTree).GetDefaultComparer();
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+
+            using (PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance))
+            {
+                Assert.That(
+                    () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
+                    Throws.TypeOf<InvalidOperationException>());
+
+                transaction.Timestamp += UInt256.One;
+                Assert.That(blobPool.TryInsert(transaction.Hash, transaction, out _), Is.True);
+                storage.FailNextFullTransactionDelete = true;
+                Assert.That(
+                    () => blobPool.UpdatePoolForRevalidation(accounts, KeepAllTransactions),
+                    Throws.TypeOf<InvalidOperationException>());
+            }
+
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            _txPool = CreatePool(txPoolConfig, specProvider, txStorage: storage);
+            await AddEmptyBlock();
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+
+            bool currentTransactionPersisted = storage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                transaction.Timestamp,
+                out _);
+            bool obsoleteTransactionPersisted = storage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                originalTimestamp,
+                out _);
+            bool elidedTransactionPersisted = storage.TryGetWithoutBlobs(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                out _);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(currentTransactionPersisted, Is.True);
+                Assert.That(obsoleteTransactionPersisted, Is.False);
                 Assert.That(elidedTransactionPersisted, Is.True);
                 Assert.That(storage.GetAll(), Is.Not.Empty);
             }
@@ -1692,6 +1763,9 @@ namespace Nethermind.TxPool.Test
                         break;
                     case TestAction.Fork:
                         await AddEmptyBlock();
+                        Assert.That(
+                            () => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader),
+                            Is.True.After(Timeout, 10));
                         break;
                     case TestAction.ResetNonce:
                         nonce = 0;
@@ -1786,6 +1860,10 @@ namespace Nethermind.TxPool.Test
 
             public List<int> FullTransactionDeleteBatchSizes { get; } = [];
 
+            public int DeleteManyFailuresRemaining { get; set; } = 1;
+
+            public bool FailNextFullTransactionDelete { get; set; }
+
             public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
                 _storage.TryGet(hash, sender, timestamp, out transaction);
 
@@ -1819,8 +1897,9 @@ namespace Nethermind.TxPool.Test
             void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
             {
                 DeleteBatchSizes.Add(keys.Length);
-                if (DeleteBatchSizes.Count == 1)
+                if (DeleteManyFailuresRemaining > 0)
                 {
+                    DeleteManyFailuresRemaining--;
                     throw new InvalidOperationException();
                 }
 
@@ -1830,8 +1909,17 @@ namespace Nethermind.TxPool.Test
             void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys)
             {
                 FullTransactionDeleteBatchSizes.Add(keys.Length);
+                if (FailNextFullTransactionDelete)
+                {
+                    FailNextFullTransactionDelete = false;
+                    throw new InvalidOperationException();
+                }
+
                 ((IBatchDeleteTxStorage)_storage).DeleteFullBlobTransactions(keys);
             }
+
+            void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions() =>
+                ((IBatchDeleteTxStorage)_storage).DeleteObsoleteFullBlobTransactions();
         }
 
         private static void RemoveAllTransactions(
@@ -1896,6 +1984,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
         }
@@ -1930,6 +2019,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -570,6 +570,46 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public void should_retry_batched_revalidation_deletes_after_storage_failure()
+        {
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+
+            Assert.That(
+                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAll),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, RemoveAll), Throws.Nothing);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(blobPool.Count, Is.Zero);
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1 }));
+            }
+
+            static void RemoveAll(
+                in AccountStruct account,
+                EnhancedSortedSet<Transaction> transactions,
+                ref Transaction lastElement,
+                TxDistinctSortedPool.UpdateTransactionDelegate updateTransaction)
+            {
+                foreach (Transaction tx in transactions)
+                {
+                    updateTransaction(transactions, tx, changedGasBottleneck: null, lastElement);
+                }
+            }
+        }
+
+        [Test]
         public void should_load_full_sidecar_from_db_when_getting_blob_tx_after_cache_eviction()
         {
             (CountingBlobTxStorage blobTxStorage, PersistentBlobTxDistinctSortedPool blobPool, Transaction target) =
@@ -1665,6 +1705,36 @@ namespace Nethermind.TxPool.Test
                 ((ISpecChangeValidationStorage)_storage).SetSpecChangeValidationMarker(marker);
 
             public void ResetFullReadCount() => FullReadCount = 0;
+        }
+
+        private sealed class FailingBatchDeleteBlobTxStorage : ITxStorage, IBatchDeleteTxStorage
+        {
+            private readonly BlobTxStorage _storage = new();
+
+            public List<int> DeleteBatchSizes { get; } = [];
+
+            public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
+                _storage.TryGet(hash, sender, timestamp, out transaction);
+
+            public int TryGetMany(TxLookupKey[] keys, int count, Transaction[] results) =>
+                _storage.TryGetMany(keys, count, results);
+
+            public IEnumerable<LightTransaction> GetAll() => _storage.GetAll();
+
+            public void Add(Transaction transaction) => _storage.Add(transaction);
+
+            public void Delete(in ValueHash256 hash, in UInt256 timestamp) => _storage.Delete(hash, timestamp);
+
+            void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
+            {
+                DeleteBatchSizes.Add(keys.Length);
+                if (DeleteBatchSizes.Count == 1)
+                {
+                    throw new InvalidOperationException();
+                }
+
+                ((IBatchDeleteTxStorage)_storage).DeleteMany(keys);
+            }
         }
 
         private sealed class NamedReleaseSpec(IReleaseSpec spec, string name) : ReleaseSpecDecorator(spec)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -625,9 +625,9 @@ namespace Nethermind.TxPool.Test
             IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
 
             Assert.That(
-                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAll),
+                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
                 Throws.TypeOf<InvalidOperationException>());
-            Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, RemoveAll), Throws.Nothing);
+            Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions), Throws.Nothing);
 
             using (Assert.EnterMultipleScope())
             {
@@ -635,17 +635,38 @@ namespace Nethermind.TxPool.Test
                 Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1 }));
             }
 
-            static void RemoveAll(
-                in AccountStruct account,
-                EnhancedSortedSet<Transaction> transactions,
-                ref Transaction lastElement,
-                TxDistinctSortedPool.UpdateTransactionDelegate updateTransaction)
+        }
+
+        [Test]
+        public void should_not_retry_stale_revalidation_delete_after_transaction_is_reinserted()
+        {
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
             {
-                foreach (Transaction tx in transactions)
-                {
-                    updateTransaction(transactions, tx, changedGasBottleneck: null, lastElement);
-                }
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+
+            Assert.That(
+                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(blobPool.TryInsert(transaction.Hash, transaction, out _), Is.True);
+            Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, KeepAllTransactions), Throws.Nothing);
+            bool persisted = storage.TryGet(transaction.Hash, transaction.SenderAddress!, transaction.Timestamp, out _);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(blobPool.Count, Is.EqualTo(1));
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1 }));
+                Assert.That(persisted, Is.True);
             }
+
         }
 
         [Test]
@@ -1789,6 +1810,26 @@ namespace Nethermind.TxPool.Test
 
                 ((IBatchDeleteTxStorage)_storage).DeleteMany(keys);
             }
+        }
+
+        private static void RemoveAllTransactions(
+            in AccountStruct account,
+            EnhancedSortedSet<Transaction> transactions,
+            ref Transaction lastElement,
+            TxDistinctSortedPool.UpdateTransactionDelegate updateTransaction)
+        {
+            foreach (Transaction tx in transactions)
+            {
+                updateTransaction(transactions, tx, changedGasBottleneck: null, lastElement);
+            }
+        }
+
+        private static void KeepAllTransactions(
+            in AccountStruct account,
+            EnhancedSortedSet<Transaction> transactions,
+            ref Transaction lastElement,
+            TxDistinctSortedPool.UpdateTransactionDelegate updateTransaction)
+        {
         }
 
         private sealed class NamedReleaseSpec(IReleaseSpec spec, string name) : ReleaseSpecDecorator(spec)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Reflection;
 using CkzgLib;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
@@ -909,6 +910,51 @@ namespace Nethermind.TxPool.Test
             }
 
             Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+        }
+
+        [Test]
+        [NonParallelizable]
+        public async Task should_skip_obsolete_full_transaction_recovery_during_shutdown()
+        {
+            int testThreadId = Environment.CurrentManagedThreadId;
+            TaskCompletionSource recoveryCheckReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRecoveryCheck = new(false);
+            ITxPoolConfig txPoolConfig = Substitute.For<ITxPoolConfig>();
+            txPoolConfig.Size.Returns(1);
+            txPoolConfig.PersistentBlobStorageSize.Returns(1);
+            txPoolConfig.BlobCacheSize.Returns(1);
+            txPoolConfig.BlobsSupport.Returns(_ =>
+            {
+                if (Environment.CurrentManagedThreadId != testThreadId)
+                {
+                    recoveryCheckReached.TrySetResult();
+                    Assert.That(
+                        releaseRecoveryCheck.Wait(TimeSpan.FromSeconds(10)),
+                        Is.True,
+                        "Timed out waiting to release the obsolete recovery check.");
+                }
+
+                return BlobsSupportMode.Storage;
+            });
+            FailingBatchDeleteBlobTxStorage storage = new();
+            _txPool = CreatePool(txPoolConfig, GetCancunSpecProvider(), txStorage: storage);
+            await recoveryCheckReached.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            CancellationTokenSource cancellation = (CancellationTokenSource)typeof(TxPool)
+                .GetField("_cts", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(_txPool)!;
+            ValueTask disposal = _txPool.DisposeAsync();
+            try
+            {
+                Assert.That(cancellation.IsCancellationRequested, Is.True);
+            }
+            finally
+            {
+                releaseRecoveryCheck.Set();
+            }
+
+            await disposal.AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.That(storage.ObsoleteRecoveryCount, Is.Zero);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -3574,8 +3574,9 @@ namespace Nethermind.TxPool.Test
                 Size = 10
             };
             IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            ManualTimeProvider timeProvider = new();
             using BlockingBlobTxStorage storage = new(failedDeleteCount: failReinsertion ? 3 : 2);
-            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance, timeProvider);
             Transaction fullBlobTx = Build.A.Transaction
                 .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
                 .WithMaxFeePerGas(1.GWei)
@@ -3623,6 +3624,7 @@ namespace Nethermind.TxPool.Test
                 Assert.That(blobPool.TryInsert(fullBlobTx.Hash, fullBlobTx, out _), Is.True);
             }
 
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromSeconds(1));
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -5,6 +5,7 @@ using System;
 using CkzgLib;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
+using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -619,7 +620,7 @@ namespace Nethermind.TxPool.Test
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1, 1 }));
-                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(recoveryCountBeforeFork + 1));
+                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(recoveryCountBeforeFork));
                 Assert.That(storage.GetAll(), Is.Empty);
                 Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
             }
@@ -759,8 +760,9 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        [Test]
-        public async Task should_defer_obsolete_full_transaction_recovery_from_startup()
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task should_defer_obsolete_full_transaction_recovery_from_startup(bool validatorHasFingerprint)
         {
             TestSpecProvider specProvider = new(Cancun.Instance);
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
@@ -792,7 +794,14 @@ namespace Nethermind.TxPool.Test
                 throw new InvalidOperationException("Simulated interrupted obsolete blob-body recovery.");
             };
 
-            Task<TxPool> poolCreation = RunOnDedicatedThread(() => CreatePool(txPoolConfig, specProvider, txStorage: storage));
+            ITxValidator specChangeTxValidator = validatorHasFingerprint
+                ? new SpecChangeTxValidator(specProvider.ChainId)
+                : Always.Valid;
+            Task<TxPool> poolCreation = RunOnDedicatedThread(() => CreatePool(
+                txPoolConfig,
+                specProvider,
+                txStorage: storage,
+                specChangeTxValidator: specChangeTxValidator));
             await recoveryStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
             TxPool createdPool = null;
             bool constructionCompletedBeforeRecovery = true;
@@ -816,9 +825,17 @@ namespace Nethermind.TxPool.Test
 
             Assert.That(constructionCompletedBeforeRecovery, Is.True, "TxPool construction waited for the recovery scan.");
             Assert.That(() => storage.ObsoleteRecoveryCount, Is.EqualTo(2).After(Timeout, 10));
-            Assert.That(
-                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
-                Is.Not.Null.After(Timeout, 10));
+            if (validatorHasFingerprint)
+            {
+                Assert.That(
+                    () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                    Is.Not.Null.After(Timeout, 10));
+            }
+            else
+            {
+                Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+            }
+
             Assert.That(
                 storage.TryGet(transaction.Hash, transaction.SenderAddress!, obsoleteTimestamp, out _),
                 Is.False);

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -918,6 +918,7 @@ namespace Nethermind.TxPool.Test
         {
             int testThreadId = Environment.CurrentManagedThreadId;
             TaskCompletionSource recoveryCheckReached = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> recoveryCheckReleased = new(TaskCreationOptions.RunContinuationsAsynchronously);
             using ManualResetEventSlim releaseRecoveryCheck = new(false);
             ITxPoolConfig txPoolConfig = Substitute.For<ITxPoolConfig>();
             txPoolConfig.Size.Returns(1);
@@ -928,10 +929,7 @@ namespace Nethermind.TxPool.Test
                 if (Environment.CurrentManagedThreadId != testThreadId)
                 {
                     recoveryCheckReached.TrySetResult();
-                    Assert.That(
-                        releaseRecoveryCheck.Wait(TimeSpan.FromSeconds(10)),
-                        Is.True,
-                        "Timed out waiting to release the obsolete recovery check.");
+                    recoveryCheckReleased.TrySetResult(releaseRecoveryCheck.Wait(TimeSpan.FromSeconds(10)));
                 }
 
                 return BlobsSupportMode.Storage;
@@ -954,7 +952,11 @@ namespace Nethermind.TxPool.Test
             }
 
             await disposal.AsTask().WaitAsync(TimeSpan.FromSeconds(10));
-            Assert.That(storage.ObsoleteRecoveryCount, Is.Zero);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(await recoveryCheckReleased.Task.WaitAsync(TimeSpan.FromSeconds(10)), Is.True);
+                Assert.That(storage.ObsoleteRecoveryCount, Is.Zero);
+            }
         }
 
         [Test]
@@ -3624,7 +3626,8 @@ namespace Nethermind.TxPool.Test
                 Assert.That(blobPool.TryInsert(fullBlobTx.Hash, fullBlobTx, out _), Is.True);
             }
 
-            timeProvider.AdvanceAndFireTimer(TimeSpan.FromSeconds(1));
+            // Advance beyond the maximum backoff so every pending retry is due.
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMinutes(1));
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -634,13 +634,14 @@ namespace Nethermind.TxPool.Test
                 Assert.That(blobPool.Count, Is.Zero);
                 Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1 }));
             }
-
         }
 
-        [Test]
-        public void should_not_retry_stale_revalidation_delete_after_transaction_is_reinserted()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void should_not_retry_stale_revalidation_delete_after_transaction_is_reinserted(bool changeTimestamp)
         {
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
+            UInt256 originalTimestamp = transaction.Timestamp;
             FailingBatchDeleteBlobTxStorage storage = new();
             storage.Add(transaction);
             TxPoolConfig txPoolConfig = new()
@@ -656,17 +657,27 @@ namespace Nethermind.TxPool.Test
             Assert.That(
                 () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
                 Throws.TypeOf<InvalidOperationException>());
+            if (changeTimestamp)
+            {
+                transaction.Timestamp += UInt256.One;
+            }
+
             Assert.That(blobPool.TryInsert(transaction.Hash, transaction, out _), Is.True);
             Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, KeepAllTransactions), Throws.Nothing);
             bool persisted = storage.TryGet(transaction.Hash, transaction.SenderAddress!, transaction.Timestamp, out _);
+            bool obsoleteTransactionPersisted = storage.TryGet(transaction.Hash, transaction.SenderAddress!, originalTimestamp, out _);
+            bool elidedTransactionPersisted = storage.TryGetWithoutBlobs(transaction.Hash, transaction.SenderAddress!, out _);
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(blobPool.Count, Is.EqualTo(1));
                 Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1 }));
+                Assert.That(storage.FullTransactionDeleteBatchSizes, Is.EqualTo(changeTimestamp ? new[] { 1 } : Array.Empty<int>()));
                 Assert.That(persisted, Is.True);
+                Assert.That(obsoleteTransactionPersisted, Is.EqualTo(!changeTimestamp));
+                Assert.That(elidedTransactionPersisted, Is.True);
+                Assert.That(storage.GetAll(), Is.Not.Empty);
             }
-
         }
 
         [Test]
@@ -1773,8 +1784,13 @@ namespace Nethermind.TxPool.Test
 
             public List<int> DeleteBatchSizes { get; } = [];
 
+            public List<int> FullTransactionDeleteBatchSizes { get; } = [];
+
             public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
                 _storage.TryGet(hash, sender, timestamp, out transaction);
+
+            public bool TryGetWithoutBlobs(in ValueHash256 hash, Address sender, out Transaction transaction) =>
+                _storage.TryGetWithoutBlobs(hash, sender, out transaction);
 
             public int TryGetMany(TxLookupKey[] keys, int count, Transaction[] results) =>
                 _storage.TryGetMany(keys, count, results);
@@ -1809,6 +1825,12 @@ namespace Nethermind.TxPool.Test
                 }
 
                 ((IBatchDeleteTxStorage)_storage).DeleteMany(keys);
+            }
+
+            void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys)
+            {
+                FullTransactionDeleteBatchSizes.Add(keys.Length);
+                ((IBatchDeleteTxStorage)_storage).DeleteFullBlobTransactions(keys);
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -912,9 +912,46 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public async Task should_stop_retrying_obsolete_full_transaction_recovery_after_repeated_failures()
+        {
+            InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+            logger.IsError.Returns(true);
+            _logManager = new OneLoggerLogManager(new ILogger(logger));
+            FailingBatchDeleteBlobTxStorage storage = new() { ObsoleteRecoveryFailuresRemaining = 2 };
+            _txPool = CreatePool(
+                new TxPoolConfig
+                {
+                    BlobsSupport = BlobsSupportMode.Storage,
+                    PersistentBlobStorageSize = 1
+                },
+                GetCancunSpecProvider(),
+                txStorage: storage);
+            Assert.That(() => storage.ObsoleteRecoveryCount, Is.EqualTo(1).After(Timeout, 10));
+
+            await AddEmptyBlock();
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+            await AddEmptyBlock();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(2));
+                Assert.That(_txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True);
+            }
+
+            logger.Received(1).Error(
+                Arg.Is<string>(static message => message.Contains("Skipping obsolete full blob transaction recovery")),
+                Arg.Any<Exception>());
+        }
+
+        [Test]
         [NonParallelizable]
         public async Task should_cancel_obsolete_full_transaction_recovery_during_shutdown()
         {
+            InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+            logger.IsWarn.Returns(true);
+            _logManager = new OneLoggerLogManager(new ILogger(logger));
             TaskCompletionSource recoveryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TaskCompletionSource<bool> recoveryReleasedAfterCancellation = new(TaskCreationOptions.RunContinuationsAsynchronously);
             using ManualResetEventSlim releaseRecovery = new(false);
@@ -945,6 +982,9 @@ namespace Nethermind.TxPool.Test
                 Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(1));
                 Assert.That(storage.ObsoleteRecoveryCancellationCount, Is.EqualTo(1));
             }
+
+            logger.DidNotReceive().Warn(Arg.Is<string>(static message =>
+                message.Contains("failed to revalidate transactions after a protocol change")));
         }
 
         [Test]
@@ -2060,6 +2100,8 @@ namespace Nethermind.TxPool.Test
 
             public int DeleteManyFailuresRemaining { get; set; } = 1;
 
+            public int ObsoleteRecoveryFailuresRemaining { get; set; }
+
             public bool FailNextFullTransactionDelete { get; set; }
 
             public Action<CancellationToken> BeforeObsoleteRecovery { get; set; }
@@ -2126,6 +2168,12 @@ namespace Nethermind.TxPool.Test
             {
                 Interlocked.Increment(ref _obsoleteRecoveryCount);
                 BeforeObsoleteRecovery?.Invoke(cancellationToken);
+                if (ObsoleteRecoveryFailuresRemaining > 0)
+                {
+                    ObsoleteRecoveryFailuresRemaining--;
+                    throw new InvalidOperationException("Simulated obsolete blob transaction recovery failure.");
+                }
+
                 try
                 {
                     ((IBatchDeleteTxStorage)_storage).DeleteObsoleteFullBlobTransactions(cancellationToken);

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -746,6 +746,12 @@ namespace Nethermind.TxPool.Test
             TaskCompletionSource revalidationStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
             using ManualResetEventSlim releaseRevalidation = new(false);
             int validationAttempts = 0;
+            Transaction invalidTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            Transaction validTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyB)
+                .TestObject;
             ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
             specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(callInfo =>
             {
@@ -760,15 +766,16 @@ namespace Nethermind.TxPool.Test
                     releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
                     Is.True,
                     "Timed out waiting to release fork revalidation.");
-                return new ValidationResult("fork rejection");
+                return ReferenceEquals(callInfo.Arg<Transaction>(), invalidTransaction)
+                    ? new ValidationResult("fork rejection")
+                    : ValidationResult.Success;
             });
 
             _txPool = CreatePool(specProvider: provider, specChangeTxValidator: specChangeTxValidator);
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
-            Transaction transaction = Build.A.Transaction
-                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
-                .TestObject;
-            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+            Assert.That(_txPool.SubmitTx(invalidTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(validTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             Block forkBlock = Build.A.Block.WithNumber(head.Number + 1).TestObject;
             _blockTree.BestSuggestedHeader = forkBlock.Header;
@@ -789,8 +796,10 @@ namespace Nethermind.TxPool.Test
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(validationAttempts, Is.EqualTo(1));
-                Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
+                Assert.That(validationAttempts, Is.EqualTo(2));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+                Assert.That(_txPool.ContainsTx(invalidTransaction.Hash!, invalidTransaction.Type), Is.False);
+                Assert.That(_txPool.ContainsTx(validTransaction.Hash!, validTransaction.Type), Is.True);
                 Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.True);
             }
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -742,6 +742,95 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public async Task should_reconcile_buckets_when_spec_change_revalidation_is_abandoned()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider provider = new(Prague.Instance)
+            {
+                NextForkSpec = Osaka.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            Transaction retainedTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            Transaction unaffordableTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyB)
+                .TestObject;
+            TaskCompletionSource firstPassStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource secondPassStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseFirstPass = new(false);
+            using ManualResetEventSlim releaseSecondPass = new(false);
+            int retainedTransactionValidations = 0;
+            ISpecChangeTxValidator specChangeTxValidator = Substitute.For<ISpecChangeTxValidator>();
+            specChangeTxValidator.IsWellFormedAfterFullValidation(
+                    Arg.Any<Transaction>(),
+                    Arg.Any<IReleaseSpec>())
+                .Returns(ValidationResult.Success);
+            specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(callInfo =>
+            {
+                if (ReferenceEquals(callInfo.Arg<Transaction>(), retainedTransaction))
+                {
+                    int validation = Interlocked.Increment(ref retainedTransactionValidations);
+                    if (validation == 1)
+                    {
+                        firstPassStarted.TrySetResult();
+                        Assert.That(releaseFirstPass.Wait(TimeSpan.FromSeconds(10)), Is.True);
+                    }
+                    else if (validation == 2)
+                    {
+                        secondPassStarted.TrySetResult();
+                        Assert.That(releaseSecondPass.Wait(TimeSpan.FromSeconds(10)), Is.True);
+                    }
+                }
+
+                return ValidationResult.Success;
+            });
+
+            _txPool = CreatePool(specProvider: provider, specChangeTxValidator: specChangeTxValidator);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+            Assert.That(_txPool.SubmitTx(retainedTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(unaffordableTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            EnsureSenderBalance(TestItem.AddressB, UInt256.Zero);
+
+            Block forkBlock = Build.A.Block.WithNumber(head.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = forkBlock.Header;
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
+            await firstPassStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Block rollbackBlock = Build.A.Block.WithNumber(head.Number).TestObject;
+            _blockTree.BestSuggestedHeader = rollbackBlock.Header;
+            Task rollbackProcessed = Wait.ForEventCondition<Block>(
+                CancellationToken.None,
+                handler => _txPool.TxPoolHeadChanged += handler,
+                handler => _txPool.TxPoolHeadChanged -= handler,
+                block => block.Hash == rollbackBlock.Hash);
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(rollbackBlock));
+
+            try
+            {
+                await rollbackProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+                releaseFirstPass.Set();
+                await secondPassStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(_txPool.ContainsTx(retainedTransaction.Hash!, retainedTransaction.Type), Is.True);
+                    Assert.That(_txPool.ContainsTx(unaffordableTransaction.Hash!, unaffordableTransaction.Type), Is.False);
+                    Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+                }
+            }
+            finally
+            {
+                releaseFirstPass.Set();
+                releaseSecondPass.Set();
+            }
+
+            Assert.That(() => _txPool.IsRevalidatedFor(rollbackBlock.Header), Is.True.After(Timeout, 10));
+        }
+
+        [Test]
         public async Task should_apply_revalidation_evictions_when_head_advances_during_pass()
         {
             Block head = _blockTree.Head;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -347,6 +347,7 @@ namespace Nethermind.TxPool.Test
             }
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
 
@@ -378,6 +379,7 @@ namespace Nethermind.TxPool.Test
 
             EnsureSenderBalance(TestItem.AddressA, UInt256.Zero);
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             int pendingTransactionsCount = _txPool.GetPendingTransactionsCount();
             AcceptTxResult resubmissionResult = _txPool.SubmitTx(transaction, TxHandlingOptions.None);
@@ -413,6 +415,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
         }
@@ -445,11 +448,11 @@ namespace Nethermind.TxPool.Test
 
             _blockTree.BestSuggestedHeader = preForkHead.Header;
             await RaiseBlockAddedToMainAndWaitForNewHead(preForkHead, forkHead);
+            Assert.That(() => _txPool.IsRevalidatedFor(preForkHead.Header), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
-                Assert.That(_txPool.IsRevalidatedFor(preForkHead.Header), Is.True);
             }
         }
 
@@ -478,6 +481,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -511,6 +515,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -552,6 +557,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -600,6 +606,7 @@ namespace Nethermind.TxPool.Test
             _blockTree.BestSuggestedHeader = nextBlock.Header;
             Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.False);
             await RaiseBlockAddedToMainAndWaitForNewHead(nextBlock);
+            Assert.That(() => _txPool.IsRevalidatedFor(nextBlock.Header), Is.True.After(Timeout, 10));
 
             specChangeTxValidator.Received(1).IsWellFormed(transaction, Osaka.Instance);
             Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.True);
@@ -620,7 +627,7 @@ namespace Nethermind.TxPool.Test
 
             await AddEmptyBlock();
 
-            Assert.That(_txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True);
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
         }
 
         [Test]
@@ -643,7 +650,7 @@ namespace Nethermind.TxPool.Test
 
             await AddEmptyBlock();
             BlockHeader forkHeader = _blockTree.BestSuggestedHeader;
-            Assert.That(_txPool.IsRevalidatedFor(forkHeader), Is.True);
+            Assert.That(() => _txPool.IsRevalidatedFor(forkHeader), Is.True.After(Timeout, 10));
 
             // A reorg back below the fork makes the pool accept transactions under the previous rules again,
             // which stops the mark left by the walk for the fork spec from covering the pool.
@@ -725,6 +732,7 @@ namespace Nethermind.TxPool.Test
             Block nextBlock = Build.A.Block.WithNumber(forkBlock.Number + 1).TestObject;
             _blockTree.BestSuggestedHeader = nextBlock.Header;
             await RaiseBlockAddedToMainAndWaitForNewHead(nextBlock);
+            Assert.That(() => _txPool.IsRevalidatedFor(nextBlock.Header), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -793,6 +801,7 @@ namespace Nethermind.TxPool.Test
             releaseRevalidation.Set();
 
             await nextHeadProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.That(() => _txPool.IsRevalidatedFor(nextBlock.Header), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -801,6 +810,77 @@ namespace Nethermind.TxPool.Test
                 Assert.That(_txPool.ContainsTx(invalidTransaction.Hash!, invalidTransaction.Type), Is.False);
                 Assert.That(_txPool.ContainsTx(validTransaction.Hash!, validTransaction.Type), Is.True);
                 Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.True);
+            }
+        }
+
+        [Test]
+        public async Task should_restart_revalidation_after_head_spec_changes_and_returns_during_pass()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider provider = new(Prague.Instance)
+            {
+                NextForkSpec = Osaka.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            TaskCompletionSource revalidationStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRevalidation = new(false);
+            Transaction existingTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            Transaction invalidUnderOsaka = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyB)
+                .TestObject;
+            ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
+            specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(callInfo =>
+            {
+                if (!ReferenceEquals(callInfo.Arg<IReleaseSpec>(), Osaka.Instance))
+                {
+                    return ValidationResult.Success;
+                }
+
+                revalidationStarted.TrySetResult();
+                Assert.That(
+                    releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "Timed out waiting to release fork revalidation.");
+                return ReferenceEquals(callInfo.Arg<Transaction>(), invalidUnderOsaka)
+                    ? new ValidationResult("fork rejection")
+                    : ValidationResult.Success;
+            });
+
+            _txPool = CreatePool(specProvider: provider, specChangeTxValidator: specChangeTxValidator);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+            Assert.That(_txPool.SubmitTx(existingTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Block forkBlock = Build.A.Block.WithNumber(head.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = forkBlock.Header;
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
+            await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Block rollbackBlock = Build.A.Block.WithNumber(head.Number).TestObject;
+            _blockTree.BestSuggestedHeader = rollbackBlock.Header;
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(rollbackBlock));
+            Assert.That(_txPool.SubmitTx(invalidUnderOsaka, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Block finalBlock = Build.A.Block.WithNumber(forkBlock.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = finalBlock.Header;
+            Task finalHeadProcessed = Wait.ForEventCondition<Block>(
+                CancellationToken.None,
+                handler => _txPool.TxPoolHeadChanged += handler,
+                handler => _txPool.TxPoolHeadChanged -= handler,
+                block => block.Hash == finalBlock.Hash);
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(finalBlock));
+            releaseRevalidation.Set();
+
+            await finalHeadProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.That(() => _txPool.IsRevalidatedFor(finalBlock.Header), Is.True.After(Timeout, 10));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(_txPool.ContainsTx(invalidUnderOsaka.Hash!, invalidUnderOsaka.Type), Is.False);
+                Assert.That(_txPool.IsRevalidatedFor(finalBlock.Header), Is.True);
             }
         }
 
@@ -862,6 +942,7 @@ namespace Nethermind.TxPool.Test
             }
 
             await finalHeadProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.That(() => _txPool.IsRevalidatedFor(head.Header), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -872,7 +953,7 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
-        public async Task should_keep_submission_and_production_view_responsive_during_revalidation()
+        public async Task should_keep_submission_production_and_head_processing_responsive_during_revalidation()
         {
             Block head = _blockTree.Head;
             _blockTree.BestSuggestedHeader = head.Header;
@@ -935,6 +1016,21 @@ namespace Nethermind.TxPool.Test
                     Assert.That(view.IsRevalidated, Is.False);
                     Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
                 }
+
+                Block nextBlock = Build.A.Block
+                    .WithNumber(forkBlock.Number + 1)
+                    .WithTransactions(concurrentTransaction)
+                    .TestObject;
+                _blockTree.BestSuggestedHeader = nextBlock.Header;
+                Task nextHeadProcessed = Wait.ForEventCondition<Block>(
+                    CancellationToken.None,
+                    handler => _txPool.TxPoolHeadChanged += handler,
+                    handler => _txPool.TxPoolHeadChanged -= handler,
+                    block => block.Hash == nextBlock.Hash);
+                _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(nextBlock));
+
+                await nextHeadProcessed.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.That(_txPool.ContainsTx(concurrentTransaction.Hash!, concurrentTransaction.Type), Is.False);
             }
             finally
             {
@@ -942,6 +1038,9 @@ namespace Nethermind.TxPool.Test
             }
 
             await headProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.That(
+                () => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader),
+                Is.True.After(Timeout, 10));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -756,7 +756,10 @@ namespace Nethermind.TxPool.Test
 
                 Interlocked.Increment(ref validationAttempts);
                 revalidationStarted.TrySetResult();
-                releaseRevalidation.Wait();
+                Assert.That(
+                    releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "Timed out waiting to release fork revalidation.");
                 return new ValidationResult("fork rejection");
             });
 
@@ -884,7 +887,10 @@ namespace Nethermind.TxPool.Test
                     && ReferenceEquals(callInfo.Arg<IReleaseSpec>(), Osaka.Instance))
                 {
                     revalidationStarted.TrySetResult();
-                    releaseRevalidation.Wait();
+                    Assert.That(
+                        releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
+                        Is.True,
+                        "Timed out waiting to release fork revalidation.");
                 }
 
                 return ValidationResult.Success;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -674,7 +674,7 @@ namespace Nethermind.TxPool.Test
                 ForkOnBlockNumber = head.Number + 1
             };
             ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
-            TaskCompletionSource revalidationFailed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource revalidationFailureTriggered = new(TaskCreationOptions.RunContinuationsAsynchronously);
             using ManualResetEventSlim allowRevalidation = new(false);
             int validationAttempts = 0;
             specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(callInfo =>
@@ -687,7 +687,7 @@ namespace Nethermind.TxPool.Test
                 Interlocked.Increment(ref validationAttempts);
                 if (!allowRevalidation.IsSet)
                 {
-                    revalidationFailed.TrySetResult();
+                    revalidationFailureTriggered.TrySetResult();
                     throw new InvalidOperationException();
                 }
 
@@ -717,13 +717,13 @@ namespace Nethermind.TxPool.Test
                 handler => _txPool.TxPoolHeadChanged -= handler,
                 block => block.Hash == forkBlock.Hash);
             _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
-            await revalidationFailed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await revalidationFailureTriggered.Task.WaitAsync(TimeSpan.FromSeconds(10));
             await forkHeadProcessed.WaitAsync(TimeSpan.FromSeconds(10));
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(_txPool.IsRevalidatedFor(forkBlock.Header), Is.False);
-                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+                Assert.That(() => _txPool.GetPendingTransactionsCount(), Is.EqualTo(1).After(Timeout, 10));
                 Assert.That(_txPool.ContainsTx(transaction.Hash!, transaction.Type), Is.True);
             }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -358,14 +358,25 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
-        public void should_revalidate_when_head_spec_changes_during_construction()
+        public async Task should_revalidate_when_head_spec_changes_during_construction()
         {
+            BlobTxStorage storage = new();
+            _txPool = CreatePool(specProvider: new TestSpecProvider(Prague.Instance), txStorage: storage);
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+            await _txPool.DisposeAsync();
+
             IChainHeadSpecProvider changingSpecProvider = Substitute.For<IChainHeadSpecProvider>();
+            // ObserveHeadSpec and InitializeValidatedSpec see Prague; the final startup check sees Osaka.
             changingSpecProvider.GetCurrentHeadSpec().Returns(Prague.Instance, Prague.Instance, Osaka.Instance);
             changingSpecProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(Osaka.Instance);
             ChainHeadInfoProvider headInfo = new(changingSpecProvider, _blockTree, _stateProvider);
 
-            _txPool = CreatePool(specProvider: new TestSpecProvider(Prague.Instance), chainHeadInfoProvider: headInfo);
+            _txPool = CreatePool(
+                specProvider: new TestSpecProvider(Prague.Instance),
+                chainHeadInfoProvider: headInfo,
+                txStorage: storage);
 
             Assert.That(
                 () => _txPool.IsRevalidatedFor(Build.A.BlockHeader.TestObject),

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -759,6 +759,8 @@ namespace Nethermind.TxPool.Test
                 .TestObject;
             TaskCompletionSource firstPassStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
             TaskCompletionSource secondPassStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> firstPassReleased = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> secondPassReleased = new(TaskCreationOptions.RunContinuationsAsynchronously);
             using ManualResetEventSlim releaseFirstPass = new(false);
             using ManualResetEventSlim releaseSecondPass = new(false);
             int retainedTransactionValidations = 0;
@@ -775,12 +777,12 @@ namespace Nethermind.TxPool.Test
                     if (validation == 1)
                     {
                         firstPassStarted.TrySetResult();
-                        Assert.That(releaseFirstPass.Wait(TimeSpan.FromSeconds(10)), Is.True);
+                        firstPassReleased.TrySetResult(releaseFirstPass.Wait(TimeSpan.FromSeconds(10)));
                     }
                     else if (validation == 2)
                     {
                         secondPassStarted.TrySetResult();
-                        Assert.That(releaseSecondPass.Wait(TimeSpan.FromSeconds(10)), Is.True);
+                        secondPassReleased.TrySetResult(releaseSecondPass.Wait(TimeSpan.FromSeconds(10)));
                     }
                 }
 
@@ -813,6 +815,7 @@ namespace Nethermind.TxPool.Test
                 await rollbackProcessed.WaitAsync(TimeSpan.FromSeconds(10));
                 releaseFirstPass.Set();
                 await secondPassStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                Assert.That(await firstPassReleased.Task.WaitAsync(TimeSpan.FromSeconds(10)), Is.True);
 
                 using (Assert.EnterMultipleScope())
                 {
@@ -827,6 +830,7 @@ namespace Nethermind.TxPool.Test
                 releaseSecondPass.Set();
             }
 
+            Assert.That(await secondPassReleased.Task.WaitAsync(TimeSpan.FromSeconds(10)), Is.True);
             Assert.That(() => _txPool.IsRevalidatedFor(rollbackBlock.Header), Is.True.After(Timeout, 10));
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -368,6 +368,7 @@ namespace Nethermind.TxPool.Test
             await _txPool.DisposeAsync();
 
             IChainHeadSpecProvider changingSpecProvider = Substitute.For<IChainHeadSpecProvider>();
+            // Both pools are empty, so UpdateBucketsWithoutRevalidation consumes no head-spec read:
             // ObserveHeadSpec and InitializeValidatedSpec see Prague; the final startup check sees Osaka.
             changingSpecProvider.GetCurrentHeadSpec().Returns(Prague.Instance, Prague.Instance, Osaka.Instance);
             changingSpecProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(Osaka.Instance);

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -571,8 +571,12 @@ namespace Nethermind.TxPool.Test
                 NextForkSpec = Osaka.Instance,
                 ForkOnBlockNumber = head.Number + 2
             };
-            ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
+            ISpecChangeTxValidator specChangeTxValidator = Substitute.For<ISpecChangeTxValidator>();
             specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(ValidationResult.Success);
+            specChangeTxValidator.IsWellFormedAfterFullValidation(
+                    Arg.Any<Transaction>(),
+                    Arg.Any<IReleaseSpec>())
+                .Returns(ValidationResult.Success);
 
             _txPool = CreatePool(specProvider: provider, specChangeTxValidator: specChangeTxValidator);
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
@@ -582,7 +586,9 @@ namespace Nethermind.TxPool.Test
                 .TestObject;
 
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
-            specChangeTxValidator.Received(1).IsWellFormed(transaction, Prague.Instance);
+            specChangeTxValidator.Received(1).IsWellFormedAfterFullValidation(
+                transaction,
+                Prague.Instance);
             specChangeTxValidator.ClearReceivedCalls();
             Assert.That(_txPool.IsRevalidatedFor(Build.A.BlockHeader.WithNumber(head.Number + 1).TestObject), Is.True);
 
@@ -724,6 +730,65 @@ namespace Nethermind.TxPool.Test
             {
                 Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.True);
                 Assert.That(validationAttempts, Is.GreaterThanOrEqualTo(2));
+            }
+        }
+
+        [Test]
+        public async Task should_apply_revalidation_evictions_when_head_advances_during_pass()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider provider = new(Prague.Instance)
+            {
+                NextForkSpec = Osaka.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            TaskCompletionSource revalidationStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRevalidation = new(false);
+            int validationAttempts = 0;
+            ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
+            specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(callInfo =>
+            {
+                if (!ReferenceEquals(callInfo.Arg<IReleaseSpec>(), Osaka.Instance))
+                {
+                    return ValidationResult.Success;
+                }
+
+                Interlocked.Increment(ref validationAttempts);
+                revalidationStarted.TrySetResult();
+                releaseRevalidation.Wait();
+                return new ValidationResult("fork rejection");
+            });
+
+            _txPool = CreatePool(specProvider: provider, specChangeTxValidator: specChangeTxValidator);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            Transaction transaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Block forkBlock = Build.A.Block.WithNumber(head.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = forkBlock.Header;
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
+            await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Block nextBlock = Build.A.Block.WithNumber(forkBlock.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = nextBlock.Header;
+            Task nextHeadProcessed = Wait.ForEventCondition<Block>(
+                CancellationToken.None,
+                handler => _txPool.TxPoolHeadChanged += handler,
+                handler => _txPool.TxPoolHeadChanged -= handler,
+                block => block.Hash == nextBlock.Hash);
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(nextBlock));
+            releaseRevalidation.Set();
+
+            await nextHeadProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(validationAttempts, Is.EqualTo(1));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
+                Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.True);
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -953,6 +953,7 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        [NonParallelizable]
         public async Task should_keep_submission_production_and_head_processing_responsive_during_revalidation()
         {
             Block head = _blockTree.Head;
@@ -999,17 +1000,19 @@ namespace Nethermind.TxPool.Test
                 handler => _txPool.TxPoolHeadChanged -= handler,
                 block => block.Hash == forkBlock.Hash);
             _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
-            await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
-
-            Task<(PendingTransactionsView View, AcceptTxResult Result)> concurrentAccess = RunOnDedicatedThread(() =>
-            {
-                PendingTransactionsView view = _txPool.GetPendingForProduction(forkBlock.Header, filterToReadyTx: false, UInt256.Zero);
-                AcceptTxResult result = _txPool.SubmitTx(concurrentTransaction, TxHandlingOptions.None);
-                return (view, result);
-            });
 
             try
             {
+                await headProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+                await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+                Task<(PendingTransactionsView View, AcceptTxResult Result)> concurrentAccess = RunOnDedicatedThread(() =>
+                {
+                    PendingTransactionsView view = _txPool.GetPendingForProduction(forkBlock.Header, filterToReadyTx: false, UInt256.Zero);
+                    AcceptTxResult result = _txPool.SubmitTx(concurrentTransaction, TxHandlingOptions.None);
+                    return (view, result);
+                });
+
                 (PendingTransactionsView view, AcceptTxResult result) = await concurrentAccess.WaitAsync(TimeSpan.FromSeconds(5));
                 using (Assert.EnterMultipleScope())
                 {
@@ -1037,7 +1040,6 @@ namespace Nethermind.TxPool.Test
                 releaseRevalidation.Set();
             }
 
-            await headProcessed.WaitAsync(TimeSpan.FromSeconds(10));
             Assert.That(
                 () => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader),
                 Is.True.After(Timeout, 10));

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -358,6 +358,21 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public void should_revalidate_when_head_spec_changes_during_construction()
+        {
+            IChainHeadSpecProvider changingSpecProvider = Substitute.For<IChainHeadSpecProvider>();
+            changingSpecProvider.GetCurrentHeadSpec().Returns(Prague.Instance, Prague.Instance, Osaka.Instance);
+            changingSpecProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(Osaka.Instance);
+            ChainHeadInfoProvider headInfo = new(changingSpecProvider, _blockTree, _stateProvider);
+
+            _txPool = CreatePool(specProvider: new TestSpecProvider(Prague.Instance), chainHeadInfoProvider: headInfo);
+
+            Assert.That(
+                () => _txPool.IsRevalidatedFor(Build.A.BlockHeader.TestObject),
+                Is.True.After(Timeout, 10));
+        }
+
+        [Test]
         public async Task should_remember_fork_invalidated_transaction_when_insufficient_balance_dumps_bucket()
         {
             Block head = _blockTree.Head;

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -198,11 +198,13 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys) =>
         DeleteMany(keys, deleteSharedEntries: false);
 
-    void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions()
+    void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken)
     {
         using ArrayPoolList<TxLookupKey> candidates = new(ObsoleteSweepBatchSize);
         foreach (byte[] key in _fullBlobTxsDb.GetAllKeys())
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             // Elided and marker keys share this column; only timestamp-prefixed full bodies are 64 bytes.
             if (key.Length != FullTxKeyLength)
             {
@@ -216,11 +218,13 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
 
             if (candidates.Count == ObsoleteSweepBatchSize)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 DeleteMany(candidates.AsSpan(), deleteSharedEntries: false, deleteOnlyIfObsolete: true);
                 candidates.Clear();
             }
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
         DeleteMany(candidates.AsSpan(), deleteSharedEntries: false, deleteOnlyIfObsolete: true);
     }
 

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -21,10 +21,12 @@ namespace Nethermind.TxPool;
 public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage, IBlobTxMetadataStorage, ISpecChangeValidationStorage, IBatchDeleteTxStorage
 {
     private const int MaxPooledKeys = 128;
+    private const int ObsoleteSweepBatchSize = 16;
     private const int TransactionLockCount = 64;
 
     // Sidecar-free records live in the full-txs column under a key shape (prefix + hash) that
     // cannot collide with the 64-byte timestamp-prefixed full-tx keys.
+    private const int FullTxKeyLength = 64;
     private const int ElidedTxKeyLength = 33;
     private const byte ElidedTxKeyPrefix = 0x01;
     private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
@@ -41,7 +43,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
 
     public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, [NotNullWhen(true)] out Transaction? transaction)
     {
-        Span<byte> txHashPrefixed = stackalloc byte[64];
+        Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
         GetHashPrefixedByTimestamp(timestamp, hash, txHashPrefixed);
 
         byte[]? txBytes = _fullBlobTxsDb.Get(txHashPrefixed);
@@ -71,7 +73,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         if (count == 0) return 0;
 
         // Outer array must be exact-size for the IDb indexer (uses keys.Length).
-        // Inner byte[64] keys are pooled via ConcurrentQueue to avoid per-call allocations.
+        // Inner full-transaction keys are pooled via ConcurrentQueue to avoid per-call allocations.
         byte[][] dbKeys = new byte[count][];
         int rentedKeyCount = 0;
         try
@@ -123,7 +125,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         ValueHash256 hash = transaction.Hash.ValueHash256;
         lock (GetTransactionLock(hash))
         {
-            Span<byte> txHashPrefixed = stackalloc byte[64];
+            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
             GetHashPrefixedByTimestamp(transaction.Timestamp, hash, txHashPrefixed);
 
             EncodeAndSaveTx(transaction, _fullBlobTxsDb, txHashPrefixed);
@@ -143,7 +145,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         ValueHash256 hash = transaction.Hash.ValueHash256;
         lock (GetTransactionLock(hash))
         {
-            Span<byte> txHashPrefixed = stackalloc byte[64];
+            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
             GetHashPrefixedByTimestamp(transaction.Timestamp, hash, txHashPrefixed);
             if (!_fullBlobTxsDb.KeyExists(txHashPrefixed))
             {
@@ -176,7 +178,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     {
         lock (GetTransactionLock(hash))
         {
-            Span<byte> txHashPrefixed = stackalloc byte[64];
+            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
             GetHashPrefixedByTimestamp(timestamp, hash, txHashPrefixed);
 
             Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
@@ -198,10 +200,11 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
 
     void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions()
     {
-        using ArrayPoolList<TxLookupKey> candidates = new(MaxPooledKeys);
+        using ArrayPoolList<TxLookupKey> candidates = new(ObsoleteSweepBatchSize);
         foreach (byte[] key in _fullBlobTxsDb.GetAllKeys())
         {
-            if (key.Length != 64)
+            // Elided and marker keys share this column; only timestamp-prefixed full bodies are 64 bytes.
+            if (key.Length != FullTxKeyLength)
             {
                 continue;
             }
@@ -211,7 +214,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
                 Address.Zero,
                 new UInt256(key.AsSpan(0, 32), isBigEndian: true)));
 
-            if (candidates.Count == MaxPooledKeys)
+            if (candidates.Count == ObsoleteSweepBatchSize)
             {
                 DeleteMany(candidates.AsSpan(), deleteSharedEntries: false, deleteOnlyIfObsolete: true);
                 candidates.Clear();
@@ -255,7 +258,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             IWriteBatch? lightBlobTxsBatch = deleteSharedEntries
                 ? batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs)
                 : null;
-            Span<byte> txHashPrefixed = stackalloc byte[64];
+            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
             Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
             for (int i = 0; i < keys.Length; i++)
             {
@@ -371,7 +374,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             return key;
         }
 
-        return new byte[64];
+        return new byte[FullTxKeyLength];
     }
 
     private void ReturnKey(byte[] key)

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -190,7 +190,13 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
     }
 
-    void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
+    void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys) =>
+        DeleteMany(keys, deleteSharedEntries: true);
+
+    void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys) =>
+        DeleteMany(keys, deleteSharedEntries: false);
+
+    private void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys, bool deleteSharedEntries)
     {
         if (keys.IsEmpty)
         {
@@ -218,17 +224,22 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
 
             using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
             IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
-            IWriteBatch lightBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs);
+            IWriteBatch? lightBlobTxsBatch = deleteSharedEntries
+                ? batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs)
+                : null;
             Span<byte> txHashPrefixed = stackalloc byte[64];
             Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
             for (int i = 0; i < keys.Length; i++)
             {
                 ref readonly TxLookupKey key = ref keys[i];
                 GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
-                GetElidedTxKey(key.Hash, elidedKey);
                 fullBlobTxsBatch.Remove(txHashPrefixed);
-                fullBlobTxsBatch.Remove(elidedKey);
-                lightBlobTxsBatch.Remove(key.Hash.BytesAsSpan);
+                if (deleteSharedEntries)
+                {
+                    GetElidedTxKey(key.Hash, elidedKey);
+                    fullBlobTxsBatch.Remove(elidedKey);
+                    lightBlobTxsBatch!.Remove(key.Hash.BytesAsSpan);
+                }
             }
         }
         finally

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -211,10 +211,16 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
                 continue;
             }
 
-            candidates.Add(new TxLookupKey(
+            TxLookupKey candidate = new(
                 new ValueHash256(key.AsSpan(32)),
                 Address.Zero,
-                new UInt256(key.AsSpan(0, 32), isBigEndian: true)));
+                new UInt256(key.AsSpan(0, 32), isBigEndian: true));
+            if (IsCurrentFullBlobTransaction(candidate))
+            {
+                continue;
+            }
+
+            candidates.Add(candidate);
 
             if (candidates.Count == ObsoleteSweepBatchSize)
             {
@@ -257,32 +263,23 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
                 }
             }
 
-            using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
-            IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
-            IWriteBatch? lightBlobTxsBatch = deleteSharedEntries
-                ? batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs)
-                : null;
-            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
-            Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
-            for (int i = 0; i < keys.Length; i++)
+            if (deleteOnlyIfObsolete)
             {
-                ref readonly TxLookupKey key = ref keys[i];
-                if (deleteOnlyIfObsolete
-                    && TryDecodeLightTx(_lightBlobTxsDb.Get(key.Hash.BytesAsSpan), out LightTransaction? currentTransaction)
-                    && currentTransaction is not null
-                    && currentTransaction.Timestamp == key.Timestamp)
+                using ArrayPoolList<TxLookupKey> obsoleteKeys = new(keys.Length);
+                for (int i = 0; i < keys.Length; i++)
                 {
-                    continue;
+                    ref readonly TxLookupKey key = ref keys[i];
+                    if (!IsCurrentFullBlobTransaction(key))
+                    {
+                        obsoleteKeys.Add(key);
+                    }
                 }
 
-                GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
-                fullBlobTxsBatch.Remove(txHashPrefixed);
-                if (deleteSharedEntries)
-                {
-                    GetElidedTxKey(key.Hash, elidedKey);
-                    fullBlobTxsBatch.Remove(elidedKey);
-                    lightBlobTxsBatch!.Remove(key.Hash.BytesAsSpan);
-                }
+                DeleteManyFromStorage(obsoleteKeys.AsSpan(), deleteSharedEntries);
+            }
+            else
+            {
+                DeleteManyFromStorage(keys, deleteSharedEntries);
             }
         }
         finally
@@ -293,6 +290,39 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             }
         }
     }
+
+    private void DeleteManyFromStorage(scoped ReadOnlySpan<TxLookupKey> keys, bool deleteSharedEntries)
+    {
+        if (keys.IsEmpty)
+        {
+            return;
+        }
+
+        using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
+        IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
+        IWriteBatch? lightBlobTxsBatch = deleteSharedEntries
+            ? batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs)
+            : null;
+        Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
+        Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
+        for (int i = 0; i < keys.Length; i++)
+        {
+            ref readonly TxLookupKey key = ref keys[i];
+            GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
+            fullBlobTxsBatch.Remove(txHashPrefixed);
+            if (deleteSharedEntries)
+            {
+                GetElidedTxKey(key.Hash, elidedKey);
+                fullBlobTxsBatch.Remove(elidedKey);
+                lightBlobTxsBatch!.Remove(key.Hash.BytesAsSpan);
+            }
+        }
+    }
+
+    private bool IsCurrentFullBlobTransaction(in TxLookupKey key) =>
+        TryDecodeLightTx(_lightBlobTxsDb.Get(key.Hash.BytesAsSpan), out LightTransaction? currentTransaction)
+        && currentTransaction is not null
+        && currentTransaction.Timestamp == key.Timestamp;
 
     string? ISpecChangeValidationStorage.GetSpecChangeValidationMarker()
     {

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -196,7 +196,35 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys) =>
         DeleteMany(keys, deleteSharedEntries: false);
 
-    private void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys, bool deleteSharedEntries)
+    void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions()
+    {
+        using ArrayPoolList<TxLookupKey> candidates = new(MaxPooledKeys);
+        foreach (byte[] key in _fullBlobTxsDb.GetAllKeys())
+        {
+            if (key.Length != 64)
+            {
+                continue;
+            }
+
+            candidates.Add(new TxLookupKey(
+                new ValueHash256(key.AsSpan(32)),
+                Address.Zero,
+                new UInt256(key.AsSpan(0, 32), isBigEndian: true)));
+
+            if (candidates.Count == MaxPooledKeys)
+            {
+                DeleteMany(candidates.AsSpan(), deleteSharedEntries: false, deleteOnlyIfObsolete: true);
+                candidates.Clear();
+            }
+        }
+
+        DeleteMany(candidates.AsSpan(), deleteSharedEntries: false, deleteOnlyIfObsolete: true);
+    }
+
+    private void DeleteMany(
+        scoped ReadOnlySpan<TxLookupKey> keys,
+        bool deleteSharedEntries,
+        bool deleteOnlyIfObsolete = false)
     {
         if (keys.IsEmpty)
         {
@@ -232,6 +260,14 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             for (int i = 0; i < keys.Length; i++)
             {
                 ref readonly TxLookupKey key = ref keys[i];
+                if (deleteOnlyIfObsolete
+                    && TryDecodeLightTx(_lightBlobTxsDb.Get(key.Hash.BytesAsSpan), out LightTransaction? currentTransaction)
+                    && currentTransaction is not null
+                    && currentTransaction.Timestamp == key.Timestamp)
+                {
+                    continue;
+                }
+
                 GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
                 fullBlobTxsBatch.Remove(txHashPrefixed);
                 if (deleteSharedEntries)

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -26,6 +26,8 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
 
     internal readonly Dictionary<byte[], List<Hash256>> BlobIndex = new(Bytes.EqualityComparer);
 
+    internal virtual void FlushPendingRevalidationDeletes() { }
+
     protected override IComparer<Transaction> GetReplacementComparer(IComparer<Transaction> comparer)
         => comparer.GetBlobReplacementComparer();
 

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -765,21 +765,37 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         finally
         {
             _batchStorageDeletes = false;
-            if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
-            {
-                batchStorage.DeleteMany(CollectionsMarshal.AsSpan(_batchedDeletes));
-            }
-            else
-            {
-                for (int i = 0; i < _batchedDeletes.Count; i++)
-                {
-                    TxLookupKey key = _batchedDeletes[i];
-                    _blobTxStorage.Delete(key.Hash, key.Timestamp);
-                }
-            }
-
-            _batchedDeletes.Clear();
+            FlushPendingRevalidationDeletesNonLocked();
         }
+    }
+
+    internal override void FlushPendingRevalidationDeletes()
+    {
+        using McsLock.Disposable lockRelease = Lock.Acquire();
+        FlushPendingRevalidationDeletesNonLocked();
+    }
+
+    private void FlushPendingRevalidationDeletesNonLocked()
+    {
+        if (_batchedDeletes.Count == 0)
+        {
+            return;
+        }
+
+        if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
+        {
+            batchStorage.DeleteMany(CollectionsMarshal.AsSpan(_batchedDeletes));
+        }
+        else
+        {
+            for (int i = 0; i < _batchedDeletes.Count; i++)
+            {
+                TxLookupKey key = _batchedDeletes[i];
+                _blobTxStorage.Delete(key.Hash, key.Timestamp);
+            }
+        }
+
+        _batchedDeletes.Clear();
     }
 
     protected override void OnBlobTransactionUpdatedNonLocked(Transaction blobTx)

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -765,8 +765,9 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         finally
         {
             _batchStorageDeletes = false;
-            FlushPendingRevalidationDeletesNonLocked();
         }
+
+        FlushPendingRevalidationDeletesNonLocked();
     }
 
     internal override void FlushPendingRevalidationDeletes()
@@ -780,6 +781,25 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         if (_batchedDeletes.Count == 0)
         {
             return;
+        }
+
+        int deleteCount = 0;
+        for (int i = 0; i < _batchedDeletes.Count; i++)
+        {
+            TxLookupKey key = _batchedDeletes[i];
+            if (!base.TryGetValueNonLocked(key.Hash, out _))
+            {
+                _batchedDeletes[deleteCount++] = key;
+            }
+        }
+
+        if (deleteCount != _batchedDeletes.Count)
+        {
+            _batchedDeletes.RemoveRange(deleteCount, _batchedDeletes.Count - deleteCount);
+            if (deleteCount == 0)
+            {
+                return;
+            }
         }
 
         if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -765,25 +765,20 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         finally
         {
             _batchStorageDeletes = false;
-            try
+            if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
             {
-                if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
+                batchStorage.DeleteMany(CollectionsMarshal.AsSpan(_batchedDeletes));
+            }
+            else
+            {
+                for (int i = 0; i < _batchedDeletes.Count; i++)
                 {
-                    batchStorage.DeleteMany(CollectionsMarshal.AsSpan(_batchedDeletes));
-                }
-                else
-                {
-                    for (int i = 0; i < _batchedDeletes.Count; i++)
-                    {
-                        TxLookupKey key = _batchedDeletes[i];
-                        _blobTxStorage.Delete(key.Hash, key.Timestamp);
-                    }
+                    TxLookupKey key = _batchedDeletes[i];
+                    _blobTxStorage.Delete(key.Hash, key.Timestamp);
                 }
             }
-            finally
-            {
-                _batchedDeletes.Clear();
-            }
+
+            _batchedDeletes.Clear();
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -812,6 +812,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
         else
         {
+            // No timestamp-only fallback exists; Delete also removes hash-keyed records owned by a reinserted transaction.
             for (int i = 0; i < deletes.Count; i++)
             {
                 TxLookupKey key = deletes[i];

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -783,34 +783,38 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             return;
         }
 
-        int deleteCount = 0;
+        using ArrayPoolList<TxLookupKey> deletes = new(_batchedDeletes.Count);
+        using ArrayPoolList<TxLookupKey> obsoleteFullTransactions = new(_batchedDeletes.Count);
         for (int i = 0; i < _batchedDeletes.Count; i++)
         {
             TxLookupKey key = _batchedDeletes[i];
-            if (!base.TryGetValueNonLocked(key.Hash, out _))
+            if (!base.TryGetValueNonLocked(key.Hash, out Transaction? liveTransaction))
             {
-                _batchedDeletes[deleteCount++] = key;
+                deletes.Add(key);
             }
-        }
-
-        if (deleteCount != _batchedDeletes.Count)
-        {
-            _batchedDeletes.RemoveRange(deleteCount, _batchedDeletes.Count - deleteCount);
-            if (deleteCount == 0)
+            else if (liveTransaction.Timestamp != key.Timestamp)
             {
-                return;
+                obsoleteFullTransactions.Add(key);
             }
         }
 
         if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
         {
-            batchStorage.DeleteMany(CollectionsMarshal.AsSpan(_batchedDeletes));
+            if (deletes.Count > 0)
+            {
+                batchStorage.DeleteMany(deletes.AsSpan());
+            }
+
+            if (obsoleteFullTransactions.Count > 0)
+            {
+                batchStorage.DeleteFullBlobTransactions(obsoleteFullTransactions.AsSpan());
+            }
         }
         else
         {
-            for (int i = 0; i < _batchedDeletes.Count; i++)
+            for (int i = 0; i < deletes.Count; i++)
             {
-                TxLookupKey key = _batchedDeletes[i];
+                TxLookupKey key = deletes[i];
                 _blobTxStorage.Delete(key.Hash, key.Timestamp);
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -63,7 +63,9 @@ namespace Nethermind.TxPool.Filters
                     blockGasLimit: 0,
                     TxValidationOptions.SkipBlobProofs);
                 return validationResult
-                    ? specChangeTxValidator.IsWellFormed(transaction, releaseSpec)
+                    ? specChangeTxValidator is ISpecChangeTxValidator incrementalValidator
+                        ? incrementalValidator.IsWellFormedAfterFullValidation(transaction, releaseSpec)
+                        : specChangeTxValidator.IsWellFormed(transaction, releaseSpec)
                     : validationResult;
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -19,6 +19,10 @@ namespace Nethermind.TxPool.Filters
         ILogger logger)
         : IIncomingTxFilter
     {
+        // Plugins may supply only ITxValidator, in which case they require the full validation pass.
+        private readonly ISpecChangeTxValidator? _incrementalSpecChangeTxValidator =
+            specChangeTxValidator as ISpecChangeTxValidator;
+
         public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             IReleaseSpec spec = state.HeadSpec;
@@ -63,9 +67,9 @@ namespace Nethermind.TxPool.Filters
                     blockGasLimit: 0,
                     TxValidationOptions.SkipBlobProofs);
                 return validationResult
-                    ? specChangeTxValidator is ISpecChangeTxValidator incrementalValidator
-                        ? incrementalValidator.IsWellFormedAfterFullValidation(transaction, releaseSpec)
-                        : specChangeTxValidator.IsWellFormed(transaction, releaseSpec)
+                    ? _incrementalSpecChangeTxValidator is null
+                        ? specChangeTxValidator.IsWellFormed(transaction, releaseSpec)
+                        : _incrementalSpecChangeTxValidator.IsWellFormedAfterFullValidation(transaction, releaseSpec)
                     : validationResult;
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -41,6 +41,9 @@ internal interface IBatchDeleteTxStorage
     /// <summary>
     /// Removes timestamped full-body records that are not referenced by their hash-keyed light record.
     /// </summary>
+    /// <remarks>
+    /// This can scan the entire persisted full-transaction collection and should run outside latency-sensitive paths.
+    /// </remarks>
     void DeleteObsoleteFullBlobTransactions();
 }
 

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -45,6 +45,10 @@ internal interface IBatchDeleteTxStorage
     /// <remarks>
     /// This can scan the entire persisted full-transaction collection and should run outside latency-sensitive paths.
     /// </remarks>
+    /// <param name="cancellationToken">
+    /// Aborts the scan. Implementations must throw rather than return early so an interrupted sweep is not treated as complete.
+    /// </param>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
     void DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken);
 }
 

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -44,7 +45,7 @@ internal interface IBatchDeleteTxStorage
     /// <remarks>
     /// This can scan the entire persisted full-transaction collection and should run outside latency-sensitive paths.
     /// </remarks>
-    void DeleteObsoleteFullBlobTransactions();
+    void DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken);
 }
 
 internal interface ISpecChangeValidationStorage

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -24,6 +24,8 @@ public interface ITxStorage
 internal interface IBatchDeleteTxStorage
 {
     void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys);
+
+    void DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys);
 }
 
 internal interface ISpecChangeValidationStorage

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -23,9 +23,25 @@ public interface ITxStorage
 
 internal interface IBatchDeleteTxStorage
 {
+    /// <summary>
+    /// Removes the timestamped full-body record and the hash-keyed light and elided records for each key.
+    /// </summary>
     void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys);
 
+    /// <summary>
+    /// Removes only the timestamped full-body record for each key, leaving the hash-keyed light and elided
+    /// records intact.
+    /// </summary>
+    /// <remarks>
+    /// Used to drop an obsolete body when the same hash is live under a different <see cref="TxLookupKey.Timestamp"/>;
+    /// use <see cref="DeleteMany"/> when no current transaction owns the hash-keyed records.
+    /// </remarks>
     void DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys);
+
+    /// <summary>
+    /// Removes timestamped full-body records that are not referenced by their hash-keyed light record.
+    /// </summary>
+    void DeleteObsoleteFullBlobTransactions();
 }
 
 internal interface ISpecChangeValidationStorage

--- a/src/Nethermind/Nethermind.TxPool/ITxValidator.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxValidator.cs
@@ -36,6 +36,12 @@ namespace Nethermind.TxPool
         /// A process-independent fingerprint that changes whenever the validator's behavior or configuration changes.
         /// </summary>
         string PersistenceFingerprint { get; }
+
+        /// <summary>
+        /// Validates rules not already covered by a successful full transaction-validation pass.
+        /// </summary>
+        ValidationResult IsWellFormedAfterFullValidation(Transaction transaction, IReleaseSpec releaseSpec) =>
+            IsWellFormed(transaction, releaseSpec);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.TxPool/PendingTransactionsView.cs
+++ b/src/Nethermind/Nethermind.TxPool/PendingTransactionsView.cs
@@ -20,17 +20,21 @@ public readonly struct PendingTransactionsView(
     IDictionary<AddressAsKey, Transaction[]> blobTransactions,
     bool isRevalidated)
 {
-    private static readonly IDictionary<AddressAsKey, Transaction[]> _empty =
+    private static readonly IReadOnlyDictionary<AddressAsKey, Transaction[]> _empty =
         new ReadOnlyDictionary<AddressAsKey, Transaction[]>(new Dictionary<AddressAsKey, Transaction[]>());
 
-    private readonly IDictionary<AddressAsKey, Transaction[]>? _transactions = transactions;
-    private readonly IDictionary<AddressAsKey, Transaction[]>? _blobTransactions = blobTransactions;
+    private readonly IReadOnlyDictionary<AddressAsKey, Transaction[]>? _transactions =
+        transactions as IReadOnlyDictionary<AddressAsKey, Transaction[]>
+        ?? new ReadOnlyDictionary<AddressAsKey, Transaction[]>(transactions);
+    private readonly IReadOnlyDictionary<AddressAsKey, Transaction[]>? _blobTransactions =
+        blobTransactions as IReadOnlyDictionary<AddressAsKey, Transaction[]>
+        ?? new ReadOnlyDictionary<AddressAsKey, Transaction[]>(blobTransactions);
 
     /// <summary>Non-blob transactions grouped by sender address, sorted by nonce and later tx pool sorting.</summary>
-    public IDictionary<AddressAsKey, Transaction[]> Transactions => _transactions ?? _empty;
+    public IReadOnlyDictionary<AddressAsKey, Transaction[]> Transactions => _transactions ?? _empty;
 
     /// <summary>Blob transaction light equivalences grouped by sender address, sorted the same way.</summary>
-    public IDictionary<AddressAsKey, Transaction[]> BlobTransactions => _blobTransactions ?? _empty;
+    public IReadOnlyDictionary<AddressAsKey, Transaction[]> BlobTransactions => _blobTransactions ?? _empty;
 
     /// <summary>
     /// Whether every transaction in this view has already been validated against the target block's release

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1141,19 +1141,19 @@ namespace Nethermind.TxPool
                 _newHeadLock.ExitWriteLock();
             }
 
+            if (requiresObsoleteBlobRecovery)
+            {
+                ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions();
+                // Retained revalidation deletes retry independently; a restart without a matching marker sweeps again.
+                Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
+            }
+
             ForkRevalidation? revalidation = isEmpty || isValidated
                 ? null
                 : new ForkRevalidation(this, spec, generation, headSpecGeneration);
             if (revalidation is { IsComplete: false })
             {
                 return false;
-            }
-
-            if (requiresObsoleteBlobRecovery)
-            {
-                ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions();
-                // Retained revalidation deletes retry independently; a restart without a matching marker sweeps again.
-                Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
             }
 
             _newHeadLock.EnterWriteLock();
@@ -1276,6 +1276,7 @@ namespace Nethermind.TxPool
 
         private bool RequiresObsoleteBlobRecovery() =>
             !Volatile.Read(ref _obsoleteBlobRecoveryCompleted)
+            && _txPoolConfig.BlobsSupport.IsPersistentStorage()
             && _blobTxStorage is IBatchDeleteTxStorage;
 
         private void PublishValidatedSpec(IReleaseSpec spec, string marker, bool persistMarker = true)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -755,6 +755,7 @@ namespace Nethermind.TxPool
             try
             {
                 IReleaseSpec headSpec = _specProvider.GetCurrentHeadSpec();
+                // Observation and insertion share the head lock so an A -> B -> A transition cannot cross a validation publish unseen.
                 ObserveHeadSpec(headSpec);
                 TxFilteringState state = new(tx, _accounts, headSpec);
                 accepted = FilterTransactions(tx, handlingOptions, ref state);
@@ -1143,7 +1144,7 @@ namespace Nethermind.TxPool
 
             if (requiresObsoleteBlobRecovery && !_cts.IsCancellationRequested)
             {
-                ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions();
+                ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions(_cts.Token);
                 // Retained revalidation deletes retry independently; a restart without a matching marker sweeps again.
                 Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
             }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -236,9 +236,8 @@ namespace Nethermind.TxPool
             }
 
             _revalidationProcessing = ProcessRevalidations();
-            if (Volatile.Read(ref _validatedSpec) is null
-                || Volatile.Read(ref _specChangeMarkerUnpublished)
-                || RequiresObsoleteBlobRecovery())
+            bool bucketsUpdated = ReferenceEquals(Volatile.Read(ref _validatedSpec), _specProvider.GetCurrentHeadSpec());
+            if (RequiresRevalidation(bucketsUpdated))
             {
                 RequestRevalidation(Volatile.Read(ref _headGeneration));
             }
@@ -428,9 +427,7 @@ namespace Nethermind.TxPool
                             }
 
                             bucketsUpdated = ReferenceEquals(Volatile.Read(ref _validatedSpec), _specProvider.GetCurrentHeadSpec());
-                            revalidationRequired = !bucketsUpdated
-                                || Volatile.Read(ref _specChangeMarkerUnpublished)
-                                || RequiresObsoleteBlobRecovery();
+                            revalidationRequired = RequiresRevalidation(bucketsUpdated);
                             if (bucketsUpdated)
                             {
                                 UpdateBucketsWithoutRevalidation();
@@ -462,6 +459,11 @@ namespace Nethermind.TxPool
         }
 
         private void RequestRevalidation(long generation) => _revalidationChannel.Writer.TryWrite(generation);
+
+        private bool RequiresRevalidation(bool bucketsUpdated) =>
+            !bucketsUpdated
+            || Volatile.Read(ref _specChangeMarkerUnpublished)
+            || RequiresObsoleteBlobRecovery();
 
         private async Task ProcessRevalidations()
         {

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -36,6 +36,7 @@ namespace Nethermind.TxPool
     /// </summary>
     public class TxPool : ITxPool, IAsyncDisposable
     {
+        private const int MaxObsoleteBlobRecoveryAttempts = 2;
         private const int RevalidationAbandonmentWarningThreshold = 3;
 
         private readonly RetryCache<PooledTransactionRequestMessage, ValueHash256> _retryCache;
@@ -62,6 +63,7 @@ namespace Nethermind.TxPool
         private readonly bool _blobReorgsSupportEnabled;
         private bool _specChangeMarkerUnpublished;
         private bool _obsoleteBlobRecoveryCompleted;
+        private int _obsoleteBlobRecoveryFailures;
         private readonly DelegationCache _pendingDelegations = new();
         private readonly HashSet<Hash256> _forkInvalidatedHashes = [];
         private IReleaseSpec? _forkInvalidatedSpec;
@@ -486,8 +488,9 @@ namespace Nethermind.TxPool
                         _newHeadLock.EnterWriteLock();
                         try
                         {
-                            if (IsRevalidationGenerationCurrent(generation))
+                            if (!_cts.IsCancellationRequested)
                             {
+                                // Bucket reconciliation uses live account state and remains valid after the requested generation becomes stale.
                                 UpdateBucketsWithoutRevalidation();
                             }
                         }
@@ -1094,6 +1097,10 @@ namespace Nethermind.TxPool
             {
                 return TryRevalidateCurrentSpecCore(generation);
             }
+            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+            {
+                return false;
+            }
             catch (Exception exception)
             {
                 if (_logger.IsWarn) _logger.Warn($"TxPool failed to revalidate transactions after a protocol change with exception {exception}");
@@ -1144,9 +1151,7 @@ namespace Nethermind.TxPool
 
             if (requiresObsoleteBlobRecovery && !_cts.IsCancellationRequested)
             {
-                ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions(_cts.Token);
-                // Retained revalidation deletes retry independently; a restart without a matching marker sweeps again.
-                Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
+                RecoverObsoleteFullBlobTransactions();
             }
 
             ForkRevalidation? revalidation = isEmpty || isValidated
@@ -1194,6 +1199,31 @@ namespace Nethermind.TxPool
             {
                 _newHeadLock.ExitWriteLock();
             }
+        }
+
+        private void RecoverObsoleteFullBlobTransactions()
+        {
+            try
+            {
+                ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions(_cts.Token);
+            }
+            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                int failures = Interlocked.Increment(ref _obsoleteBlobRecoveryFailures);
+                if (failures < MaxObsoleteBlobRecoveryAttempts)
+                {
+                    throw;
+                }
+
+                if (_logger.IsError) _logger.Error($"Skipping obsolete full blob transaction recovery after {failures} failed attempts.", exception);
+            }
+
+            // Retained revalidation deletes retry independently of this one-time recovery sweep.
+            Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
         }
 
         private bool IsRevalidationGenerationCurrent(long generation) =>

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -236,7 +236,12 @@ namespace Nethermind.TxPool
             }
 
             _revalidationProcessing = ProcessRevalidations();
-            RequestRevalidation(Volatile.Read(ref _headGeneration));
+            if (Volatile.Read(ref _validatedSpec) is null
+                || Volatile.Read(ref _specChangeMarkerUnpublished)
+                || RequiresObsoleteBlobRecovery())
+            {
+                RequestRevalidation(Volatile.Read(ref _headGeneration));
+            }
             _headProcessing = ProcessNewHeads();
         }
 
@@ -1073,6 +1078,7 @@ namespace Nethermind.TxPool
 
             if (markerMatches)
             {
+                // A marker can also record a sweep abandoned after bounded failures; it suppresses recovery retries in either case.
                 Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
                 PublishValidatedSpec(headSpec, expectedMarker);
             }
@@ -1222,7 +1228,8 @@ namespace Nethermind.TxPool
                 if (_logger.IsError) _logger.Error($"Skipping obsolete full blob transaction recovery after {failures} failed attempts.", exception);
             }
 
-            // Retained revalidation deletes retry independently of this one-time recovery sweep.
+            // Retained revalidation deletes retry independently. Abandoning this sweep after bounded failures
+            // deliberately trades orphan reclamation for progress; the marker written by this pass suppresses later retries.
             Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
         }
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1141,7 +1141,7 @@ namespace Nethermind.TxPool
                 _newHeadLock.ExitWriteLock();
             }
 
-            if (requiresObsoleteBlobRecovery)
+            if (requiresObsoleteBlobRecovery && !_cts.IsCancellationRequested)
             {
                 ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions();
                 // Retained revalidation deletes retry independently; a restart without a matching marker sweeps again.

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1148,6 +1148,8 @@ namespace Nethermind.TxPool
 
         private void PublishValidatedSpec(IReleaseSpec spec)
         {
+            _blobTransactions.FlushPendingRevalidationDeletes();
+
             lock (_forkStateLock)
             {
                 Interlocked.Increment(ref _forkStateVersion);

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -236,8 +236,8 @@ namespace Nethermind.TxPool
             }
 
             _revalidationProcessing = ProcessRevalidations();
-            bool bucketsUpdated = ReferenceEquals(Volatile.Read(ref _validatedSpec), _specProvider.GetCurrentHeadSpec());
-            if (RequiresRevalidation(bucketsUpdated))
+            bool specValidatedForHead = ReferenceEquals(Volatile.Read(ref _validatedSpec), _specProvider.GetCurrentHeadSpec());
+            if (RequiresRevalidation(specValidatedForHead))
             {
                 RequestRevalidation(Volatile.Read(ref _headGeneration));
             }
@@ -460,8 +460,8 @@ namespace Nethermind.TxPool
 
         private void RequestRevalidation(long generation) => _revalidationChannel.Writer.TryWrite(generation);
 
-        private bool RequiresRevalidation(bool bucketsUpdated) =>
-            !bucketsUpdated
+        private bool RequiresRevalidation(bool specValidatedForHead) =>
+            !specValidatedForHead
             || Volatile.Read(ref _specChangeMarkerUnpublished)
             || RequiresObsoleteBlobRecovery();
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1065,7 +1065,7 @@ namespace Nethermind.TxPool
                     if (_logger.IsInfo) _logger.Info($"Removed {revalidation.RemovedCount:N0} transactions invalid under {spec.Name} after the protocol change.");
                 }
 
-                if (!CanApplyRevalidation(spec, generation))
+                if (!CanApplyRevalidationResults(spec))
                 {
                     InvalidateValidatedSpec();
                     RecordAbandonedRevalidation(spec, generation);
@@ -1084,9 +1084,6 @@ namespace Nethermind.TxPool
 
         private bool IsRevalidationGenerationCurrent(long generation) =>
             !_cts.IsCancellationRequested && generation == Volatile.Read(ref _headGeneration);
-
-        private bool CanApplyRevalidation(IReleaseSpec spec, long generation) =>
-            IsRevalidationGenerationCurrent(generation) && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());
 
         private bool CanApplyRevalidationResults(IReleaseSpec spec) =>
             !_cts.IsCancellationRequested && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1113,7 +1113,7 @@ namespace Nethermind.TxPool
                 IReleaseSpec currentSpec = _specProvider.GetCurrentHeadSpec();
                 reason = !ReferenceEquals(spec, currentSpec)
                     ? $"the head specification changed from {spec.Name} to {currentSpec.Name}"
-                    : $"head generation advanced from {generation} to {currentGeneration}";
+                    : $"the head changed during the pass (generation {generation}, now {currentGeneration})";
             }
 
             if (_logger.IsDebug) _logger.Debug($"Abandoned transaction pool revalidation for {spec.Name} because {reason}.");

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -60,7 +60,7 @@ namespace Nethermind.TxPool
         private readonly string? _specChangeValidationFingerprint;
         private readonly ISpecChangeValidationStorage? _specChangeValidationStorage;
         private readonly bool _blobReorgsSupportEnabled;
-        private bool _pendingObsoleteBlobRecovery;
+        private bool _specChangeMarkerUnpublished;
         private bool _obsoleteBlobRecoveryCompleted;
         private readonly DelegationCache _pendingDelegations = new();
         private readonly HashSet<Hash256> _forkInvalidatedHashes = [];
@@ -421,7 +421,9 @@ namespace Nethermind.TxPool
                             }
 
                             bucketsUpdated = ReferenceEquals(Volatile.Read(ref _validatedSpec), _specProvider.GetCurrentHeadSpec());
-                            revalidationRequired = !bucketsUpdated || Volatile.Read(ref _pendingObsoleteBlobRecovery);
+                            revalidationRequired = !bucketsUpdated
+                                || Volatile.Read(ref _specChangeMarkerUnpublished)
+                                || RequiresObsoleteBlobRecovery();
                             if (bucketsUpdated)
                             {
                                 UpdateBucketsWithoutRevalidation();
@@ -1072,12 +1074,11 @@ namespace Nethermind.TxPool
             }
             else
             {
-                if (_specChangeValidationStorage is not null || _blobTxStorage is IBatchDeleteTxStorage)
+                if (_specChangeValidationStorage is not null)
                 {
-                    Volatile.Write(ref _pendingObsoleteBlobRecovery, true);
+                    Volatile.Write(ref _specChangeMarkerUnpublished, true);
+                    _specChangeValidationStorage.SetSpecChangeValidationMarker(null);
                 }
-
-                _specChangeValidationStorage?.SetSpecChangeValidationMarker(null);
 
                 if (isEmpty)
                 {
@@ -1119,10 +1120,10 @@ namespace Nethermind.TxPool
                 spec = _specProvider.GetCurrentHeadSpec();
                 headSpecGeneration = ObserveHeadSpec(spec);
                 marker = GetSpecChangeValidationMarker(spec);
-                bool hasPendingObsoleteBlobRecovery = Volatile.Read(ref _pendingObsoleteBlobRecovery);
+                bool isSpecChangeMarkerUnpublished = Volatile.Read(ref _specChangeMarkerUnpublished);
                 requiresObsoleteBlobRecovery = RequiresObsoleteBlobRecovery();
                 isValidated = ReferenceEquals(Volatile.Read(ref _validatedSpec), spec);
-                if (isValidated && !hasPendingObsoleteBlobRecovery)
+                if (isValidated && !isSpecChangeMarkerUnpublished && !requiresObsoleteBlobRecovery)
                 {
                     return true;
                 }
@@ -1274,8 +1275,7 @@ namespace Nethermind.TxPool
         }
 
         private bool RequiresObsoleteBlobRecovery() =>
-            Volatile.Read(ref _pendingObsoleteBlobRecovery)
-            && !Volatile.Read(ref _obsoleteBlobRecoveryCompleted)
+            !Volatile.Read(ref _obsoleteBlobRecoveryCompleted)
             && _blobTxStorage is IBatchDeleteTxStorage;
 
         private void PublishValidatedSpec(IReleaseSpec spec, string marker, bool persistMarker = true)
@@ -1290,7 +1290,7 @@ namespace Nethermind.TxPool
                     if (persistMarker)
                     {
                         _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
-                        Volatile.Write(ref _pendingObsoleteBlobRecovery, false);
+                        Volatile.Write(ref _specChangeMarkerUnpublished, false);
                     }
 
                     Volatile.Write(ref _validatedSpec, spec);
@@ -1316,12 +1316,11 @@ namespace Nethermind.TxPool
                 try
                 {
                     Volatile.Write(ref _validatedSpec, null);
-                    if (_specChangeValidationStorage is not null || _blobTxStorage is IBatchDeleteTxStorage)
+                    if (_specChangeValidationStorage is not null)
                     {
-                        Volatile.Write(ref _pendingObsoleteBlobRecovery, true);
+                        Volatile.Write(ref _specChangeMarkerUnpublished, true);
+                        _specChangeValidationStorage.SetSpecChangeValidationMarker(null);
                     }
-
-                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(null);
                 }
                 finally
                 {

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -409,6 +409,7 @@ namespace Nethermind.TxPool
                             }
                         }
 
+                        // Subscribers can re-enter the pool, so invoke them after releasing _newHeadLock.
                         TxPoolHeadChanged?.Invoke(this, args.Block);
                         Metrics.TransactionCount = _transactions.Count;
                         Metrics.BlobTransactionCount = _blobTransactions.Count;
@@ -1048,14 +1049,21 @@ namespace Nethermind.TxPool
             _newHeadLock.EnterWriteLock();
             try
             {
-                if (!CanApplyRevalidation(spec, generation))
+                if (!CanApplyRevalidationResults(spec))
                 {
                     RecordAbandonedRevalidation(spec, generation);
                     return false;
                 }
 
-                _transactions.UpdatePool(_accounts, revalidation.UpdateBucket);
-                _blobTransactions.UpdatePoolForRevalidation(_accounts, revalidation.UpdateBlobBucket);
+                UpdateGroupDelegate updateBucket = revalidation.UpdateBucket;
+                _transactions.UpdatePool(_accounts, updateBucket);
+                _blobTransactions.UpdatePoolForRevalidation(_accounts, updateBucket);
+
+                if (revalidation.RemovedCount != 0)
+                {
+                    Metrics.PendingTransactionsEvicted += revalidation.RemovedCount;
+                    if (_logger.IsInfo) _logger.Info($"Removed {revalidation.RemovedCount:N0} transactions invalid under {spec.Name} after the protocol change.");
+                }
 
                 if (!CanApplyRevalidation(spec, generation))
                 {
@@ -1065,12 +1073,6 @@ namespace Nethermind.TxPool
                 }
 
                 PublishValidatedSpec(spec);
-
-                if (revalidation.RemovedCount != 0)
-                {
-                    Metrics.PendingTransactionsEvicted += revalidation.RemovedCount;
-                    if (_logger.IsInfo) _logger.Info($"Removed {revalidation.RemovedCount:N0} transactions invalid under {spec.Name} after the protocol change.");
-                }
 
                 return true;
             }
@@ -1086,9 +1088,12 @@ namespace Nethermind.TxPool
         private bool CanApplyRevalidation(IReleaseSpec spec, long generation) =>
             IsRevalidationGenerationCurrent(generation) && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());
 
+        private bool CanApplyRevalidationResults(IReleaseSpec spec) =>
+            !_cts.IsCancellationRequested && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());
+
         private bool CanContinueRevalidation(IReleaseSpec spec, long generation)
         {
-            if (IsRevalidationGenerationCurrent(generation))
+            if (CanApplyRevalidationResults(spec))
             {
                 return true;
             }
@@ -1223,9 +1228,6 @@ namespace Nethermind.TxPool
             public int RemovedCount { get; private set; }
 
             public void UpdateBucket(in AccountStruct account, EnhancedSortedSet<Transaction> transactions, ref Transaction? lastElement, UpdateTransactionDelegate updateTx) =>
-                RemovedCount += _pool.UpdateBucketCore(account, transactions, ref lastElement, updateTx, this);
-
-            public void UpdateBlobBucket(in AccountStruct account, EnhancedSortedSet<Transaction> transactions, ref Transaction? lastElement, UpdateTransactionDelegate updateTx) =>
                 RemovedCount += _pool.UpdateBucketCore(account, transactions, ref lastElement, updateTx, this);
 
             public ForkValidationResult Validate(Transaction transaction) =>

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -60,6 +60,8 @@ namespace Nethermind.TxPool
         private readonly string? _specChangeValidationFingerprint;
         private readonly ISpecChangeValidationStorage? _specChangeValidationStorage;
         private readonly bool _blobReorgsSupportEnabled;
+        private bool _pendingObsoleteBlobRecovery;
+        private string? _lastObsoleteBlobRecoveryMarker;
         private readonly DelegationCache _pendingDelegations = new();
         private readonly HashSet<Hash256> _forkInvalidatedHashes = [];
         private IReleaseSpec? _forkInvalidatedSpec;
@@ -389,6 +391,7 @@ namespace Nethermind.TxPool
                     try
                     {
                         bool bucketsUpdated;
+                        bool revalidationRequired;
                         _newHeadLock.EnterWriteLock();
                         try
                         {
@@ -418,6 +421,7 @@ namespace Nethermind.TxPool
                             }
 
                             bucketsUpdated = ReferenceEquals(Volatile.Read(ref _validatedSpec), _specProvider.GetCurrentHeadSpec());
+                            revalidationRequired = !bucketsUpdated || Volatile.Read(ref _pendingObsoleteBlobRecovery);
                             if (bucketsUpdated)
                             {
                                 UpdateBucketsWithoutRevalidation();
@@ -428,7 +432,7 @@ namespace Nethermind.TxPool
                             _newHeadLock.ExitWriteLock();
                         }
 
-                        if (!bucketsUpdated)
+                        if (revalidationRequired)
                         {
                             RequestRevalidation(headChange.Generation);
                         }
@@ -1067,7 +1071,12 @@ namespace Nethermind.TxPool
             }
             else
             {
-                _specChangeValidationStorage?.SetSpecChangeValidationMarker(null);
+                if (_specChangeValidationStorage is not null)
+                {
+                    Volatile.Write(ref _pendingObsoleteBlobRecovery, true);
+                    _specChangeValidationStorage.SetSpecChangeValidationMarker(null);
+                }
+
                 if (isEmpty)
                 {
                     PublishValidatedSpec(headSpec, expectedMarker, persistMarker: false);
@@ -1093,6 +1102,7 @@ namespace Nethermind.TxPool
             IReleaseSpec spec;
             long headSpecGeneration;
             bool isEmpty;
+            bool isValidated;
             string marker;
             bool requiresObsoleteBlobRecovery;
 
@@ -1107,9 +1117,10 @@ namespace Nethermind.TxPool
                 spec = _specProvider.GetCurrentHeadSpec();
                 headSpecGeneration = ObserveHeadSpec(spec);
                 marker = GetSpecChangeValidationMarker(spec);
+                bool hasPendingObsoleteBlobRecovery = Volatile.Read(ref _pendingObsoleteBlobRecovery);
                 requiresObsoleteBlobRecovery = RequiresObsoleteBlobRecovery(marker);
-                bool isValidated = ReferenceEquals(Volatile.Read(ref _validatedSpec), spec);
-                if (isValidated && !requiresObsoleteBlobRecovery)
+                isValidated = ReferenceEquals(Volatile.Read(ref _validatedSpec), spec);
+                if (isValidated && !hasPendingObsoleteBlobRecovery)
                 {
                     return true;
                 }
@@ -1127,7 +1138,7 @@ namespace Nethermind.TxPool
                 _newHeadLock.ExitWriteLock();
             }
 
-            ForkRevalidation? revalidation = isEmpty
+            ForkRevalidation? revalidation = isEmpty || isValidated
                 ? null
                 : new ForkRevalidation(this, spec, generation, headSpecGeneration);
             if (revalidation is { IsComplete: false })
@@ -1138,6 +1149,7 @@ namespace Nethermind.TxPool
             if (requiresObsoleteBlobRecovery)
             {
                 (_blobTxStorage as IBatchDeleteTxStorage)?.DeleteObsoleteFullBlobTransactions();
+                Volatile.Write(ref _lastObsoleteBlobRecoveryMarker, marker);
             }
 
             _newHeadLock.EnterWriteLock();
@@ -1194,7 +1206,11 @@ namespace Nethermind.TxPool
 
         private bool CanContinueRevalidation(IReleaseSpec spec, long generation, long headSpecGeneration)
         {
-            if (CanApplyRevalidationResults(spec, headSpecGeneration))
+            HeadSpecObservation? observation = Volatile.Read(ref _headSpecObservation);
+            if (!_cts.IsCancellationRequested
+                && observation is not null
+                && observation.Generation == headSpecGeneration
+                && ReferenceEquals(observation.Spec, spec))
             {
                 return true;
             }
@@ -1255,8 +1271,8 @@ namespace Nethermind.TxPool
         }
 
         private bool RequiresObsoleteBlobRecovery(string marker) =>
-            _specChangeValidationStorage is not null
-            && _specChangeValidationStorage.GetSpecChangeValidationMarker() != marker;
+            Volatile.Read(ref _pendingObsoleteBlobRecovery)
+            && !string.Equals(Volatile.Read(ref _lastObsoleteBlobRecoveryMarker), marker, StringComparison.Ordinal);
 
         private void PublishValidatedSpec(IReleaseSpec spec, string marker, bool persistMarker = true)
         {
@@ -1267,9 +1283,11 @@ namespace Nethermind.TxPool
                 Interlocked.Increment(ref _forkStateVersion);
                 try
                 {
-                    if (persistMarker)
+                    if (persistMarker && _specChangeValidationStorage is not null)
                     {
-                        _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
+                        _specChangeValidationStorage.SetSpecChangeValidationMarker(marker);
+                        Volatile.Write(ref _lastObsoleteBlobRecoveryMarker, marker);
+                        Volatile.Write(ref _pendingObsoleteBlobRecovery, false);
                     }
 
                     Volatile.Write(ref _validatedSpec, spec);
@@ -1295,7 +1313,11 @@ namespace Nethermind.TxPool
                 try
                 {
                     Volatile.Write(ref _validatedSpec, null);
-                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(null);
+                    if (_specChangeValidationStorage is not null)
+                    {
+                        Volatile.Write(ref _pendingObsoleteBlobRecovery, true);
+                        _specChangeValidationStorage.SetSpecChangeValidationMarker(null);
+                    }
                 }
                 finally
                 {

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -74,11 +74,10 @@ namespace Nethermind.TxPool
             FullMode = BoundedChannelFullMode.DropOldest
         });
         private readonly ReaderWriterLockSlim _newHeadLock = new(LockRecursionPolicy.SupportsRecursion);
-        private readonly Lock _headSpecGenerationLock = new();
         private readonly Lock _forkStateLock = new();
-        private IReleaseSpec? _observedHeadSpec;
+        // Publish the spec and its epoch through one reference so readers cannot combine different observations.
+        private HeadSpecObservation? _headSpecObservation;
         private long _headGeneration;
-        private long _headSpecGeneration;
         private long _forkStateVersion;
         private int _consecutiveRevalidationAbandonments;
 
@@ -326,7 +325,6 @@ namespace Nethermind.TxPool
 
         private void OnHeadChange(object? sender, BlockReplacementEventArgs e)
         {
-            ObserveHeadSpec(_specProvider.GetSpec(e.Block.Header));
             if (_headInfo.IsSyncing)
             {
                 DisposeBlockAccountChanges(e.Block);
@@ -348,22 +346,24 @@ namespace Nethermind.TxPool
 
         private long ObserveHeadSpec(IReleaseSpec spec)
         {
-            if (ReferenceEquals(Volatile.Read(ref _observedHeadSpec), spec))
+            HeadSpecObservation? observation = Volatile.Read(ref _headSpecObservation);
+            while (!ReferenceEquals(observation?.Spec, spec))
             {
-                return Volatile.Read(ref _headSpecGeneration);
-            }
+                HeadSpecObservation updated = new(spec, (observation?.Generation ?? 0) + 1);
+                HeadSpecObservation? published = Interlocked.CompareExchange(
+                    ref _headSpecObservation,
+                    updated,
+                    observation);
 
-            lock (_headSpecGenerationLock)
-            {
-                if (!ReferenceEquals(_observedHeadSpec, spec))
+                if (ReferenceEquals(published, observation))
                 {
-                    long generation = Interlocked.Increment(ref _headSpecGeneration);
-                    Volatile.Write(ref _observedHeadSpec, spec);
-                    return generation;
+                    return updated.Generation;
                 }
 
-                return Volatile.Read(ref _headSpecGeneration);
+                observation = published;
             }
+
+            return observation.Generation;
         }
 
         private async Task ProcessNewHeads()
@@ -1061,13 +1061,17 @@ namespace Nethermind.TxPool
             bool isEmpty = _transactions.Count == 0 && _blobTransactions.Count == 0;
             bool markerMatches = _specChangeValidationStorage?.GetSpecChangeValidationMarker() == expectedMarker;
 
-            if (isEmpty || markerMatches)
+            if (markerMatches)
             {
-                PublishValidatedSpec(headSpec, PrepareSpecChangeValidationMarker(headSpec));
+                PublishValidatedSpec(headSpec, expectedMarker);
             }
             else
             {
                 _specChangeValidationStorage?.SetSpecChangeValidationMarker(null);
+                if (isEmpty)
+                {
+                    PublishValidatedSpec(headSpec, expectedMarker, persistMarker: false);
+                }
             }
         }
 
@@ -1089,6 +1093,8 @@ namespace Nethermind.TxPool
             IReleaseSpec spec;
             long headSpecGeneration;
             bool isEmpty;
+            string marker;
+            bool requiresObsoleteBlobRecovery;
 
             _newHeadLock.EnterWriteLock();
             try
@@ -1100,13 +1106,20 @@ namespace Nethermind.TxPool
 
                 spec = _specProvider.GetCurrentHeadSpec();
                 headSpecGeneration = ObserveHeadSpec(spec);
-                if (ReferenceEquals(Volatile.Read(ref _validatedSpec), spec))
+                marker = GetSpecChangeValidationMarker(spec);
+                requiresObsoleteBlobRecovery = RequiresObsoleteBlobRecovery(marker);
+                bool isValidated = ReferenceEquals(Volatile.Read(ref _validatedSpec), spec);
+                if (isValidated && !requiresObsoleteBlobRecovery)
                 {
                     return true;
                 }
 
-                ReleaseForkInvalidatedHashesFor(spec);
-                InvalidateValidatedSpec();
+                if (!isValidated)
+                {
+                    ReleaseForkInvalidatedHashesFor(spec);
+                    InvalidateValidatedSpec();
+                }
+
                 isEmpty = _transactions.Count == 0 && _blobTransactions.Count == 0;
             }
             finally
@@ -1122,7 +1135,10 @@ namespace Nethermind.TxPool
                 return false;
             }
 
-            string marker = PrepareSpecChangeValidationMarker(spec);
+            if (requiresObsoleteBlobRecovery)
+            {
+                (_blobTxStorage as IBatchDeleteTxStorage)?.DeleteObsoleteFullBlobTransactions();
+            }
 
             _newHeadLock.EnterWriteLock();
             try
@@ -1166,10 +1182,15 @@ namespace Nethermind.TxPool
         private bool IsRevalidationGenerationCurrent(long generation) =>
             !_cts.IsCancellationRequested && generation == Volatile.Read(ref _headGeneration);
 
-        private bool CanApplyRevalidationResults(IReleaseSpec spec, long headSpecGeneration) =>
-            !_cts.IsCancellationRequested
-            && headSpecGeneration == Volatile.Read(ref _headSpecGeneration)
-            && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());
+        private bool CanApplyRevalidationResults(IReleaseSpec spec, long headSpecGeneration)
+        {
+            HeadSpecObservation? observation = Volatile.Read(ref _headSpecObservation);
+            return !_cts.IsCancellationRequested
+                && observation is not null
+                && observation.Generation == headSpecGeneration
+                && ReferenceEquals(observation.Spec, spec)
+                && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());
+        }
 
         private bool CanContinueRevalidation(IReleaseSpec spec, long generation, long headSpecGeneration)
         {
@@ -1233,19 +1254,11 @@ namespace Nethermind.TxPool
             _forkInvalidatedHashes.Add(hash);
         }
 
-        private string PrepareSpecChangeValidationMarker(IReleaseSpec spec)
-        {
-            string marker = GetSpecChangeValidationMarker(spec);
-            if (_specChangeValidationStorage is not null
-                && _specChangeValidationStorage.GetSpecChangeValidationMarker() != marker)
-            {
-                (_blobTxStorage as IBatchDeleteTxStorage)?.DeleteObsoleteFullBlobTransactions();
-            }
+        private bool RequiresObsoleteBlobRecovery(string marker) =>
+            _specChangeValidationStorage is not null
+            && _specChangeValidationStorage.GetSpecChangeValidationMarker() != marker;
 
-            return marker;
-        }
-
-        private void PublishValidatedSpec(IReleaseSpec spec, string marker)
+        private void PublishValidatedSpec(IReleaseSpec spec, string marker, bool persistMarker = true)
         {
             _blobTransactions.FlushPendingRevalidationDeletes();
 
@@ -1254,7 +1267,11 @@ namespace Nethermind.TxPool
                 Interlocked.Increment(ref _forkStateVersion);
                 try
                 {
-                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
+                    if (persistMarker)
+                    {
+                        _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
+                    }
+
                     Volatile.Write(ref _validatedSpec, spec);
                     Interlocked.Exchange(ref _consecutiveRevalidationAbandonments, 0);
                 }
@@ -1727,6 +1744,8 @@ namespace Nethermind.TxPool
         }
 
         private readonly record struct HeadChange(BlockReplacementEventArgs Args, long Generation);
+
+        private sealed record HeadSpecObservation(IReleaseSpec Spec, long Generation);
 
 
         private sealed class AccountCache : IAccountStateProvider

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1103,11 +1103,18 @@ namespace Nethermind.TxPool
         {
             bool isCancellationRequested = _cts.IsCancellationRequested;
             long currentGeneration = Volatile.Read(ref _headGeneration);
-            string reason = isCancellationRequested
-                ? "shutdown was requested"
-                : generation != currentGeneration
-                    ? $"head generation advanced from {generation} to {currentGeneration}"
-                    : $"the head specification changed from {spec.Name} to {_specProvider.GetCurrentHeadSpec().Name}";
+            string reason;
+            if (isCancellationRequested)
+            {
+                reason = "shutdown was requested";
+            }
+            else
+            {
+                IReleaseSpec currentSpec = _specProvider.GetCurrentHeadSpec();
+                reason = !ReferenceEquals(spec, currentSpec)
+                    ? $"the head specification changed from {spec.Name} to {currentSpec.Name}"
+                    : $"head generation advanced from {generation} to {currentGeneration}";
+            }
 
             if (_logger.IsDebug) _logger.Debug($"Abandoned transaction pool revalidation for {spec.Name} because {reason}.");
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -67,15 +67,25 @@ namespace Nethermind.TxPool
         private readonly ILogger _logger;
 
         private readonly Channel<HeadChange> _headBlocksChannel = Channel.CreateUnbounded<HeadChange>(new UnboundedChannelOptions() { SingleReader = true, SingleWriter = true });
+        private readonly Channel<long> _revalidationChannel = Channel.CreateBounded<long>(new BoundedChannelOptions(1)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropOldest
+        });
         private readonly ReaderWriterLockSlim _newHeadLock = new(LockRecursionPolicy.SupportsRecursion);
+        private readonly Lock _headSpecGenerationLock = new();
         private readonly Lock _forkStateLock = new();
+        private IReleaseSpec? _observedHeadSpec;
         private long _headGeneration;
+        private long _headSpecGeneration;
         private long _forkStateVersion;
         private int _consecutiveRevalidationAbandonments;
 
         private readonly UpdateGroupDelegate _updateBucket;
         private readonly UpdateGroupDelegate _updateBucketAdded;
         private readonly Task _headProcessing;
+        private readonly Task _revalidationProcessing;
         private readonly CancellationTokenSource _cts;
 
         public event EventHandler<Block>? TxPoolHeadChanged;
@@ -147,6 +157,7 @@ namespace Nethermind.TxPool
             _blobReorgsSupportEnabled = txPoolConfig.BlobsSupport.SupportsReorgs();
             _accounts = _accountCache = new AccountCache(_headInfo.ReadOnlyStateProvider);
             _specProvider = _headInfo.SpecProvider;
+            ObserveHeadSpec(_specProvider.GetCurrentHeadSpec());
             SupportsBlobs = _txPoolConfig.BlobsSupport != BlobsSupportMode.Disabled;
             _cts = new();
             _retryCache = new RetryCache<PooledTransactionRequestMessage, ValueHash256>(
@@ -221,6 +232,8 @@ namespace Nethermind.TxPool
                 _timer.Start();
             }
 
+            _revalidationProcessing = ProcessRevalidations();
+            RequestRevalidation(Volatile.Read(ref _headGeneration));
             _headProcessing = ProcessNewHeads();
         }
 
@@ -313,6 +326,7 @@ namespace Nethermind.TxPool
 
         private void OnHeadChange(object? sender, BlockReplacementEventArgs e)
         {
+            ObserveHeadSpec(_specProvider.GetSpec(e.Block.Header));
             if (_headInfo.IsSyncing)
             {
                 DisposeBlockAccountChanges(e.Block);
@@ -332,6 +346,26 @@ namespace Nethermind.TxPool
             }
         }
 
+        private long ObserveHeadSpec(IReleaseSpec spec)
+        {
+            if (ReferenceEquals(Volatile.Read(ref _observedHeadSpec), spec))
+            {
+                return Volatile.Read(ref _headSpecGeneration);
+            }
+
+            lock (_headSpecGenerationLock)
+            {
+                if (!ReferenceEquals(_observedHeadSpec, spec))
+                {
+                    long generation = Interlocked.Increment(ref _headSpecGeneration);
+                    Volatile.Write(ref _observedHeadSpec, spec);
+                    return generation;
+                }
+
+                return Volatile.Read(ref _headSpecGeneration);
+            }
+        }
+
         private async Task ProcessNewHeads()
         {
             try
@@ -347,8 +381,6 @@ namespace Nethermind.TxPool
 
         private async Task ProcessNewHeadLoop()
         {
-            TryRevalidateCurrentSpec(Volatile.Read(ref _headGeneration));
-
             while (await _headBlocksChannel.Reader.WaitToReadAsync(_cts.Token))
             {
                 while (_headBlocksChannel.Reader.TryRead(out HeadChange headChange))
@@ -396,17 +428,9 @@ namespace Nethermind.TxPool
                             _newHeadLock.ExitWriteLock();
                         }
 
-                        if (!TryRevalidateCurrentSpec(headChange.Generation) && !bucketsUpdated)
+                        if (!bucketsUpdated)
                         {
-                            _newHeadLock.EnterWriteLock();
-                            try
-                            {
-                                UpdateBucketsWithoutRevalidation();
-                            }
-                            finally
-                            {
-                                _newHeadLock.ExitWriteLock();
-                            }
+                            RequestRevalidation(headChange.Generation);
                         }
 
                         // Subscribers can re-enter the pool, so invoke them after releasing _newHeadLock.
@@ -422,6 +446,56 @@ namespace Nethermind.TxPool
             }
 
             bool CanUseCache(Block block, [NotNullWhen(true)] ArrayPoolList<AddressAsKey>? accountChanges) => accountChanges is not null && block.ParentHash == _lastBlockHash && _lastBlockNumber + 1 == block.Number;
+        }
+
+        private void RequestRevalidation(long generation) => _revalidationChannel.Writer.TryWrite(generation);
+
+        private async Task ProcessRevalidations()
+        {
+            try
+            {
+                await Task.Run(ProcessRevalidationLoop);
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                if (_logger.IsError) _logger.Error("Transaction pool revalidation failed.", ex);
+            }
+        }
+
+        private async Task ProcessRevalidationLoop()
+        {
+            while (await _revalidationChannel.Reader.WaitToReadAsync(_cts.Token))
+            {
+                long generation = 0;
+                while (_revalidationChannel.Reader.TryRead(out long requestedGeneration))
+                {
+                    generation = requestedGeneration;
+                }
+
+                try
+                {
+                    if (!TryRevalidateCurrentSpec(generation))
+                    {
+                        _newHeadLock.EnterWriteLock();
+                        try
+                        {
+                            if (IsRevalidationGenerationCurrent(generation))
+                            {
+                                UpdateBucketsWithoutRevalidation();
+                            }
+                        }
+                        finally
+                        {
+                            _newHeadLock.ExitWriteLock();
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (_logger.IsWarn) _logger.Warn($"Transaction pool failed to update after an unsuccessful revalidation with exception {ex}");
+                }
+            }
         }
 
         private void ReAddReorganisedTransactions(Block? previousBlock)
@@ -674,7 +748,9 @@ namespace Nethermind.TxPool
             _newHeadLock.EnterReadLock();
             try
             {
-                TxFilteringState state = new(tx, _accounts, _specProvider.GetCurrentHeadSpec());
+                IReleaseSpec headSpec = _specProvider.GetCurrentHeadSpec();
+                ObserveHeadSpec(headSpec);
+                TxFilteringState state = new(tx, _accounts, headSpec);
                 accepted = FilterTransactions(tx, handlingOptions, ref state);
                 if (accepted)
                 {
@@ -987,7 +1063,7 @@ namespace Nethermind.TxPool
 
             if (isEmpty || markerMatches)
             {
-                PublishValidatedSpec(headSpec);
+                PublishValidatedSpec(headSpec, PrepareSpecChangeValidationMarker(headSpec));
             }
             else
             {
@@ -1011,6 +1087,8 @@ namespace Nethermind.TxPool
         private bool TryRevalidateCurrentSpecCore(long generation)
         {
             IReleaseSpec spec;
+            long headSpecGeneration;
+            bool isEmpty;
 
             _newHeadLock.EnterWriteLock();
             try
@@ -1021,6 +1099,7 @@ namespace Nethermind.TxPool
                 }
 
                 spec = _specProvider.GetCurrentHeadSpec();
+                headSpecGeneration = ObserveHeadSpec(spec);
                 if (ReferenceEquals(Volatile.Read(ref _validatedSpec), spec))
                 {
                     return true;
@@ -1028,51 +1107,53 @@ namespace Nethermind.TxPool
 
                 ReleaseForkInvalidatedHashesFor(spec);
                 InvalidateValidatedSpec();
-
-                if (_transactions.Count == 0 && _blobTransactions.Count == 0)
-                {
-                    PublishValidatedSpec(spec);
-                    return true;
-                }
+                isEmpty = _transactions.Count == 0 && _blobTransactions.Count == 0;
             }
             finally
             {
                 _newHeadLock.ExitWriteLock();
             }
 
-            ForkRevalidation revalidation = new(this, spec, generation);
-            if (!revalidation.IsComplete)
+            ForkRevalidation? revalidation = isEmpty
+                ? null
+                : new ForkRevalidation(this, spec, generation, headSpecGeneration);
+            if (revalidation is { IsComplete: false })
             {
                 return false;
             }
 
+            string marker = PrepareSpecChangeValidationMarker(spec);
+
             _newHeadLock.EnterWriteLock();
             try
             {
-                if (!CanApplyRevalidationResults(spec))
+                if (!CanApplyRevalidationResults(spec, headSpecGeneration))
                 {
                     RecordAbandonedRevalidation(spec, generation);
                     return false;
                 }
 
-                UpdateGroupDelegate updateBucket = revalidation.UpdateBucket;
-                _transactions.UpdatePool(_accounts, updateBucket);
-                _blobTransactions.UpdatePoolForRevalidation(_accounts, updateBucket);
-
-                if (revalidation.RemovedCount != 0)
+                if (revalidation is not null)
                 {
-                    Metrics.PendingTransactionsEvicted += revalidation.RemovedCount;
-                    if (_logger.IsInfo) _logger.Info($"Removed {revalidation.RemovedCount:N0} transactions invalid under {spec.Name} after the protocol change.");
+                    UpdateGroupDelegate updateBucket = revalidation.UpdateBucket;
+                    _transactions.UpdatePool(_accounts, updateBucket);
+                    _blobTransactions.UpdatePoolForRevalidation(_accounts, updateBucket);
+
+                    if (revalidation.RemovedCount != 0)
+                    {
+                        Metrics.PendingTransactionsEvicted += revalidation.RemovedCount;
+                        if (_logger.IsInfo) _logger.Info($"Removed {revalidation.RemovedCount:N0} transactions invalid under {spec.Name} after the protocol change.");
+                    }
                 }
 
-                if (!CanApplyRevalidationResults(spec))
+                if (!CanApplyRevalidationResults(spec, headSpecGeneration))
                 {
                     InvalidateValidatedSpec();
                     RecordAbandonedRevalidation(spec, generation);
                     return true;
                 }
 
-                PublishValidatedSpec(spec);
+                PublishValidatedSpec(spec, marker);
 
                 return true;
             }
@@ -1085,12 +1166,14 @@ namespace Nethermind.TxPool
         private bool IsRevalidationGenerationCurrent(long generation) =>
             !_cts.IsCancellationRequested && generation == Volatile.Read(ref _headGeneration);
 
-        private bool CanApplyRevalidationResults(IReleaseSpec spec) =>
-            !_cts.IsCancellationRequested && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());
+        private bool CanApplyRevalidationResults(IReleaseSpec spec, long headSpecGeneration) =>
+            !_cts.IsCancellationRequested
+            && headSpecGeneration == Volatile.Read(ref _headSpecGeneration)
+            && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());
 
-        private bool CanContinueRevalidation(IReleaseSpec spec, long generation)
+        private bool CanContinueRevalidation(IReleaseSpec spec, long generation, long headSpecGeneration)
         {
-            if (CanApplyRevalidationResults(spec))
+            if (CanApplyRevalidationResults(spec, headSpecGeneration))
             {
                 return true;
             }
@@ -1150,7 +1233,19 @@ namespace Nethermind.TxPool
             _forkInvalidatedHashes.Add(hash);
         }
 
-        private void PublishValidatedSpec(IReleaseSpec spec)
+        private string PrepareSpecChangeValidationMarker(IReleaseSpec spec)
+        {
+            string marker = GetSpecChangeValidationMarker(spec);
+            if (_specChangeValidationStorage is not null
+                && _specChangeValidationStorage.GetSpecChangeValidationMarker() != marker)
+            {
+                (_blobTxStorage as IBatchDeleteTxStorage)?.DeleteObsoleteFullBlobTransactions();
+            }
+
+            return marker;
+        }
+
+        private void PublishValidatedSpec(IReleaseSpec spec, string marker)
         {
             _blobTransactions.FlushPendingRevalidationDeletes();
 
@@ -1159,7 +1254,7 @@ namespace Nethermind.TxPool
                 Interlocked.Increment(ref _forkStateVersion);
                 try
                 {
-                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(GetSpecChangeValidationMarker(spec));
+                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
                     Volatile.Write(ref _validatedSpec, spec);
                     Interlocked.Exchange(ref _consecutiveRevalidationAbandonments, 0);
                 }
@@ -1221,11 +1316,11 @@ namespace Nethermind.TxPool
             private readonly IReleaseSpec _spec;
             private readonly Dictionary<Hash256, ForkValidationResult> _invalidTransactions = [];
 
-            public ForkRevalidation(TxPool pool, IReleaseSpec spec, long generation)
+            public ForkRevalidation(TxPool pool, IReleaseSpec spec, long generation, long headSpecGeneration)
             {
                 _pool = pool;
                 _spec = spec;
-                IsComplete = FindInvalidTransactions(generation);
+                IsComplete = FindInvalidTransactions(generation, headSpecGeneration);
             }
 
             public bool IsComplete { get; }
@@ -1254,12 +1349,12 @@ namespace Nethermind.TxPool
                 return false;
             }
 
-            private bool FindInvalidTransactions(long generation)
+            private bool FindInvalidTransactions(long generation, long headSpecGeneration)
             {
                 Transaction[] transactions = _pool._transactions.GetSnapshot();
                 for (int i = 0; i < transactions.Length; i++)
                 {
-                    if (!_pool.CanContinueRevalidation(_spec, generation))
+                    if (!_pool.CanContinueRevalidation(_spec, generation, headSpecGeneration))
                     {
                         return false;
                     }
@@ -1275,7 +1370,7 @@ namespace Nethermind.TxPool
 
                 for (int i = 0; i < blobTransactions.Length; i++)
                 {
-                    if (!_pool.CanContinueRevalidation(_spec, generation))
+                    if (!_pool.CanContinueRevalidation(_spec, generation, headSpecGeneration))
                     {
                         return false;
                     }
@@ -1304,7 +1399,7 @@ namespace Nethermind.TxPool
 
                     if (batchCount == BlobReadBatchSize)
                     {
-                        if (!ProcessBlobBatch(batchCount, generation, keys, hashes, fullTransactions))
+                        if (!ProcessBlobBatch(batchCount, generation, headSpecGeneration, keys, hashes, fullTransactions))
                         {
                             return false;
                         }
@@ -1313,12 +1408,13 @@ namespace Nethermind.TxPool
                     }
                 }
 
-                return batchCount == 0 || ProcessBlobBatch(batchCount, generation, keys, hashes, fullTransactions);
+                return batchCount == 0 || ProcessBlobBatch(batchCount, generation, headSpecGeneration, keys, hashes, fullTransactions);
             }
 
             private bool ProcessBlobBatch(
                 int count,
                 long generation,
+                long headSpecGeneration,
                 TxLookupKey[] keys,
                 Hash256[] hashes,
                 Transaction?[] fullTransactions)
@@ -1328,7 +1424,7 @@ namespace Nethermind.TxPool
 
                 for (int i = 0; i < count; i++)
                 {
-                    if (!_pool.CanContinueRevalidation(_spec, generation))
+                    if (!_pool.CanContinueRevalidation(_spec, generation, headSpecGeneration))
                     {
                         return false;
                     }
@@ -1603,15 +1699,17 @@ namespace Nethermind.TxPool
             _timer?.Dispose();
             await _cts.CancelAsync();
             TxPoolHeadChanged -= _broadcaster.OnNewHead;
-            _broadcaster.Dispose();
             _headInfo.HeadChanged -= OnHeadChange;
             _headBlocksChannel.Writer.Complete();
+            _revalidationChannel.Writer.Complete();
             _transactions.Inserted -= OnInsertedTx;
             _transactions.Removed -= OnRemovedTx;
-            (_blobTransactions as IDisposable)?.Dispose();
 
             await _retryCache.DisposeAsync();
             await _headProcessing;
+            await _revalidationProcessing;
+            _broadcaster.Dispose();
+            (_blobTransactions as IDisposable)?.Dispose();
         }
 
         private void TimerOnElapsed(object? sender, EventArgs e)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -61,7 +61,7 @@ namespace Nethermind.TxPool
         private readonly ISpecChangeValidationStorage? _specChangeValidationStorage;
         private readonly bool _blobReorgsSupportEnabled;
         private bool _pendingObsoleteBlobRecovery;
-        private string? _lastObsoleteBlobRecoveryMarker;
+        private bool _obsoleteBlobRecoveryCompleted;
         private readonly DelegationCache _pendingDelegations = new();
         private readonly HashSet<Hash256> _forkInvalidatedHashes = [];
         private IReleaseSpec? _forkInvalidatedSpec;
@@ -1067,15 +1067,17 @@ namespace Nethermind.TxPool
 
             if (markerMatches)
             {
+                Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
                 PublishValidatedSpec(headSpec, expectedMarker);
             }
             else
             {
-                if (_specChangeValidationStorage is not null)
+                if (_specChangeValidationStorage is not null || _blobTxStorage is IBatchDeleteTxStorage)
                 {
                     Volatile.Write(ref _pendingObsoleteBlobRecovery, true);
-                    _specChangeValidationStorage.SetSpecChangeValidationMarker(null);
                 }
+
+                _specChangeValidationStorage?.SetSpecChangeValidationMarker(null);
 
                 if (isEmpty)
                 {
@@ -1118,7 +1120,7 @@ namespace Nethermind.TxPool
                 headSpecGeneration = ObserveHeadSpec(spec);
                 marker = GetSpecChangeValidationMarker(spec);
                 bool hasPendingObsoleteBlobRecovery = Volatile.Read(ref _pendingObsoleteBlobRecovery);
-                requiresObsoleteBlobRecovery = RequiresObsoleteBlobRecovery(marker);
+                requiresObsoleteBlobRecovery = RequiresObsoleteBlobRecovery();
                 isValidated = ReferenceEquals(Volatile.Read(ref _validatedSpec), spec);
                 if (isValidated && !hasPendingObsoleteBlobRecovery)
                 {
@@ -1148,8 +1150,9 @@ namespace Nethermind.TxPool
 
             if (requiresObsoleteBlobRecovery)
             {
-                (_blobTxStorage as IBatchDeleteTxStorage)?.DeleteObsoleteFullBlobTransactions();
-                Volatile.Write(ref _lastObsoleteBlobRecoveryMarker, marker);
+                ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions();
+                // Retained revalidation deletes retry independently; a restart without a matching marker sweeps again.
+                Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
             }
 
             _newHeadLock.EnterWriteLock();
@@ -1270,9 +1273,10 @@ namespace Nethermind.TxPool
             _forkInvalidatedHashes.Add(hash);
         }
 
-        private bool RequiresObsoleteBlobRecovery(string marker) =>
+        private bool RequiresObsoleteBlobRecovery() =>
             Volatile.Read(ref _pendingObsoleteBlobRecovery)
-            && !string.Equals(Volatile.Read(ref _lastObsoleteBlobRecoveryMarker), marker, StringComparison.Ordinal);
+            && !Volatile.Read(ref _obsoleteBlobRecoveryCompleted)
+            && _blobTxStorage is IBatchDeleteTxStorage;
 
         private void PublishValidatedSpec(IReleaseSpec spec, string marker, bool persistMarker = true)
         {
@@ -1283,10 +1287,9 @@ namespace Nethermind.TxPool
                 Interlocked.Increment(ref _forkStateVersion);
                 try
                 {
-                    if (persistMarker && _specChangeValidationStorage is not null)
+                    if (persistMarker)
                     {
-                        _specChangeValidationStorage.SetSpecChangeValidationMarker(marker);
-                        Volatile.Write(ref _lastObsoleteBlobRecoveryMarker, marker);
+                        _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
                         Volatile.Write(ref _pendingObsoleteBlobRecovery, false);
                     }
 
@@ -1313,11 +1316,12 @@ namespace Nethermind.TxPool
                 try
                 {
                     Volatile.Write(ref _validatedSpec, null);
-                    if (_specChangeValidationStorage is not null)
+                    if (_specChangeValidationStorage is not null || _blobTxStorage is IBatchDeleteTxStorage)
                     {
                         Volatile.Write(ref _pendingObsoleteBlobRecovery, true);
-                        _specChangeValidationStorage.SetSpecChangeValidationMarker(null);
                     }
+
+                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(null);
                 }
                 finally
                 {
@@ -1768,7 +1772,6 @@ namespace Nethermind.TxPool
         private readonly record struct HeadChange(BlockReplacementEventArgs Args, long Generation);
 
         private sealed record HeadSpecObservation(IReleaseSpec Spec, long Generation);
-
 
         private sealed class AccountCache : IAccountStateProvider
         {


### PR DESCRIPTION
## Changes

- close Optimism legacy-validation gaps by enforcing the EIP-2681 nonce cap after Bedrock and the EIP-7825 transaction gas-limit cap after Karst during full and block validation
- use the injected fork-sensitive validator consistently across TxPool construction paths and avoid duplicate ingress validation while preserving conservative plugin fallback behaviour
- make fork revalidation safe across A→B→A head-spec transitions by publishing results and persistence markers only when the observed spec epoch is unchanged
- move long transaction and persistent-blob revalidation scans off the head-processing loop onto a bounded, latest-generation worker so mined-transaction removal, account-cache updates, submission, and block-production views remain responsive; avoid redundant startup passes while still detecting a head-spec change during construction
- retry persistent blob deletes before marker publication and recover obsolete timestamped full bodies without deleting the current body or its light/elided records; limit the scan to persistent modes, filter live rows before locking or writing, cancel it when shutdown starts, bound repeated failures, and retain recovery when the validator has no persistence fingerprint
- prevent invalid blob candidates from starving valid block-production candidates while bounding rejected sidecar resolutions to `maxBlobs * 10`
- include composed validator behaviour in persistence fingerprints, disable persisted validation reuse when no fingerprint is available, and expose pending transaction views through read-only dictionary APIs
- add deterministic regression coverage for spec-transition races, head-loop responsiveness, marker ordering, restart recovery, Optimism fork boundaries and block validation, validator composition, and blob candidate bounds

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `Nethermind.TxPool.Test` no-intrinsics run: 756 passed, 1 existing skipped; the startup/fallback regressions also passed in Checked and in 30 repeated no-intrinsics runs
- `Nethermind.Blockchain.Test`: `TxPoolSourceTests` — 85 passed
- `Nethermind.Blockchain.Test`: `TxValidatorTests` — 123 passed
- `Nethermind.Optimism.Test`: 716 passed
- `Nethermind.AuRa.Test`: `PermissionTxComparerTests` — 5 passed
- focused bucket-reconciliation, concurrency, shutdown, restart-recovery, live-row sweep, and persistent-delete retry regressions also passed repeatedly
- `dotnet format whitespace --verify-no-changes` and `git diff --check` pass

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Optimism previously omitted the EIP-2681 nonce cap from post-Bedrock legacy full/block validation and accepted post-Karst blocks containing a legacy transaction with `gasLimit > 16,777,216` that op-geth rejects. This change applies both checks in the shared full/block-validation path. Pre-Bedrock validation and pre-Karst gas-limit behaviour remain unchanged.

## Remarks

Addresses the review follow-ups on #12755, including safe revalidation across advancing and reorganized heads, fail-closed persistence reuse, and recovery from failed persistent blob deletions.

A validator without a persistence fingerprint cannot provide durable proof that recovery already ran, so persistent blob storage performs a background full-column recovery scan per process start. Failed scans are retried once, then abandoned with an error so they cannot pin revalidation and block production to the slow path indefinitely.

The Optimism consensus fix is independently backportable; splitting or backporting it is left to the maintainer release decision.

