### PR TITLE
fix(simulate): keep traceTransfers synthetic log under EIP-7708

### DIFF
--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockMutatorTracerFactory.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockMutatorTracerFactory.cs
@@ -12,5 +12,5 @@ namespace Nethermind.Facade.Simulate;
 public class SimulateBlockMutatorTracerFactory : ISimulateBlockTracerFactory<SimulateCallResult>
 {
     public IBlockTracer<SimulateCallResult> CreateSimulateBlockTracer(bool isTracingLogs, IWorldState worldState, ISpecProvider spec, BlockHeader block) =>
-        new SimulateBlockTracer(isTracingLogs, spec);
+        new SimulateBlockTracer(isTracingLogs);
 }

--- a/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockTracer.cs
+++ b/src/Nethermind/Nethermind.Facade/Simulate/SimulateBlockTracer.cs
@@ -5,23 +5,21 @@ using System;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
-using Nethermind.Core.Specs;
 using Nethermind.Facade.Proxy.Models.Simulate;
 
 namespace Nethermind.Facade.Simulate;
 
-public class SimulateBlockTracer(bool isTracingLogs, ISpecProvider spec) : BlockTracerBase<SimulateCallResult, SimulateTxTracer>
+public class SimulateBlockTracer(bool isTracingLogs) : BlockTracerBase<SimulateCallResult, SimulateTxTracer>
 {
     private ulong _txIndex = 0;
     private ulong _logIndex = 0;
 
     private ulong _blockNumber;
     private ulong _blockTimestamp;
-    private bool _isTracingLogs = isTracingLogs;
 
     protected override SimulateTxTracer OnStart(Transaction? tx) =>
         tx?.Hash is not null
-            ? new(_isTracingLogs, tx, _blockNumber, Hash256.Zero, _blockTimestamp, _txIndex++, _logIndex)
+            ? new(isTracingLogs, tx, _blockNumber, Hash256.Zero, _blockTimestamp, _txIndex++, _logIndex)
             : throw new InvalidOperationException($"{nameof(SimulateBlockTracer)} does not support tracing rewards.");
 
     protected override SimulateCallResult OnEnd(SimulateTxTracer txTracer)
@@ -47,7 +45,6 @@ public class SimulateBlockTracer(bool isTracingLogs, ISpecProvider spec) : Block
         _logIndex = 0;
         _blockNumber = block.Number;
         _blockTimestamp = block.Timestamp;
-        _isTracingLogs &= !spec.GetSpec(block.Header).IsEip7708Enabled;
         base.StartNewBlockTrace(block);
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/Simulate/EthSimulateTestsBlocksAndTransactions.cs
@@ -432,11 +432,21 @@ public class EthSimulateTestsBlocksAndTransactions
         OverridableReleaseSpec spec = new(London.Instance);
         TestRpcBlockchain chain = await EthRpcSimulateTestsBase.CreateChain(spec);
         spec.IsEip7708Enabled = eip7708;
-        Console.WriteLine("current test: simulateTransferOverBlockStateCalls");
         ResultWrapper<IReadOnlyList<SimulateBlockResult<SimulateCallResult>>> result = chain.EthRpcModule.eth_simulateV1(payload!, BlockParameter.Latest);
         Log[] logs = result.Data.First().Calls.First().Logs.ToArray();
-        Assert.That(logs.Length, Is.EqualTo(1));
-        Assert.That(logs.First().Address == (eip7708 ? TransferLog.Sender : TransferLog.Erc20Sender));
+
+        if (eip7708)
+        {
+            // traceTransfers adds its synthetic ERC-20 log on top of the EIP-7708 protocol log.
+            Assert.That(logs.Length, Is.EqualTo(2));
+            Assert.That(logs[0].Address, Is.EqualTo(TransferLog.Erc20Sender));
+            Assert.That(logs[1].Address, Is.EqualTo(TransferLog.Sender));
+        }
+        else
+        {
+            Assert.That(logs.Length, Is.EqualTo(1));
+            Assert.That(logs[0].Address, Is.EqualTo(TransferLog.Erc20Sender));
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Changes

`eth_simulateV1` with `traceTransfers=true` under EIP-7708 (Amsterdam) returned only the protocol transfer log (`0xffff…fffe`): `SimulateBlockTracer` suppressed the `traceTransfers` synthetic ERC-20 log (`0xeeee…eeee`) once EIP-7708 was active.

The execution-apis Amsterdam fixtures — regenerated from go-ethereum master in [ethereum/execution-apis#867](https://github.com/ethereum/execution-apis/pull/867) — define `traceTransfers` as **additive** to the protocol log. `eth_simulateV1/ethSimulate-eth-send-should-produce-logs` expects two logs, `0xeeee…eeee` (synthesized) then `0xffff…fffe` (protocol); the default (`traceTransfers=false`) case expects only the protocol log. Nethermind's single-log output diverged from geth/reth/erigon and those fixtures.

- Drop the EIP-7708 suppression in `SimulateBlockTracer` so `traceTransfers=true` returns both the synthetic and protocol logs. This also removes the now-unused `ISpecProvider` constructor dependency.
- Update `TestTransferLogsAddress` to expect both logs (synthesized then protocol) under EIP-7708, and one otherwise.

Verified end-to-end against a node built from this branch on an Amsterdam-at-genesis chainspec (EIP-7708 + EIP-7928 active): `traceTransfers=true` → 2 logs `[0xeeee…eeee, 0xffff…fffe]`; `traceTransfers=false` → 1 log `0xffff…fffe`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`TestTransferLogsAddress` (both `traceTransfers` × EIP-7708 combinations) and the full `~Simulate` suite (115 tests) pass. Also confirmed live via `eth_simulateV1` HTTP requests against a Docker node built from this branch.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
