### PR TITLE
fix(engine): enforce MaxBlobsRequest in GetBlobs SSZ handlers

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -797,6 +797,16 @@ public class SszMiddlewareTests
     private static byte[] BuildPayloadBodiesByHashRequest(Hash256[] hashes) =>
         BuildHashListRequest(Array.ConvertAll(hashes, h => h.Bytes.ToArray()));
 
+    // Hand-builds a GetBlobsV4 request: a 4-byte offset to the variable hash list, the fixed
+    // 128-bit indices bitvector (16 zero bytes), then hashCount 32-byte versioned hashes.
+    private static byte[] BuildGetBlobsV4Request(int hashCount)
+    {
+        const int fixedSection = 4 + 16;
+        byte[] result = new byte[fixedSection + hashCount * 32];
+        BitConverter.TryWriteBytes(result.AsSpan(0, 4), (uint)fixedSection);
+        return result;
+    }
+
     [Test]
     public async Task ClientVersion_reads_X_Engine_Client_Version_header()
     {
@@ -1468,5 +1478,31 @@ public class SszMiddlewareTests
         string body = System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx));
         Assert.That(body, Does.Contain("ssz-decode-error"));
         _engineModule.DidNotReceive().engine_getPayloadBodiesByHashV1(Arg.Any<IReadOnlyList<Hash256>>());
+    }
+
+    [TestCase("/engine/v1/blobs/v1")]
+    [TestCase("/engine/v1/blobs/v2")]
+    [TestCase("/engine/v1/blobs/v3")]
+    [TestCase("/engine/v1/blobs/v4")]
+    public async Task GetBlobs_over_limit_is_rejected_before_the_engine_module(string path)
+    {
+        int overLimit = SszRestLimits.MaxBlobsRequest + 1;
+        byte[] body = path.EndsWith("/v4")
+            ? BuildGetBlobsV4Request(overLimit)
+            : BuildHashListRequest(new byte[overLimit][].Select(static _ => new byte[32]).ToArray());
+        DefaultHttpContext ctx = MakePostContext(path, body);
+
+        await _middleware.InvokeAsync(ctx);
+
+        // The wire schema caps the list at MaxBlobsRequest, so the decoder rejects an over-limit
+        // request (the handler's explicit 413 guard is the belt-and-suspenders should the cap ever
+        // be raised). Either way it must never dispatch to the engine.
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        string responseBody = System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx));
+        Assert.That(responseBody, Does.Contain("ssz-decode-error"));
+        await _engineModule.DidNotReceive().engine_getBlobsV1(Arg.Any<byte[][]>());
+        await _engineModule.DidNotReceive().engine_getBlobsV2(Arg.Any<byte[][]>());
+        await _engineModule.DidNotReceive().engine_getBlobsV3(Arg.Any<byte[][]>());
+        await _engineModule.DidNotReceive().engine_getBlobsV4(Arg.Any<byte[][]>(), Arg.Any<System.Collections.BitArray>());
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetBlobsSszHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/SszRest/Handlers/GetBlobsSszHandler.cs
@@ -21,6 +21,13 @@ public sealed class GetBlobsV1SszHandler(IEngineRpcModule engineModule) : SszEnd
     public override async Task HandleAsync(HttpContext ctx, int version, ReadOnlyMemory<char> extra, ReadOnlySequence<byte> body)
     {
         byte[][] hashes = SszCodec.DecodeGetBlobsRequest(body);
+        if (hashes.Length > SszRestLimits.MaxBlobsRequest)
+        {
+            await WriteErrorAsync(ctx, StatusCodes.Status413PayloadTooLarge,
+                $"hash count {hashes.Length} exceeds the limit of {SszRestLimits.MaxBlobsRequest}",
+                MergeErrorCodes.TooLargeRequest);
+            return;
+        }
         ResultWrapper<IReadOnlyList<BlobAndProofV1?>> result = await engineModule.engine_getBlobsV1(hashes);
         await WriteSszResultAsync(ctx, result, SszCodec.EncodeGetBlobsV1Response);
     }
@@ -37,6 +44,13 @@ public sealed class GetBlobsV2SszHandler<TVersion>(IEngineRpcModule engineModule
     public override async Task HandleAsync(HttpContext ctx, int v, ReadOnlyMemory<char> extra, ReadOnlySequence<byte> body)
     {
         byte[][] hashes = SszCodec.DecodeGetBlobsRequest(body);
+        if (hashes.Length > SszRestLimits.MaxBlobsRequest)
+        {
+            await WriteErrorAsync(ctx, StatusCodes.Status413PayloadTooLarge,
+                $"hash count {hashes.Length} exceeds the limit of {SszRestLimits.MaxBlobsRequest}",
+                MergeErrorCodes.TooLargeRequest);
+            return;
+        }
         ResultWrapper<IReadOnlyList<BlobAndProofV2?>?> result = await TVersion.Call(engineModule, hashes);
         await WriteSszResultAsync(ctx, result, static (d, w) => TVersion.Encode(d!, w));
     }
@@ -51,6 +65,13 @@ public sealed class GetBlobsV4SszHandler(IEngineRpcModule engineModule) : SszEnd
     public override async Task HandleAsync(HttpContext ctx, int version, ReadOnlyMemory<char> extra, ReadOnlySequence<byte> body)
     {
         (byte[][] hashes, System.Collections.BitArray indices) = SszCodec.DecodeGetBlobsV4Request(body);
+        if (hashes.Length > SszRestLimits.MaxBlobsRequest)
+        {
+            await WriteErrorAsync(ctx, StatusCodes.Status413PayloadTooLarge,
+                $"hash count {hashes.Length} exceeds the limit of {SszRestLimits.MaxBlobsRequest}",
+                MergeErrorCodes.TooLargeRequest);
+            return;
+        }
         ResultWrapper<IReadOnlyList<BlobCellsAndProofs?>?> result = await engineModule.engine_getBlobsV4(hashes, indices);
         await WriteSszResultAsync(ctx, result, static (d, w) => SszCodec.EncodeGetBlobsV4Response(d!, w));
     }


### PR DESCRIPTION
## Changes

- Add the explicit `hashes.Length > SszRestLimits.MaxBlobsRequest` (128) guard to `GetBlobsV1SszHandler`, `GetBlobsV2SszHandler<TVersion>` (V2/V3) and `GetBlobsV4SszHandler`, returning **413** with `MergeErrorCodes.TooLargeRequest` — mirroring the existing `GetPayloadBodiesByHashSszHandler` / `GetPayloadBodiesByRangeSszHandler` pattern.
- Add a parameterized regression test (`GetBlobs_over_limit_is_rejected_before_the_engine_module`) covering all four blob endpoints (v1/v2/v3/v4), matching the existing `GetPayloadBodiesByHash_over_limit_is_rejected_before_the_engine_module` test.

### Background

`SszRestLimits.MaxBlobsRequest` is documented as *"enforced by the corresponding handlers"*, but the GetBlobs handlers dispatched the decoded versioned-hash list straight to `engine_getBlobs*` without that check — unlike the bodies handlers. Over-limit requests were only implicitly bounded by the SSZ wire schema's `SszList(128)` cap. Relying on that implicit bound means a future PeerDAS fork that raises the `SszList` limit would silently widen the endpoint cap, and over-limit behaviour would change from a clear 413 to whatever the decoder/engine does (per execution-apis#793).

The added guard is defense-in-depth: today the decoder already rejects an over-limit list with a 400 `ssz-decode-error` before the handler runs (as the sibling by-hash test asserts), so this change is behaviourally inert on current constants but keeps the documented 413 contract stable if the wire cap is ever raised. This matches how the existing by-hash guard is written and tested.

For V4 only `hashes.Length` is guarded: `IndicesBitarray` is a fixed `SszVector(128)` cell-index bitfield (always length 128, unrelated to blob count), so a length check against `MaxBlobsRequest` would be meaningless.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

All 86 `SszMiddlewareTests` pass, including the 4 new parameterized cases. Build clean, 0 warnings.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No