### PR TITLE
fix(aura): preserve existing accounts in BAL preprocessing

### DIFF
--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Config;
@@ -189,6 +190,129 @@ namespace Nethermind.AuRa.Test
                 Assert.That(stateProvider.GetCode(TestItem.AddressC), Is.EqualTo(Bytes.FromHexString("0x456")));
                 Assert.That(stateProvider.GetCode(TestItem.AddressD), Is.EqualTo(Bytes.FromHexString("0x654")));
             }
+        }
+
+        // Regression for BAL preprocessing overwriting pre-existing protocol accounts.
+        // On chains such as Gnosis the withdrawal-contract address hosts a deployed contract
+        // (code, balance, nonce); ApplyAuRaPreprocessingChanges must materialise it without
+        // erasing that state. See AuRaBlockProcessor.ApplyAuRaPreprocessingChanges.
+        [Test]
+        public void ApplyAuRaPreprocessingChanges_preserves_existing_withdrawal_contract_account()
+        {
+            Address withdrawalAddress = TestItem.AddressF;
+            byte[] code = Bytes.FromHexString("0x60006000");
+            UInt256 balance = new(1_000_000_000_000_000_000);
+            const ulong nonce = 7;
+
+            (AuRaBlockProcessor processor, BlockAccessListManager balManager, IWorldState stateProvider) =
+                CreateBalAwareProcessor(withdrawalAddress);
+
+            Hash256 stateRoot;
+            using (stateProvider.BeginScope(IWorldState.PreGenesis))
+            {
+                stateProvider.CreateAccount(withdrawalAddress, balance, nonce);
+                stateProvider.InsertCode(withdrawalAddress, code, Amsterdam.Instance, isGenesis: true);
+                stateProvider.Commit(Amsterdam.Instance);
+                stateProvider.CommitTree(0);
+                stateProvider.RecalculateStateRoot();
+                stateRoot = stateProvider.StateRoot;
+            }
+
+            BlockHeader parent = Build.A.BlockHeader.WithNumber(0).WithStateRoot(stateRoot).TestObject;
+
+            using (stateProvider.BeginScope(parent))
+            {
+                EnableBal(balManager);
+                InvokeApplyAuRaPreprocessingChanges(processor);
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(stateProvider.GetCode(withdrawalAddress), Is.EqualTo(code));
+                    Assert.That(stateProvider.GetBalance(withdrawalAddress), Is.EqualTo(balance));
+                    Assert.That(stateProvider.GetNonce(withdrawalAddress), Is.EqualTo(nonce));
+                }
+            }
+        }
+
+        // Guards the other half of the contract: when the accounts are genuinely absent
+        // (the case the BAL integration tests already cover) they must still be materialised
+        // so the BAL parent-snapshot in parallel mode can see them.
+        [Test]
+        public void ApplyAuRaPreprocessingChanges_materialises_absent_accounts()
+        {
+            Address withdrawalAddress = TestItem.AddressF;
+
+            (AuRaBlockProcessor processor, BlockAccessListManager balManager, IWorldState stateProvider) =
+                CreateBalAwareProcessor(withdrawalAddress);
+
+            Hash256 stateRoot;
+            using (stateProvider.BeginScope(IWorldState.PreGenesis))
+            {
+                stateProvider.Commit(Amsterdam.Instance);
+                stateProvider.CommitTree(0);
+                stateProvider.RecalculateStateRoot();
+                stateRoot = stateProvider.StateRoot;
+            }
+
+            BlockHeader parent = Build.A.BlockHeader.WithNumber(0).WithStateRoot(stateRoot).TestObject;
+
+            using (stateProvider.BeginScope(parent))
+            {
+                EnableBal(balManager);
+                InvokeApplyAuRaPreprocessingChanges(processor);
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(stateProvider.AccountExists(Address.SystemUser), Is.True);
+                    Assert.That(stateProvider.AccountExists(withdrawalAddress), Is.True);
+                }
+            }
+        }
+
+        // Flip BlockAccessListManager.Enabled to true via the production entry point: a non-genesis
+        // block under a spec with EIP-7928 active. A null BlockAccessList keeps the sequential path
+        // (no read-warming), which is all the preprocessing step needs.
+        private static void EnableBal(BlockAccessListManager balManager)
+        {
+            Block block = Build.A.Block.WithNumber(1).TestObject;
+            balManager.PrepareForProcessing(block, Amsterdam.Instance, ProcessingOptions.None);
+            Assert.That(balManager.Enabled, Is.True);
+        }
+
+        private static void InvokeApplyAuRaPreprocessingChanges(AuRaBlockProcessor processor)
+        {
+            MethodInfo method = typeof(AuRaBlockProcessor).GetMethod(
+                "ApplyAuRaPreprocessingChanges",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            method.Invoke(processor, [Amsterdam.Instance]);
+        }
+
+        private static (AuRaBlockProcessor Processor, BlockAccessListManager BalManager, IWorldState StateProvider) CreateBalAwareProcessor(Address withdrawalContractAddress)
+        {
+            IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+            IBlockTree blockTree = Build.A.BlockTree(GnosisSpecProvider.Instance).TestObject;
+            ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
+            IBlockhashProvider blockhashProvider = Substitute.For<IBlockhashProvider>();
+            BlockAccessListManager balManager = new(stateProvider, LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), new BalTxProcessorFactory(blockhashProvider, GnosisSpecProvider.Instance, LimboLogs.Instance));
+            ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
+            IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider);
+            AuRaBlockProcessor processor = new(
+                GnosisSpecProvider.Instance,
+                new AuRaChainSpecEngineParameters { WithdrawalContractAddress = withdrawalContractAddress },
+                TestBlockValidator.AlwaysValid,
+                NoBlockRewards.Instance,
+                transactionsExecutor,
+                stateProvider,
+                NullReceiptStorage.Instance,
+                new BeaconBlockRootHandler(transactionProcessor, stateProvider),
+                LimboLogs.Instance,
+                blockTree,
+                new WithdrawalProcessor(stateProvider, LimboLogs.Instance),
+                new ExecutionRequestsProcessor(transactionProcessor),
+                balManager,
+                auRaValidator: null);
+
+            return (processor, balManager, stateProvider);
         }
 
         private (BranchProcessor Processor, IWorldState StateProvider, IBlockTree blockTree) CreateProcessor(ITxFilter? txFilter = null, ContractRewriter? contractRewriter = null)

--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -203,42 +203,26 @@ namespace Nethermind.AuRa.Test
             byte[] code = Bytes.FromHexString("0x60006000");
             UInt256 balance = new(1_000_000_000_000_000_000);
             const ulong nonce = 7;
-            // Address.SystemUser goes through the identical two-line change and can hold a balance
-            // on AuRa (AuRaChainSpecEngineParameters even sets Eip158IgnoredAccount = SystemUser).
+            // Address.SystemUser goes through the identical two-line change; it is a persisted
+            // protocol account whose balance and nonce must survive preprocessing too.
             UInt256 systemUserBalance = new(3_000_000_000);
             const ulong systemUserNonce = 2;
 
-            (AuRaBlockProcessor processor, BlockAccessListManager balManager, IWorldState stateProvider) =
-                CreateBalAwareProcessor(withdrawalAddress);
-
-            Hash256 stateRoot;
-            using (stateProvider.BeginScope(IWorldState.PreGenesis))
-            {
-                stateProvider.CreateAccount(withdrawalAddress, balance, nonce);
-                stateProvider.InsertCode(withdrawalAddress, code, Amsterdam.Instance, isGenesis: true);
-                stateProvider.CreateAccount(Address.SystemUser, systemUserBalance, systemUserNonce);
-                stateProvider.Commit(Amsterdam.Instance);
-                stateProvider.CommitTree(0);
-                stateProvider.RecalculateStateRoot();
-                stateRoot = stateProvider.StateRoot;
-            }
-
-            BlockHeader parent = Build.A.BlockHeader.WithNumber(0).WithStateRoot(stateRoot).TestObject;
-
-            using (stateProvider.BeginScope(parent))
-            {
-                EnableBal(balManager);
-                InvokeApplyAuRaPreprocessingChanges(processor);
-
-                using (Assert.EnterMultipleScope())
+            SeedThenPreprocess(withdrawalAddress,
+                seed: s =>
                 {
-                    Assert.That(stateProvider.GetCode(withdrawalAddress), Is.EqualTo(code));
-                    Assert.That(stateProvider.GetBalance(withdrawalAddress), Is.EqualTo(balance));
-                    Assert.That(stateProvider.GetNonce(withdrawalAddress), Is.EqualTo(nonce));
-                    Assert.That(stateProvider.GetBalance(Address.SystemUser), Is.EqualTo(systemUserBalance));
-                    Assert.That(stateProvider.GetNonce(Address.SystemUser), Is.EqualTo(systemUserNonce));
-                }
-            }
+                    s.CreateAccount(withdrawalAddress, balance, nonce);
+                    s.InsertCode(withdrawalAddress, code, Amsterdam.Instance, isGenesis: true);
+                    s.CreateAccount(Address.SystemUser, systemUserBalance, systemUserNonce);
+                },
+                assert: s =>
+                {
+                    Assert.That(s.GetCode(withdrawalAddress), Is.EqualTo(code));
+                    Assert.That(s.GetBalance(withdrawalAddress), Is.EqualTo(balance));
+                    Assert.That(s.GetNonce(withdrawalAddress), Is.EqualTo(nonce));
+                    Assert.That(s.GetBalance(Address.SystemUser), Is.EqualTo(systemUserBalance));
+                    Assert.That(s.GetNonce(Address.SystemUser), Is.EqualTo(systemUserNonce));
+                });
         }
 
         // Guards the other half of the contract: when the accounts are genuinely absent
@@ -249,12 +233,26 @@ namespace Nethermind.AuRa.Test
         {
             Address withdrawalAddress = TestItem.AddressF;
 
+            SeedThenPreprocess(withdrawalAddress,
+                seed: static _ => { },
+                assert: s =>
+                {
+                    Assert.That(s.AccountExists(Address.SystemUser), Is.True);
+                    Assert.That(s.AccountExists(withdrawalAddress), Is.True);
+                });
+        }
+
+        // Shared scaffolding: seed a pre-genesis state, then process BAL preprocessing on top of a
+        // block scope with BAL enabled, and run the caller's assertions against the resulting state.
+        private static void SeedThenPreprocess(Address withdrawalAddress, Action<IWorldState> seed, Action<IWorldState> assert)
+        {
             (AuRaBlockProcessor processor, BlockAccessListManager balManager, IWorldState stateProvider) =
                 CreateBalAwareProcessor(withdrawalAddress);
 
             Hash256 stateRoot;
             using (stateProvider.BeginScope(IWorldState.PreGenesis))
             {
+                seed(stateProvider);
                 stateProvider.Commit(Amsterdam.Instance);
                 stateProvider.CommitTree(0);
                 stateProvider.RecalculateStateRoot();
@@ -270,8 +268,7 @@ namespace Nethermind.AuRa.Test
 
                 using (Assert.EnterMultipleScope())
                 {
-                    Assert.That(stateProvider.AccountExists(Address.SystemUser), Is.True);
-                    Assert.That(stateProvider.AccountExists(withdrawalAddress), Is.True);
+                    assert(stateProvider);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -203,6 +203,10 @@ namespace Nethermind.AuRa.Test
             byte[] code = Bytes.FromHexString("0x60006000");
             UInt256 balance = new(1_000_000_000_000_000_000);
             const ulong nonce = 7;
+            // Address.SystemUser goes through the identical two-line change and can hold a balance
+            // on AuRa (AuRaChainSpecEngineParameters even sets Eip158IgnoredAccount = SystemUser).
+            UInt256 systemUserBalance = new(3_000_000_000);
+            const ulong systemUserNonce = 2;
 
             (AuRaBlockProcessor processor, BlockAccessListManager balManager, IWorldState stateProvider) =
                 CreateBalAwareProcessor(withdrawalAddress);
@@ -212,6 +216,7 @@ namespace Nethermind.AuRa.Test
             {
                 stateProvider.CreateAccount(withdrawalAddress, balance, nonce);
                 stateProvider.InsertCode(withdrawalAddress, code, Amsterdam.Instance, isGenesis: true);
+                stateProvider.CreateAccount(Address.SystemUser, systemUserBalance, systemUserNonce);
                 stateProvider.Commit(Amsterdam.Instance);
                 stateProvider.CommitTree(0);
                 stateProvider.RecalculateStateRoot();
@@ -230,6 +235,8 @@ namespace Nethermind.AuRa.Test
                     Assert.That(stateProvider.GetCode(withdrawalAddress), Is.EqualTo(code));
                     Assert.That(stateProvider.GetBalance(withdrawalAddress), Is.EqualTo(balance));
                     Assert.That(stateProvider.GetNonce(withdrawalAddress), Is.EqualTo(nonce));
+                    Assert.That(stateProvider.GetBalance(Address.SystemUser), Is.EqualTo(systemUserBalance));
+                    Assert.That(stateProvider.GetNonce(Address.SystemUser), Is.EqualTo(systemUserNonce));
                 }
             }
         }
@@ -281,54 +288,66 @@ namespace Nethermind.AuRa.Test
 
         private static void InvokeApplyAuRaPreprocessingChanges(AuRaBlockProcessor processor)
         {
-            MethodInfo method = typeof(AuRaBlockProcessor).GetMethod(
-                "ApplyAuRaPreprocessingChanges",
-                BindingFlags.Instance | BindingFlags.NonPublic)!;
+            const string methodName = "ApplyAuRaPreprocessingChanges";
+            MethodInfo method = typeof(AuRaBlockProcessor).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new MissingMethodException(nameof(AuRaBlockProcessor), methodName);
             method.Invoke(processor, [Amsterdam.Instance]);
         }
 
         private static (AuRaBlockProcessor Processor, BlockAccessListManager BalManager, IWorldState StateProvider) CreateBalAwareProcessor(Address withdrawalContractAddress)
         {
-            IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
-            IBlockTree blockTree = Build.A.BlockTree(GnosisSpecProvider.Instance).TestObject;
-            ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
-            IBlockhashProvider blockhashProvider = Substitute.For<IBlockhashProvider>();
-            BlockAccessListManager balManager = new(stateProvider, LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), new BalTxProcessorFactory(blockhashProvider, GnosisSpecProvider.Instance, LimboLogs.Instance));
+            (IWorldState stateProvider, IBlockTree blockTree, ITransactionProcessor transactionProcessor, _, BlockAccessListManager balManager) = CreateSharedDeps();
             ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
             IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider);
-            AuRaBlockProcessor processor = new(
-                GnosisSpecProvider.Instance,
-                new AuRaChainSpecEngineParameters { WithdrawalContractAddress = withdrawalContractAddress },
-                TestBlockValidator.AlwaysValid,
-                NoBlockRewards.Instance,
-                transactionsExecutor,
-                stateProvider,
-                NullReceiptStorage.Instance,
-                new BeaconBlockRootHandler(transactionProcessor, stateProvider),
-                LimboLogs.Instance,
-                blockTree,
-                new WithdrawalProcessor(stateProvider, LimboLogs.Instance),
-                new ExecutionRequestsProcessor(transactionProcessor),
-                balManager,
-                auRaValidator: null);
+            AuRaBlockProcessor processor = BuildAuRaProcessor(stateProvider, blockTree, transactionProcessor, transactionsExecutor, balManager, withdrawalContractAddress);
 
             return (processor, balManager, stateProvider);
         }
 
         private (BranchProcessor Processor, IWorldState StateProvider, IBlockTree blockTree) CreateProcessor(ITxFilter? txFilter = null, ContractRewriter? contractRewriter = null)
         {
+            (IWorldState stateProvider, IBlockTree blockTree, ITransactionProcessor transactionProcessor, IBlockhashProvider blockhashProvider, BlockAccessListManager balManager) = CreateSharedDeps();
+            ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
+            IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.ParallelBlockValidationTransactionsExecutor(
+                new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider),
+                stateProvider, HoodiSpecProvider.Instance, balManager, LimboLogs.Instance);
+            AuRaBlockProcessor processor = BuildAuRaProcessor(stateProvider, blockTree, transactionProcessor, transactionsExecutor, balManager, txFilter: txFilter, contractRewriter: contractRewriter);
+
+            BranchProcessor branchProcessor = new(
+                processor,
+                GnosisSpecProvider.Instance,
+                stateProvider,
+                blockhashProvider,
+                new InclusionListSatisfactionChecker(GnosisSpecProvider.Instance, Substitute.For<ITxValidator>()),
+                LimboLogs.Instance);
+
+            return (branchProcessor, stateProvider, blockTree);
+        }
+
+        private static (IWorldState StateProvider, IBlockTree BlockTree, ITransactionProcessor TransactionProcessor, IBlockhashProvider BlockhashProvider, BlockAccessListManager BalManager) CreateSharedDeps()
+        {
             IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
             IBlockTree blockTree = Build.A.BlockTree(GnosisSpecProvider.Instance).TestObject;
             ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
             IBlockhashProvider blockhashProvider = Substitute.For<IBlockhashProvider>();
             BlockAccessListManager balManager = new(stateProvider, LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), new BalTxProcessorFactory(blockhashProvider, GnosisSpecProvider.Instance, LimboLogs.Instance));
-            ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
-            IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.ParallelBlockValidationTransactionsExecutor(
-                new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider),
-                stateProvider, HoodiSpecProvider.Instance, balManager, LimboLogs.Instance);
-            AuRaBlockProcessor processor = new(
+            return (stateProvider, blockTree, transactionProcessor, blockhashProvider, balManager);
+        }
+
+        private static AuRaBlockProcessor BuildAuRaProcessor(
+            IWorldState stateProvider,
+            IBlockTree blockTree,
+            ITransactionProcessor transactionProcessor,
+            IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor,
+            BlockAccessListManager balManager,
+            Address? withdrawalContractAddress = null,
+            ITxFilter? txFilter = null,
+            ContractRewriter? contractRewriter = null) =>
+            new(
                 GnosisSpecProvider.Instance,
-                new AuRaChainSpecEngineParameters(),
+                withdrawalContractAddress is null
+                    ? new AuRaChainSpecEngineParameters()
+                    : new AuRaChainSpecEngineParameters { WithdrawalContractAddress = withdrawalContractAddress },
                 TestBlockValidator.AlwaysValid,
                 NoBlockRewards.Instance,
                 transactionsExecutor,
@@ -343,16 +362,5 @@ namespace Nethermind.AuRa.Test
                 auRaValidator: null,
                 txFilter,
                 contractRewriter: contractRewriter);
-
-            BranchProcessor branchProcessor = new(
-                processor,
-                GnosisSpecProvider.Instance,
-                stateProvider,
-                blockhashProvider,
-                new InclusionListSatisfactionChecker(GnosisSpecProvider.Instance, Substitute.For<ITxValidator>()),
-                LimboLogs.Instance);
-
-            return (branchProcessor, stateProvider, blockTree);
-        }
     }
 }

--- a/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.AuRa.Test/AuraBlockProcessorTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Config;
@@ -192,159 +191,20 @@ namespace Nethermind.AuRa.Test
             }
         }
 
-        // Regression for BAL preprocessing overwriting pre-existing protocol accounts.
-        // On chains such as Gnosis the withdrawal-contract address hosts a deployed contract
-        // (code, balance, nonce); ApplyAuRaPreprocessingChanges must materialise it without
-        // erasing that state. See AuRaBlockProcessor.ApplyAuRaPreprocessingChanges.
-        [Test]
-        public void ApplyAuRaPreprocessingChanges_preserves_existing_withdrawal_contract_account()
-        {
-            Address withdrawalAddress = TestItem.AddressF;
-            byte[] code = Bytes.FromHexString("0x60006000");
-            UInt256 balance = new(1_000_000_000_000_000_000);
-            const ulong nonce = 7;
-            // Address.SystemUser goes through the identical two-line change; it is a persisted
-            // protocol account whose balance and nonce must survive preprocessing too.
-            UInt256 systemUserBalance = new(3_000_000_000);
-            const ulong systemUserNonce = 2;
-
-            SeedThenPreprocess(withdrawalAddress,
-                seed: s =>
-                {
-                    s.CreateAccount(withdrawalAddress, balance, nonce);
-                    s.InsertCode(withdrawalAddress, code, Amsterdam.Instance, isGenesis: true);
-                    s.CreateAccount(Address.SystemUser, systemUserBalance, systemUserNonce);
-                },
-                assert: s =>
-                {
-                    Assert.That(s.GetCode(withdrawalAddress), Is.EqualTo(code));
-                    Assert.That(s.GetBalance(withdrawalAddress), Is.EqualTo(balance));
-                    Assert.That(s.GetNonce(withdrawalAddress), Is.EqualTo(nonce));
-                    Assert.That(s.GetBalance(Address.SystemUser), Is.EqualTo(systemUserBalance));
-                    Assert.That(s.GetNonce(Address.SystemUser), Is.EqualTo(systemUserNonce));
-                });
-        }
-
-        // Guards the other half of the contract: when the accounts are genuinely absent
-        // (the case the BAL integration tests already cover) they must still be materialised
-        // so the BAL parent-snapshot in parallel mode can see them.
-        [Test]
-        public void ApplyAuRaPreprocessingChanges_materialises_absent_accounts()
-        {
-            Address withdrawalAddress = TestItem.AddressF;
-
-            SeedThenPreprocess(withdrawalAddress,
-                seed: static _ => { },
-                assert: s =>
-                {
-                    Assert.That(s.AccountExists(Address.SystemUser), Is.True);
-                    Assert.That(s.AccountExists(withdrawalAddress), Is.True);
-                });
-        }
-
-        // Shared scaffolding: seed a pre-genesis state, then process BAL preprocessing on top of a
-        // block scope with BAL enabled, and run the caller's assertions against the resulting state.
-        private static void SeedThenPreprocess(Address withdrawalAddress, Action<IWorldState> seed, Action<IWorldState> assert)
-        {
-            (AuRaBlockProcessor processor, BlockAccessListManager balManager, IWorldState stateProvider) =
-                CreateBalAwareProcessor(withdrawalAddress);
-
-            Hash256 stateRoot;
-            using (stateProvider.BeginScope(IWorldState.PreGenesis))
-            {
-                seed(stateProvider);
-                stateProvider.Commit(Amsterdam.Instance);
-                stateProvider.CommitTree(0);
-                stateProvider.RecalculateStateRoot();
-                stateRoot = stateProvider.StateRoot;
-            }
-
-            BlockHeader parent = Build.A.BlockHeader.WithNumber(0).WithStateRoot(stateRoot).TestObject;
-
-            using (stateProvider.BeginScope(parent))
-            {
-                EnableBal(balManager);
-                InvokeApplyAuRaPreprocessingChanges(processor);
-
-                using (Assert.EnterMultipleScope())
-                {
-                    assert(stateProvider);
-                }
-            }
-        }
-
-        // Flip BlockAccessListManager.Enabled to true via the production entry point: a non-genesis
-        // block under a spec with EIP-7928 active. A null BlockAccessList keeps the sequential path
-        // (no read-warming), which is all the preprocessing step needs.
-        private static void EnableBal(BlockAccessListManager balManager)
-        {
-            Block block = Build.A.Block.WithNumber(1).TestObject;
-            balManager.PrepareForProcessing(block, Amsterdam.Instance, ProcessingOptions.None);
-            Assert.That(balManager.Enabled, Is.True);
-        }
-
-        private static void InvokeApplyAuRaPreprocessingChanges(AuRaBlockProcessor processor)
-        {
-            const string methodName = "ApplyAuRaPreprocessingChanges";
-            MethodInfo method = typeof(AuRaBlockProcessor).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
-                ?? throw new MissingMethodException(nameof(AuRaBlockProcessor), methodName);
-            method.Invoke(processor, [Amsterdam.Instance]);
-        }
-
-        private static (AuRaBlockProcessor Processor, BlockAccessListManager BalManager, IWorldState StateProvider) CreateBalAwareProcessor(Address withdrawalContractAddress)
-        {
-            (IWorldState stateProvider, IBlockTree blockTree, ITransactionProcessor transactionProcessor, _, BlockAccessListManager balManager) = CreateSharedDeps();
-            ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
-            IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider);
-            AuRaBlockProcessor processor = BuildAuRaProcessor(stateProvider, blockTree, transactionProcessor, transactionsExecutor, balManager, withdrawalContractAddress);
-
-            return (processor, balManager, stateProvider);
-        }
-
         private (BranchProcessor Processor, IWorldState StateProvider, IBlockTree blockTree) CreateProcessor(ITxFilter? txFilter = null, ContractRewriter? contractRewriter = null)
-        {
-            (IWorldState stateProvider, IBlockTree blockTree, ITransactionProcessor transactionProcessor, IBlockhashProvider blockhashProvider, BlockAccessListManager balManager) = CreateSharedDeps();
-            ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
-            IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.ParallelBlockValidationTransactionsExecutor(
-                new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider),
-                stateProvider, HoodiSpecProvider.Instance, balManager, LimboLogs.Instance);
-            AuRaBlockProcessor processor = BuildAuRaProcessor(stateProvider, blockTree, transactionProcessor, transactionsExecutor, balManager, txFilter: txFilter, contractRewriter: contractRewriter);
-
-            BranchProcessor branchProcessor = new(
-                processor,
-                GnosisSpecProvider.Instance,
-                stateProvider,
-                blockhashProvider,
-                new InclusionListSatisfactionChecker(GnosisSpecProvider.Instance, Substitute.For<ITxValidator>()),
-                LimboLogs.Instance);
-
-            return (branchProcessor, stateProvider, blockTree);
-        }
-
-        private static (IWorldState StateProvider, IBlockTree BlockTree, ITransactionProcessor TransactionProcessor, IBlockhashProvider BlockhashProvider, BlockAccessListManager BalManager) CreateSharedDeps()
         {
             IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
             IBlockTree blockTree = Build.A.BlockTree(GnosisSpecProvider.Instance).TestObject;
             ITransactionProcessor transactionProcessor = Substitute.For<ITransactionProcessor>();
             IBlockhashProvider blockhashProvider = Substitute.For<IBlockhashProvider>();
             BlockAccessListManager balManager = new(stateProvider, LimboLogs.Instance, new BlocksConfig(), new WithdrawalProcessorFactory(LimboLogs.Instance), new BalTxProcessorFactory(blockhashProvider, GnosisSpecProvider.Instance, LimboLogs.Instance));
-            return (stateProvider, blockTree, transactionProcessor, blockhashProvider, balManager);
-        }
-
-        private static AuRaBlockProcessor BuildAuRaProcessor(
-            IWorldState stateProvider,
-            IBlockTree blockTree,
-            ITransactionProcessor transactionProcessor,
-            IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor,
-            BlockAccessListManager balManager,
-            Address? withdrawalContractAddress = null,
-            ITxFilter? txFilter = null,
-            ContractRewriter? contractRewriter = null) =>
-            new(
+            ExecuteTransactionProcessorAdapter txAdapter = new(transactionProcessor);
+            IBlockProcessor.IBlockTransactionsExecutor transactionsExecutor = new BlockProcessor.ParallelBlockValidationTransactionsExecutor(
+                new BlockProcessor.BlockValidationTransactionsExecutor(txAdapter, stateProvider),
+                stateProvider, HoodiSpecProvider.Instance, balManager, LimboLogs.Instance);
+            AuRaBlockProcessor processor = new(
                 GnosisSpecProvider.Instance,
-                withdrawalContractAddress is null
-                    ? new AuRaChainSpecEngineParameters()
-                    : new AuRaChainSpecEngineParameters { WithdrawalContractAddress = withdrawalContractAddress },
+                new AuRaChainSpecEngineParameters(),
                 TestBlockValidator.AlwaysValid,
                 NoBlockRewards.Instance,
                 transactionsExecutor,
@@ -359,5 +219,16 @@ namespace Nethermind.AuRa.Test
                 auRaValidator: null,
                 txFilter,
                 contractRewriter: contractRewriter);
+
+            BranchProcessor branchProcessor = new(
+                processor,
+                GnosisSpecProvider.Instance,
+                stateProvider,
+                blockhashProvider,
+                new InclusionListSatisfactionChecker(GnosisSpecProvider.Instance, Substitute.For<ITxValidator>()),
+                LimboLogs.Instance);
+
+            return (branchProcessor, stateProvider, blockTree);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
@@ -123,10 +123,6 @@ namespace Nethermind.Consensus.AuRa
         // BAL is off — pre-EIP-7928 chains continue to rely on the EVM's lazy account creation.
         // Done BEFORE base.ProcessBlock so the BAL parent-snapshot in parallel mode reflects the
         // materialised accounts.
-        // Must not overwrite an existing account: on chains such as Gnosis the withdrawal-contract
-        // address hosts a deployed protocol contract (code, balance, nonce). CreateAccount would
-        // journal a New empty account that Commit persists under the EIP-158-disabled system spec,
-        // wiping it. CreateAccountIfNotExists only materialises when genuinely absent.
         private void ApplyAuRaPreprocessingChanges(IReleaseSpec spec)
         {
             if (!_balManager.Enabled) return;

--- a/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/AuRaBlockProcessor.cs
@@ -123,12 +123,16 @@ namespace Nethermind.Consensus.AuRa
         // BAL is off — pre-EIP-7928 chains continue to rely on the EVM's lazy account creation.
         // Done BEFORE base.ProcessBlock so the BAL parent-snapshot in parallel mode reflects the
         // materialised accounts.
+        // Must not overwrite an existing account: on chains such as Gnosis the withdrawal-contract
+        // address hosts a deployed protocol contract (code, balance, nonce). CreateAccount would
+        // journal a New empty account that Commit persists under the EIP-158-disabled system spec,
+        // wiping it. CreateAccountIfNotExists only materialises when genuinely absent.
         private void ApplyAuRaPreprocessingChanges(IReleaseSpec spec)
         {
             if (!_balManager.Enabled) return;
 
-            _stateProvider.CreateAccount(Address.SystemUser, UInt256.Zero, 0);
-            _stateProvider.CreateAccount(_withdrawalContractAddress, UInt256.Zero, 0);
+            _stateProvider.CreateAccountIfNotExists(Address.SystemUser, UInt256.Zero, 0);
+            _stateProvider.CreateAccountIfNotExists(_withdrawalContractAddress, UInt256.Zero, 0);
             _stateProvider.Commit(spec.ForSystemTransaction(isGenesis: false), commitRoots: false);
         }
 

--- a/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
+++ b/src/Nethermind/Nethermind.Merge.AuRa.Test/AuRaMergeEngineModuleTests.cs
@@ -15,9 +15,14 @@ using Nethermind.Consensus.AuRa.Validators;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Container;
+using Nethermind.Evm.State;
 using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
 using Nethermind.Merge.Plugin;
 using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Test;
@@ -136,6 +141,41 @@ public class AuRaMergeEngineModuleTests(bool parallel) : EngineModuleTests(paral
     [Platform(Exclude = "MacOsX", Reason = "Timing-sensitive 10ms delays too tight on macOS ARM runners")]
     public Task AuRa_getPayloadV1_does_not_wait_for_improvement_when_block_is_not_empty()
         => base.getPayloadV1_does_not_wait_for_improvement_when_block_is_not_empty();
+
+    // Regression: BAL preprocessing (AuRaMergeBlockProcessor -> ApplyAuRaPreprocessingChanges)
+    // must not overwrite an existing account at the withdrawal-contract or system-user address.
+    // On Gnosis the withdrawal address hosts a deployed protocol contract; wiping it to an empty
+    // account under the EIP-158-disabled system spec diverges state at EIP-7928 activation.
+    [Test]
+    public async Task BAL_preprocessing_preserves_existing_withdrawal_and_system_accounts()
+    {
+        Address withdrawalContract = new(_auraWithdrawalContractAddress);
+        byte[] code = Bytes.FromHexString("0x60006000");
+        UInt256 withdrawalBalance = new(1_000_000_000_000_000_000);
+        const ulong withdrawalNonce = 7;
+        UInt256 systemUserBalance = new(3_000_000_000);
+        const ulong systemUserNonce = 2;
+
+        using MergeTestBlockchain chain = await CreateBlockchain(Amsterdam.Instance, configurer: builder =>
+            builder.WithGenesisPostProcessor((_, state) =>
+            {
+                state.CreateAccount(withdrawalContract, withdrawalBalance, withdrawalNonce);
+                state.InsertCode(withdrawalContract, code, Amsterdam.Instance);
+                state.CreateAccount(Address.SystemUser, systemUserBalance, systemUserNonce);
+            }));
+
+        await AddNewBlockV6(chain.EngineRpcModule, chain);
+
+        BlockHeader head = chain.BlockTree.Head!.Header;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(chain.StateReader.GetCode(head, withdrawalContract), Is.EqualTo(code));
+            Assert.That(chain.StateReader.GetBalance(head, withdrawalContract), Is.EqualTo(withdrawalBalance));
+            Assert.That(chain.StateReader.GetNonce(head, withdrawalContract), Is.EqualTo(withdrawalNonce));
+            Assert.That(chain.StateReader.GetBalance(head, Address.SystemUser), Is.EqualTo(systemUserBalance));
+            Assert.That(chain.StateReader.GetNonce(head, Address.SystemUser), Is.EqualTo(systemUserNonce));
+        }
+    }
 
     protected override BlockBuilder BuildNewBlock(Block head)
         => base.BuildNewBlock(head).WithAura(0, []);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -1122,7 +1122,7 @@ public partial class EngineModuleTests
         Assert.That(chain.BlockTree.Head!.Number, Is.EqualTo(4));
     }
 
-    private async Task<ExecutionPayloadV4> AddNewBlockV6(IEngineRpcModule rpcModule, MergeTestBlockchain chain, int transactionCount = 0)
+    protected async Task<ExecutionPayloadV4> AddNewBlockV6(IEngineRpcModule rpcModule, MergeTestBlockchain chain, int transactionCount = 0)
     {
         Transaction[] txs = BuildTransactions(chain, chain.BlockTree.Head!.Hash!, TestItem.PrivateKeyA, TestItem.AddressB, (uint)transactionCount, 0, out _, out _, 0);
         chain.AddTransactions(txs);


### PR DESCRIPTION
## Changes

`AuRaBlockProcessor.ApplyAuRaPreprocessingChanges` (AuRa + Merge, BAL era) materialised the system-user and withdrawal-contract accounts with `CreateAccount`, which unconditionally journals an empty `Account.TotallyEmpty`. Because the follow-up commit runs under `spec.ForSystemTransaction(...)` (EIP-158 disabled), the empty `New` account is persisted, **wiping any pre-existing account at those addresses**.

On chains such as Gnosis the withdrawal-contract address hosts a deployed protocol contract (code, balance, nonce) — and is also the deposit contract (`0x0B98057eA310F4d31F2a452B414647007d1645d9`). Overwriting it with an empty account diverges state from clients that preserve it: an invalid state root / consensus split once EIP-7928 (BAL) activates on an AuRa chain. It is latent today only because EIP-7928 is not yet activated on Gnosis.

- Replace `CreateAccount` with `CreateAccountIfNotExists` for both `Address.SystemUser` and the withdrawal-contract address, so absent accounts are still materialised for the BAL parent-snapshot while existing accounts are left untouched.
- Add regression tests in `AuraBlockProcessorTests` covering both the preserve-existing and materialise-absent cases (the existing BAL integration tests only exercised a previously-absent custom withdrawal address).

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`ApplyAuRaPreprocessingChanges_preserves_existing_withdrawal_contract_account` fails on the pre-fix code (code, balance and nonce all wiped) and passes with the fix; `ApplyAuRaPreprocessingChanges_materialises_absent_accounts` guards the other half. Full `AuraBlockProcessorTests` class green (7/7).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Reported by the audit team as finding F-02. The finding is confirmed real; severity is latent (not currently exploitable) purely because EIP-7928/BAL is not yet live on any AuRa chain, and becomes high (consensus split) at BAL activation.