### PR TITLE
test(eip8141): add a block-import lane for the frozen frame-transaction fixtures

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -370,7 +370,7 @@ jobs:
     name: EEST nethtest
     uses: ./.github/workflows/run-nethtest.yml
     with:
-      test_types: engineTest,blockTest,stateTest,syncTest,txTest,zkevmTest,focilTest,frameTest
+      test_types: engineTest,blockTest,stateTest,syncTest,txTest,zkevmTest,focilTest,frameTest,frameBlockTest
       setup_group: sequential
 
   matrix-guard:

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -38,7 +38,7 @@ on:
         default: tests-focil-devnet@v0.2.0
         type: string
       frames_version:
-        description: Frame-transaction fixtures release tag (frameTest only) - pin to an exact tag
+        description: Frame-transaction fixtures release tag (frame lanes only) - pin to an exact tag
         required: false
         default: tests-frames-devnet@v0.1.0
         type: string
@@ -94,7 +94,7 @@ on:
         default: tests-focil-devnet@v0.2.0
         type: string
       frames_version:
-        description: Frame-transaction fixtures release tag (frameTest only) - pin to an exact tag
+        description: Frame-transaction fixtures release tag (frame lanes only) - pin to an exact tag
         required: false
         default: tests-frames-devnet@v0.1.0
         type: string
@@ -137,8 +137,8 @@ env:
   # means Amsterdam plus EIP-7805; nothing inside a fixture separates the two, so the lane names the
   # fork it means through the runner's --forkAlias.
   FRAMES_VERSION: ${{ inputs.frames_version || 'tests-frames-devnet@v0.1.0' }}
-  # Cases the pinned release ships under that scope. Asserted so a scope resolving to nothing fails
-  # rather than reporting a clean run of no tests.
+  # Minimum cases the pinned release ships across the frame lanes. Asserted so a scope resolving to
+  # nothing fails rather than reporting a clean run of no tests.
   FRAME_MIN_CASES: '214'
   # ubuntu-latest runners have 16 GB of RAM. The runner ships with server GC
   # (throughput-oriented, collects lazily), which previously ballooned past the

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -330,9 +330,10 @@ jobs:
                   emit "$type" sequential bogota '' false false 4 2
                 fi
                 ;;
-              frameTest)
-                # One EIP's worth of engine fixtures, so the BAL toggles and the flat layout add
-                # nothing over the Amsterdam corpus the other lanes already run.
+              frameTest|frameBlockTest)
+                # One EIP's worth of fixtures, so the BAL toggles and the flat layout add nothing
+                # over the Amsterdam corpus the other lanes already run. frameTest runs the engine
+                # payloads; frameBlockTest runs the block-import path over the same subtree.
                 if run_sequential; then
                   emit "$type" sequential frames '' false false 4 1
                 fi
@@ -398,7 +399,7 @@ jobs:
             echo "Resolved FOCIL release: $RESOLVED_FOCIL"
           fi
 
-          if [[ "$TEST_TYPES" == *frameTest* ]]; then
+          if [[ "$TEST_TYPES" == *frameTest* || "$TEST_TYPES" == *frameBlockTest* ]]; then
             RESOLVED_FRAMES="$(resolve "$FRAMES_VERSION")"
             echo "frames_version=$RESOLVED_FRAMES" >> "$GITHUB_OUTPUT"
             echo "Resolved frame-transaction release: $RESOLVED_FRAMES"
@@ -454,7 +455,7 @@ jobs:
             RESOLVED_EEST_VERSION="$RESOLVED_FOCIL"
             VERSION_INPUT="$FOCIL_VERSION"
             EEST_ARCHIVE="fixtures_focil-devnet.tar.gz"
-          elif [ "$TEST_TYPE" = "frameTest" ]; then
+          elif [ "$TEST_TYPE" = "frameTest" ] || [ "$TEST_TYPE" = "frameBlockTest" ]; then
             RESOLVED_EEST_VERSION="$RESOLVED_FRAMES"
             VERSION_INPUT="$FRAMES_VERSION"
             EEST_ARCHIVE="fixtures_frames-devnet.tar.gz"
@@ -522,6 +523,8 @@ jobs:
             focilTest)  FIXTURE_NAME=blockchain_tests_engine; RUNNER_FLAG=--engineTest ;;
             # The frame-transaction archive likewise ships engine-format fixtures.
             frameTest)  FIXTURE_NAME=blockchain_tests_engine; RUNNER_FLAG=--engineTest ;;
+            # The same archive's block-import fixtures for the frame-transaction subtree.
+            frameBlockTest) FIXTURE_NAME=blockchain_tests;    RUNNER_FLAG=--blockTest ;;
             *) echo "::error::Unknown test type: '$TEST_TYPE'"; exit 1 ;;
           esac
 
@@ -905,10 +908,10 @@ jobs:
 
             # A scope that resolved to nothing reports no failures, so the narrowed lanes assert they
             # actually ran their fixtures. Only the unfiltered run has a known count.
-            if [ "$TEST_TYPE" = "frameTest" ] && [ -z "$FILTER" ] && [ $rc -eq 0 ]; then
+            if { [ "$TEST_TYPE" = "frameTest" ] || [ "$TEST_TYPE" = "frameBlockTest" ]; } && [ -z "$FILTER" ] && [ $rc -eq 0 ]; then
               RAN=$(jq 'length' "$RESULTS_FILE" 2>/dev/null || echo 0)
               if [ "$RAN" -lt "$FRAME_MIN_CASES" ]; then
-                echo "::error::frameTest ran $RAN cases, fewer than the $FRAME_MIN_CASES expected; the fixture scope or the release pin has moved"
+                echo "::error::$TEST_TYPE ran $RAN cases, fewer than the $FRAME_MIN_CASES expected; the fixture scope or the release pin has moved"
                 rc=1
               fi
             fi


### PR DESCRIPTION
## Changes
Add a `frameBlockTest` lane to `run-nethtest.yml` that runs the frozen
frame-transaction conformance set (`tests-frames-devnet@v0.1.0`,
`eip8141_frame_transactions`) through the block-import path.

The existing `frameTest` lane runs the same subtree through the engine-payload
path only (`blockchain_tests_engine`, `--engineTest`). This lane runs
`blockchain_tests` with `--blockTest`, reusing the frames archive pin, the
`Bogota=Eip8141Prototype` fork alias, and the `FRAME_MIN_CASES` guard.

## Types of changes
- [x] New feature (test coverage)

## Testing
`nethtest --blockTest --forkAlias Bogota=Eip8141Prototype` over the subtree:
214 pass, 0 fail. RED control without the alias: 75 pass, 139 fail
(InvalidTxType), confirming the lane exercises EIP-8141.
