### PR TITLE
Fix atomic blob transaction persistence after revalidation

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/ColumnsDb.cs
@@ -155,6 +155,8 @@ public class ColumnsDb<T> : DbOnTheRocks, IColumnsDb<T> where T : struct, Enum
 
         public void Set(ReadOnlySpan<byte> key, byte[]? value, WriteFlags flags = WriteFlags.None) => _writeBatch.WriteBatch.Set(key, value, _column._columnFamily, flags);
 
+        public void PutSpan(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) => _writeBatch.WriteBatch.Set(key, value, _column._columnFamily, flags);
+
         public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) => _writeBatch.WriteBatch.Merge(key, value, _column._columnFamily, flags);
     }
 

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -108,6 +108,22 @@ public class ColumnsDbTests
     }
 
     [Test]
+    public void WriteBatch_PutSpan_DoesNotCopyValueToManagedArray()
+    {
+        const int valueLength = 128 * 1024;
+        byte[] value = GC.AllocateUninitializedArray<byte>(valueLength);
+        using IColumnsWriteBatch<ReceiptsColumns> batch = _db.StartWriteBatch();
+        IWriteBatch column = batch.GetColumnBatch(ReceiptsColumns.Blocks);
+        column.PutSpan(TestItem.KeccakA.Bytes, [1]);
+
+        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        column.PutSpan(TestItem.KeccakB.Bytes, value);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+        Assert.That(allocated, Is.LessThan(valueLength));
+    }
+
+    [Test]
     public void SmokeTest_Snapshot()
     {
         IColumnsDb<ReceiptsColumns> asColumnsDb = _db;

--- a/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
+++ b/src/Nethermind/Nethermind.Db.Test/ColumnsDbTests.cs
@@ -112,15 +112,23 @@ public class ColumnsDbTests
     {
         const int valueLength = 128 * 1024;
         byte[] value = GC.AllocateUninitializedArray<byte>(valueLength);
-        using IColumnsWriteBatch<ReceiptsColumns> batch = _db.StartWriteBatch();
-        IWriteBatch column = batch.GetColumnBatch(ReceiptsColumns.Blocks);
-        column.PutSpan(TestItem.KeccakA.Bytes, [1]);
+        long allocated;
+        using (IColumnsWriteBatch<ReceiptsColumns> batch = _db.StartWriteBatch())
+        {
+            IWriteBatch column = batch.GetColumnBatch(ReceiptsColumns.Blocks);
+            column.PutSpan(TestItem.KeccakA.Bytes, [1]);
 
-        long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
-        column.PutSpan(TestItem.KeccakB.Bytes, value);
-        long allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+            long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            column.PutSpan(TestItem.KeccakB.Bytes, value);
+            allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        }
 
-        Assert.That(allocated, Is.LessThan(valueLength));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(allocated, Is.LessThan(valueLength));
+            Assert.That(_db.GetColumnDb(ReceiptsColumns.Blocks).Get(TestItem.KeccakB), Is.EqualTo(value));
+            Assert.That(_db.GetColumnDb(ReceiptsColumns.Transactions).Get(TestItem.KeccakB), Is.Null);
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
@@ -320,6 +320,35 @@ public class BlobTxStorageTests
         }
     }
 
+    [Test]
+    public void DeleteMany_should_not_commit_partial_batch_when_column_write_fails()
+    {
+        TrackingColumnsDb columnsDb = new();
+        BlobTxStorage blobTxStorage = new(columnsDb);
+        Transaction transaction = CreateBlobTransaction();
+        blobTxStorage.Add(transaction);
+        columnsDb.FailNextLightColumnWrite = true;
+
+        Assert.That(
+            () => ((IAtomicBlobTxStorage)blobTxStorage).DeleteMany(
+                [new TxLookupKey(transaction.Hash!.ValueHash256, transaction.SenderAddress!, transaction.Timestamp)]),
+            Throws.TypeOf<InvalidOperationException>());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(blobTxStorage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                transaction.Timestamp,
+                out _), Is.True);
+            Assert.That(blobTxStorage.TryGetWithoutBlobs(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                out _), Is.True);
+            Assert.That(CountLightTransactions(blobTxStorage), Is.EqualTo(1));
+        }
+    }
+
     private static int CountLightTransactions(BlobTxStorage storage)
     {
         int count = 0;

--- a/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
@@ -187,6 +187,7 @@ public class BlobTxStorageTests
         Transaction tx = CreateBlobTransaction();
 
         blobTxStorage.Add(tx);
+        columnsDb.ResetWriteBatchTracking();
         blobTxStorage.Delete(tx.Hash, tx.Timestamp);
 
         using (Assert.EnterMultipleScope())
@@ -216,6 +217,7 @@ public class BlobTxStorageTests
             new(second.Hash, second.SenderAddress!, second.Timestamp)
         ];
 
+        columnsDb.ResetWriteBatchTracking();
         ((IBatchDeleteTxStorage)blobTxStorage).DeleteMany(keys);
 
         using (Assert.EnterMultipleScope())
@@ -230,39 +232,69 @@ public class BlobTxStorageTests
     }
 
     [Test]
-    public void DeleteObsoleteFullBlobTransactions_should_skip_write_batches_for_live_entries()
+    public void Add_should_use_one_write_batch_across_columns()
     {
-        const int transactionCount = 17;
         TrackingColumnsDb columnsDb = new();
         BlobTxStorage blobTxStorage = new(columnsDb);
-        Transaction[] transactions = new Transaction[transactionCount];
-        EthereumEcdsa ecdsa = new(BlockchainIds.Mainnet);
-        for (int i = 0; i < transactions.Length; i++)
-        {
-            transactions[i] = Build.A.Transaction
-                .WithShardBlobTxTypeAndFields()
-                .WithNonce((ulong)i)
-                .WithMaxFeePerGas(1.GWei)
-                .WithMaxPriorityFeePerGas(1.GWei)
-                .SignedAndResolved(ecdsa, TestItem.PrivateKeyA).TestObject;
-            blobTxStorage.Add(transactions[i]);
-        }
+        Transaction transaction = CreateBlobTransaction();
 
-        ((IBatchDeleteTxStorage)blobTxStorage).DeleteObsoleteFullBlobTransactions(CancellationToken.None);
+        blobTxStorage.Add(transaction);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(columnsDb.StartedWriteBatchCount, Is.Zero);
-            for (int i = 0; i < transactions.Length; i++)
-            {
-                Transaction transaction = transactions[i];
-                Assert.That(blobTxStorage.TryGet(
-                    transaction.Hash,
-                    transaction.SenderAddress!,
-                    transaction.Timestamp,
-                    out _), Is.True);
-            }
+            Assert.That(columnsDb.StartedWriteBatchCount, Is.EqualTo(1));
+            Assert.That(blobTxStorage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                transaction.Timestamp,
+                out _), Is.True);
+            Assert.That(blobTxStorage.TryGetWithoutBlobs(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                out _), Is.True);
+            Assert.That(CountLightTransactions(blobTxStorage), Is.EqualTo(1));
         }
+    }
+
+    [Test]
+    public void Replace_should_remove_obsolete_body_in_same_write_batch()
+    {
+        TrackingColumnsDb columnsDb = new();
+        BlobTxStorage blobTxStorage = new(columnsDb);
+        Transaction transaction = CreateBlobTransaction();
+        blobTxStorage.Add(transaction);
+        UInt256 obsoleteTimestamp = transaction.Timestamp;
+        transaction.Timestamp += UInt256.One;
+        columnsDb.ResetWriteBatchTracking();
+
+        ((IBatchDeleteTxStorage)blobTxStorage).Replace(transaction, [obsoleteTimestamp]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(columnsDb.StartedWriteBatchCount, Is.EqualTo(1));
+            Assert.That(blobTxStorage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                obsoleteTimestamp,
+                out _), Is.False);
+            Assert.That(blobTxStorage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                transaction.Timestamp,
+                out _), Is.True);
+            Assert.That(CountLightTransactions(blobTxStorage), Is.EqualTo(1));
+        }
+    }
+
+    private static int CountLightTransactions(BlobTxStorage storage)
+    {
+        int count = 0;
+        foreach (LightTransaction _ in storage.GetAll())
+        {
+            count++;
+        }
+
+        return count;
     }
 
     [Test]
@@ -304,6 +336,8 @@ public class BlobTxStorageTests
             StartedWriteBatchCount++;
             return _inner.StartWriteBatch();
         }
+
+        public void ResetWriteBatchTracking() => StartedWriteBatchCount = 0;
 
         public IColumnDbSnapshot<BlobTxsColumns> CreateSnapshot() => _inner.CreateSnapshot();
 

--- a/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;

--- a/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
@@ -197,6 +197,34 @@ public class BlobTxStorageTests
     }
 
     [Test]
+    public void Delete_should_not_commit_partial_batch_when_column_write_fails()
+    {
+        TrackingColumnsDb columnsDb = new();
+        BlobTxStorage blobTxStorage = new(columnsDb);
+        Transaction transaction = CreateBlobTransaction();
+        blobTxStorage.Add(transaction);
+        columnsDb.FailNextLightColumnWrite = true;
+
+        Assert.That(
+            () => blobTxStorage.Delete(transaction.Hash, transaction.Timestamp),
+            Throws.TypeOf<InvalidOperationException>());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(blobTxStorage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                transaction.Timestamp,
+                out _), Is.True);
+            Assert.That(blobTxStorage.TryGetWithoutBlobs(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                out _), Is.True);
+            Assert.That(CountLightTransactions(blobTxStorage), Is.EqualTo(1));
+        }
+    }
+
+    [Test]
     public void DeleteMany_should_use_one_write_batch()
     {
         TrackingColumnsDb columnsDb = new();
@@ -210,10 +238,10 @@ public class BlobTxStorageTests
             .SignedAndResolved(new EthereumEcdsa(BlockchainIds.Mainnet), TestItem.PrivateKeyB).TestObject;
         blobTxStorage.Add(first);
         blobTxStorage.Add(second);
-        TxLookupKey[] keys =
+        BlobTxDeleteKey[] keys =
         [
-            new(first.Hash, first.SenderAddress!, first.Timestamp),
-            new(second.Hash, second.SenderAddress!, second.Timestamp)
+            new(first.Hash, first.Timestamp),
+            new(second.Hash, second.Timestamp)
         ];
 
         columnsDb.ResetWriteBatchTracking();
@@ -331,7 +359,7 @@ public class BlobTxStorageTests
 
         Assert.That(
             () => ((IAtomicBlobTxStorage)blobTxStorage).DeleteMany(
-                [new TxLookupKey(transaction.Hash!.ValueHash256, transaction.SenderAddress!, transaction.Timestamp)]),
+                [new BlobTxDeleteKey(transaction.Hash!.ValueHash256, transaction.Timestamp)]),
             Throws.TypeOf<InvalidOperationException>());
 
         using (Assert.EnterMultipleScope())
@@ -388,12 +416,22 @@ public class BlobTxStorageTests
     private sealed class TrackingColumnsDb : IColumnsDb<BlobTxsColumns>
     {
         private readonly MemColumnsDb<BlobTxsColumns> _inner = new();
+        private readonly Dictionary<BlobTxsColumns, IDb> _columnDbs = [];
 
         public int StartedWriteBatchCount { get; private set; }
         public bool FailNextLightColumnWrite { get; set; }
         public IEnumerable<BlobTxsColumns> ColumnKeys => _inner.ColumnKeys;
 
-        public IDb GetColumnDb(BlobTxsColumns key) => new DirectWriteRejectingDb(_inner.GetColumnDb(key));
+        public IDb GetColumnDb(BlobTxsColumns key)
+        {
+            if (!_columnDbs.TryGetValue(key, out IDb db))
+            {
+                db = new DirectWriteRejectingDb(_inner.GetColumnDb(key), key);
+                _columnDbs.Add(key, db);
+            }
+
+            return db;
+        }
 
         public IColumnsWriteBatch<BlobTxsColumns> StartWriteBatch()
         {
@@ -444,7 +482,7 @@ public class BlobTxStorageTests
         public void Dispose() { }
     }
 
-    private sealed class DirectWriteRejectingDb(IDb inner) : IDb
+    private sealed class DirectWriteRejectingDb(IDb inner, BlobTxsColumns column) : IDb
     {
         public string Name => inner.Name;
 
@@ -452,8 +490,16 @@ public class BlobTxStorageTests
 
         public byte[] Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => inner.Get(key, flags);
 
-        public void Set(ReadOnlySpan<byte> key, byte[] value, WriteFlags flags = WriteFlags.None) =>
-            throw new InvalidOperationException("Blob transaction writes must use a columns batch.");
+        public void Set(ReadOnlySpan<byte> key, byte[] value, WriteFlags flags = WriteFlags.None)
+        {
+            if (column == BlobTxsColumns.LightBlobTxs
+                || column == BlobTxsColumns.FullBlobTxs && key.Length == 64)
+            {
+                throw new InvalidOperationException("Full and light blob transaction writes must use a columns batch.");
+            }
+
+            inner.Set(key, value, flags);
+        }
 
         public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false) => inner.GetAll(ordered);
 

--- a/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
@@ -217,7 +217,7 @@ public class BlobTxStorageTests
         ];
 
         columnsDb.ResetWriteBatchTracking();
-        ((IBatchDeleteTxStorage)blobTxStorage).DeleteMany(keys);
+        ((IAtomicBlobTxStorage)blobTxStorage).DeleteMany(keys);
 
         using (Assert.EnterMultipleScope())
         {
@@ -266,7 +266,7 @@ public class BlobTxStorageTests
         transaction.Timestamp += UInt256.One;
         columnsDb.ResetWriteBatchTracking();
 
-        ((IBatchDeleteTxStorage)blobTxStorage).Replace(transaction, [obsoleteTimestamp]);
+        ((IAtomicBlobTxStorage)blobTxStorage).Replace(transaction, [obsoleteTimestamp]);
 
         using (Assert.EnterMultipleScope())
         {
@@ -280,6 +280,41 @@ public class BlobTxStorageTests
                 transaction.Hash,
                 transaction.SenderAddress!,
                 transaction.Timestamp,
+                out _), Is.True);
+            Assert.That(CountLightTransactions(blobTxStorage), Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void Replace_should_not_commit_partial_batch_when_column_write_fails()
+    {
+        TrackingColumnsDb columnsDb = new();
+        BlobTxStorage blobTxStorage = new(columnsDb);
+        Transaction transaction = CreateBlobTransaction();
+        blobTxStorage.Add(transaction);
+        UInt256 originalTimestamp = transaction.Timestamp;
+        transaction.Timestamp += UInt256.One;
+        columnsDb.FailNextLightColumnWrite = true;
+
+        Assert.That(
+            () => ((IAtomicBlobTxStorage)blobTxStorage).Replace(transaction, [originalTimestamp]),
+            Throws.TypeOf<InvalidOperationException>());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(blobTxStorage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                originalTimestamp,
+                out _), Is.True);
+            Assert.That(blobTxStorage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                transaction.Timestamp,
+                out _), Is.False);
+            Assert.That(blobTxStorage.TryGetWithoutBlobs(
+                transaction.Hash,
+                transaction.SenderAddress!,
                 out _), Is.True);
             Assert.That(CountLightTransactions(blobTxStorage), Is.EqualTo(1));
         }
@@ -326,14 +361,15 @@ public class BlobTxStorageTests
         private readonly MemColumnsDb<BlobTxsColumns> _inner = new();
 
         public int StartedWriteBatchCount { get; private set; }
+        public bool FailNextLightColumnWrite { get; set; }
         public IEnumerable<BlobTxsColumns> ColumnKeys => _inner.ColumnKeys;
 
-        public IDb GetColumnDb(BlobTxsColumns key) => _inner.GetColumnDb(key);
+        public IDb GetColumnDb(BlobTxsColumns key) => new DirectWriteRejectingDb(_inner.GetColumnDb(key));
 
         public IColumnsWriteBatch<BlobTxsColumns> StartWriteBatch()
         {
             StartedWriteBatchCount++;
-            return _inner.StartWriteBatch();
+            return new TrackingColumnsWriteBatch(_inner.StartWriteBatch(), this);
         }
 
         public void ResetWriteBatchTracking() => StartedWriteBatchCount = 0;
@@ -343,5 +379,64 @@ public class BlobTxStorageTests
         public void Flush(bool onlyWal = false) => _inner.Flush(onlyWal);
 
         public void Dispose() => _inner.Dispose();
+    }
+
+    private sealed class TrackingColumnsWriteBatch(
+        IColumnsWriteBatch<BlobTxsColumns> inner,
+        TrackingColumnsDb owner) : IColumnsWriteBatch<BlobTxsColumns>
+    {
+        public IWriteBatch GetColumnBatch(BlobTxsColumns key)
+        {
+            IWriteBatch batch = inner.GetColumnBatch(key);
+            if (key == BlobTxsColumns.LightBlobTxs && owner.FailNextLightColumnWrite)
+            {
+                owner.FailNextLightColumnWrite = false;
+                return new FailingWriteBatch(batch);
+            }
+
+            return batch;
+        }
+
+        public void Clear() => inner.Clear();
+
+        public void Dispose() => inner.Dispose();
+    }
+
+    private sealed class FailingWriteBatch(IWriteBatch inner) : IWriteBatch
+    {
+        public void Set(ReadOnlySpan<byte> key, byte[] value, WriteFlags flags = WriteFlags.None) =>
+            throw new InvalidOperationException("Simulated column write failure.");
+
+        public void Merge(ReadOnlySpan<byte> key, ReadOnlySpan<byte> value, WriteFlags flags = WriteFlags.None) =>
+            inner.Merge(key, value, flags);
+
+        public void Clear() => inner.Clear();
+
+        public void Dispose() { }
+    }
+
+    private sealed class DirectWriteRejectingDb(IDb inner) : IDb
+    {
+        public string Name => inner.Name;
+
+        public KeyValuePair<byte[], byte[]>[] this[byte[][] keys] => inner[keys];
+
+        public byte[] Get(scoped ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => inner.Get(key, flags);
+
+        public void Set(ReadOnlySpan<byte> key, byte[] value, WriteFlags flags = WriteFlags.None) =>
+            throw new InvalidOperationException("Blob transaction writes must use a columns batch.");
+
+        public IEnumerable<KeyValuePair<byte[], byte[]>> GetAll(bool ordered = false) => inner.GetAll(ordered);
+
+        public IEnumerable<byte[]> GetAllKeys(bool ordered = false) => inner.GetAllKeys(ordered);
+
+        public IEnumerable<byte[]> GetAllValues(bool ordered = false) => inner.GetAllValues(ordered);
+
+        public IWriteBatch StartWriteBatch() =>
+            throw new InvalidOperationException("Blob transaction writes must use a columns batch.");
+
+        public void Flush(bool onlyWal = false) => inner.Flush(onlyWal);
+
+        public void Dispose() { }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -29,6 +29,7 @@ using Nethermind.TxPool.Collections;
 using NSubstitute;
 using NUnit.Framework;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -599,7 +600,6 @@ namespace Nethermind.TxPool.Test
             Assert.That(
                 () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
                 Is.Not.Null.After(Timeout, 10));
-            int recoveryCountBeforeFork = storage.ObsoleteRecoveryCount;
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
@@ -620,7 +620,6 @@ namespace Nethermind.TxPool.Test
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1, 1 }));
-                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(recoveryCountBeforeFork));
                 Assert.That(storage.GetAll(), Is.Empty);
                 Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
             }
@@ -690,7 +689,8 @@ namespace Nethermind.TxPool.Test
             {
                 Assert.That(blobPool.Count, Is.EqualTo(1));
                 Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1 }));
-                Assert.That(storage.FullTransactionDeleteBatchSizes, Is.EqualTo(changeTimestamp ? new[] { 1 } : Array.Empty<int>()));
+                Assert.That(storage.FullTransactionDeleteBatchSizes, Is.Empty);
+                Assert.That(storage.ReplaceDeleteBatchSizes, Is.EqualTo(new[] { 1 }));
                 Assert.That(persisted, Is.True);
                 Assert.That(obsoleteTransactionPersisted, Is.EqualTo(!changeTimestamp));
                 Assert.That(elidedTransactionPersisted, Is.True);
@@ -723,10 +723,10 @@ namespace Nethermind.TxPool.Test
 
                 transaction.Timestamp += UInt256.One;
                 Assert.That(blobPool.TryInsert(transaction.Hash, transaction, out _), Is.True);
-                storage.FailNextFullTransactionDelete = true;
                 Assert.That(
                     () => blobPool.UpdatePoolForRevalidation(accounts, KeepAllTransactions),
-                    Throws.TypeOf<InvalidOperationException>());
+                    Throws.Nothing);
+                Assert.That(storage.ReplaceDeleteBatchSizes, Is.EqualTo(new[] { 1 }));
             }
 
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
@@ -758,233 +758,6 @@ namespace Nethermind.TxPool.Test
                 Assert.That(elidedTransactionPersisted, Is.True);
                 Assert.That(storage.GetAll(), Is.Not.Empty);
             }
-        }
-
-        [TestCase(false)]
-        [TestCase(true)]
-        public async Task should_defer_obsolete_full_transaction_recovery_from_startup(bool validatorHasFingerprint)
-        {
-            TestSpecProvider specProvider = new(Cancun.Instance);
-            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
-            UInt256 obsoleteTimestamp = transaction.Timestamp;
-            FailingBatchDeleteBlobTxStorage storage = new();
-            storage.Add(transaction);
-            transaction.Timestamp += UInt256.One;
-            storage.Add(transaction);
-            storage.Delete(transaction.Hash, transaction.Timestamp);
-            TxPoolConfig txPoolConfig = new()
-            {
-                BlobsSupport = BlobsSupportMode.Storage,
-                PersistentBlobStorageSize = 1
-            };
-            TaskCompletionSource recoveryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            using ManualResetEventSlim releaseRecovery = new(false);
-            storage.BeforeObsoleteRecovery = _ =>
-            {
-                if (storage.ObsoleteRecoveryCount != 1)
-                {
-                    return;
-                }
-
-                recoveryStarted.TrySetResult();
-                Assert.That(
-                    releaseRecovery.Wait(TimeSpan.FromSeconds(10)),
-                    Is.True,
-                    "Timed out waiting to release obsolete blob-body recovery.");
-                throw new InvalidOperationException("Simulated interrupted obsolete blob-body recovery.");
-            };
-
-            ITxValidator specChangeTxValidator = validatorHasFingerprint
-                ? new SpecChangeTxValidator(specProvider.ChainId)
-                : Always.Valid;
-            Task<TxPool> poolCreation = RunOnDedicatedThread(() => CreatePool(
-                txPoolConfig,
-                specProvider,
-                txStorage: storage,
-                specChangeTxValidator: specChangeTxValidator));
-            await recoveryStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
-            TxPool createdPool = null;
-            bool constructionCompletedBeforeRecovery = true;
-            try
-            {
-                createdPool = await poolCreation.WaitAsync(TimeSpan.FromSeconds(5));
-                _txPool = createdPool;
-                Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
-                await AddEmptyBlock();
-            }
-            catch (TimeoutException)
-            {
-                constructionCompletedBeforeRecovery = false;
-            }
-            finally
-            {
-                releaseRecovery.Set();
-            }
-
-            _txPool = createdPool ?? await poolCreation.WaitAsync(TimeSpan.FromSeconds(10));
-
-            Assert.That(constructionCompletedBeforeRecovery, Is.True, "TxPool construction waited for the recovery scan.");
-            Assert.That(() => storage.ObsoleteRecoveryCount, Is.EqualTo(2).After(Timeout, 10));
-            if (validatorHasFingerprint)
-            {
-                Assert.That(
-                    () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
-                    Is.Not.Null.After(Timeout, 10));
-            }
-            else
-            {
-                Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
-            }
-
-            Assert.That(
-                storage.TryGet(transaction.Hash, transaction.SenderAddress!, obsoleteTimestamp, out _),
-                Is.False);
-        }
-
-        [TestCase(BlobsSupportMode.Disabled)]
-        [TestCase(BlobsSupportMode.InMemory)]
-        public async Task should_not_recover_obsolete_full_transactions_for_non_persistent_blob_pool(BlobsSupportMode blobsSupport)
-        {
-            Block head = _blockTree.Head;
-            _blockTree.BestSuggestedHeader = head.Header;
-            TestSpecProvider specProvider = new(Prague.Instance)
-            {
-                NextForkSpec = Osaka.Instance,
-                ForkOnBlockNumber = head.Number + 1
-            };
-            FailingBatchDeleteBlobTxStorage storage = new();
-            TxPoolConfig txPoolConfig = new() { BlobsSupport = blobsSupport };
-            _txPool = CreatePool(txPoolConfig, specProvider, txStorage: storage);
-            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
-            Transaction transaction = Build.A.Transaction
-                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
-                .TestObject;
-            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
-
-            await AddEmptyBlock();
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
-
-            Assert.That(storage.ObsoleteRecoveryCount, Is.Zero);
-        }
-
-        [Test]
-        public async Task should_recover_obsolete_full_transactions_before_revalidation_walk()
-        {
-            TestSpecProvider specProvider = new(Cancun.Instance);
-            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
-            FailingBatchDeleteBlobTxStorage storage = new();
-            storage.Add(transaction);
-            TxPoolConfig txPoolConfig = new()
-            {
-                BlobsSupport = BlobsSupportMode.Storage,
-                PersistentBlobStorageSize = 1
-            };
-            TaskCompletionSource revalidationStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            using ManualResetEventSlim releaseRevalidation = new(false);
-            ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
-            specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(_ =>
-            {
-                revalidationStarted.TrySetResult();
-                Assert.That(
-                    releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
-                    Is.True,
-                    "Timed out waiting to release fork revalidation.");
-                return ValidationResult.Success;
-            });
-            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
-
-            _txPool = CreatePool(
-                txPoolConfig,
-                specProvider,
-                txStorage: storage,
-                specChangeTxValidator: specChangeTxValidator);
-            await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
-            try
-            {
-                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(1));
-            }
-            finally
-            {
-                releaseRevalidation.Set();
-            }
-
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
-        }
-
-        [Test]
-        public async Task should_stop_retrying_obsolete_full_transaction_recovery_after_repeated_failures()
-        {
-            InterfaceLogger logger = Substitute.For<InterfaceLogger>();
-            logger.IsError.Returns(true);
-            _logManager = new OneLoggerLogManager(new ILogger(logger));
-            FailingBatchDeleteBlobTxStorage storage = new() { ObsoleteRecoveryFailuresRemaining = 2 };
-            _txPool = CreatePool(
-                new TxPoolConfig
-                {
-                    BlobsSupport = BlobsSupportMode.Storage,
-                    PersistentBlobStorageSize = 1
-                },
-                GetCancunSpecProvider(),
-                txStorage: storage);
-            Assert.That(() => storage.ObsoleteRecoveryCount, Is.EqualTo(1).After(Timeout, 10));
-
-            await AddEmptyBlock();
-            Assert.That(
-                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
-                Is.Not.Null.After(Timeout, 10));
-            await AddEmptyBlock();
-
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(2));
-                Assert.That(_txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True);
-            }
-
-            logger.Received(1).Error(
-                Arg.Is<string>(static message => message.Contains("Skipping obsolete full blob transaction recovery")),
-                Arg.Any<Exception>());
-        }
-
-        [Test]
-        [NonParallelizable]
-        public async Task should_cancel_obsolete_full_transaction_recovery_during_shutdown()
-        {
-            InterfaceLogger logger = Substitute.For<InterfaceLogger>();
-            logger.IsWarn.Returns(true);
-            _logManager = new OneLoggerLogManager(new ILogger(logger));
-            TaskCompletionSource recoveryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            TaskCompletionSource<bool> recoveryReleasedAfterCancellation = new(TaskCreationOptions.RunContinuationsAsynchronously);
-            using ManualResetEventSlim releaseRecovery = new(false);
-            FailingBatchDeleteBlobTxStorage storage = new();
-            storage.BeforeObsoleteRecovery = cancellationToken =>
-            {
-                recoveryStarted.TrySetResult();
-                bool released = releaseRecovery.Wait(TimeSpan.FromSeconds(10));
-                recoveryReleasedAfterCancellation.TrySetResult(released && cancellationToken.IsCancellationRequested);
-            };
-            _txPool = CreatePool(
-                new TxPoolConfig
-                {
-                    BlobsSupport = BlobsSupportMode.Storage,
-                    PersistentBlobStorageSize = 1
-                },
-                GetCancunSpecProvider(),
-                txStorage: storage);
-            await recoveryStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
-
-            ValueTask disposal = _txPool.DisposeAsync();
-            releaseRecovery.Set();
-
-            await disposal.AsTask().WaitAsync(TimeSpan.FromSeconds(10));
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(await recoveryReleasedAfterCancellation.Task.WaitAsync(TimeSpan.FromSeconds(10)), Is.True);
-                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(1));
-                Assert.That(storage.ObsoleteRecoveryCancellationCount, Is.EqualTo(1));
-            }
-
-            logger.DidNotReceive().Warn(Arg.Is<string>(static message =>
-                message.Contains("failed to revalidate transactions after a protocol change")));
         }
 
         [Test]
@@ -2091,24 +1864,14 @@ namespace Nethermind.TxPool.Test
         private sealed class FailingBatchDeleteBlobTxStorage : IBlobTxStorage, IBatchDeleteTxStorage, ISpecChangeValidationStorage
         {
             private readonly BlobTxStorage _storage = new();
-            private int _obsoleteRecoveryCount;
-            private int _obsoleteRecoveryCancellationCount;
 
-            public List<int> DeleteBatchSizes { get; } = [];
+            public ConcurrentQueue<int> DeleteBatchSizes { get; } = [];
 
-            public List<int> FullTransactionDeleteBatchSizes { get; } = [];
+            public ConcurrentQueue<int> FullTransactionDeleteBatchSizes { get; } = [];
+
+            public ConcurrentQueue<int> ReplaceDeleteBatchSizes { get; } = [];
 
             public int DeleteManyFailuresRemaining { get; set; } = 1;
-
-            public int ObsoleteRecoveryFailuresRemaining { get; set; }
-
-            public bool FailNextFullTransactionDelete { get; set; }
-
-            public Action<CancellationToken> BeforeObsoleteRecovery { get; set; }
-
-            public int ObsoleteRecoveryCount => Volatile.Read(ref _obsoleteRecoveryCount);
-
-            public int ObsoleteRecoveryCancellationCount => Volatile.Read(ref _obsoleteRecoveryCancellationCount);
 
             public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
                 _storage.TryGet(hash, sender, timestamp, out transaction);
@@ -2142,7 +1905,7 @@ namespace Nethermind.TxPool.Test
 
             void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
             {
-                DeleteBatchSizes.Add(keys.Length);
+                DeleteBatchSizes.Enqueue(keys.Length);
                 if (DeleteManyFailuresRemaining > 0)
                 {
                     DeleteManyFailuresRemaining--;
@@ -2154,35 +1917,14 @@ namespace Nethermind.TxPool.Test
 
             void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys)
             {
-                FullTransactionDeleteBatchSizes.Add(keys.Length);
-                if (FailNextFullTransactionDelete)
-                {
-                    FailNextFullTransactionDelete = false;
-                    throw new InvalidOperationException();
-                }
-
+                FullTransactionDeleteBatchSizes.Enqueue(keys.Length);
                 ((IBatchDeleteTxStorage)_storage).DeleteFullBlobTransactions(keys);
             }
 
-            void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken)
+            void IBatchDeleteTxStorage.Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
             {
-                Interlocked.Increment(ref _obsoleteRecoveryCount);
-                BeforeObsoleteRecovery?.Invoke(cancellationToken);
-                if (ObsoleteRecoveryFailuresRemaining > 0)
-                {
-                    ObsoleteRecoveryFailuresRemaining--;
-                    throw new InvalidOperationException("Simulated obsolete blob transaction recovery failure.");
-                }
-
-                try
-                {
-                    ((IBatchDeleteTxStorage)_storage).DeleteObsoleteFullBlobTransactions(cancellationToken);
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    Interlocked.Increment(ref _obsoleteRecoveryCancellationCount);
-                    throw;
-                }
+                ReplaceDeleteBatchSizes.Enqueue(obsoleteTimestamps.Length);
+                ((IBatchDeleteTxStorage)_storage).Replace(transaction, obsoleteTimestamps);
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -684,6 +684,64 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public async Task should_publish_marker_after_in_flight_blob_update_completes_without_another_head()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider provider = new(Osaka.Instance)
+            {
+                NextForkSpec = Amsterdam.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            using BlockingBlobTxStorage storage = new();
+            _txPool = CreatePool(
+                new TxPoolConfig
+                {
+                    BlobsSupport = BlobsSupportMode.Storage,
+                    BlobCacheSize = 1,
+                    PersistentBlobStorageSize = 1
+                },
+                provider,
+                txStorage: storage);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            Transaction transaction = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+                .WithAccessList(BuildUnderGassedAccessList())
+                .WithGasLimit(UnderGassedTransactionGasLimit)
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            ShardBlobNetworkWrapper wrapper = (ShardBlobNetworkWrapper)transaction.NetworkWrapper!;
+            BlobCellMask initialMask = BlobCellMask.FromIndices([1]);
+            BlobCellMask updateMask = BlobCellMask.FromIndices([3]);
+            Assert.That(BlobCellsHelper.TryGetFlattenedCells(wrapper, updateMask, out byte[][] updateCells), Is.True);
+            ConvertToSparseBlobTransaction(transaction, initialMask);
+            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Task<bool> update = RunOnDedicatedThread(() =>
+                _txPool.TryMergeBlobCells(transaction.Hash!, updateMask, updateCells));
+            Assert.That(storage.WaitForFirstUpdate(TimeSpan.FromSeconds(5)), Is.True);
+            try
+            {
+                await AddEmptyBlock();
+                Assert.That(
+                    () => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader),
+                    Is.True.After(Timeout, 10));
+                Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+            }
+            finally
+            {
+                storage.ReleaseFirstUpdate();
+            }
+
+            Assert.That(await update.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+        }
+
+        [Test]
         public void should_retry_batched_revalidation_deletes_after_storage_failure()
         {
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
@@ -718,6 +776,7 @@ namespace Nethermind.TxPool.Test
             };
             FailingAtomicBlobTxStorage storage = new();
             IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            ManualTimeProvider timeProvider = new();
             Transaction transaction = Build.A.Transaction
                 .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
                 .WithMaxFeePerGas(1.GWei)
@@ -729,7 +788,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(BlobCellsHelper.TryGetFlattenedCells(wrapper, updateMask, out byte[][] updateCells), Is.True);
             ConvertToSparseBlobTransaction(transaction, initialMask);
             storage.Add(transaction);
-            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance, timeProvider);
             IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
             UInt256 originalTimestamp = transaction.Timestamp;
 
@@ -740,6 +799,7 @@ namespace Nethermind.TxPool.Test
             transaction.Timestamp += UInt256.One;
             storage.ReplaceFailuresRemaining = 1;
             Assert.That(() => blobPool.TryInsert(transaction.Hash, transaction, out _), Throws.TypeOf<InvalidOperationException>());
+            Assert.That(blobPool.TryFlushPendingRevalidationDeletes(), Is.False);
 
             Assert.That(
                 blobPool.MergeCells(transaction.Hash!.ValueHash256, updateMask, updateCells),
@@ -747,6 +807,7 @@ namespace Nethermind.TxPool.Test
 
             using (Assert.EnterMultipleScope())
             {
+                Assert.That(blobPool.TryFlushPendingRevalidationDeletes(), Is.True);
                 Assert.That(storage.TryGet(
                     transaction.Hash!.ValueHash256,
                     transaction.SenderAddress!,
@@ -794,6 +855,48 @@ namespace Nethermind.TxPool.Test
                 Assert.That(obsoleteTransactionPersisted, Is.EqualTo(!changeTimestamp));
                 Assert.That(elidedTransactionPersisted, Is.True);
                 Assert.That(storage.GetAll(), Is.Not.Empty);
+            }
+        }
+
+        [Test]
+        public void should_consume_retained_delete_when_non_atomic_storage_reinserts_transaction()
+        {
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
+            UInt256 originalTimestamp = transaction.Timestamp;
+            using BlockingBlobTxStorage innerStorage = new(failedDeleteCount: 1);
+            innerStorage.ReleaseFirstUpdate();
+            NonAtomicBlobTxStorage storage = new(innerStorage);
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+
+            Assert.That(
+                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
+                Throws.TypeOf<InvalidOperationException>());
+            transaction.Timestamp += UInt256.One;
+
+            Assert.That(blobPool.TryInsert(transaction.Hash, transaction, out _), Is.True);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(blobPool.TryFlushPendingRevalidationDeletes(), Is.True);
+                Assert.That(storage.TryGet(
+                    transaction.Hash!.ValueHash256,
+                    transaction.SenderAddress!,
+                    originalTimestamp,
+                    out _), Is.False);
+                Assert.That(storage.TryGet(
+                    transaction.Hash!.ValueHash256,
+                    transaction.SenderAddress!,
+                    transaction.Timestamp,
+                    out _), Is.True);
             }
         }
 
@@ -2021,7 +2124,7 @@ namespace Nethermind.TxPool.Test
             void ISpecChangeValidationStorage.SetSpecChangeValidationMarker(string marker) =>
                 ((ISpecChangeValidationStorage)_storage).SetSpecChangeValidationMarker(marker);
 
-            void IAtomicBlobTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
+            void IAtomicBlobTxStorage.DeleteMany(scoped ReadOnlySpan<BlobTxDeleteKey> keys)
             {
                 DeleteBatchSizes.Enqueue(keys.Length);
                 if (DeleteManyFailuresRemaining > 0)
@@ -3314,15 +3417,22 @@ namespace Nethermind.TxPool.Test
                 .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
             ShardBlobNetworkWrapper fullWrapper = (ShardBlobNetworkWrapper)fullBlobTx.NetworkWrapper!;
             BlobCellMask initialMask = BlobCellMask.FromIndices([1]);
-            BlobCellMask updateMask = BlobCellMask.FromIndices([3]);
-            Assert.That(BlobCellsHelper.TryGetFlattenedCells(fullWrapper, updateMask, out byte[][] updateCells), Is.True);
+            BlobCellMask firstUpdateMask = BlobCellMask.FromIndices([3]);
+            BlobCellMask secondUpdateMask = BlobCellMask.FromIndices([5]);
+            Assert.That(BlobCellsHelper.TryGetFlattenedCells(fullWrapper, firstUpdateMask, out byte[][] firstUpdateCells), Is.True);
+            Assert.That(BlobCellsHelper.TryGetFlattenedCells(fullWrapper, secondUpdateMask, out byte[][] secondUpdateCells), Is.True);
             ConvertToSparseBlobTransaction(fullBlobTx, initialMask);
             Assert.That(blobPool.TryInsert(fullBlobTx.Hash, fullBlobTx, out _), Is.True);
 
-            Task<BlobCellMergeResult> update = RunOnDedicatedThread(() => blobPool.MergeCells(fullBlobTx.Hash!.ValueHash256, updateMask, updateCells));
+            Task<BlobCellMergeResult> update = RunOnDedicatedThread(() =>
+                blobPool.MergeCells(fullBlobTx.Hash!.ValueHash256, firstUpdateMask, firstUpdateCells));
             Assert.That(storage.WaitForFirstUpdate(TimeSpan.FromSeconds(5)), Is.True);
+            Assert.That(
+                blobPool.MergeCells(fullBlobTx.Hash!.ValueHash256, secondUpdateMask, secondUpdateCells),
+                Is.EqualTo(BlobCellMergeResult.Accepted));
             storage.ReleaseFirstUpdate();
             Assert.That(await update, Is.EqualTo(BlobCellMergeResult.Accepted));
+            Assert.That(storage.WaitForSuccessfulUpdate(TimeSpan.FromMilliseconds(100)), Is.False);
 
             timeProvider.AdvanceAndFireTimer(TimeSpan.FromSeconds(1));
             Assert.That(storage.WaitForSuccessfulUpdate(TimeSpan.FromSeconds(1)), Is.True);
@@ -3330,7 +3440,9 @@ namespace Nethermind.TxPool.Test
             Assert.That(storage.TryGet(fullBlobTx.Hash!.ValueHash256, fullBlobTx.SenderAddress!, fullBlobTx.Timestamp, out Transaction storedTx), Is.True);
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(((ShardBlobNetworkWrapper)storedTx.NetworkWrapper!).CellMask, Is.EqualTo(initialMask | updateMask));
+                Assert.That(
+                    ((ShardBlobNetworkWrapper)storedTx.NetworkWrapper!).CellMask,
+                    Is.EqualTo(initialMask | firstUpdateMask | secondUpdateMask));
                 Assert.That(storage.ReplaceDeleteBatchSizes, Is.EqualTo(new[] { 0, 0, 0 }));
             }
         }
@@ -3460,7 +3572,7 @@ namespace Nethermind.TxPool.Test
             try
             {
                 await removal.WaitAsync(TimeSpan.FromSeconds(5));
-                Assert.That(blobPool.FlushPendingRevalidationDeletes(), Is.False);
+                Assert.That(blobPool.TryFlushPendingRevalidationDeletes(), Is.False);
             }
             finally
             {
@@ -3472,7 +3584,7 @@ namespace Nethermind.TxPool.Test
             {
                 Assert.That(updated, Is.EqualTo(BlobCellMergeResult.Accepted));
                 Assert.That(blobPool.Count, Is.Zero);
-                Assert.That(blobPool.FlushPendingRevalidationDeletes(), Is.True);
+                Assert.That(blobPool.TryFlushPendingRevalidationDeletes(), Is.True);
                 Assert.That(storage.WaitForDelete(TimeSpan.FromSeconds(5)), Is.True);
                 Assert.That(storage.TryGet(
                     fullBlobTx.Hash!.ValueHash256,
@@ -4203,6 +4315,29 @@ namespace Nethermind.TxPool.Test
             public void DeleteBlobTransactionsFromBlock(ulong blockNumber) => inner.DeleteBlobTransactionsFromBlock(blockNumber);
         }
 
+        private sealed class NonAtomicBlobTxStorage(BlockingBlobTxStorage inner) : IBlobTxStorage
+        {
+            public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
+                inner.TryGet(hash, sender, timestamp, out transaction);
+
+            public int TryGetMany(TxLookupKey[] keys, int count, Transaction[] results) =>
+                inner.TryGetMany(keys, count, results);
+
+            public IEnumerable<LightTransaction> GetAll() => inner.GetAll();
+
+            public void Add(Transaction transaction) => inner.Add(transaction);
+
+            public void Delete(in ValueHash256 hash, in UInt256 timestamp) => inner.Delete(hash, timestamp);
+
+            public bool TryGetBlobTransactionsFromBlock(ulong blockNumber, out Transaction[] blockBlobTransactions) =>
+                inner.TryGetBlobTransactionsFromBlock(blockNumber, out blockBlobTransactions);
+
+            public void AddBlobTransactionsFromBlock(ulong blockNumber, in ArrayPoolListRef<Transaction> blockBlobTransactions) =>
+                inner.AddBlobTransactionsFromBlock(blockNumber, blockBlobTransactions);
+
+            public void DeleteBlobTransactionsFromBlock(ulong blockNumber) => inner.DeleteBlobTransactionsFromBlock(blockNumber);
+        }
+
         private sealed class RehydratingBlobTxDistinctSortedPool(
             int capacity,
             IComparer<Transaction> comparer,
@@ -4329,6 +4464,7 @@ namespace Nethermind.TxPool.Test
             IBlobTxStorage,
             IBlobTxMetadataStorage,
             IAtomicBlobTxStorage,
+            ISpecChangeValidationStorage,
             IDisposable
         {
             private readonly BlobTxStorage _inner = new();
@@ -4429,7 +4565,7 @@ namespace Nethermind.TxPool.Test
                 Interlocked.Increment(ref _successfulDeleteCount);
             }
 
-            void IAtomicBlobTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
+            void IAtomicBlobTxStorage.DeleteMany(scoped ReadOnlySpan<BlobTxDeleteKey> keys)
             {
                 DeleteBatchSizes.Enqueue(keys.Length);
                 BeforeDelete();
@@ -4453,6 +4589,12 @@ namespace Nethermind.TxPool.Test
                 => _inner.AddBlobTransactionsFromBlock(blockNumber, blockBlobTransactions);
 
             public void DeleteBlobTransactionsFromBlock(ulong blockNumber) => _inner.DeleteBlobTransactionsFromBlock(blockNumber);
+
+            string ISpecChangeValidationStorage.GetSpecChangeValidationMarker() =>
+                ((ISpecChangeValidationStorage)_inner).GetSpecChangeValidationMarker();
+
+            void ISpecChangeValidationStorage.SetSpecChangeValidationMarker(string marker) =>
+                ((ISpecChangeValidationStorage)_inner).SetSpecChangeValidationMarker(marker);
 
             public void Dispose()
             {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -700,6 +700,43 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public void should_preserve_retained_delete_when_replacement_fails()
+        {
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
+            UInt256 originalTimestamp = transaction.Timestamp;
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+
+            Assert.That(
+                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
+                Throws.TypeOf<InvalidOperationException>());
+            transaction.Timestamp += UInt256.One;
+            storage.ReplaceFailuresRemaining = 1;
+            Assert.That(
+                () => blobPool.TryInsert(transaction.Hash, transaction, out _),
+                Throws.TypeOf<InvalidOperationException>());
+
+            Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions), Throws.Nothing);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(blobPool.Count, Is.Zero);
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1 }));
+                Assert.That(storage.TryGet(transaction.Hash, transaction.SenderAddress!, originalTimestamp, out _), Is.False);
+                Assert.That(storage.GetAll(), Is.Empty);
+            }
+        }
+
+        [Test]
         public async Task should_remove_obsolete_full_transaction_after_failed_delete_and_restart()
         {
             TestSpecProvider specProvider = new(Cancun.Instance);
@@ -1872,6 +1909,8 @@ namespace Nethermind.TxPool.Test
 
             public int DeleteManyFailuresRemaining { get; set; } = 1;
 
+            public int ReplaceFailuresRemaining { get; set; }
+
             public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
                 _storage.TryGet(hash, sender, timestamp, out transaction);
 
@@ -1917,6 +1956,12 @@ namespace Nethermind.TxPool.Test
             void IBatchDeleteTxStorage.Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
             {
                 ReplaceDeleteBatchSizes.Enqueue(obsoleteTimestamps.Length);
+                if (ReplaceFailuresRemaining > 0)
+                {
+                    ReplaceFailuresRemaining--;
+                    throw new InvalidOperationException();
+                }
+
                 ((IBatchDeleteTxStorage)_storage).Replace(transaction, obsoleteTimestamps);
             }
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -974,7 +974,12 @@ namespace Nethermind.TxPool.Test
             };
             IComparer<Transaction> comparer = new TransactionComparerProvider(specProvider ?? _specProvider, _blockTree).GetDefaultComparer();
             accounts = Substitute.For<IAccountStateProvider>();
-            return new PersistentBlobTxDistinctSortedPool(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            return new PersistentBlobTxDistinctSortedPool(
+                storage,
+                txPoolConfig,
+                comparer,
+                LimboLogs.Instance,
+                new ManualTimeProvider());
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -5,7 +5,6 @@ using System;
 using CkzgLib;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
-using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -5,6 +5,7 @@ using System;
 using CkzgLib;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
+using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -594,11 +595,9 @@ namespace Nethermind.TxPool.Test
                 BlobsSupport = BlobsSupportMode.Storage,
                 PersistentBlobStorageSize = 1
             };
-            FailingBatchDeleteBlobTxStorage storage = new() { DeleteManyFailuresRemaining = 2 };
+            FailingAtomicBlobTxStorage storage = new() { DeleteManyFailuresRemaining = 2 };
             _txPool = CreatePool(txPoolConfig, provider, txStorage: storage);
-            Assert.That(
-                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
-                Is.Not.Null.After(Timeout, 10));
+            Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Not.Null);
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
@@ -625,14 +624,73 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public void should_not_persist_spec_change_marker_without_validation_fingerprint()
+        {
+            FailingAtomicBlobTxStorage storage = new();
+            _txPool = CreatePool(
+                new TxPoolConfig { BlobsSupport = BlobsSupportMode.Storage },
+                GetCancunSpecProvider(),
+                txStorage: storage,
+                specChangeTxValidator: Always.Valid);
+
+            Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+        }
+
+        [Test]
+        public async Task should_not_publish_marker_when_pending_blob_update_delete_fails()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider provider = new(Osaka.Instance)
+            {
+                NextForkSpec = Amsterdam.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            FailingAtomicBlobTxStorage storage = new()
+            {
+                ReplaceFailuresRemaining = int.MaxValue,
+                DeleteManyFailuresRemaining = int.MaxValue
+            };
+            _txPool = CreatePool(
+                new TxPoolConfig
+                {
+                    BlobsSupport = BlobsSupportMode.Storage,
+                    BlobCacheSize = 1,
+                    PersistentBlobStorageSize = 1
+                },
+                provider,
+                txStorage: storage);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            Transaction transaction = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+                .WithAccessList(BuildUnderGassedAccessList())
+                .WithGasLimit(UnderGassedTransactionGasLimit)
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            ShardBlobNetworkWrapper wrapper = (ShardBlobNetworkWrapper)transaction.NetworkWrapper!;
+            BlobCellMask initialMask = BlobCellMask.FromIndices([1]);
+            BlobCellMask updateMask = BlobCellMask.FromIndices([3]);
+            Assert.That(BlobCellsHelper.TryGetFlattenedCells(wrapper, updateMask, out byte[][] updateCells), Is.True);
+            ConvertToSparseBlobTransaction(transaction, initialMask);
+            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.TryMergeBlobCells(transaction.Hash!, updateMask, updateCells), Is.True);
+
+            await AddEmptyBlock();
+
+            Assert.That(() => storage.DeleteBatchSizes.Count, Is.GreaterThanOrEqualTo(1).After(Timeout, 10));
+            Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+        }
+
+        [Test]
         public void should_retry_batched_revalidation_deletes_after_storage_failure()
         {
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
             Transaction secondTransaction = CreateBlobTx(TestItem.PrivateKeyB);
             using PersistentBlobTxDistinctSortedPool blobPool = CreateFailingBlobPool(
                 transaction,
-                out FailingBatchDeleteBlobTxStorage storage,
-                out _,
+                out FailingAtomicBlobTxStorage storage,
                 out IAccountStateProvider accounts);
 
             Assert.That(
@@ -657,8 +715,7 @@ namespace Nethermind.TxPool.Test
             UInt256 originalTimestamp = transaction.Timestamp;
             using PersistentBlobTxDistinctSortedPool blobPool = CreateFailingBlobPool(
                 transaction,
-                out FailingBatchDeleteBlobTxStorage storage,
-                out _,
+                out FailingAtomicBlobTxStorage storage,
                 out IAccountStateProvider accounts);
 
             Assert.That(
@@ -694,8 +751,7 @@ namespace Nethermind.TxPool.Test
             UInt256 originalTimestamp = transaction.Timestamp;
             using PersistentBlobTxDistinctSortedPool blobPool = CreateFailingBlobPool(
                 transaction,
-                out FailingBatchDeleteBlobTxStorage storage,
-                out _,
+                out FailingAtomicBlobTxStorage storage,
                 out IAccountStateProvider accounts);
 
             Assert.That(
@@ -712,80 +768,49 @@ namespace Nethermind.TxPool.Test
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(blobPool.Count, Is.Zero);
-                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1 }));
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 2 }));
                 Assert.That(storage.TryGet(transaction.Hash, transaction.SenderAddress!, originalTimestamp, out _), Is.False);
                 Assert.That(storage.GetAll(), Is.Empty);
             }
         }
 
         [Test]
-        public async Task should_remove_obsolete_full_transaction_after_failed_delete_and_restart()
+        public void should_delete_newer_body_after_replacement_commits_then_throws()
         {
-            TestSpecProvider specProvider = new(Cancun.Instance);
-            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
-            UInt256 originalTimestamp = transaction.Timestamp;
-            FailingBatchDeleteBlobTxStorage storage;
-            TxPoolConfig txPoolConfig;
-            using (PersistentBlobTxDistinctSortedPool blobPool = CreateFailingBlobPool(
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
+            using PersistentBlobTxDistinctSortedPool blobPool = CreateFailingBlobPool(
                 transaction,
-                out storage,
-                out txPoolConfig,
-                out IAccountStateProvider accounts,
-                specProvider))
-            {
-                Assert.That(
-                    () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
-                    Throws.TypeOf<InvalidOperationException>());
-
-                transaction.Timestamp += UInt256.One;
-                Assert.That(blobPool.TryInsert(transaction.Hash, transaction, out _), Is.True);
-                Assert.That(
-                    () => blobPool.UpdatePoolForRevalidation(accounts, KeepAllTransactions),
-                    Throws.Nothing);
-                Assert.That(storage.ReplaceDeleteBatchSizes, Is.EqualTo(new[] { 1 }));
-            }
-
-            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
-            _txPool = CreatePool(txPoolConfig, specProvider, txStorage: storage);
-            await AddEmptyBlock();
+                out FailingAtomicBlobTxStorage storage,
+                out IAccountStateProvider accounts);
             Assert.That(
-                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
-                Is.Not.Null.After(Timeout, 10));
+                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
+                Throws.TypeOf<InvalidOperationException>());
+            transaction.Timestamp += UInt256.One;
+            storage.ReplaceFailuresAfterWriteRemaining = 1;
+            Assert.That(
+                () => blobPool.TryInsert(transaction.Hash, transaction, out _),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(storage.TryGet(transaction.Hash, transaction.SenderAddress!, transaction.Timestamp, out _), Is.True);
 
-            bool currentTransactionPersisted = storage.TryGet(
-                transaction.Hash,
-                transaction.SenderAddress!,
-                transaction.Timestamp,
-                out _);
-            bool obsoleteTransactionPersisted = storage.TryGet(
-                transaction.Hash,
-                transaction.SenderAddress!,
-                originalTimestamp,
-                out _);
-            bool elidedTransactionPersisted = storage.TryGetWithoutBlobs(
-                transaction.Hash,
-                transaction.SenderAddress!,
-                out _);
+            Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions), Throws.Nothing);
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(currentTransactionPersisted, Is.True);
-                Assert.That(obsoleteTransactionPersisted, Is.False);
-                Assert.That(elidedTransactionPersisted, Is.True);
-                Assert.That(storage.GetAll(), Is.Not.Empty);
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 2 }));
+                Assert.That(storage.TryGet(transaction.Hash, transaction.SenderAddress!, transaction.Timestamp, out _), Is.False);
+                Assert.That(storage.GetAll(), Is.Empty);
             }
         }
 
         private PersistentBlobTxDistinctSortedPool CreateFailingBlobPool(
             Transaction transaction,
-            out FailingBatchDeleteBlobTxStorage storage,
-            out TxPoolConfig txPoolConfig,
+            out FailingAtomicBlobTxStorage storage,
             out IAccountStateProvider accounts,
             ISpecProvider specProvider = null)
         {
-            storage = new FailingBatchDeleteBlobTxStorage();
+            storage = new FailingAtomicBlobTxStorage();
             storage.Add(transaction);
-            txPoolConfig = new TxPoolConfig
+            TxPoolConfig txPoolConfig = new()
             {
                 BlobsSupport = BlobsSupportMode.Storage,
                 BlobCacheSize = 1,
@@ -1897,7 +1922,7 @@ namespace Nethermind.TxPool.Test
             public void ResetFullReadCount() => FullReadCount = 0;
         }
 
-        private sealed class FailingBatchDeleteBlobTxStorage : IBlobTxStorage, IBatchDeleteTxStorage, ISpecChangeValidationStorage
+        private sealed class FailingAtomicBlobTxStorage : IBlobTxStorage, IBlobTxMetadataStorage, IAtomicBlobTxStorage, ISpecChangeValidationStorage
         {
             private readonly BlobTxStorage _storage = new();
 
@@ -1909,11 +1934,15 @@ namespace Nethermind.TxPool.Test
 
             public int ReplaceFailuresRemaining { get; set; }
 
+            public int ReplaceFailuresAfterWriteRemaining { get; set; }
+
             public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
                 _storage.TryGet(hash, sender, timestamp, out transaction);
 
             public bool TryGetWithoutBlobs(in ValueHash256 hash, Address sender, out Transaction transaction) =>
                 _storage.TryGetWithoutBlobs(hash, sender, out transaction);
+
+            public void AddWithoutBlobs(Transaction transaction) => _storage.AddWithoutBlobs(transaction);
 
             public int TryGetMany(TxLookupKey[] keys, int count, Transaction[] results) =>
                 _storage.TryGetMany(keys, count, results);
@@ -1939,7 +1968,7 @@ namespace Nethermind.TxPool.Test
             void ISpecChangeValidationStorage.SetSpecChangeValidationMarker(string marker) =>
                 ((ISpecChangeValidationStorage)_storage).SetSpecChangeValidationMarker(marker);
 
-            void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
+            void IAtomicBlobTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
             {
                 DeleteBatchSizes.Enqueue(keys.Length);
                 if (DeleteManyFailuresRemaining > 0)
@@ -1948,10 +1977,10 @@ namespace Nethermind.TxPool.Test
                     throw new InvalidOperationException();
                 }
 
-                ((IBatchDeleteTxStorage)_storage).DeleteMany(keys);
+                ((IAtomicBlobTxStorage)_storage).DeleteMany(keys);
             }
 
-            void IBatchDeleteTxStorage.Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
+            void IAtomicBlobTxStorage.Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
             {
                 ReplaceDeleteBatchSizes.Enqueue(obsoleteTimestamps.Length);
                 if (ReplaceFailuresRemaining > 0)
@@ -1960,7 +1989,12 @@ namespace Nethermind.TxPool.Test
                     throw new InvalidOperationException();
                 }
 
-                ((IBatchDeleteTxStorage)_storage).Replace(transaction, obsoleteTimestamps);
+                ((IAtomicBlobTxStorage)_storage).Replace(transaction, obsoleteTimestamps);
+                if (ReplaceFailuresAfterWriteRemaining > 0)
+                {
+                    ReplaceFailuresAfterWriteRemaining--;
+                    throw new InvalidOperationException();
+                }
             }
         }
 
@@ -3241,7 +3275,11 @@ namespace Nethermind.TxPool.Test
             Assert.That(storage.WaitForSuccessfulUpdate(TimeSpan.FromSeconds(1)), Is.True);
 
             Assert.That(storage.TryGet(fullBlobTx.Hash!.ValueHash256, fullBlobTx.SenderAddress!, fullBlobTx.Timestamp, out Transaction storedTx), Is.True);
-            Assert.That(((ShardBlobNetworkWrapper)storedTx.NetworkWrapper!).CellMask, Is.EqualTo(initialMask | updateMask));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(((ShardBlobNetworkWrapper)storedTx.NetworkWrapper!).CellMask, Is.EqualTo(initialMask | updateMask));
+                Assert.That(storage.ReplaceDeleteBatchSizes, Is.EqualTo(new[] { 0, 0, 0 }));
+            }
         }
 
         [Test]
@@ -3481,6 +3519,12 @@ namespace Nethermind.TxPool.Test
                         fullBlobTx.SenderAddress!,
                         removedTimestamp,
                         out _), Is.False);
+                }
+
+                Assert.That(storage.ReplaceDeleteBatchSizes, Does.Contain(1));
+                if (changeTimestamp && failReinsertion && removeAfterFailedReinsertion)
+                {
+                    Assert.That(storage.DeleteBatchSizes, Does.Contain(2));
                 }
             }
         }
@@ -4222,7 +4266,11 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        private sealed class BlockingBlobTxStorage(int failedUpdateCount = 0, int failedDeleteCount = 0) : IBlobTxStorage, IBlobTxMetadataStorage, IDisposable
+        private sealed class BlockingBlobTxStorage(int failedUpdateCount = 0, int failedDeleteCount = 0) :
+            IBlobTxStorage,
+            IBlobTxMetadataStorage,
+            IAtomicBlobTxStorage,
+            IDisposable
         {
             private readonly BlobTxStorage _inner = new();
             private readonly ManualResetEventSlim _firstUpdateEntered = new();
@@ -4233,6 +4281,10 @@ namespace Nethermind.TxPool.Test
             private int _remainingDeleteFailures = failedDeleteCount;
             private int _successfulDeleteCount;
             private int _addCount;
+
+            public ConcurrentQueue<int> DeleteBatchSizes { get; } = [];
+
+            public ConcurrentQueue<int> ReplaceDeleteBatchSizes { get; } = [];
 
             public bool WaitForFirstUpdate(TimeSpan timeout) => _firstUpdateEntered.Wait(timeout);
 
@@ -4258,7 +4310,27 @@ namespace Nethermind.TxPool.Test
 
             public IEnumerable<LightTransaction> GetAll() => _inner.GetAll();
 
-            public void Add(Transaction transaction)
+            public void Add(Transaction transaction) => Persist(transaction, [], replace: false);
+
+            void IAtomicBlobTxStorage.Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
+            {
+                ReplaceDeleteBatchSizes.Enqueue(obsoleteTimestamps.Length);
+                if (!obsoleteTimestamps.IsEmpty)
+                {
+                    BeforeDelete();
+                }
+
+                Persist(transaction, obsoleteTimestamps, replace: true);
+                if (!obsoleteTimestamps.IsEmpty)
+                {
+                    Interlocked.Add(ref _successfulDeleteCount, obsoleteTimestamps.Length);
+                }
+            }
+
+            private void Persist(
+                Transaction transaction,
+                scoped ReadOnlySpan<UInt256> obsoleteTimestamps,
+                bool replace)
             {
                 int addCount = Interlocked.Increment(ref _addCount);
                 if (addCount == 2)
@@ -4276,7 +4348,15 @@ namespace Nethermind.TxPool.Test
                     throw new InvalidOperationException("Transient sparse blob update failure.");
                 }
 
-                _inner.Add(transaction);
+                if (replace)
+                {
+                    ((IAtomicBlobTxStorage)_inner).Replace(transaction, obsoleteTimestamps);
+                }
+                else
+                {
+                    _inner.Add(transaction);
+                }
+
                 if (addCount > 1)
                 {
                     _successfulUpdate.Set();
@@ -4285,14 +4365,26 @@ namespace Nethermind.TxPool.Test
 
             public void Delete(in ValueHash256 hash, in UInt256 timestamp)
             {
+                BeforeDelete();
+                _inner.Delete(hash, timestamp);
+                Interlocked.Increment(ref _successfulDeleteCount);
+            }
+
+            void IAtomicBlobTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
+            {
+                DeleteBatchSizes.Enqueue(keys.Length);
+                BeforeDelete();
+                ((IAtomicBlobTxStorage)_inner).DeleteMany(keys);
+                Interlocked.Add(ref _successfulDeleteCount, keys.Length);
+            }
+
+            private void BeforeDelete()
+            {
                 _deleteEntered.Set();
                 if (Interlocked.Decrement(ref _remainingDeleteFailures) >= 0)
                 {
                     throw new InvalidOperationException("Transient sparse blob delete failure.");
                 }
-
-                _inner.Delete(hash, timestamp);
-                Interlocked.Increment(ref _successfulDeleteCount);
             }
 
             public bool TryGetBlobTransactionsFromBlock(ulong blockNumber, out Transaction[] blockBlobTransactions)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -628,6 +628,7 @@ namespace Nethermind.TxPool.Test
         public void should_retry_batched_revalidation_deletes_after_storage_failure()
         {
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
+            Transaction secondTransaction = CreateBlobTx(TestItem.PrivateKeyB);
             FailingBatchDeleteBlobTxStorage storage = new();
             storage.Add(transaction);
             TxPoolConfig txPoolConfig = new()
@@ -643,12 +644,14 @@ namespace Nethermind.TxPool.Test
             Assert.That(
                 () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
                 Throws.TypeOf<InvalidOperationException>());
+            Assert.That(blobPool.TryInsert(secondTransaction.Hash, secondTransaction, out _), Is.True);
+            storage.DeleteManyFailuresRemaining = 1;
             Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions), Throws.Nothing);
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(blobPool.Count, Is.Zero);
-                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1 }));
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1, 2 }));
             }
         }
 
@@ -688,7 +691,6 @@ namespace Nethermind.TxPool.Test
             {
                 Assert.That(blobPool.Count, Is.EqualTo(1));
                 Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1 }));
-                Assert.That(storage.FullTransactionDeleteBatchSizes, Is.Empty);
                 Assert.That(storage.ReplaceDeleteBatchSizes, Is.EqualTo(new[] { 1 }));
                 Assert.That(persisted, Is.True);
                 Assert.That(obsoleteTransactionPersisted, Is.EqualTo(!changeTimestamp));
@@ -1866,8 +1868,6 @@ namespace Nethermind.TxPool.Test
 
             public ConcurrentQueue<int> DeleteBatchSizes { get; } = [];
 
-            public ConcurrentQueue<int> FullTransactionDeleteBatchSizes { get; } = [];
-
             public ConcurrentQueue<int> ReplaceDeleteBatchSizes { get; } = [];
 
             public int DeleteManyFailuresRemaining { get; set; } = 1;
@@ -1912,12 +1912,6 @@ namespace Nethermind.TxPool.Test
                 }
 
                 ((IBatchDeleteTxStorage)_storage).DeleteMany(keys);
-            }
-
-            void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys)
-            {
-                FullTransactionDeleteBatchSizes.Enqueue(keys.Length);
-                ((IBatchDeleteTxStorage)_storage).DeleteFullBlobTransactions(keys);
             }
 
             void IBatchDeleteTxStorage.Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -707,6 +707,59 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        [Test]
+        public void should_retain_pending_revalidation_delete_through_failed_reinsertion_update()
+        {
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            FailingAtomicBlobTxStorage storage = new();
+            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            Transaction transaction = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+            ShardBlobNetworkWrapper wrapper = (ShardBlobNetworkWrapper)transaction.NetworkWrapper!;
+            BlobCellMask initialMask = BlobCellMask.FromIndices([1]);
+            BlobCellMask updateMask = BlobCellMask.FromIndices([3]);
+            Assert.That(BlobCellsHelper.TryGetFlattenedCells(wrapper, updateMask, out byte[][] updateCells), Is.True);
+            ConvertToSparseBlobTransaction(transaction, initialMask);
+            storage.Add(transaction);
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+            UInt256 originalTimestamp = transaction.Timestamp;
+
+            Assert.That(
+                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
+                Throws.TypeOf<InvalidOperationException>());
+
+            transaction.Timestamp += UInt256.One;
+            storage.ReplaceFailuresRemaining = 1;
+            Assert.That(() => blobPool.TryInsert(transaction.Hash, transaction, out _), Throws.TypeOf<InvalidOperationException>());
+
+            Assert.That(
+                blobPool.MergeCells(transaction.Hash!.ValueHash256, updateMask, updateCells),
+                Is.EqualTo(BlobCellMergeResult.Accepted));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(storage.TryGet(
+                    transaction.Hash!.ValueHash256,
+                    transaction.SenderAddress!,
+                    originalTimestamp,
+                    out _), Is.False);
+                Assert.That(storage.TryGet(
+                    transaction.Hash!.ValueHash256,
+                    transaction.SenderAddress!,
+                    transaction.Timestamp,
+                    out _), Is.True);
+            }
+        }
+
         [TestCase(false)]
         [TestCase(true)]
         public void should_not_retry_stale_revalidation_delete_after_transaction_is_reinserted(bool changeTimestamp)
@@ -3398,11 +3451,16 @@ namespace Nethermind.TxPool.Test
 
             Task<BlobCellMergeResult> update = RunOnDedicatedThread(() => blobPool.MergeCells(fullBlobTx.Hash!.ValueHash256, updateMask, updateCells));
             Assert.That(storage.WaitForFirstUpdate(TimeSpan.FromSeconds(5)), Is.True);
-            Task<bool> removal = RunOnDedicatedThread(() => blobPool.TryRemove(fullBlobTx.Hash!.ValueHash256));
-            bool removed;
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+            Task<bool> removal = RunOnDedicatedThread(() =>
+            {
+                blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions);
+                return true;
+            });
             try
             {
-                removed = await removal.WaitAsync(TimeSpan.FromSeconds(5));
+                await removal.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.That(blobPool.FlushPendingRevalidationDeletes(), Is.False);
             }
             finally
             {
@@ -3413,7 +3471,8 @@ namespace Nethermind.TxPool.Test
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(updated, Is.EqualTo(BlobCellMergeResult.Accepted));
-                Assert.That(removed, Is.True);
+                Assert.That(blobPool.Count, Is.Zero);
+                Assert.That(blobPool.FlushPendingRevalidationDeletes(), Is.True);
                 Assert.That(storage.WaitForDelete(TimeSpan.FromSeconds(5)), Is.True);
                 Assert.That(storage.TryGet(
                     fullBlobTx.Hash!.ValueHash256,

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -629,17 +629,11 @@ namespace Nethermind.TxPool.Test
         {
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
             Transaction secondTransaction = CreateBlobTx(TestItem.PrivateKeyB);
-            FailingBatchDeleteBlobTxStorage storage = new();
-            storage.Add(transaction);
-            TxPoolConfig txPoolConfig = new()
-            {
-                BlobsSupport = BlobsSupportMode.Storage,
-                BlobCacheSize = 1,
-                PersistentBlobStorageSize = 2
-            };
-            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
-            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
-            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+            using PersistentBlobTxDistinctSortedPool blobPool = CreateFailingBlobPool(
+                transaction,
+                out FailingBatchDeleteBlobTxStorage storage,
+                out _,
+                out IAccountStateProvider accounts);
 
             Assert.That(
                 () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
@@ -661,17 +655,11 @@ namespace Nethermind.TxPool.Test
         {
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
             UInt256 originalTimestamp = transaction.Timestamp;
-            FailingBatchDeleteBlobTxStorage storage = new();
-            storage.Add(transaction);
-            TxPoolConfig txPoolConfig = new()
-            {
-                BlobsSupport = BlobsSupportMode.Storage,
-                BlobCacheSize = 1,
-                PersistentBlobStorageSize = 2
-            };
-            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
-            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
-            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+            using PersistentBlobTxDistinctSortedPool blobPool = CreateFailingBlobPool(
+                transaction,
+                out FailingBatchDeleteBlobTxStorage storage,
+                out _,
+                out IAccountStateProvider accounts);
 
             Assert.That(
                 () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
@@ -704,17 +692,11 @@ namespace Nethermind.TxPool.Test
         {
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
             UInt256 originalTimestamp = transaction.Timestamp;
-            FailingBatchDeleteBlobTxStorage storage = new();
-            storage.Add(transaction);
-            TxPoolConfig txPoolConfig = new()
-            {
-                BlobsSupport = BlobsSupportMode.Storage,
-                BlobCacheSize = 1,
-                PersistentBlobStorageSize = 2
-            };
-            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
-            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
-            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+            using PersistentBlobTxDistinctSortedPool blobPool = CreateFailingBlobPool(
+                transaction,
+                out FailingBatchDeleteBlobTxStorage storage,
+                out _,
+                out IAccountStateProvider accounts);
 
             Assert.That(
                 () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
@@ -742,18 +724,14 @@ namespace Nethermind.TxPool.Test
             TestSpecProvider specProvider = new(Cancun.Instance);
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
             UInt256 originalTimestamp = transaction.Timestamp;
-            FailingBatchDeleteBlobTxStorage storage = new();
-            storage.Add(transaction);
-            TxPoolConfig txPoolConfig = new()
-            {
-                BlobsSupport = BlobsSupportMode.Storage,
-                BlobCacheSize = 1,
-                PersistentBlobStorageSize = 2
-            };
-            IComparer<Transaction> comparer = new TransactionComparerProvider(specProvider, _blockTree).GetDefaultComparer();
-            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
-
-            using (PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance))
+            FailingBatchDeleteBlobTxStorage storage;
+            TxPoolConfig txPoolConfig;
+            using (PersistentBlobTxDistinctSortedPool blobPool = CreateFailingBlobPool(
+                transaction,
+                out storage,
+                out txPoolConfig,
+                out IAccountStateProvider accounts,
+                specProvider))
             {
                 Assert.That(
                     () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
@@ -796,6 +774,26 @@ namespace Nethermind.TxPool.Test
                 Assert.That(elidedTransactionPersisted, Is.True);
                 Assert.That(storage.GetAll(), Is.Not.Empty);
             }
+        }
+
+        private PersistentBlobTxDistinctSortedPool CreateFailingBlobPool(
+            Transaction transaction,
+            out FailingBatchDeleteBlobTxStorage storage,
+            out TxPoolConfig txPoolConfig,
+            out IAccountStateProvider accounts,
+            ISpecProvider specProvider = null)
+        {
+            storage = new FailingBatchDeleteBlobTxStorage();
+            storage.Add(transaction);
+            txPoolConfig = new TxPoolConfig
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            IComparer<Transaction> comparer = new TransactionComparerProvider(specProvider ?? _specProvider, _blockTree).GetDefaultComparer();
+            accounts = Substitute.For<IAccountStateProvider>();
+            return new PersistentBlobTxDistinctSortedPool(storage, txPoolConfig, comparer, LimboLogs.Instance);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -690,6 +690,17 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public void should_keep_latest_revalidation_request_when_an_older_request_arrives_last()
+        {
+            LatestRevalidationRequest request = new();
+
+            request.Update(2);
+            request.Update(1);
+
+            Assert.That(request.Generation, Is.EqualTo(2));
+        }
+
+        [Test]
         public async Task should_retry_spec_change_revalidation_after_failure()
         {
             Block head = _blockTree.Head;

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -296,18 +296,26 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
 
         using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
-        IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
-        IWriteBatch lightBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs);
-        Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
-        Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
-        for (int i = 0; i < keys.Length; i++)
+        try
         {
-            ref readonly TxLookupKey key = ref keys[i];
-            GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
-            fullBlobTxsBatch.Remove(txHashPrefixed);
-            GetElidedTxKey(key.Hash, elidedKey);
-            fullBlobTxsBatch.Remove(elidedKey);
-            lightBlobTxsBatch.Remove(key.Hash.BytesAsSpan);
+            IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
+            IWriteBatch lightBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs);
+            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
+            Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
+            for (int i = 0; i < keys.Length; i++)
+            {
+                ref readonly TxLookupKey key = ref keys[i];
+                GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
+                fullBlobTxsBatch.Remove(txHashPrefixed);
+                GetElidedTxKey(key.Hash, elidedKey);
+                fullBlobTxsBatch.Remove(elidedKey);
+                lightBlobTxsBatch.Remove(key.Hash.BytesAsSpan);
+            }
+        }
+        catch
+        {
+            batch.Clear();
+            throw;
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -21,7 +21,6 @@ namespace Nethermind.TxPool;
 public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage, IBlobTxMetadataStorage, ISpecChangeValidationStorage, IBatchDeleteTxStorage
 {
     private const int MaxPooledKeys = 128;
-    private const int ObsoleteSweepBatchSize = 16;
     private const int TransactionLockCount = 64;
 
     // Sidecar-free records live in the full-txs column under a key shape (prefix + hash) that
@@ -116,6 +115,12 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     }
 
     public void Add(Transaction transaction)
+        => Replace(transaction, []);
+
+    void IBatchDeleteTxStorage.Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
+        => Replace(transaction, obsoleteTimestamps);
+
+    private void Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
     {
         if (transaction?.Hash is null)
         {
@@ -125,12 +130,26 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         ValueHash256 hash = transaction.Hash.ValueHash256;
         lock (GetTransactionLock(hash))
         {
-            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
-            GetHashPrefixedByTimestamp(transaction.Timestamp, hash, txHashPrefixed);
+            using ArrayPoolSpan<byte> fullRlp = _txDecoder.EncodeToArrayPoolSpan(
+                transaction,
+                RlpBehaviors.InMempoolForm | RlpBehaviors.Storage);
+            byte[] lightRlp = LightTxDecoder.Encode(transaction);
 
-            EncodeAndSaveTx(transaction, _fullBlobTxsDb, txHashPrefixed);
-            SaveWithoutBlobsIfMissing(transaction);
-            _lightBlobTxsDb.Set(transaction.Hash, LightTxDecoder.Encode(transaction));
+            Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
+            GetElidedTxKey(hash, elidedKey);
+            bool writeElided = transaction.NetworkWrapper is ShardBlobNetworkWrapper
+                && !_fullBlobTxsDb.KeyExists(elidedKey);
+            if (writeElided)
+            {
+                using ArrayPoolSpan<byte> elidedRlp = _txDecoder.EncodeToArrayPoolSpan(
+                    BlobTransactionPayload.Elide(transaction),
+                    RlpBehaviors.InMempoolForm);
+                WriteTransaction(transaction, obsoleteTimestamps, fullRlp, lightRlp, elidedKey, elidedRlp);
+            }
+            else
+            {
+                WriteTransaction(transaction, obsoleteTimestamps, fullRlp, lightRlp, elidedKey, []);
+            }
         }
     }
 
@@ -198,46 +217,35 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys) =>
         DeleteMany(keys, deleteSharedEntries: false);
 
-    void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken)
+    private void WriteTransaction(
+        Transaction transaction,
+        scoped ReadOnlySpan<UInt256> obsoleteTimestamps,
+        scoped ReadOnlySpan<byte> fullRlp,
+        byte[] lightRlp,
+        scoped ReadOnlySpan<byte> elidedKey,
+        scoped ReadOnlySpan<byte> elidedRlp)
     {
-        using ArrayPoolList<TxLookupKey> candidates = new(ObsoleteSweepBatchSize);
-        foreach (byte[] key in _fullBlobTxsDb.GetAllKeys())
+        ValueHash256 hash = transaction.Hash!.ValueHash256;
+        using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
+        IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
+        Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
+        for (int i = 0; i < obsoleteTimestamps.Length; i++)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Elided and marker keys share this column; only timestamp-prefixed full bodies are 64 bytes.
-            if (key.Length != FullTxKeyLength)
-            {
-                continue;
-            }
-
-            TxLookupKey candidate = new(
-                new ValueHash256(key.AsSpan(32)),
-                Address.Zero,
-                new UInt256(key.AsSpan(0, 32), isBigEndian: true));
-            if (IsCurrentFullBlobTransaction(candidate))
-            {
-                continue;
-            }
-
-            candidates.Add(candidate);
-
-            if (candidates.Count == ObsoleteSweepBatchSize)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                DeleteMany(candidates.AsSpan(), deleteSharedEntries: false, deleteOnlyIfObsolete: true);
-                candidates.Clear();
-            }
+            GetHashPrefixedByTimestamp(obsoleteTimestamps[i], hash, txHashPrefixed);
+            fullBlobTxsBatch.Remove(txHashPrefixed);
         }
 
-        cancellationToken.ThrowIfCancellationRequested();
-        DeleteMany(candidates.AsSpan(), deleteSharedEntries: false, deleteOnlyIfObsolete: true);
+        GetHashPrefixedByTimestamp(transaction.Timestamp, hash, txHashPrefixed);
+        fullBlobTxsBatch.PutSpan(txHashPrefixed, fullRlp);
+        if (!elidedRlp.IsEmpty)
+        {
+            fullBlobTxsBatch.PutSpan(elidedKey, elidedRlp);
+        }
+
+        batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs).Set(hash.BytesAsSpan, lightRlp);
     }
 
-    private void DeleteMany(
-        scoped ReadOnlySpan<TxLookupKey> keys,
-        bool deleteSharedEntries,
-        bool deleteOnlyIfObsolete = false)
+    private void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys, bool deleteSharedEntries)
     {
         if (keys.IsEmpty)
         {
@@ -263,24 +271,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
                 }
             }
 
-            if (deleteOnlyIfObsolete)
-            {
-                using ArrayPoolList<TxLookupKey> obsoleteKeys = new(keys.Length);
-                for (int i = 0; i < keys.Length; i++)
-                {
-                    ref readonly TxLookupKey key = ref keys[i];
-                    if (!IsCurrentFullBlobTransaction(key))
-                    {
-                        obsoleteKeys.Add(key);
-                    }
-                }
-
-                DeleteManyFromStorage(obsoleteKeys.AsSpan(), deleteSharedEntries);
-            }
-            else
-            {
-                DeleteManyFromStorage(keys, deleteSharedEntries);
-            }
+            DeleteManyFromStorage(keys, deleteSharedEntries);
         }
         finally
         {
@@ -318,11 +309,6 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             }
         }
     }
-
-    private bool IsCurrentFullBlobTransaction(in TxLookupKey key) =>
-        TryDecodeLightTx(_lightBlobTxsDb.Get(key.Hash.BytesAsSpan), out LightTransaction? currentTransaction)
-        && currentTransaction is not null
-        && currentTransaction.Timestamp == key.Timestamp;
 
     string? ISpecChangeValidationStorage.GetSpecChangeValidationMarker()
     {
@@ -449,12 +435,6 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
 
         return locks;
-    }
-
-    private void EncodeAndSaveTx(Transaction transaction, IDb db, scoped Span<byte> txHashPrefixed)
-    {
-        using ArrayPoolSpan<byte> rlp = _txDecoder.EncodeToArrayPoolSpan(transaction, RlpBehaviors.InMempoolForm | RlpBehaviors.Storage);
-        db.PutSpan(txHashPrefixed, rlp);
     }
 
     private void EncodeAndSaveTxs(in ArrayPoolListRef<Transaction> blockBlobTransactions, IDb db, ulong blockNumber)

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -18,7 +18,7 @@ using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.TxPool;
 
-public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage, IBlobTxMetadataStorage, ISpecChangeValidationStorage, IBatchDeleteTxStorage
+public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage, IBlobTxMetadataStorage, ISpecChangeValidationStorage, IAtomicBlobTxStorage
 {
     private const int MaxPooledKeys = 128;
     private const int TransactionLockCount = 64;
@@ -117,7 +117,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     public void Add(Transaction transaction)
         => Replace(transaction, []);
 
-    void IBatchDeleteTxStorage.Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
+    void IAtomicBlobTxStorage.Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
         => Replace(transaction, obsoleteTimestamps);
 
     private void Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
@@ -211,7 +211,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
     }
 
-    void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys) =>
+    void IAtomicBlobTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys) =>
         DeleteMany(keys);
 
     private void WriteTransaction(
@@ -224,23 +224,31 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     {
         ValueHash256 hash = transaction.Hash!.ValueHash256;
         using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
-        IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
-        Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
-        // Obsolete timestamps can include the current one; remove first so the ordered batch's final put preserves it.
-        for (int i = 0; i < obsoleteTimestamps.Length; i++)
+        try
         {
-            GetHashPrefixedByTimestamp(obsoleteTimestamps[i], hash, txHashPrefixed);
-            fullBlobTxsBatch.Remove(txHashPrefixed);
-        }
+            IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
+            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
+            // Obsolete timestamps can include the current one; remove first so the ordered batch's final put preserves it.
+            for (int i = 0; i < obsoleteTimestamps.Length; i++)
+            {
+                GetHashPrefixedByTimestamp(obsoleteTimestamps[i], hash, txHashPrefixed);
+                fullBlobTxsBatch.Remove(txHashPrefixed);
+            }
 
-        GetHashPrefixedByTimestamp(transaction.Timestamp, hash, txHashPrefixed);
-        fullBlobTxsBatch.PutSpan(txHashPrefixed, fullRlp);
-        if (!elidedRlp.IsEmpty)
+            GetHashPrefixedByTimestamp(transaction.Timestamp, hash, txHashPrefixed);
+            fullBlobTxsBatch.PutSpan(txHashPrefixed, fullRlp);
+            if (!elidedRlp.IsEmpty)
+            {
+                fullBlobTxsBatch.PutSpan(elidedKey, elidedRlp);
+            }
+
+            batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs).Set(hash.BytesAsSpan, lightRlp);
+        }
+        catch
         {
-            fullBlobTxsBatch.PutSpan(elidedKey, elidedRlp);
+            batch.Clear();
+            throw;
         }
-
-        batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs).Set(hash.BytesAsSpan, lightRlp);
     }
 
     private void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -136,10 +136,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             byte[] lightRlp = LightTxDecoder.Encode(transaction);
 
             Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
-            GetElidedTxKey(hash, elidedKey);
-            bool writeElided = transaction.NetworkWrapper is ShardBlobNetworkWrapper
-                && !_fullBlobTxsDb.KeyExists(elidedKey);
-            if (writeElided)
+            if (ShouldWriteElided(transaction, elidedKey))
             {
                 using ArrayPoolSpan<byte> elidedRlp = _txDecoder.EncodeToArrayPoolSpan(
                     BlobTransactionPayload.Elide(transaction),
@@ -177,14 +174,8 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
 
     private void SaveWithoutBlobsIfMissing(Transaction transaction)
     {
-        if (transaction.NetworkWrapper is not ShardBlobNetworkWrapper)
-        {
-            return;
-        }
-
         Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
-        GetElidedTxKey(transaction.Hash, elidedKey);
-        if (_fullBlobTxsDb.KeyExists(elidedKey))
+        if (!ShouldWriteElided(transaction, elidedKey))
         {
             return;
         }
@@ -204,14 +195,22 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             GetElidedTxKey(hash, elidedKey);
 
             using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
-            IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
-            fullBlobTxsBatch.Remove(txHashPrefixed);
-            fullBlobTxsBatch.Remove(elidedKey);
-            batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs).Remove(hash.BytesAsSpan);
+            try
+            {
+                IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
+                fullBlobTxsBatch.Remove(txHashPrefixed);
+                fullBlobTxsBatch.Remove(elidedKey);
+                batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs).Remove(hash.BytesAsSpan);
+            }
+            catch
+            {
+                batch.Clear();
+                throw;
+            }
         }
     }
 
-    void IAtomicBlobTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys) =>
+    void IAtomicBlobTxStorage.DeleteMany(scoped ReadOnlySpan<BlobTxDeleteKey> keys) =>
         DeleteMany(keys);
 
     private void WriteTransaction(
@@ -251,7 +250,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
     }
 
-    private void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
+    private void DeleteMany(scoped ReadOnlySpan<BlobTxDeleteKey> keys)
     {
         if (keys.IsEmpty)
         {
@@ -288,7 +287,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
     }
 
-    private void DeleteManyFromStorage(scoped ReadOnlySpan<TxLookupKey> keys)
+    private void DeleteManyFromStorage(scoped ReadOnlySpan<BlobTxDeleteKey> keys)
     {
         if (keys.IsEmpty)
         {
@@ -304,7 +303,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
             for (int i = 0; i < keys.Length; i++)
             {
-                ref readonly TxLookupKey key = ref keys[i];
+                ref readonly BlobTxDeleteKey key = ref keys[i];
                 GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
                 fullBlobTxsBatch.Remove(txHashPrefixed);
                 GetElidedTxKey(key.Hash, elidedKey);
@@ -422,6 +421,17 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     {
         elidedKey[0] = ElidedTxKeyPrefix;
         hash.Bytes.CopyTo(elidedKey[1..]);
+    }
+
+    private bool ShouldWriteElided(Transaction transaction, scoped Span<byte> elidedKey)
+    {
+        if (transaction.NetworkWrapper is not ShardBlobNetworkWrapper)
+        {
+            return false;
+        }
+
+        GetElidedTxKey(transaction.Hash, elidedKey);
+        return !_fullBlobTxsDb.KeyExists(elidedKey);
     }
 
     private static void GetHashPrefixedByTimestamp(in UInt256 timestamp, in ValueHash256 hash, scoped Span<byte> txHashPrefixed)

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -212,10 +212,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     }
 
     void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys) =>
-        DeleteMany(keys, deleteSharedEntries: true);
-
-    void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys) =>
-        DeleteMany(keys, deleteSharedEntries: false);
+        DeleteMany(keys);
 
     private void WriteTransaction(
         Transaction transaction,
@@ -246,7 +243,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs).Set(hash.BytesAsSpan, lightRlp);
     }
 
-    private void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys, bool deleteSharedEntries)
+    private void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
     {
         if (keys.IsEmpty)
         {
@@ -272,7 +269,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
                 }
             }
 
-            DeleteManyFromStorage(keys, deleteSharedEntries);
+            DeleteManyFromStorage(keys);
         }
         finally
         {
@@ -283,7 +280,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
     }
 
-    private void DeleteManyFromStorage(scoped ReadOnlySpan<TxLookupKey> keys, bool deleteSharedEntries)
+    private void DeleteManyFromStorage(scoped ReadOnlySpan<TxLookupKey> keys)
     {
         if (keys.IsEmpty)
         {
@@ -292,9 +289,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
 
         using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
         IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
-        IWriteBatch? lightBlobTxsBatch = deleteSharedEntries
-            ? batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs)
-            : null;
+        IWriteBatch lightBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs);
         Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
         Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
         for (int i = 0; i < keys.Length; i++)
@@ -302,12 +297,9 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             ref readonly TxLookupKey key = ref keys[i];
             GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
             fullBlobTxsBatch.Remove(txHashPrefixed);
-            if (deleteSharedEntries)
-            {
-                GetElidedTxKey(key.Hash, elidedKey);
-                fullBlobTxsBatch.Remove(elidedKey);
-                lightBlobTxsBatch!.Remove(key.Hash.BytesAsSpan);
-            }
+            GetElidedTxKey(key.Hash, elidedKey);
+            fullBlobTxsBatch.Remove(elidedKey);
+            lightBlobTxsBatch.Remove(key.Hash.BytesAsSpan);
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -229,6 +229,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
         IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
         Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
+        // Obsolete timestamps can include the current one; remove first so the ordered batch's final put preserves it.
         for (int i = 0; i < obsoleteTimestamps.Length; i++)
         {
             GetHashPrefixedByTimestamp(obsoleteTimestamps[i], hash, txHashPrefixed);

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -26,6 +26,10 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
 
     internal readonly Dictionary<byte[], List<Hash256>> BlobIndex = new(Bytes.EqualityComparer);
 
+    /// <summary>
+    /// Flushes retained deletes before publishing a spec-change validation marker.
+    /// </summary>
+    /// <returns><see langword="false"/> when an active writer still owns a retained delete and the marker must remain unpublished.</returns>
     internal virtual bool FlushPendingRevalidationDeletes() => true;
 
     protected override IComparer<Transaction> GetReplacementComparer(IComparer<Transaction> comparer)

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -26,7 +26,7 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
 
     internal readonly Dictionary<byte[], List<Hash256>> BlobIndex = new(Bytes.EqualityComparer);
 
-    internal virtual void FlushPendingRevalidationDeletes() { }
+    internal virtual bool FlushPendingRevalidationDeletes() => true;
 
     protected override IComparer<Transaction> GetReplacementComparer(IComparer<Transaction> comparer)
         => comparer.GetBlobReplacementComparer();

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -27,10 +27,10 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
     internal readonly Dictionary<byte[], List<Hash256>> BlobIndex = new(Bytes.EqualityComparer);
 
     /// <summary>
-    /// Flushes retained deletes before publishing a spec-change validation marker.
+    /// Attempts to flush retained deletes before publishing a spec-change validation marker.
     /// </summary>
-    /// <returns><see langword="false"/> when an active writer still owns a retained delete and the marker must remain unpublished.</returns>
-    internal virtual bool FlushPendingRevalidationDeletes() => true;
+    /// <returns><see langword="false"/> when a retained delete cannot yet be flushed and the marker must remain unpublished.</returns>
+    internal virtual bool TryFlushPendingRevalidationDeletes() => true;
 
     protected override IComparer<Transaction> GetReplacementComparer(IComparer<Transaction> comparer)
         => comparer.GetBlobReplacementComparer();

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -115,13 +115,9 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             _blobTxMetadataCache.Set(hash, BlobTransactionPayload.Elide(fullBlobTx));
             if (_pendingBlobUpdates.TryGetValue(hash, out PendingBlobUpdate? pendingUpdate))
             {
-                if (pendingUpdate.WriterActive)
+                _ = TrackBlobUpdateNonLocked(fullBlobTx);
+                if (!pendingUpdate.WriterActive)
                 {
-                    _ = TrackBlobUpdateNonLocked(fullBlobTx);
-                }
-                else
-                {
-                    _ = TrackBlobUpdateNonLocked(fullBlobTx);
                     try
                     {
                         PersistBlobTransaction(fullBlobTx, pendingUpdate.DeleteTimestamps);

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -775,22 +775,30 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         FlushPendingRevalidationDeletesNonLocked();
     }
 
-    internal override void FlushPendingRevalidationDeletes()
+    internal override bool FlushPendingRevalidationDeletes()
     {
         using McsLock.Disposable lockRelease = Lock.Acquire();
-        FlushPendingRevalidationDeletesNonLocked();
+        return FlushPendingRevalidationDeletesNonLocked();
     }
 
-    private void FlushPendingRevalidationDeletesNonLocked()
+    private bool FlushPendingRevalidationDeletesNonLocked()
     {
         if (_batchedDeletes.Count == 0)
         {
-            return;
+            return true;
         }
 
         using ArrayPoolList<TxLookupKey> deletes = new(_batchedDeletes.Count);
+        bool hasActiveWriter = false;
         foreach (KeyValuePair<ValueHash256, HashSet<TxLookupKey>> pendingDeletes in _batchedDeletes)
         {
+            if (_pendingBlobUpdates.TryGetValue(pendingDeletes.Key, out PendingBlobUpdate? pendingUpdate)
+                && pendingUpdate.WriterActive)
+            {
+                hasActiveWriter = true;
+                continue;
+            }
+
             if (!base.TryGetValueNonLocked(pendingDeletes.Key, out _))
             {
                 foreach (TxLookupKey key in pendingDeletes.Value)
@@ -821,6 +829,8 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         {
             _batchedDeletes.Remove(deletes[i].Hash);
         }
+
+        return !hasActiveWriter;
     }
 
     protected override void OnBlobTransactionUpdatedNonLocked(Transaction blobTx)
@@ -1151,7 +1161,16 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
         else
         {
-            _pendingBlobUpdates[blobTx.Hash!] = new PendingBlobUpdate(token, snapshot, blobTx.Timestamp, blobTx.SenderAddress!);
+            PendingBlobUpdate newPendingUpdate = new(token, snapshot, blobTx.Timestamp, blobTx.SenderAddress!);
+            if (_batchedDeletes.TryGetValue(blobTx.Hash!.ValueHash256, out HashSet<TxLookupKey>? deletes))
+            {
+                foreach (TxLookupKey delete in deletes)
+                {
+                    newPendingUpdate.DeleteTimestamps.Add(delete.Timestamp);
+                }
+            }
+
+            _pendingBlobUpdates[blobTx.Hash!] = newPendingUpdate;
         }
 
         return true;

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -33,6 +33,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
     private readonly Dictionary<ValueHash256, PendingBlobUpdate> _pendingBlobUpdates = [];
     private readonly Dictionary<ValueHash256, Transaction> _unpersistableBlobUpdates = [];
     private readonly HashSet<ValueHash256> _metadataFallbackReads = [];
+    // Reinsertion consumes a retained delete through Replace before the same hash can be removed again.
     private readonly Dictionary<ValueHash256, TxLookupKey> _batchedDeletes = [];
     private bool _batchStorageDeletes;
     private readonly int _maxPendingBlobUpdates;
@@ -752,7 +753,15 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         using McsLock.Disposable lockRelease = Lock.Acquire();
 
         Debug.Assert(!_batchStorageDeletes);
-        FlushPendingRevalidationDeletesNonLocked();
+        try
+        {
+            FlushPendingRevalidationDeletesNonLocked();
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsError) _logger.Error("Failed to flush retained blob revalidation deletes before revalidating the pool.", ex);
+        }
+
         _batchStorageDeletes = true;
         try
         {
@@ -780,16 +789,11 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
 
         using ArrayPoolList<TxLookupKey> deletes = new(_batchedDeletes.Count);
-        using ArrayPoolList<TxLookupKey> obsoleteFullTransactions = new(_batchedDeletes.Count);
         foreach (TxLookupKey key in _batchedDeletes.Values)
         {
-            if (!base.TryGetValueNonLocked(key.Hash, out Transaction? liveTransaction))
+            if (!base.TryGetValueNonLocked(key.Hash, out _))
             {
                 deletes.Add(key);
-            }
-            else if (liveTransaction.Timestamp != key.Timestamp)
-            {
-                obsoleteFullTransactions.Add(key);
             }
         }
 
@@ -798,11 +802,6 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             if (deletes.Count > 0)
             {
                 batchStorage.DeleteMany(deletes.AsSpan());
-            }
-
-            if (obsoleteFullTransactions.Count > 0)
-            {
-                batchStorage.DeleteFullBlobTransactions(obsoleteFullTransactions.AsSpan());
             }
         }
         else

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -33,7 +33,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
     private readonly Dictionary<ValueHash256, PendingBlobUpdate> _pendingBlobUpdates = [];
     private readonly Dictionary<ValueHash256, Transaction> _unpersistableBlobUpdates = [];
     private readonly HashSet<ValueHash256> _metadataFallbackReads = [];
-    private readonly List<TxLookupKey> _batchedDeletes = [];
+    private readonly Dictionary<ValueHash256, TxLookupKey> _batchedDeletes = [];
     private bool _batchStorageDeletes;
     private readonly int _maxPendingBlobUpdates;
     private const int MaxBlobUpdateWriteAttempts = 2;
@@ -111,12 +111,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
                     TrackBlobUpdateNonLocked(fullBlobTx);
                     try
                     {
-                        foreach (UInt256 timestamp in pendingUpdate.DeleteTimestamps)
-                        {
-                            _blobTxStorage.Delete(hash, timestamp);
-                        }
-
-                        _blobTxStorage.Add(fullBlobTx);
+                        PersistBlobTransaction(fullBlobTx, pendingUpdate.DeleteTimestamps);
                         _pendingBlobUpdates.Remove(hash);
                     }
                     catch
@@ -130,7 +125,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             }
             else
             {
-                _blobTxStorage.Add(fullBlobTx);
+                PersistInsertedBlobTransaction(fullBlobTx);
             }
 
             return true;
@@ -731,7 +726,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             {
                 if (_batchStorageDeletes)
                 {
-                    _batchedDeletes.Add(new TxLookupKey(hash, tx.SenderAddress!, tx.Timestamp));
+                    _batchedDeletes[hash] = new TxLookupKey(hash, tx.SenderAddress!, tx.Timestamp);
                 }
                 else
                 {
@@ -757,6 +752,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         using McsLock.Disposable lockRelease = Lock.Acquire();
 
         Debug.Assert(!_batchStorageDeletes);
+        FlushPendingRevalidationDeletesNonLocked();
         _batchStorageDeletes = true;
         try
         {
@@ -785,9 +781,8 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
 
         using ArrayPoolList<TxLookupKey> deletes = new(_batchedDeletes.Count);
         using ArrayPoolList<TxLookupKey> obsoleteFullTransactions = new(_batchedDeletes.Count);
-        for (int i = 0; i < _batchedDeletes.Count; i++)
+        foreach (TxLookupKey key in _batchedDeletes.Values)
         {
-            TxLookupKey key = _batchedDeletes[i];
             if (!base.TryGetValueNonLocked(key.Hash, out Transaction? liveTransaction))
             {
                 deletes.Add(key);
@@ -903,14 +898,16 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
 
             try
             {
-                for (int i = 0; i < deleteTimestamps.Length; i++)
-                {
-                    _blobTxStorage.Delete(hash, deleteTimestamps[i]);
-                }
-
                 if (transaction is not null)
                 {
-                    _blobTxStorage.Add(transaction);
+                    PersistBlobTransaction(transaction, deleteTimestamps);
+                }
+                else
+                {
+                    for (int i = 0; i < deleteTimestamps.Length; i++)
+                    {
+                        _blobTxStorage.Delete(hash, deleteTimestamps[i]);
+                    }
                 }
 
                 failedWriteAttempts = 0;
@@ -957,6 +954,50 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
                 }
             }
         }
+    }
+
+    private void PersistBlobTransaction(Transaction transaction, HashSet<UInt256> obsoleteTimestamps)
+    {
+        using ArrayPoolSpan<UInt256> timestamps = new(obsoleteTimestamps.Count);
+        int index = 0;
+        foreach (UInt256 timestamp in obsoleteTimestamps)
+        {
+            timestamps[index++] = timestamp;
+        }
+
+        PersistBlobTransaction(transaction, timestamps);
+    }
+
+    private void PersistBlobTransaction(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
+    {
+        if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
+        {
+            batchStorage.Replace(transaction, obsoleteTimestamps);
+            return;
+        }
+
+        for (int i = 0; i < obsoleteTimestamps.Length; i++)
+        {
+            _blobTxStorage.Delete(transaction.Hash!, obsoleteTimestamps[i]);
+        }
+
+        _blobTxStorage.Add(transaction);
+    }
+
+    private void PersistInsertedBlobTransaction(Transaction transaction)
+    {
+        ValueHash256 hash = transaction.Hash!.ValueHash256;
+        if (_blobTxStorage is not IBatchDeleteTxStorage
+            || !_batchedDeletes.TryGetValue(hash, out TxLookupKey obsoleteTransaction))
+        {
+            _blobTxStorage.Add(transaction);
+            return;
+        }
+
+        Span<UInt256> obsoleteTimestamp = stackalloc UInt256[1];
+        obsoleteTimestamp[0] = obsoleteTransaction.Timestamp;
+        PersistBlobTransaction(transaction, obsoleteTimestamp);
+        _batchedDeletes.Remove(hash);
     }
 
     private void ScheduleBlobUpdateRetry(DateTimeOffset retryAt)

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -1162,6 +1162,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         else
         {
             PendingBlobUpdate newPendingUpdate = new(token, snapshot, blobTx.Timestamp, blobTx.SenderAddress!);
+            // The writer consumes these deletes atomically with its own write before clearing the retained set.
             if (_batchedDeletes.TryGetValue(blobTx.Hash!.ValueHash256, out HashSet<TxLookupKey>? deletes))
             {
                 foreach (TxLookupKey delete in deletes)

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -33,8 +33,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
     private readonly Dictionary<ValueHash256, PendingBlobUpdate> _pendingBlobUpdates = [];
     private readonly Dictionary<ValueHash256, Transaction> _unpersistableBlobUpdates = [];
     private readonly HashSet<ValueHash256> _metadataFallbackReads = [];
-    // Keep the first pending timestamp: a failed replacement can leave it as the only persisted body.
-    private readonly Dictionary<ValueHash256, TxLookupKey> _batchedDeletes = [];
+    private readonly Dictionary<ValueHash256, HashSet<TxLookupKey>> _batchedDeletes = [];
     private bool _batchStorageDeletes;
     private readonly int _maxPendingBlobUpdates;
     private const int MaxBlobUpdateWriteAttempts = 2;
@@ -114,6 +113,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
                     {
                         PersistBlobTransaction(fullBlobTx, pendingUpdate.DeleteTimestamps);
                         _pendingBlobUpdates.Remove(hash);
+                        _batchedDeletes.Remove(hash);
                     }
                     catch
                     {
@@ -723,13 +723,13 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
                 }
             }
 
-            if (tx is not null && !hasPendingUpdate)
+            if (tx is not null)
             {
                 if (_batchStorageDeletes)
                 {
-                    _batchedDeletes.TryAdd(hash, new TxLookupKey(hash, tx.SenderAddress!, tx.Timestamp));
+                    AddBatchedDeleteNonLocked(new TxLookupKey(hash, tx.SenderAddress!, tx.Timestamp));
                 }
-                else
+                else if (!hasPendingUpdate)
                 {
                     _blobTxStorage.Delete(hash, tx.Timestamp);
                 }
@@ -789,15 +789,18 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
 
         using ArrayPoolList<TxLookupKey> deletes = new(_batchedDeletes.Count);
-        foreach (TxLookupKey key in _batchedDeletes.Values)
+        foreach (KeyValuePair<ValueHash256, HashSet<TxLookupKey>> pendingDeletes in _batchedDeletes)
         {
-            if (!base.TryGetValueNonLocked(key.Hash, out _))
+            if (!base.TryGetValueNonLocked(pendingDeletes.Key, out _))
             {
-                deletes.Add(key);
+                foreach (TxLookupKey key in pendingDeletes.Value)
+                {
+                    deletes.Add(key);
+                }
             }
         }
 
-        if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
+        if (_blobTxStorage is IAtomicBlobTxStorage batchStorage)
         {
             if (deletes.Count > 0)
             {
@@ -884,6 +887,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         {
             long token;
             Transaction? transaction;
+            Address sender;
             UInt256[] deleteTimestamps;
             using (McsLock.Disposable lockRelease = Lock.Acquire())
             {
@@ -895,6 +899,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
 
                 token = current.Token;
                 transaction = current.Transaction;
+                sender = current.Sender;
                 deleteTimestamps = [.. current.DeleteTimestamps];
             }
 
@@ -906,10 +911,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
                 }
                 else
                 {
-                    for (int i = 0; i < deleteTimestamps.Length; i++)
-                    {
-                        _blobTxStorage.Delete(hash, deleteTimestamps[i]);
-                    }
+                    DeleteBlobTransactions(hash, sender, deleteTimestamps);
                 }
 
                 failedWriteAttempts = 0;
@@ -923,6 +925,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
                 if (current.Token == token)
                 {
                     _pendingBlobUpdates.Remove(hash);
+                    _batchedDeletes.Remove(hash);
                     return;
                 }
             }
@@ -972,7 +975,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
 
     private void PersistBlobTransaction(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps)
     {
-        if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
+        if (_blobTxStorage is IAtomicBlobTxStorage batchStorage)
         {
             batchStorage.Replace(transaction, obsoleteTimestamps);
             return;
@@ -986,20 +989,59 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         _blobTxStorage.Add(transaction);
     }
 
+    private void DeleteBlobTransactions(
+        in ValueHash256 hash,
+        Address sender,
+        scoped ReadOnlySpan<UInt256> timestamps)
+    {
+        if (_blobTxStorage is IAtomicBlobTxStorage batchStorage)
+        {
+            using ArrayPoolSpan<TxLookupKey> keys = new(timestamps.Length);
+            for (int i = 0; i < timestamps.Length; i++)
+            {
+                keys[i] = new TxLookupKey(hash, sender, timestamps[i]);
+            }
+
+            batchStorage.DeleteMany(keys);
+            return;
+        }
+
+        for (int i = 0; i < timestamps.Length; i++)
+        {
+            _blobTxStorage.Delete(hash, timestamps[i]);
+        }
+    }
+
     private void PersistInsertedBlobTransaction(Transaction transaction)
     {
         ValueHash256 hash = transaction.Hash!.ValueHash256;
-        if (_blobTxStorage is not IBatchDeleteTxStorage
-            || !_batchedDeletes.TryGetValue(hash, out TxLookupKey obsoleteTransaction))
+        if (_blobTxStorage is not IAtomicBlobTxStorage
+            || !_batchedDeletes.TryGetValue(hash, out HashSet<TxLookupKey>? obsoleteTransactions))
         {
             _blobTxStorage.Add(transaction);
             return;
         }
 
-        Span<UInt256> obsoleteTimestamp = stackalloc UInt256[1];
-        obsoleteTimestamp[0] = obsoleteTransaction.Timestamp;
-        PersistBlobTransaction(transaction, obsoleteTimestamp);
+        using ArrayPoolSpan<UInt256> obsoleteTimestamps = new(obsoleteTransactions.Count);
+        int index = 0;
+        foreach (TxLookupKey obsoleteTransaction in obsoleteTransactions)
+        {
+            obsoleteTimestamps[index++] = obsoleteTransaction.Timestamp;
+        }
+
+        PersistBlobTransaction(transaction, obsoleteTimestamps);
         _batchedDeletes.Remove(hash);
+    }
+
+    private void AddBatchedDeleteNonLocked(in TxLookupKey key)
+    {
+        if (!_batchedDeletes.TryGetValue(key.Hash, out HashSet<TxLookupKey>? deletes))
+        {
+            deletes = [];
+            _batchedDeletes.Add(key.Hash, deletes);
+        }
+
+        deletes.Add(key);
     }
 
     private void ScheduleBlobUpdateRetry(DateTimeOffset retryAt)
@@ -1109,7 +1151,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
         else
         {
-            _pendingBlobUpdates[blobTx.Hash!] = new PendingBlobUpdate(token, snapshot, blobTx.Timestamp);
+            _pendingBlobUpdates[blobTx.Hash!] = new PendingBlobUpdate(token, snapshot, blobTx.Timestamp, blobTx.SenderAddress!);
         }
 
         return true;
@@ -1141,11 +1183,12 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         int BlobIndex,
         BlobCellMask AvailableMask);
 
-    private sealed class PendingBlobUpdate(long token, Transaction? transaction, UInt256 timestamp)
+    private sealed class PendingBlobUpdate(long token, Transaction? transaction, UInt256 timestamp, Address sender)
     {
         public long Token { get; set; } = token;
         public Transaction? Transaction { get; set; } = transaction;
         public UInt256 Timestamp { get; set; } = timestamp;
+        public Address Sender { get; } = sender;
         public HashSet<UInt256> DeleteTimestamps { get; } = [];
         public bool WriterActive { get; set; }
         public int RetryCount { get; set; }

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -33,13 +33,14 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
     private readonly Dictionary<ValueHash256, PendingBlobUpdate> _pendingBlobUpdates = [];
     private readonly Dictionary<ValueHash256, Transaction> _unpersistableBlobUpdates = [];
     private readonly HashSet<ValueHash256> _metadataFallbackReads = [];
-    private readonly Dictionary<ValueHash256, HashSet<TxLookupKey>> _batchedDeletes = [];
+    private readonly Dictionary<ValueHash256, BatchedDeletes> _batchedDeletes = [];
     private bool _batchStorageDeletes;
     private readonly int _maxPendingBlobUpdates;
     private const int MaxBlobUpdateWriteAttempts = 2;
     private const int MaxBlobUpdateRetryExponent = 5;
     private static readonly TimeSpan InitialBlobUpdateRetryDelay = TimeSpan.FromSeconds(1);
     private readonly TimeProvider _timeProvider;
+    private readonly Action? _onRetainedDeletesFlushed;
     private readonly object _blobUpdateRetryTimerLock = new();
     private ITimer? _blobUpdateRetryTimer;
     private DateTimeOffset? _nextBlobUpdateRetryAt;
@@ -47,7 +48,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
     private int _disposed;
 
     public PersistentBlobTxDistinctSortedPool(ITxStorage blobTxStorage, ITxPoolConfig txPoolConfig, IComparer<Transaction> comparer, ILogManager logManager)
-        : this(blobTxStorage, txPoolConfig, comparer, logManager, TimeProvider.System)
+        : this(blobTxStorage, txPoolConfig, comparer, logManager, TimeProvider.System, null)
     {
     }
 
@@ -57,6 +58,17 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         IComparer<Transaction> comparer,
         ILogManager logManager,
         TimeProvider timeProvider)
+        : this(blobTxStorage, txPoolConfig, comparer, logManager, timeProvider, null)
+    {
+    }
+
+    internal PersistentBlobTxDistinctSortedPool(
+        ITxStorage blobTxStorage,
+        ITxPoolConfig txPoolConfig,
+        IComparer<Transaction> comparer,
+        ILogManager logManager,
+        TimeProvider timeProvider,
+        Action? onRetainedDeletesFlushed)
         : base(txPoolConfig.PersistentBlobStorageSize, comparer, logManager)
     {
         _blobTxStorage = blobTxStorage ?? throw new ArgumentNullException(nameof(blobTxStorage));
@@ -66,6 +78,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         _maxPendingBlobUpdates = Math.Max(1, txPoolConfig.BlobCacheSize);
         _logger = logManager?.GetClassLogger<PersistentBlobTxDistinctSortedPool>() ?? throw new ArgumentNullException(nameof(logManager));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _onRetainedDeletesFlushed = onRetainedDeletesFlushed;
 
         RecreateLightTxCollectionAndCache(blobTxStorage);
     }
@@ -113,7 +126,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
                     {
                         PersistBlobTransaction(fullBlobTx, pendingUpdate.DeleteTimestamps);
                         _pendingBlobUpdates.Remove(hash);
-                        _batchedDeletes.Remove(hash);
+                        CompleteRetainedDeletesNonLocked(hash);
                     }
                     catch
                     {
@@ -727,7 +740,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             {
                 if (_batchStorageDeletes)
                 {
-                    AddBatchedDeleteNonLocked(new TxLookupKey(hash, tx.SenderAddress!, tx.Timestamp));
+                    AddBatchedDeleteNonLocked(new BlobTxDeleteKey(hash, tx.Timestamp));
                 }
                 else if (!hasPendingUpdate)
                 {
@@ -775,7 +788,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         FlushPendingRevalidationDeletesNonLocked();
     }
 
-    internal override bool FlushPendingRevalidationDeletes()
+    internal override bool TryFlushPendingRevalidationDeletes()
     {
         using McsLock.Disposable lockRelease = Lock.Acquire();
         return FlushPendingRevalidationDeletesNonLocked();
@@ -788,23 +801,27 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             return true;
         }
 
-        using ArrayPoolList<TxLookupKey> deletes = new(_batchedDeletes.Count);
-        bool hasActiveWriter = false;
-        foreach (KeyValuePair<ValueHash256, HashSet<TxLookupKey>> pendingDeletes in _batchedDeletes)
+        using ArrayPoolList<BlobTxDeleteKey> deletes = new(_batchedDeletes.Count);
+        bool hasUnflushedDelete = false;
+        foreach (KeyValuePair<ValueHash256, BatchedDeletes> pendingDeletes in _batchedDeletes)
         {
-            if (_pendingBlobUpdates.TryGetValue(pendingDeletes.Key, out PendingBlobUpdate? pendingUpdate)
-                && pendingUpdate.WriterActive)
+            if (base.TryGetValueNonLocked(pendingDeletes.Key, out _))
             {
-                hasActiveWriter = true;
+                hasUnflushedDelete = true;
                 continue;
             }
 
-            if (!base.TryGetValueNonLocked(pendingDeletes.Key, out _))
+            if (_pendingBlobUpdates.TryGetValue(pendingDeletes.Key, out PendingBlobUpdate? pendingUpdate)
+                && pendingUpdate.WriterActive)
             {
-                foreach (TxLookupKey key in pendingDeletes.Value)
-                {
-                    deletes.Add(key);
-                }
+                hasUnflushedDelete = true;
+                continue;
+            }
+
+            deletes.Add(pendingDeletes.Value.First);
+            if (pendingDeletes.Value.Additional is { } additional)
+            {
+                deletes.AddRange(CollectionsMarshal.AsSpan(additional));
             }
         }
 
@@ -820,7 +837,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             // No timestamp-only fallback exists; Delete also removes hash-keyed records owned by a reinserted transaction.
             for (int i = 0; i < deletes.Count; i++)
             {
-                TxLookupKey key = deletes[i];
+                BlobTxDeleteKey key = deletes[i];
                 _blobTxStorage.Delete(key.Hash, key.Timestamp);
             }
         }
@@ -830,7 +847,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             _batchedDeletes.Remove(deletes[i].Hash);
         }
 
-        return !hasActiveWriter;
+        return !hasUnflushedDelete;
     }
 
     protected override void OnBlobTransactionUpdatedNonLocked(Transaction blobTx)
@@ -893,82 +910,107 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
 
         int failedWriteAttempts = 0;
-        while (true)
+        try
         {
-            long token;
-            Transaction? transaction;
-            Address sender;
-            UInt256[] deleteTimestamps;
-            using (McsLock.Disposable lockRelease = Lock.Acquire())
+            while (true)
             {
-                if (!_pendingBlobUpdates.TryGetValue(hash, out PendingBlobUpdate? current)
-                    || !ReferenceEquals(current, state))
-                {
-                    return;
-                }
-
-                token = current.Token;
-                transaction = current.Transaction;
-                sender = current.Sender;
-                deleteTimestamps = [.. current.DeleteTimestamps];
-            }
-
-            try
-            {
-                if (transaction is not null)
-                {
-                    PersistBlobTransaction(transaction, deleteTimestamps);
-                }
-                else
-                {
-                    DeleteBlobTransactions(hash, sender, deleteTimestamps);
-                }
-
-                failedWriteAttempts = 0;
-                using McsLock.Disposable lockRelease = Lock.Acquire();
-                if (!_pendingBlobUpdates.TryGetValue(hash, out PendingBlobUpdate? current)
-                    || !ReferenceEquals(current, state))
-                {
-                    return;
-                }
-
-                if (current.Token == token)
-                {
-                    _pendingBlobUpdates.Remove(hash);
-                    _batchedDeletes.Remove(hash);
-                    return;
-                }
-            }
-            catch (Exception ex)
-            {
-                bool retry;
-                DateTimeOffset? retryAt = null;
+                long token;
+                Transaction? transaction;
+                UInt256[] deleteTimestamps;
                 using (McsLock.Disposable lockRelease = Lock.Acquire())
                 {
                     if (!_pendingBlobUpdates.TryGetValue(hash, out PendingBlobUpdate? current)
                         || !ReferenceEquals(current, state))
                     {
-                        throw;
+                        return;
                     }
 
-                    retry = current.Token != token || ++failedWriteAttempts < MaxBlobUpdateWriteAttempts;
-                    if (!retry)
-                    {
-                        current.WriterActive = false;
-                        int retryExponent = Math.Min(current.RetryCount++, MaxBlobUpdateRetryExponent);
-                        retryAt = _timeProvider.GetUtcNow() + InitialBlobUpdateRetryDelay * (1 << retryExponent);
-                        current.NextRetryAt = retryAt;
-                    }
+                    token = current.Token;
+                    transaction = current.Transaction;
+                    deleteTimestamps = [.. current.DeleteTimestamps];
                 }
 
-                if (!retry)
+                try
                 {
-                    if (_logger.IsError) _logger.Error($"Failed to persist blob transaction update for {hash}; retry scheduled.", ex);
-                    ScheduleBlobUpdateRetry(retryAt!.Value);
-                    return;
+                    if (transaction is not null)
+                    {
+                        PersistBlobTransaction(transaction, deleteTimestamps);
+                    }
+                    else
+                    {
+                        DeleteBlobTransactions(hash, deleteTimestamps);
+                    }
+
+                    failedWriteAttempts = 0;
+                    using McsLock.Disposable lockRelease = Lock.Acquire();
+                    if (!_pendingBlobUpdates.TryGetValue(hash, out PendingBlobUpdate? current)
+                        || !ReferenceEquals(current, state))
+                    {
+                        return;
+                    }
+
+                    if (current.Token == token)
+                    {
+                        _pendingBlobUpdates.Remove(hash);
+                        CompleteRetainedDeletesNonLocked(hash);
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    bool retry;
+                    DateTimeOffset? retryAt = null;
+                    using (McsLock.Disposable lockRelease = Lock.Acquire())
+                    {
+                        if (!_pendingBlobUpdates.TryGetValue(hash, out PendingBlobUpdate? current)
+                            || !ReferenceEquals(current, state))
+                        {
+                            throw;
+                        }
+
+                        retry = ++failedWriteAttempts < MaxBlobUpdateWriteAttempts;
+                        if (!retry)
+                        {
+                            retryAt = PrepareBlobUpdateRetryNonLocked(current);
+                        }
+                    }
+
+                    if (!retry)
+                    {
+                        if (_logger.IsError) _logger.Error($"Failed to persist blob transaction update for {hash}; retry scheduled.", ex);
+                        ScheduleBlobUpdateRetry(retryAt!.Value);
+                        return;
+                    }
                 }
             }
         }
+        finally
+        {
+            DateTimeOffset? retryAt = null;
+            using (McsLock.Disposable lockRelease = Lock.Acquire())
+            {
+                if (_pendingBlobUpdates.TryGetValue(hash, out PendingBlobUpdate? current)
+                    && ReferenceEquals(current, state)
+                    && current.WriterActive)
+                {
+                    retryAt = PrepareBlobUpdateRetryNonLocked(current);
+                }
+            }
+
+            if (retryAt is { } pendingRetryAt)
+            {
+                ScheduleBlobUpdateRetry(pendingRetryAt);
+            }
+        }
+    }
+
+    private DateTimeOffset PrepareBlobUpdateRetryNonLocked(PendingBlobUpdate pendingUpdate)
+    {
+        pendingUpdate.WriterActive = false;
+        int retryExponent = Math.Min(pendingUpdate.RetryCount++, MaxBlobUpdateRetryExponent);
+        DateTimeOffset retryAt = _timeProvider.GetUtcNow() + InitialBlobUpdateRetryDelay * (1 << retryExponent);
+        pendingUpdate.NextRetryAt = retryAt;
+        return retryAt;
     }
 
     private void PersistBlobTransaction(Transaction transaction, HashSet<UInt256> obsoleteTimestamps)
@@ -1001,15 +1043,14 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
 
     private void DeleteBlobTransactions(
         in ValueHash256 hash,
-        Address sender,
         scoped ReadOnlySpan<UInt256> timestamps)
     {
         if (_blobTxStorage is IAtomicBlobTxStorage batchStorage)
         {
-            using ArrayPoolSpan<TxLookupKey> keys = new(timestamps.Length);
+            using ArrayPoolSpan<BlobTxDeleteKey> keys = new(timestamps.Length);
             for (int i = 0; i < timestamps.Length; i++)
             {
-                keys[i] = new TxLookupKey(hash, sender, timestamps[i]);
+                keys[i] = new BlobTxDeleteKey(hash, timestamps[i]);
             }
 
             batchStorage.DeleteMany(keys);
@@ -1025,33 +1066,59 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
     private void PersistInsertedBlobTransaction(Transaction transaction)
     {
         ValueHash256 hash = transaction.Hash!.ValueHash256;
-        if (_blobTxStorage is not IAtomicBlobTxStorage
-            || !_batchedDeletes.TryGetValue(hash, out HashSet<TxLookupKey>? obsoleteTransactions))
+        if (!_batchedDeletes.TryGetValue(hash, out BatchedDeletes obsoleteTransactions))
         {
             _blobTxStorage.Add(transaction);
             return;
         }
 
         using ArrayPoolSpan<UInt256> obsoleteTimestamps = new(obsoleteTransactions.Count);
-        int index = 0;
-        foreach (TxLookupKey obsoleteTransaction in obsoleteTransactions)
+        obsoleteTimestamps[0] = obsoleteTransactions.First.Timestamp;
+        if (obsoleteTransactions.Additional is { } additional)
         {
-            obsoleteTimestamps[index++] = obsoleteTransaction.Timestamp;
+            for (int i = 0; i < additional.Count; i++)
+            {
+                obsoleteTimestamps[i + 1] = additional[i].Timestamp;
+            }
         }
 
-        PersistBlobTransaction(transaction, obsoleteTimestamps);
-        _batchedDeletes.Remove(hash);
+        try
+        {
+            PersistBlobTransaction(transaction, obsoleteTimestamps);
+            CompleteRetainedDeletesNonLocked(hash);
+        }
+        catch
+        {
+            TrackBlobUpdateNonLocked(transaction, ignoreCapacity: true);
+            PendingBlobUpdate pendingUpdate = _pendingBlobUpdates[hash];
+            DateTimeOffset retryAt = _timeProvider.GetUtcNow();
+            pendingUpdate.NextRetryAt = retryAt;
+            ScheduleBlobUpdateRetry(retryAt);
+            throw;
+        }
     }
 
-    private void AddBatchedDeleteNonLocked(in TxLookupKey key)
+    private void AddBatchedDeleteNonLocked(in BlobTxDeleteKey key)
     {
-        if (!_batchedDeletes.TryGetValue(key.Hash, out HashSet<TxLookupKey>? deletes))
+        ref BatchedDeletes deletes = ref CollectionsMarshal.GetValueRefOrAddDefault(
+            _batchedDeletes,
+            key.Hash,
+            out bool exists);
+        if (!exists)
         {
-            deletes = [];
-            _batchedDeletes.Add(key.Hash, deletes);
+            deletes.First = key;
+            return;
         }
 
-        deletes.Add(key);
+        deletes.AddAdditional(key);
+    }
+
+    private void CompleteRetainedDeletesNonLocked(in ValueHash256 hash)
+    {
+        if (_batchedDeletes.Remove(hash))
+        {
+            _onRetainedDeletesFlushed?.Invoke();
+        }
     }
 
     private void ScheduleBlobUpdateRetry(DateTimeOffset retryAt)
@@ -1140,9 +1207,10 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
     }
 
-    private bool TrackBlobUpdateNonLocked(Transaction blobTx)
+    private bool TrackBlobUpdateNonLocked(Transaction blobTx, bool ignoreCapacity = false)
     {
         if (!_pendingBlobUpdates.ContainsKey(blobTx.Hash!)
+            && !ignoreCapacity
             && _pendingBlobUpdates.Count >= _maxPendingBlobUpdates)
         {
             return false;
@@ -1161,13 +1229,17 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
         else
         {
-            PendingBlobUpdate newPendingUpdate = new(token, snapshot, blobTx.Timestamp, blobTx.SenderAddress!);
+            PendingBlobUpdate newPendingUpdate = new(token, snapshot, blobTx.Timestamp);
             // The writer consumes these deletes atomically with its own write before clearing the retained set.
-            if (_batchedDeletes.TryGetValue(blobTx.Hash!.ValueHash256, out HashSet<TxLookupKey>? deletes))
+            if (_batchedDeletes.TryGetValue(blobTx.Hash!.ValueHash256, out BatchedDeletes deletes))
             {
-                foreach (TxLookupKey delete in deletes)
+                newPendingUpdate.DeleteTimestamps.Add(deletes.First.Timestamp);
+                if (deletes.Additional is { } additional)
                 {
-                    newPendingUpdate.DeleteTimestamps.Add(delete.Timestamp);
+                    for (int i = 0; i < additional.Count; i++)
+                    {
+                        newPendingUpdate.DeleteTimestamps.Add(additional[i].Timestamp);
+                    }
                 }
             }
 
@@ -1203,12 +1275,28 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         int BlobIndex,
         BlobCellMask AvailableMask);
 
-    private sealed class PendingBlobUpdate(long token, Transaction? transaction, UInt256 timestamp, Address sender)
+    private struct BatchedDeletes
+    {
+        public BlobTxDeleteKey First;
+        public List<BlobTxDeleteKey>? Additional;
+        public readonly int Count => 1 + (Additional?.Count ?? 0);
+
+        public void AddAdditional(in BlobTxDeleteKey key)
+        {
+            if (key == First || Additional?.Contains(key) == true)
+            {
+                return;
+            }
+
+            (Additional ??= []).Add(key);
+        }
+    }
+
+    private sealed class PendingBlobUpdate(long token, Transaction? transaction, UInt256 timestamp)
     {
         public long Token { get; set; } = token;
         public Transaction? Transaction { get; set; } = transaction;
         public UInt256 Timestamp { get; set; } = timestamp;
-        public Address Sender { get; } = sender;
         public HashSet<UInt256> DeleteTimestamps { get; } = [];
         public bool WriterActive { get; set; }
         public int RetryCount { get; set; }

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -33,7 +33,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
     private readonly Dictionary<ValueHash256, PendingBlobUpdate> _pendingBlobUpdates = [];
     private readonly Dictionary<ValueHash256, Transaction> _unpersistableBlobUpdates = [];
     private readonly HashSet<ValueHash256> _metadataFallbackReads = [];
-    // Reinsertion consumes a retained delete through Replace before the same hash can be removed again.
+    // Keep the first pending timestamp: a failed replacement can leave it as the only persisted body.
     private readonly Dictionary<ValueHash256, TxLookupKey> _batchedDeletes = [];
     private bool _batchStorageDeletes;
     private readonly int _maxPendingBlobUpdates;
@@ -727,7 +727,7 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             {
                 if (_batchStorageDeletes)
                 {
-                    _batchedDeletes[hash] = new TxLookupKey(hash, tx.SenderAddress!, tx.Timestamp);
+                    _batchedDeletes.TryAdd(hash, new TxLookupKey(hash, tx.SenderAddress!, tx.Timestamp));
                 }
                 else
                 {
@@ -814,7 +814,10 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             }
         }
 
-        _batchedDeletes.Clear();
+        for (int i = 0; i < deletes.Count; i++)
+        {
+            _batchedDeletes.Remove(deletes[i].Hash);
+        }
     }
 
     protected override void OnBlobTransactionUpdatedNonLocked(Transaction blobTx)

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -117,11 +117,11 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             {
                 if (pendingUpdate.WriterActive)
                 {
-                    TrackBlobUpdateNonLocked(fullBlobTx);
+                    _ = TrackBlobUpdateNonLocked(fullBlobTx);
                 }
                 else
                 {
-                    TrackBlobUpdateNonLocked(fullBlobTx);
+                    _ = TrackBlobUpdateNonLocked(fullBlobTx);
                     try
                     {
                         PersistBlobTransaction(fullBlobTx, pendingUpdate.DeleteTimestamps);
@@ -862,9 +862,17 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
 
         _blobTxCache.Set(blobTx.Hash, blobTx);
-        if (!TrackBlobUpdateNonLocked(blobTx) && lightTx is not null)
+        ValueHash256 hash = blobTx.Hash!.ValueHash256;
+        if (!_pendingBlobUpdates.ContainsKey(hash) && _pendingBlobUpdates.Count >= _maxPendingBlobUpdates)
         {
-            _unpersistableBlobUpdates[blobTx.Hash!.ValueHash256] = lightTx;
+            if (lightTx is not null)
+            {
+                _unpersistableBlobUpdates[hash] = lightTx;
+            }
+        }
+        else
+        {
+            _ = TrackBlobUpdateNonLocked(blobTx);
         }
     }
 
@@ -1089,8 +1097,8 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
         catch
         {
-            TrackBlobUpdateNonLocked(transaction, ignoreCapacity: true);
-            PendingBlobUpdate pendingUpdate = _pendingBlobUpdates[hash];
+            // Retained deletes must remain retryable even when the ordinary cell-update queue is full.
+            PendingBlobUpdate pendingUpdate = TrackBlobUpdateNonLocked(transaction);
             DateTimeOffset retryAt = _timeProvider.GetUtcNow();
             pendingUpdate.NextRetryAt = retryAt;
             ScheduleBlobUpdateRetry(retryAt);
@@ -1207,15 +1215,8 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         }
     }
 
-    private bool TrackBlobUpdateNonLocked(Transaction blobTx, bool ignoreCapacity = false)
+    private PendingBlobUpdate TrackBlobUpdateNonLocked(Transaction blobTx)
     {
-        if (!_pendingBlobUpdates.ContainsKey(blobTx.Hash!)
-            && !ignoreCapacity
-            && _pendingBlobUpdates.Count >= _maxPendingBlobUpdates)
-        {
-            return false;
-        }
-
         Transaction snapshot = new();
         blobTx.CopyTo(snapshot, copyHash: true);
         long token = ++_nextBlobUpdateToken;
@@ -1226,27 +1227,25 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
             pendingUpdate.Timestamp = blobTx.Timestamp;
             pendingUpdate.RetryCount = 0;
             pendingUpdate.NextRetryAt = null;
+            return pendingUpdate;
         }
-        else
+
+        PendingBlobUpdate newPendingUpdate = new(token, snapshot, blobTx.Timestamp);
+        // The writer consumes these deletes atomically with its own write before clearing the retained set.
+        if (_batchedDeletes.TryGetValue(blobTx.Hash!.ValueHash256, out BatchedDeletes deletes))
         {
-            PendingBlobUpdate newPendingUpdate = new(token, snapshot, blobTx.Timestamp);
-            // The writer consumes these deletes atomically with its own write before clearing the retained set.
-            if (_batchedDeletes.TryGetValue(blobTx.Hash!.ValueHash256, out BatchedDeletes deletes))
+            newPendingUpdate.DeleteTimestamps.Add(deletes.First.Timestamp);
+            if (deletes.Additional is { } additional)
             {
-                newPendingUpdate.DeleteTimestamps.Add(deletes.First.Timestamp);
-                if (deletes.Additional is { } additional)
+                for (int i = 0; i < additional.Count; i++)
                 {
-                    for (int i = 0; i < additional.Count; i++)
-                    {
-                        newPendingUpdate.DeleteTimestamps.Add(additional[i].Timestamp);
-                    }
+                    newPendingUpdate.DeleteTimestamps.Add(additional[i].Timestamp);
                 }
             }
-
-            _pendingBlobUpdates[blobTx.Hash!] = newPendingUpdate;
         }
 
-        return true;
+        _pendingBlobUpdates[blobTx.Hash!] = newPendingUpdate;
+        return newPendingUpdate;
     }
 
     public void Dispose()

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -12,6 +12,8 @@ namespace Nethermind.TxPool;
 
 public readonly record struct TxLookupKey(ValueHash256 Hash, Address Sender, UInt256 Timestamp);
 
+internal readonly record struct BlobTxDeleteKey(ValueHash256 Hash, UInt256 Timestamp);
+
 public interface ITxStorage
 {
     bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, [NotNullWhen(true)] out Transaction? transaction);
@@ -26,7 +28,7 @@ internal interface IAtomicBlobTxStorage
     /// <summary>
     /// Atomically removes the timestamped full-body record and the hash-keyed light and elided records for each key.
     /// </summary>
-    void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys);
+    void DeleteMany(scoped ReadOnlySpan<BlobTxDeleteKey> keys);
 
     /// <summary>
     /// Atomically writes <paramref name="transaction"/> and removes obsolete full bodies for the same hash.

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -29,16 +29,6 @@ internal interface IBatchDeleteTxStorage
     void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys);
 
     /// <summary>
-    /// Removes only the timestamped full-body record for each key, leaving the hash-keyed light and elided
-    /// records intact.
-    /// </summary>
-    /// <remarks>
-    /// Used to drop an obsolete body when the same hash is live under a different <see cref="TxLookupKey.Timestamp"/>;
-    /// use <see cref="DeleteMany"/> when no current transaction owns the hash-keyed records.
-    /// </remarks>
-    void DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys);
-
-    /// <summary>
     /// Atomically writes <paramref name="transaction"/> and removes obsolete full bodies for the same hash.
     /// </summary>
     void Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps);

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -21,10 +21,10 @@ public interface ITxStorage
     void Delete(in ValueHash256 hash, in UInt256 timestamp);
 }
 
-internal interface IBatchDeleteTxStorage
+internal interface IAtomicBlobTxStorage
 {
     /// <summary>
-    /// Removes the timestamped full-body record and the hash-keyed light and elided records for each key.
+    /// Atomically removes the timestamped full-body record and the hash-keyed light and elided records for each key.
     /// </summary>
     void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys);
 

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -40,16 +40,9 @@ internal interface IBatchDeleteTxStorage
     void DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys);
 
     /// <summary>
-    /// Removes timestamped full-body records that are not referenced by their hash-keyed light record.
+    /// Atomically writes <paramref name="transaction"/> and removes obsolete full bodies for the same hash.
     /// </summary>
-    /// <remarks>
-    /// This can scan the entire persisted full-transaction collection and should run outside latency-sensitive paths.
-    /// </remarks>
-    /// <param name="cancellationToken">
-    /// Aborts the scan. Implementations must throw rather than return early so an interrupted sweep is not treated as complete.
-    /// </param>
-    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
-    void DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken);
+    void Replace(Transaction transaction, scoped ReadOnlySpan<UInt256> obsoleteTimestamps);
 }
 
 internal interface ISpecChangeValidationStorage

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -36,7 +36,6 @@ namespace Nethermind.TxPool
     /// </summary>
     public class TxPool : ITxPool, IAsyncDisposable
     {
-        private const int MaxObsoleteBlobRecoveryAttempts = 2;
         private const int RevalidationAbandonmentWarningThreshold = 3;
 
         private readonly RetryCache<PooledTransactionRequestMessage, ValueHash256> _retryCache;
@@ -62,8 +61,6 @@ namespace Nethermind.TxPool
         private readonly ISpecChangeValidationStorage? _specChangeValidationStorage;
         private readonly bool _blobReorgsSupportEnabled;
         private bool _specChangeMarkerUnpublished;
-        private bool _obsoleteBlobRecoveryCompleted;
-        private int _obsoleteBlobRecoveryFailures;
         private readonly DelegationCache _pendingDelegations = new();
         private readonly HashSet<Hash256> _forkInvalidatedHashes = [];
         private IReleaseSpec? _forkInvalidatedSpec;
@@ -462,8 +459,7 @@ namespace Nethermind.TxPool
 
         private bool RequiresRevalidation(bool specValidatedForHead) =>
             !specValidatedForHead
-            || Volatile.Read(ref _specChangeMarkerUnpublished)
-            || RequiresObsoleteBlobRecovery();
+            || Volatile.Read(ref _specChangeMarkerUnpublished);
 
         private async Task ProcessRevalidations()
         {
@@ -495,9 +491,9 @@ namespace Nethermind.TxPool
                         _newHeadLock.EnterWriteLock();
                         try
                         {
-                            if (!_cts.IsCancellationRequested)
+                            if (!_cts.IsCancellationRequested
+                                && !ReferenceEquals(Volatile.Read(ref _validatedSpec), _specProvider.GetCurrentHeadSpec()))
                             {
-                                // Bucket reconciliation uses live account state and remains valid after the requested generation becomes stale.
                                 UpdateBucketsWithoutRevalidation();
                             }
                         }
@@ -1078,10 +1074,8 @@ namespace Nethermind.TxPool
             bool isEmpty = _transactions.Count == 0 && _blobTransactions.Count == 0;
             bool markerMatches = _specChangeValidationStorage?.GetSpecChangeValidationMarker() == expectedMarker;
 
-            if (markerMatches)
+            if (markerMatches || isEmpty)
             {
-                // A marker can also record a sweep abandoned after bounded failures; it suppresses recovery retries in either case.
-                Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
                 PublishValidatedSpec(headSpec, expectedMarker);
             }
             else
@@ -1090,11 +1084,6 @@ namespace Nethermind.TxPool
                 {
                     Volatile.Write(ref _specChangeMarkerUnpublished, true);
                     _specChangeValidationStorage.SetSpecChangeValidationMarker(null);
-                }
-
-                if (isEmpty)
-                {
-                    PublishValidatedSpec(headSpec, expectedMarker, persistMarker: false);
                 }
             }
         }
@@ -1123,7 +1112,6 @@ namespace Nethermind.TxPool
             bool isEmpty;
             bool isValidated;
             string marker;
-            bool requiresObsoleteBlobRecovery;
 
             _newHeadLock.EnterWriteLock();
             try
@@ -1137,9 +1125,8 @@ namespace Nethermind.TxPool
                 headSpecGeneration = ObserveHeadSpec(spec);
                 marker = GetSpecChangeValidationMarker(spec);
                 bool isSpecChangeMarkerUnpublished = Volatile.Read(ref _specChangeMarkerUnpublished);
-                requiresObsoleteBlobRecovery = RequiresObsoleteBlobRecovery();
                 isValidated = ReferenceEquals(Volatile.Read(ref _validatedSpec), spec);
-                if (isValidated && !isSpecChangeMarkerUnpublished && !requiresObsoleteBlobRecovery)
+                if (isValidated && !isSpecChangeMarkerUnpublished)
                 {
                     return true;
                 }
@@ -1155,11 +1142,6 @@ namespace Nethermind.TxPool
             finally
             {
                 _newHeadLock.ExitWriteLock();
-            }
-
-            if (requiresObsoleteBlobRecovery && !_cts.IsCancellationRequested)
-            {
-                RecoverObsoleteFullBlobTransactions();
             }
 
             ForkRevalidation? revalidation = isEmpty || isValidated
@@ -1207,32 +1189,6 @@ namespace Nethermind.TxPool
             {
                 _newHeadLock.ExitWriteLock();
             }
-        }
-
-        private void RecoverObsoleteFullBlobTransactions()
-        {
-            try
-            {
-                ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions(_cts.Token);
-            }
-            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
-            {
-                throw;
-            }
-            catch (Exception exception)
-            {
-                int failures = Interlocked.Increment(ref _obsoleteBlobRecoveryFailures);
-                if (failures < MaxObsoleteBlobRecoveryAttempts)
-                {
-                    throw;
-                }
-
-                if (_logger.IsError) _logger.Error($"Skipping obsolete full blob transaction recovery after {failures} failed attempts.", exception);
-            }
-
-            // Retained revalidation deletes retry independently. Abandoning this sweep after bounded failures
-            // deliberately trades orphan reclamation for progress; the marker written by this pass suppresses later retries.
-            Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
         }
 
         private bool IsRevalidationGenerationCurrent(long generation) =>
@@ -1314,12 +1270,7 @@ namespace Nethermind.TxPool
             _forkInvalidatedHashes.Add(hash);
         }
 
-        private bool RequiresObsoleteBlobRecovery() =>
-            !Volatile.Read(ref _obsoleteBlobRecoveryCompleted)
-            && _txPoolConfig.BlobsSupport.IsPersistentStorage()
-            && _blobTxStorage is IBatchDeleteTxStorage;
-
-        private void PublishValidatedSpec(IReleaseSpec spec, string marker, bool persistMarker = true)
+        private void PublishValidatedSpec(IReleaseSpec spec, string marker)
         {
             _blobTransactions.FlushPendingRevalidationDeletes();
 
@@ -1328,11 +1279,8 @@ namespace Nethermind.TxPool
                 Interlocked.Increment(ref _forkStateVersion);
                 try
                 {
-                    if (persistMarker)
-                    {
-                        _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
-                        Volatile.Write(ref _specChangeMarkerUnpublished, false);
-                    }
+                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
+                    Volatile.Write(ref _specChangeMarkerUnpublished, false);
 
                     Volatile.Write(ref _validatedSpec, spec);
                     Interlocked.Exchange(ref _consecutiveRevalidationAbandonments, 0);

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -37,6 +37,7 @@ namespace Nethermind.TxPool
     public class TxPool : ITxPool, IAsyncDisposable
     {
         private const int RevalidationAbandonmentWarningThreshold = 3;
+        private const int MarkerPublicationDeferralWarningThreshold = 3;
 
         private readonly RetryCache<PooledTransactionRequestMessage, ValueHash256> _retryCache;
 
@@ -81,6 +82,7 @@ namespace Nethermind.TxPool
         private long _headGeneration;
         private long _forkStateVersion;
         private int _consecutiveRevalidationAbandonments;
+        private int _consecutiveMarkerPublicationDeferrals;
 
         private readonly UpdateGroupDelegate _updateBucket;
         private readonly UpdateGroupDelegate _updateBucketAdded;
@@ -181,7 +183,13 @@ namespace Nethermind.TxPool
             _transactions.Removed += OnRemovedTx;
 
             _blobTransactions = txPoolConfig.BlobsSupport.IsPersistentStorage()
-                ? new PersistentBlobTxDistinctSortedPool(blobTxStorage, _txPoolConfig, comparer, logManager)
+                ? new PersistentBlobTxDistinctSortedPool(
+                    blobTxStorage,
+                    _txPoolConfig,
+                    comparer,
+                    logManager,
+                    TimeProvider.System,
+                    RequestCurrentSpecRevalidation)
                 : new BlobTxDistinctSortedPool(txPoolConfig.BlobsSupport == BlobsSupportMode.InMemory ? _txPoolConfig.InMemoryBlobPoolSize : 0, comparer, logManager);
             UpdateBucketsWithoutRevalidation();
             InitializeValidatedSpec();
@@ -456,6 +464,8 @@ namespace Nethermind.TxPool
         }
 
         private void RequestRevalidation(long generation) => _revalidationChannel.Writer.TryWrite(generation);
+
+        private void RequestCurrentSpecRevalidation() => RequestRevalidation(Volatile.Read(ref _headGeneration));
 
         private bool RequiresRevalidation(bool specValidatedForHead) =>
             !specValidatedForHead
@@ -1076,7 +1086,8 @@ namespace Nethermind.TxPool
 
             if (markerMatches || isEmpty)
             {
-                _ = PublishValidatedSpec(headSpec, expectedMarker);
+                // Retained deletes are process-local and cannot exist during construction.
+                _ = TryPublishValidatedSpec(headSpec, expectedMarker);
             }
             else
             {
@@ -1181,7 +1192,7 @@ namespace Nethermind.TxPool
                     return true;
                 }
 
-                if (!PublishValidatedSpec(spec, marker))
+                if (!TryPublishValidatedSpec(spec, marker))
                 {
                     return false;
                 }
@@ -1274,23 +1285,29 @@ namespace Nethermind.TxPool
         }
 
         /// <summary>
-        /// Publishes the validated specification and its persistence marker.
+        /// Attempts to publish the validated specification and its persistence marker.
         /// </summary>
-        /// <returns><see langword="false"/> when an active blob writer still owns a retained delete.</returns>
-        private bool PublishValidatedSpec(IReleaseSpec spec, string marker)
+        /// <returns><see langword="false"/> when a retained blob delete cannot yet be flushed.</returns>
+        private bool TryPublishValidatedSpec(IReleaseSpec spec, string marker)
         {
-            if (!_blobTransactions.FlushPendingRevalidationDeletes())
-            {
-                return false;
-            }
+            bool deletesFlushed = _blobTransactions.TryFlushPendingRevalidationDeletes();
 
             lock (_forkStateLock)
             {
                 Interlocked.Increment(ref _forkStateVersion);
                 try
                 {
-                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
-                    Volatile.Write(ref _specChangeMarkerUnpublished, false);
+                    if (deletesFlushed)
+                    {
+                        _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
+                        Volatile.Write(ref _specChangeMarkerUnpublished, false);
+                        _consecutiveMarkerPublicationDeferrals = 0;
+                    }
+                    else
+                    {
+                        Volatile.Write(ref _specChangeMarkerUnpublished, true);
+                        _consecutiveMarkerPublicationDeferrals++;
+                    }
 
                     Volatile.Write(ref _validatedSpec, spec);
                     Interlocked.Exchange(ref _consecutiveRevalidationAbandonments, 0);
@@ -1301,7 +1318,18 @@ namespace Nethermind.TxPool
                 }
             }
 
-            return true;
+            if (!deletesFlushed
+                && _consecutiveMarkerPublicationDeferrals == MarkerPublicationDeferralWarningThreshold
+                && _logger.IsWarn)
+            {
+                _logger.Warn("Transaction pool validation marker publication remains deferred while a blob persistence update completes.");
+            }
+            else if (!deletesFlushed && _logger.IsDebug)
+            {
+                _logger.Debug("Deferred transaction pool validation marker publication while a blob persistence update completes.");
+            }
+
+            return deletesFlushed;
         }
 
         private void InvalidateValidatedSpec()

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1944,6 +1944,13 @@ Db usage:
         private static void DisposeBlockAccountChanges(Block block) => block.DisposeAccountChanges();
     }
 
+    /// <summary>
+    /// Retains the newest requested revalidation generation independently of the lossy wake-up channel.
+    /// </summary>
+    /// <remarks>
+    /// Producers must update the generation before signalling the channel. The consumer must drain pending
+    /// signals before reading <see cref="Generation"/>, so every consumed signal is covered by the observed generation.
+    /// </remarks>
     internal sealed class LatestRevalidationRequest
     {
         private long _generation;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1181,7 +1181,10 @@ namespace Nethermind.TxPool
                     return true;
                 }
 
-                PublishValidatedSpec(spec, marker);
+                if (!PublishValidatedSpec(spec, marker))
+                {
+                    return false;
+                }
 
                 return true;
             }
@@ -1270,9 +1273,12 @@ namespace Nethermind.TxPool
             _forkInvalidatedHashes.Add(hash);
         }
 
-        private void PublishValidatedSpec(IReleaseSpec spec, string marker)
+        private bool PublishValidatedSpec(IReleaseSpec spec, string marker)
         {
-            _blobTransactions.FlushPendingRevalidationDeletes();
+            if (!_blobTransactions.FlushPendingRevalidationDeletes())
+            {
+                return false;
+            }
 
             lock (_forkStateLock)
             {
@@ -1290,6 +1296,8 @@ namespace Nethermind.TxPool
                     Interlocked.Increment(ref _forkStateVersion);
                 }
             }
+
+            return true;
         }
 
         private void InvalidateValidatedSpec()

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1076,7 +1076,7 @@ namespace Nethermind.TxPool
 
             if (markerMatches || isEmpty)
             {
-                PublishValidatedSpec(headSpec, expectedMarker);
+                _ = PublishValidatedSpec(headSpec, expectedMarker);
             }
             else
             {
@@ -1273,6 +1273,10 @@ namespace Nethermind.TxPool
             _forkInvalidatedHashes.Add(hash);
         }
 
+        /// <summary>
+        /// Publishes the validated specification and its persistence marker.
+        /// </summary>
+        /// <returns><see langword="false"/> when an active blob writer still owns a retained delete.</returns>
         private bool PublishValidatedSpec(IReleaseSpec spec, string marker)
         {
             if (!_blobTransactions.FlushPendingRevalidationDeletes())

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -69,7 +69,7 @@ namespace Nethermind.TxPool
         private readonly ILogger _logger;
 
         private readonly Channel<HeadChange> _headBlocksChannel = Channel.CreateUnbounded<HeadChange>(new UnboundedChannelOptions() { SingleReader = true, SingleWriter = true });
-        private readonly Channel<long> _revalidationChannel = Channel.CreateBounded<long>(new BoundedChannelOptions(1)
+        private readonly Channel<bool> _revalidationChannel = Channel.CreateBounded<bool>(new BoundedChannelOptions(1)
         {
             SingleReader = true,
             SingleWriter = false,
@@ -77,6 +77,7 @@ namespace Nethermind.TxPool
         });
         private readonly ReaderWriterLockSlim _newHeadLock = new(LockRecursionPolicy.SupportsRecursion);
         private readonly Lock _forkStateLock = new();
+        private readonly LatestRevalidationRequest _latestRevalidationRequest = new();
         // Publish the spec and its epoch through one reference so readers cannot combine different observations.
         private HeadSpecObservation? _headSpecObservation;
         private long _headGeneration;
@@ -463,7 +464,11 @@ namespace Nethermind.TxPool
             bool CanUseCache(Block block, [NotNullWhen(true)] ArrayPoolList<AddressAsKey>? accountChanges) => accountChanges is not null && block.ParentHash == _lastBlockHash && _lastBlockNumber + 1 == block.Number;
         }
 
-        private void RequestRevalidation(long generation) => _revalidationChannel.Writer.TryWrite(generation);
+        private void RequestRevalidation(long generation)
+        {
+            _latestRevalidationRequest.Update(generation);
+            _revalidationChannel.Writer.TryWrite(true);
+        }
 
         private void RequestCurrentSpecRevalidation() => RequestRevalidation(Volatile.Read(ref _headGeneration));
 
@@ -488,11 +493,9 @@ namespace Nethermind.TxPool
         {
             while (await _revalidationChannel.Reader.WaitToReadAsync(_cts.Token))
             {
-                long generation = 0;
-                while (_revalidationChannel.Reader.TryRead(out long requestedGeneration))
-                {
-                    generation = requestedGeneration;
-                }
+                while (_revalidationChannel.Reader.TryRead(out _)) { }
+
+                long generation = _latestRevalidationRequest.Generation;
 
                 try
                 {
@@ -1939,5 +1942,27 @@ Db usage:
 
         // Cleanup ArrayPoolList AccountChanges as they are not used anywhere else
         private static void DisposeBlockAccountChanges(Block block) => block.DisposeAccountChanges();
+    }
+
+    internal sealed class LatestRevalidationRequest
+    {
+        private long _generation;
+
+        public long Generation => Volatile.Read(ref _generation);
+
+        public void Update(long generation)
+        {
+            long current = Volatile.Read(ref _generation);
+            while (generation > current)
+            {
+                long observed = Interlocked.CompareExchange(ref _generation, generation, current);
+                if (observed == current)
+                {
+                    return;
+                }
+
+                current = observed;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Changes

- Persist full blob transactions, light records, elided payloads, and obsolete-body removals in one atomic RocksDB write batch.
- Consume and deduplicate retained revalidation deletes by transaction hash so reinsertion cannot leave an obsolete body behind.
- Preserve retained deletes across failed atomic and non-atomic reinsertion, then retry persistence without losing the original timestamp.
- Keep validation-marker publication deferred while retained cleanup is outstanding, and retry the marker as soon as persistence completes without repeating the full fork-validation walk.
- Preserve the newest requested revalidation generation when an older background wake-up arrives later.
- Bound immediate blob persistence retries even when concurrent cell updates change the writer token, and recover the writer state if it exits unexpectedly.
- Remove the startup orphan sweep and its retry, marker, and shutdown coupling because replacement and cleanup now share the atomic write path.
- Persist the current validation marker immediately when both pools load empty, since no transaction or deferred recovery work remains to validate.
- Avoid repeating full bucket reconciliation when a stale revalidation request targets the already validated head specification.
- Keep column-family batch `PutSpan` calls span-native, avoiding a managed copy and LOH allocation for large blob bodies.
- Use a compact, sender-free retained-delete representation and allocate overflow storage only when one hash has multiple timestamps.
- Add regression coverage for atomic replacement and deletion, failed reinsertion cleanup, deferred marker publication, retry bounds, restart behaviour, column-family routing, and span-write allocations.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Focused retained-delete, retry, marker-publication, request-ordering, and batch-atomicity regressions: 6 passed in 10 consecutive runs.
- `Nethermind.TxPool.Test`: 760 passed, 1 skipped.
- `Nethermind.Db.Test`: 612 passed, 544 skipped.
- Release build: 0 warnings and 0 errors.
- Whitespace verification and `git diff --check` pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Follow-up to `b7fdae843bb40a803b0d69d7355c4e978ea1cc20`. It replaces recovery-time cleanup with crash-consistent persistence and removes the recovery lifecycle added by that unreleased change. Atomic writes prevent new orphaned bodies. This PR deliberately does not add a migration sweep for rare rows that may already have been orphaned by the released pre-`b7fdae84` non-atomic add path.