### PR TITLE
test(txpool): keyed nonce lane does not pipeline the next sequence

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -3144,6 +3144,28 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        [Test]
+        public void SubmitTx_KeyedNonce_DoesNotPipelineTheNextSequence()
+        {
+            _txPool = CreatePool(null, KeyedNonceSpecProvider());
+            Address sender = TestItem.PrivateKeyA.Address;
+            EnsureSenderBalance(sender, 100.Ether);
+
+            Transaction current = BuildKeyedFrameTx(sender, nonceKey: 0xbeef, seq: 0, value: UInt256.Zero, maxFee: 1.GWei);
+            Assert.That(_txPool.SubmitTx(current, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Transaction next = BuildKeyedFrameTx(sender, nonceKey: 0xbeef, seq: 1, value: UInt256.Zero, maxFee: 1.GWei);
+            AcceptTxResult result = _txPool.SubmitTx(next, TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.ToString(), Does.Contain(TxPoolErrorMessages.KeyedNonceUnmet),
+                    "a keyed sequence past the current one is rejected outright, not queued the way the account nonce lane queues a future successor");
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1),
+                    "only the current keyed sequence pends, so the keyed lane admits at most one transaction per key per block");
+            }
+        }
+
         static IEnumerable<(byte[], AcceptTxResult)> CodeCases()
         {
             yield return (new byte[16], AcceptTxResult.SenderIsContract);


### PR DESCRIPTION
## Changes

Adds a pool-level guard test pinning EIP-8250 keyed-nonce admission behavior: a keyed set is admissible only at its current sequence, and a future successor of the same key is rejected rather than queued the way the account-nonce lane queues a future successor.

This documents, at test level, that the keyed-nonce lane admits at most one transaction per key per block through the public mempool. This matches EIP-8250, which preserves EIP-8141's one-pending-frame-transaction-per-sender guidance and admits concurrent transactions only on disjoint non-zero key sets under a future policy.

No production code is touched.

## Types of changes

- [x] Tests

## Testing

`Nethermind.TxPool.Test` green (16/16 keyed cases). Verified by RED control: forcing `KeyedNonceFilter` to admit a future sequence makes the new test fail on the exact property (`Expected "keyed nonce sequence not current", But was "Accepted"`); reverting restores green.
