### PR TITLE
Add EIP-8141 APPROVE authorization conformance tests

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxApproveAuthorizationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxApproveAuthorizationTests.cs
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using Nethermind.State;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// EIP-8141 APPROVE authorization scope. A SENDER frame reaches its target with the account as caller
+/// without invoking the account's own entrypoint, so what an account authorizes is decided entirely by
+/// its authorizing frame. These tests confirm that the authorizing frame can bind APPROVE to data it
+/// observes, either account storage or a declared recent-root reference, and that a scope of zero
+/// withholds the approval and fails the transaction.
+/// </summary>
+[TestFixture]
+public class FrameTxApproveAuthorizationTests
+{
+    private static readonly Address Account = TestItem.AddressA;
+    private static readonly Address Target = TestItem.AddressC;
+    private static readonly Address Beneficiary = TestItem.AddressE;
+
+    private const int ObservedSlot = 0;
+    private const int CallerSlot = 0;
+
+    private const ulong ExpectedSlot = 1_000;
+    private const ulong OtherSlot = 999;
+    private const ulong HeadSlot = 1_001;
+
+    private ISpecProvider _specProvider;
+    private IWorldState _state;
+    private IDisposable _stateCloser;
+    private EthereumTransactionProcessor _processor;
+    private IReleaseSpec Spec => _specProvider.GenesisSpec;
+
+    [SetUp]
+    public void Setup()
+    {
+        OverridableReleaseSpec spec = new(Eip8141Prototype.Instance) { IsEip8250Enabled = true, IsEip8272Enabled = true, IsEip7906Enabled = true };
+        _specProvider = new TestSpecProvider(spec);
+        _state = TestWorldStateFactory.CreateForTest();
+        _stateCloser = _state.BeginScope(IWorldState.PreGenesis);
+        _processor = new EthereumTransactionProcessor(BlobBaseFeeCalculator.Instance, _specProvider, _state,
+            new EthereumVirtualMachine(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance),
+            new EthereumCodeInfoRepository(_state), LimboLogs.Instance);
+    }
+
+    [TearDown]
+    public void TearDown() => _stateCloser?.Dispose();
+
+    [Test]
+    public void SenderFrame_ReachesTarget_WithAccountAsCaller()
+    {
+        Deploy(Account, StaticApprove(), 1.Ether);
+        Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
+        SetObservedSlot();
+
+        TransactionResult result = Process(FrameTx(SelfVerify(), SenderFrameTo(Target)));
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(RecordedCaller(), Is.EqualTo(AsWord(Account)));
+    }
+
+    [Test]
+    public void AuthorizingFrame_WithholdsApprove_WhenObservedStorageIsSet()
+    {
+        Deploy(Account, StorageGatedApprove(), 1.Ether);
+        Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
+        SetObservedSlot();
+
+        TransactionResult result = Process(FrameTx(SelfVerify(), SenderFrameTo(Target)));
+
+        Assert.That(result.TransactionExecuted, Is.False);
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+        Assert.That(RecordedCaller(), Is.EqualTo(UInt256.Zero));
+    }
+
+    [Test]
+    public void AuthorizingFrame_GrantsApprove_WhenObservedStorageIsClear()
+    {
+        Deploy(Account, StorageGatedApprove(), 1.Ether);
+        Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
+        _state.Commit(Spec);
+
+        TransactionResult result = Process(FrameTx(SelfVerify(), SenderFrameTo(Target)));
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(RecordedCaller(), Is.EqualTo(AsWord(Account)));
+    }
+
+    [Test]
+    public void AuthorizingFrame_GrantsApprove_WhenReferenceMatchesExpectedRoot()
+    {
+        ValueHash256 sourceId = RecentRootStore.SourceId(Account, TestItem.KeccakA.ValueHash256);
+        ValueHash256 expected = TestItem.KeccakB.ValueHash256;
+        Deploy(Account, ReferenceGatedApprove(expected), 1.Ether);
+        Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
+        CommitRootEntry(sourceId, ExpectedSlot, expected);
+
+        Transaction tx = FrameTx(SelfVerify(), SenderFrameTo(Target));
+        tx.RecentRootReferences = [new RecentRootReference(sourceId, ExpectedSlot, expected)];
+
+        TransactionResult result = ProcessAt(tx, HeadSlot);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(RecordedCaller(), Is.EqualTo(AsWord(Account)));
+    }
+
+    [Test]
+    public void AuthorizingFrame_WithholdsApprove_WhenReferenceRootDiffers()
+    {
+        ValueHash256 sourceId = RecentRootStore.SourceId(Account, TestItem.KeccakA.ValueHash256);
+        ValueHash256 expected = TestItem.KeccakB.ValueHash256;
+        ValueHash256 other = TestItem.KeccakC.ValueHash256;
+        Deploy(Account, ReferenceGatedApprove(expected), 1.Ether);
+        Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
+        CommitRootEntry(sourceId, OtherSlot, other);
+
+        Transaction tx = FrameTx(SelfVerify(), SenderFrameTo(Target));
+        tx.RecentRootReferences = [new RecentRootReference(sourceId, OtherSlot, other)];
+
+        TransactionResult result = ProcessAt(tx, HeadSlot);
+
+        Assert.That(result.TransactionExecuted, Is.False);
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+        Assert.That(RecordedCaller(), Is.EqualTo(UInt256.Zero));
+    }
+
+    private static byte[] StaticApprove() =>
+        Prepare.EvmCode
+            .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0)
+            .Op(Instruction.APPROVE).Done;
+
+    private static byte[] StorageGatedApprove() =>
+        Prepare.EvmCode
+            .PushData(ObservedSlot).Op(Instruction.SLOAD).Op(Instruction.ISZERO)
+            .PushData(TxFrame.ApproveExecutionAndPayment).Op(Instruction.MUL)
+            .PushData(0).PushData(0)
+            .Op(Instruction.APPROVE).Done;
+
+    private static byte[] ReferenceGatedApprove(ValueHash256 expectedRoot) =>
+        Prepare.EvmCode
+            .PushData(0).PushData(2).Op(Instruction.RECENTROOTREFLOAD)
+            .PushData(expectedRoot.Bytes.ToArray()).Op(Instruction.EQ)
+            .PushData(TxFrame.ApproveExecutionAndPayment).Op(Instruction.MUL)
+            .PushData(0).PushData(0)
+            .Op(Instruction.APPROVE).Done;
+
+    private static byte[] TargetRecordsCaller() =>
+        Prepare.EvmCode
+            .Op(Instruction.CALLER).PushData(CallerSlot).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done;
+
+    private void Deploy(Address address, byte[] code, UInt256 balance)
+    {
+        _state.CreateAccount(address, balance);
+        _state.InsertCode(address, code, Spec);
+    }
+
+    private void SetObservedSlot()
+    {
+        _state.Set(new StorageCell(Account, ObservedSlot), [1]);
+        _state.Commit(Spec);
+    }
+
+    private void CommitRootEntry(ValueHash256 sourceId, ulong slot, ValueHash256 root)
+    {
+        if (!_state.AccountExists(Eip8272Constants.RecentRootAddress))
+            _state.CreateAccount(Eip8272Constants.RecentRootAddress, UInt256.Zero, 1);
+        _state.Set(RecentRootStore.ReferenceCell(sourceId, slot),
+            RecentRootStore.EntryHash(sourceId, slot, root).Bytes.WithoutLeadingZeros().ToArray());
+        _state.Commit(Spec);
+    }
+
+    private UInt256 RecordedCaller() => new(_state.Get(new StorageCell(Target, CallerSlot)), isBigEndian: true);
+
+    private static UInt256 AsWord(Address address) => new(address.Bytes, isBigEndian: true);
+
+    private static TxFrame SelfVerify() =>
+        new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default);
+
+    private static TxFrame SenderFrameTo(Address target) =>
+        new(TxFrame.ModeSender, 0, target, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, Array.Empty<byte>());
+
+    private static Transaction FrameTx(params TxFrame[] frames) =>
+        new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            Nonce = 0,
+            SenderAddress = Account,
+            Frames = frames,
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+
+    private TransactionResult Process(Transaction tx)
+    {
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        return _processor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
+    }
+
+    private TransactionResult ProcessAt(Transaction tx, ulong slot)
+    {
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithSlotNumber(slot)
+            .WithGasLimit(30_000_000).TestObject;
+        return _processor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxApproveAuthorizationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxApproveAuthorizationTests.cs
@@ -17,7 +17,6 @@ using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
-using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test;
@@ -39,8 +38,7 @@ public class FrameTxApproveAuthorizationTests
     private const int ObservedSlot = 0;
     private const int CallerSlot = 0;
 
-    private const ulong ExpectedSlot = 1_000;
-    private const ulong OtherSlot = 999;
+    private const ulong ReferenceSlot = 1_000;
     private const ulong HeadSlot = 1_001;
 
     private ISpecProvider _specProvider;
@@ -69,77 +67,60 @@ public class FrameTxApproveAuthorizationTests
     {
         Deploy(Account, StaticApprove(), 1.Ether);
         Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
-        SetObservedSlot();
-
-        TransactionResult result = Process(FrameTx(SelfVerify(), SenderFrameTo(Target)));
-
-        Assert.That(result.TransactionExecuted, Is.True);
-        Assert.That(RecordedCaller(), Is.EqualTo(AsWord(Account)));
-    }
-
-    [Test]
-    public void AuthorizingFrame_WithholdsApprove_WhenObservedStorageIsSet()
-    {
-        Deploy(Account, StorageGatedApprove(), 1.Ether);
-        Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
-        SetObservedSlot();
-
-        TransactionResult result = Process(FrameTx(SelfVerify(), SenderFrameTo(Target)));
-
-        Assert.That(result.TransactionExecuted, Is.False);
-        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
-        Assert.That(RecordedCaller(), Is.EqualTo(UInt256.Zero));
-    }
-
-    [Test]
-    public void AuthorizingFrame_GrantsApprove_WhenObservedStorageIsClear()
-    {
-        Deploy(Account, StorageGatedApprove(), 1.Ether);
-        Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
         _state.Commit(Spec);
 
-        TransactionResult result = Process(FrameTx(SelfVerify(), SenderFrameTo(Target)));
+        TransactionResult result = Process(FrameTx(FrameTxTestFrames.SelfVerify(200_000), SenderFrameTo(Target)));
 
         Assert.That(result.TransactionExecuted, Is.True);
         Assert.That(RecordedCaller(), Is.EqualTo(AsWord(Account)));
     }
 
-    [Test]
-    public void AuthorizingFrame_GrantsApprove_WhenReferenceMatchesExpectedRoot()
+    [TestCase(true, false, TestName = "observed storage set withholds the approval")]
+    [TestCase(false, true, TestName = "observed storage clear grants the approval")]
+    public void AuthorizingFrame_GatesApproveOnObservedStorage(bool observedSet, bool expectedExecuted)
     {
-        ValueHash256 sourceId = RecentRootStore.SourceId(Account, TestItem.KeccakA.ValueHash256);
-        ValueHash256 expected = TestItem.KeccakB.ValueHash256;
-        Deploy(Account, ReferenceGatedApprove(expected), 1.Ether);
+        Deploy(Account, StorageGatedApprove(), 1.Ether);
         Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
-        CommitRootEntry(sourceId, ExpectedSlot, expected);
+        if (observedSet) SetObservedSlot(); else _state.Commit(Spec);
 
-        Transaction tx = FrameTx(SelfVerify(), SenderFrameTo(Target));
-        tx.RecentRootReferences = [new RecentRootReference(sourceId, ExpectedSlot, expected)];
+        TransactionResult result = Process(FrameTx(FrameTxTestFrames.SelfVerify(200_000), SenderFrameTo(Target)));
 
-        TransactionResult result = ProcessAt(tx, HeadSlot);
-
-        Assert.That(result.TransactionExecuted, Is.True);
-        Assert.That(RecordedCaller(), Is.EqualTo(AsWord(Account)));
+        AssertApproval(result, expectedExecuted);
     }
 
-    [Test]
-    public void AuthorizingFrame_WithholdsApprove_WhenReferenceRootDiffers()
+    [TestCase(true, true, TestName = "reference root matching the gate grants the approval")]
+    [TestCase(false, false, TestName = "reference root differing from the gate withholds the approval")]
+    public void AuthorizingFrame_GatesApproveOnReferenceRoot(bool rootMatchesGate, bool expectedExecuted)
     {
         ValueHash256 sourceId = RecentRootStore.SourceId(Account, TestItem.KeccakA.ValueHash256);
-        ValueHash256 expected = TestItem.KeccakB.ValueHash256;
-        ValueHash256 other = TestItem.KeccakC.ValueHash256;
-        Deploy(Account, ReferenceGatedApprove(expected), 1.Ether);
+        ValueHash256 gate = TestItem.KeccakB.ValueHash256;
+        ValueHash256 committed = rootMatchesGate ? gate : TestItem.KeccakC.ValueHash256;
+        Deploy(Account, ReferenceGatedApprove(gate), 1.Ether);
         Deploy(Target, TargetRecordsCaller(), UInt256.Zero);
-        CommitRootEntry(sourceId, OtherSlot, other);
+        CommitRootEntry(sourceId, ReferenceSlot, committed);
 
-        Transaction tx = FrameTx(SelfVerify(), SenderFrameTo(Target));
-        tx.RecentRootReferences = [new RecentRootReference(sourceId, OtherSlot, other)];
+        Transaction tx = FrameTx(FrameTxTestFrames.SelfVerify(200_000), SenderFrameTo(Target));
+        tx.RecentRootReferences = [new RecentRootReference(sourceId, ReferenceSlot, committed)];
 
-        TransactionResult result = ProcessAt(tx, HeadSlot);
+        AssertApproval(Process(tx, HeadSlot), expectedExecuted);
+    }
 
-        Assert.That(result.TransactionExecuted, Is.False);
-        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
-        Assert.That(RecordedCaller(), Is.EqualTo(UInt256.Zero));
+    private void AssertApproval(TransactionResult result, bool expectedExecuted)
+    {
+        if (expectedExecuted)
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(RecordedCaller(), Is.EqualTo(AsWord(Account)));
+            return;
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False);
+            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+            Assert.That(result.ErrorDescription, Does.Contain("VERIFY frame reverted"));
+            Assert.That(RecordedCaller(), Is.EqualTo(UInt256.Zero));
+        }
     }
 
     private static byte[] StaticApprove() =>
@@ -192,11 +173,8 @@ public class FrameTxApproveAuthorizationTests
 
     private static UInt256 AsWord(Address address) => new(address.Bytes, isBigEndian: true);
 
-    private static TxFrame SelfVerify() =>
-        new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default);
-
     private static TxFrame SenderFrameTo(Address target) =>
-        new(TxFrame.ModeSender, 0, target, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, Array.Empty<byte>());
+        new(TxFrame.ModeSender, TxFrame.ApproveScopeNone, target, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, Array.Empty<byte>());
 
     private static Transaction FrameTx(params TxFrame[] frames) =>
         new()
@@ -211,16 +189,7 @@ public class FrameTxApproveAuthorizationTests
             DecodedMaxFeePerGas = 1,
         };
 
-    private TransactionResult Process(Transaction tx)
-    {
-        Block block = Build.A.Block.WithNumber(1)
-            .WithBeneficiary(Beneficiary)
-            .WithTransactions(tx)
-            .WithGasLimit(30_000_000).TestObject;
-        return _processor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
-    }
-
-    private TransactionResult ProcessAt(Transaction tx, ulong slot)
+    private TransactionResult Process(Transaction tx, ulong? slot = null)
     {
         Block block = Build.A.Block.WithNumber(1)
             .WithBeneficiary(Beneficiary)

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1454,6 +1454,32 @@ public class FrameTxProcessorTests
             "the sender nonce bump is part of the prefix that payment approval committed");
     }
 
+    [Test]
+    public void Execute_PostTxReverts_KeepsTheConsumedKeyedNonce()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+        UInt256[] keys = [1, 7];
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, target: Observer),
+            Frame(TxFrame.ModePostTx, target: Recipient));
+        tx.NonceKeys = keys;
+
+        Assert.That(Process(tx).TransactionExecuted, Is.True, "a POST_TX revert must not invalidate the transaction");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_stateProvider.GetNonce(Sender), Is.Zero, "a keyed transaction leaves the account nonce alone");
+            foreach (UInt256 key in keys)
+            {
+                Assert.That(new UInt256(_stateProvider.Get(KeyedNonceManager.StorageSlot(Sender, key)), isBigEndian: true),
+                    Is.EqualTo(UInt256.One), "the consumed nonce set stays spent across the assertion revert");
+            }
+        }
+    }
+
     // An unrolled batch truncates the journal past the prefix snapshot taken inside it, so the failed
     // assertion below would otherwise restore into the future.
     [Test]


### PR DESCRIPTION
## Changes

Adds unit coverage for how a frame-transaction authorizing frame binds APPROVE scope to the data it observes.

A SENDER frame reaches its target with the account as caller without invoking the account's own entrypoint, so what the account authorizes is decided by the authorizing frame. These tests confirm, against the real transaction processor, that the authorizing frame can gate APPROVE on:

- account storage it reads, and
- a declared recent-root reference it reads,

and that a zero scope withholds the approval and fails the transaction, while an unconditional scope authorizes.

## Types of changes

- [x] New feature (test-only, no production code change)

## Testing

Five cases in `FrameTxApproveAuthorizationTests`, all green. Each gating case is paired with a passing counterpart so the gate is shown to accept as well as reject.