### PR TITLE
fix(portfolio): scan available window before the retained-receipts floor

### DIFF
--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin.Test/DetectionScannerTests.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin.Test/DetectionScannerTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Db.LogIndex;
 using Nethermind.Facade.Filters;
 using Nethermind.Facade.Find;
 using Nethermind.Logging;
@@ -28,6 +29,7 @@ public class DetectionScannerTests
     private DetectionCache _cache = null!;
     private ILogFinder _logFinder = null!;
     private IBlockFinder _blockFinder = null!;
+    private ILogIndexStorage _logIndexStorage = null!;
     private CapturingScheduler _scheduler = null!;
     private DetectionScanner _scanner = null!;
 
@@ -39,13 +41,17 @@ public class DetectionScannerTests
         _cache = new DetectionCache(_dir, LimboLogs.Instance);
         _logFinder = Substitute.For<ILogFinder>();
         _blockFinder = Substitute.For<IBlockFinder>();
+        // No index floor by default (MinBlockNumber returns null), so scans keep their full-history bound;
+        // the pivot-underflow test sets a floor explicitly.
+        _logIndexStorage = Substitute.For<ILogIndexStorage>();
         _scheduler = new CapturingScheduler();
-        _scanner = new DetectionScanner(_scheduler, _logFinder, _blockFinder, _cache, LimboLogs.Instance, (ulong)ChainId);
+        _scanner = new DetectionScanner(_scheduler, _logFinder, _blockFinder, _logIndexStorage, _cache, LimboLogs.Instance, (ulong)ChainId);
     }
 
     [TearDown]
-    public void TearDown()
+    public async Task TearDown()
     {
+        await _logIndexStorage.DisposeAsync();
         if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
     }
 
@@ -269,6 +275,34 @@ public class DetectionScannerTests
 
         DetectionEntry? entry = _cache.Get(ChainId, Account.ToString());
         Assert.That(entry!.Complete, Is.True, "hitting the retained-history floor completes the scan");
+    }
+
+    [Test]
+    public async Task First_scan_covers_the_window_above_the_index_floor_on_a_snap_synced_node()
+    {
+        // Regression for #13051: on a freshly snap-synced node the head sits just above the snap pivot, so the
+        // first downward chunk [head-5000, head] underflows below the log-index floor, where receipts aren't
+        // backfilled and FindLogs throws up-front. The scan must clamp to the floor and surface the tokens in the
+        // available [floor, head] window, not abort with an empty complete:true entry.
+        const long floor = 500;
+        _logIndexStorage.MinBlockNumber.Returns((int)floor);
+        _blockFinder.Head.Returns(Build.A.Block.WithNumber(800).TestObject); // only a few hundred blocks above the floor
+        _logFinder.FindLogs(Arg.Any<LogFilter>(), Arg.Any<CancellationToken>())
+            .Returns(ci => (long)(ci.Arg<LogFilter>().FromBlock.BlockNumber ?? 0) < floor
+                ? throw new ResourceNotFoundException("receipts unavailable below the snap pivot")
+                : [Log(Token, Transfer, Keccak.Zero, Keccak.Zero)]);
+
+        _scanner.RequestScan(ChainId, Account);
+        await _scheduler.RunAll();
+
+        DetectionEntry? entry = _cache.Get(ChainId, Account.ToString());
+        Assert.That(entry, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(entry!.Contracts, Does.Contain(Token.ToString()), "token in the window above the pivot is detected, not lost to an underflowing first chunk");
+            Assert.That(entry.Complete, Is.True, "scan completes at the index floor");
+            Assert.That(entry.ScannedFrom, Is.EqualTo(0), "completed scans reset the resume cursor");
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin.Test/DetectionScannerTests.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin.Test/DetectionScannerTests.cs
@@ -51,6 +51,8 @@ public class DetectionScannerTests
     [TearDown]
     public async Task TearDown()
     {
+        // ILogIndexStorage is IAsyncDisposable, so the NUnit1032 analyzer requires disposing the field here (the
+        // substitute's DisposeAsync is a no-op).
         await _logIndexStorage.DisposeAsync();
         if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
     }
@@ -284,8 +286,8 @@ public class DetectionScannerTests
         // first downward chunk [head-5000, head] underflows below the log-index floor, where receipts aren't
         // backfilled and FindLogs throws up-front. The scan must clamp to the floor and surface the tokens in the
         // available [floor, head] window, not abort with an empty complete:true entry.
-        const long floor = 500;
-        _logIndexStorage.MinBlockNumber.Returns((int)floor);
+        const int floor = 500;
+        _logIndexStorage.MinBlockNumber.Returns(floor);
         _blockFinder.Head.Returns(Build.A.Block.WithNumber(800).TestObject); // only a few hundred blocks above the floor
         _logFinder.FindLogs(Arg.Any<LogFilter>(), Arg.Any<CancellationToken>())
             .Returns(ci => (long)(ci.Arg<LogFilter>().FromBlock.BlockNumber ?? 0) < floor
@@ -300,8 +302,35 @@ public class DetectionScannerTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(entry!.Contracts, Does.Contain(Token.ToString()), "token in the window above the pivot is detected, not lost to an underflowing first chunk");
-            Assert.That(entry.Complete, Is.True, "scan completes at the index floor");
+            Assert.That(entry.Complete, Is.True, "scan completes once the walk drops below the pivot and receipts are unavailable");
             Assert.That(entry.ScannedFrom, Is.EqualTo(0), "completed scans reset the resume cursor");
+        }
+    }
+
+    [Test]
+    public async Task Receipts_below_the_index_floor_are_still_walked_to_genesis()
+    {
+        // Regression for the #13052 review: the index floor moves down as the index backfills, so it must only
+        // clamp a straddling chunk, never terminate the scan. A fully-synced node has receipts below the floor,
+        // so a token transferred there must still be detected rather than lost to a premature complete-at-floor.
+        const int floor = 700;
+        _logIndexStorage.MinBlockNumber.Returns(floor);
+        _blockFinder.Head.Returns(Build.A.Block.WithNumber(800).TestObject);
+        // Receipts available at every depth (full node); the token lives only below the index floor.
+        _logFinder.FindLogs(Arg.Any<LogFilter>(), Arg.Any<CancellationToken>())
+            .Returns(ci => (long)(ci.Arg<LogFilter>().FromBlock.BlockNumber ?? 0) < floor
+                ? [Log(Token, Transfer, Keccak.Zero, Keccak.Zero)]
+                : []);
+
+        _scanner.RequestScan(ChainId, Account);
+        await _scheduler.RunAll();
+
+        DetectionEntry? entry = _cache.Get(ChainId, Account.ToString());
+        Assert.That(entry, Is.Not.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(entry!.Contracts, Does.Contain(Token.ToString()), "a token below the moving index floor is still detected");
+            Assert.That(entry.Complete, Is.True, "scan completes at genesis, not at the index floor");
         }
     }
 

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin/DetectionScanner.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin/DetectionScanner.cs
@@ -6,6 +6,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Db.LogIndex;
 using Nethermind.Facade.Filters;
 using Nethermind.Facade.Filters.Topics;
 using Nethermind.Facade.Find;
@@ -26,7 +27,7 @@ public interface IDetectionScanner
 /// chunks chained until retained history is covered, so a deep scan can't affect validator performance.
 /// </remarks>
 public sealed class DetectionScanner(
-    IBackgroundTaskScheduler scheduler, ILogFinder logFinder, IBlockFinder blockFinder, IDetectionCache cache, ILogManager logManager, ulong localChainId)
+    IBackgroundTaskScheduler scheduler, ILogFinder logFinder, IBlockFinder blockFinder, ILogIndexStorage logIndexStorage, IDetectionCache cache, ILogManager logManager, ulong localChainId)
     : IDetectionScanner
 {
     // ERC-20/ERC-721 Transfer, and ERC-1155 TransferSingle/TransferBatch event signatures
@@ -51,6 +52,13 @@ public sealed class DetectionScanner(
     private int CurrentChunk(string key) => _active.TryGetValue(key, out int c) ? c : BaseChunkBlocks;
     private void Grow(string key) => _active.AddOrUpdate(key, BaseChunkBlocks, static (_, c) => Math.Min(c * 2, MaxChunkBlocks));
     private void Shrink(string key) => _active.AddOrUpdate(key, MinChunkBlocks, static (_, c) => Math.Max(c / 2, MinChunkBlocks));
+
+    // Lowest block the log index covers, and thus the deepest block a scan can reach. On a freshly snap-synced
+    // node the head sits just above the snap pivot, so a full base-size chunk below it would underflow into blocks
+    // whose receipts aren't backfilled yet — clamping the walk to this floor scans the available window instead of
+    // aborting empty. Returns 0 when no index floor is known (index disabled or not yet built), leaving the walk's
+    // default full-history bound and completion condition unchanged.
+    private long IndexFloor() => logIndexStorage.MinBlockNumber is { } min ? min : 0;
 
     private readonly record struct DetectRequest(long ChainId, Address Account);
 
@@ -92,7 +100,7 @@ public sealed class DetectionScanner(
             // the downward history walk.
             if (existing is not null && curHead > existing.Head)
             {
-                long flo = Math.Max(0, existing.Head + 1 - ForwardReorgOverlapBlocks);
+                long flo = Math.Max(IndexFloor(), existing.Head + 1 - ForwardReorgOverlapBlocks);
                 long fhi = Math.Min(curHead, flo + chunk - 1);
                 HashSet<string> fErc20 = [.. existing.Contracts];
                 HashSet<string> fNfts = [.. existing.NftContracts];
@@ -127,10 +135,13 @@ public sealed class DetectionScanner(
             long head = existing?.Head ?? curHead;
             if (head <= 0) { _active.TryRemove(key, out _); return Task.CompletedTask; } // node not ready; client re-triggers
 
+            long floor = IndexFloor();
             long priorScannedFrom = existing is { ScannedFrom: > 0 } ? existing.ScannedFrom : head + 1;
             long hi = priorScannedFrom - 1;
-            if (hi <= 0) { Persist(chainId, account, existing?.Contracts, existing?.NftContracts, 0, head, complete: true); _active.TryRemove(key, out _); return Task.CompletedTask; }
-            long lo = Math.Max(0, hi - chunk + 1);
+            // Reached the bottom of scannable history — genesis, or the log-index floor (below which a snap-synced
+            // node has no indexed logs and its receipts aren't backfilled yet). Nothing left to walk down into.
+            if (hi <= 0 || hi < floor) { Persist(chainId, account, existing?.Contracts, existing?.NftContracts, 0, head, complete: true); _active.TryRemove(key, out _); return Task.CompletedTask; }
+            long lo = Math.Max(floor, hi - chunk + 1);
 
             HashSet<string> erc20 = existing is null ? [] : [.. existing.Contracts];
             HashSet<string> nfts = existing is null ? [] : [.. existing.NftContracts];
@@ -155,7 +166,7 @@ public sealed class DetectionScanner(
                 return Task.CompletedTask;
             }
 
-            bool complete = lo <= 0 || erc20.Count + nfts.Count >= MaxContractsPerScan;
+            bool complete = lo <= floor || erc20.Count + nfts.Count >= MaxContractsPerScan;
             Persist(chainId, account, erc20, nfts, complete ? 0 : lo, head, complete);
             if (complete) _active.TryRemove(key, out _);
             else { Grow(key); Schedule(req); } // chunk finished within the gap — go wider next time

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin/DetectionScanner.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin/DetectionScanner.cs
@@ -53,11 +53,9 @@ public sealed class DetectionScanner(
     private void Grow(string key) => _active.AddOrUpdate(key, BaseChunkBlocks, static (_, c) => Math.Min(c * 2, MaxChunkBlocks));
     private void Shrink(string key) => _active.AddOrUpdate(key, MinChunkBlocks, static (_, c) => Math.Max(c / 2, MinChunkBlocks));
 
-    // Lowest block the log index covers, and thus the deepest block a scan can reach. On a freshly snap-synced
-    // node the head sits just above the snap pivot, so a full base-size chunk below it would underflow into blocks
-    // whose receipts aren't backfilled yet — clamping the walk to this floor scans the available window instead of
-    // aborting empty. Returns 0 when no index floor is known (index disabled or not yet built), leaving the walk's
-    // default full-history bound and completion condition unchanged.
+    /// <summary>Lowest block the log index covers, or <c>0</c> when no floor is known (index disabled or not yet built).</summary>
+    /// <remarks>On a freshly snap-synced node the head sits just above the snap pivot, so a full base-size chunk below
+    /// it would underflow into blocks whose receipts aren't backfilled yet; the floor clamps only such a straddling chunk.</remarks>
     private long IndexFloor() => logIndexStorage.MinBlockNumber is { } min ? min : 0;
 
     private readonly record struct DetectRequest(long ChainId, Address Account);
@@ -100,7 +98,7 @@ public sealed class DetectionScanner(
             // the downward history walk.
             if (existing is not null && curHead > existing.Head)
             {
-                long flo = Math.Max(IndexFloor(), existing.Head + 1 - ForwardReorgOverlapBlocks);
+                long flo = Math.Max(0, existing.Head + 1 - ForwardReorgOverlapBlocks);
                 long fhi = Math.Min(curHead, flo + chunk - 1);
                 HashSet<string> fErc20 = [.. existing.Contracts];
                 HashSet<string> fNfts = [.. existing.NftContracts];
@@ -138,10 +136,11 @@ public sealed class DetectionScanner(
             long floor = IndexFloor();
             long priorScannedFrom = existing is { ScannedFrom: > 0 } ? existing.ScannedFrom : head + 1;
             long hi = priorScannedFrom - 1;
-            // Reached the bottom of scannable history — genesis, or the log-index floor (below which a snap-synced
-            // node has no indexed logs and its receipts aren't backfilled yet). Nothing left to walk down into.
-            if (hi <= 0 || hi < floor) { Persist(chainId, account, existing?.Contracts, existing?.NftContracts, 0, head, complete: true); _active.TryRemove(key, out _); return Task.CompletedTask; }
-            long lo = Math.Max(floor, hi - chunk + 1);
+            if (hi <= 0) { Persist(chainId, account, existing?.Contracts, existing?.NftContracts, 0, head, complete: true); _active.TryRemove(key, out _); return Task.CompletedTask; }
+            // Clamp only a chunk that straddles the index floor so it can't underflow into blocks whose receipts a
+            // snap-synced node hasn't backfilled yet. Below the floor a fully-synced node still has receipts, so let
+            // LogFinder's availability guard (ResourceNotFoundException) remain the single terminal signal.
+            long lo = hi >= floor ? Math.Max(floor, hi - chunk + 1) : Math.Max(0, hi - chunk + 1);
 
             HashSet<string> erc20 = existing is null ? [] : [.. existing.Contracts];
             HashSet<string> nfts = existing is null ? [] : [.. existing.NftContracts];
@@ -166,7 +165,7 @@ public sealed class DetectionScanner(
                 return Task.CompletedTask;
             }
 
-            bool complete = lo <= floor || erc20.Count + nfts.Count >= MaxContractsPerScan;
+            bool complete = lo <= 0 || erc20.Count + nfts.Count >= MaxContractsPerScan;
             Persist(chainId, account, erc20, nfts, complete ? 0 : lo, head, complete);
             if (complete) _active.TryRemove(key, out _);
             else { Grow(key); Schedule(req); } // chunk finished within the gap — go wider next time

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin/PortfolioViewerConfigurer.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin/PortfolioViewerConfigurer.cs
@@ -13,6 +13,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
+using Nethermind.Db.LogIndex;
 using Nethermind.Facade.Find;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
@@ -26,7 +27,7 @@ namespace Nethermind.PortfolioViewer.Plugin;
 /// </remarks>
 public sealed class PortfolioViewerConfigurer(
     IPortfolioViewerConfig config, IInitConfig initConfig, IBackgroundTaskScheduler scheduler,
-    ILogFinder logFinder, IBlockFinder blockFinder, ISpecProvider specProvider, ILogManager logManager) : IJsonRpcServiceConfigurer
+    ILogFinder logFinder, IBlockFinder blockFinder, ILogIndexStorage logIndexStorage, ISpecProvider specProvider, ILogManager logManager) : IJsonRpcServiceConfigurer
 {
     public void Configure(IServiceCollection services)
     {
@@ -36,7 +37,7 @@ public sealed class PortfolioViewerConfigurer(
         services.AddSingleton<ISiblingNodeRegistry, SiblingNodeRegistry>();
         services.AddSingleton<IDetectionCache>(cache);
         services.AddSingleton<IPinnedCidStore>(new PinnedCidStore(initConfig.BaseDbPath, logManager));
-        services.AddSingleton<IDetectionScanner>(new DetectionScanner(scheduler, logFinder, blockFinder, cache, logManager, specProvider.ChainId));
+        services.AddSingleton<IDetectionScanner>(new DetectionScanner(scheduler, logFinder, blockFinder, logIndexStorage, cache, logManager, specProvider.ChainId));
         services.AddTransient<IStartupFilter, PortfolioViewerStartupFilter>();
     }
 }


### PR DESCRIPTION
Fixes #13051

## Changes

The Portfolio Viewer plugin's token/NFT auto-detection (`DetectionScanner`) returned empty results on the **first** scan of an active address on a freshly snap-synced node.

**Root cause.** A first scan (no cached `DetectionEntry`) starts the downward history walk with the chunk `[head - 5000, head]` (`long lo = Math.Max(0, hi - BaseChunkBlocks + 1)`). On a snap-synced node the head sits only a few hundred blocks above the snap pivot, so `lo = head - 4999` lands **below the pivot**, where receipts/log-index aren't backfilled yet. `LogFinder.FindLogs` has a correct up-front guard that throws `ResourceNotFoundException` *before iterating any block* when `fromBlock`'s receipts aren't on disk. The downward phase's `catch (ResourceNotFoundException)` then persisted `complete: true` with empty results and removed the active scan — so the ~hundreds of *available* blocks above the pivot (which contain the account's `Transfer` logs) were never scanned. A re-request after the head advanced recovered the full token set via the forward phase (entirely above the pivot), which is why the bug only manifested on the very first scan.

**Fix (in the caller only — `LogFinder` is untouched).** The downward walk now clamps its lower bound to the log-index floor and treats reaching that floor as the completion condition, so it scans the available `[floor, head]` window and surfaces the tokens there:

- `DetectionScanner` takes `ILogIndexStorage` (always registered in `BlockTreeModule` — `LogIndexStorage` when the index is enabled, `DisabledLogIndexStorage` otherwise), threaded through `PortfolioViewerConfigurer` (both resolved from Autofac).
- New `IndexFloor()` returns `ILogIndexStorage.MinBlockNumber` (the lowest indexed block, which advances downward as backfill proceeds), or `0` when no floor is known (index disabled, or enabled-but-not-yet-built). When it returns `0` the walk keeps its previous full-history bound and `lo <= 0` completion condition, so **the index-disabled path is unchanged**.
- The downward `lo` is clamped to `Math.Max(floor, …)`, the forward-phase floor likewise, and completion is `lo <= floor` plus a guard that completes cleanly if the cursor is already at/below the floor.

The existing `ResourceNotFoundException` handling is retained as the genuine retained-history-floor signal (its "reached pruned history → complete" semantics are preserved and still covered by `Reaching_pruned_history_marks_complete`).

This targets the config #13051 reproduced under and that the plugin README recommends (`--LogIndex.Enabled true`).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added `DetectionScannerTests.First_scan_covers_the_window_above_the_index_floor_on_a_snap_synced_node`: with an index floor at block 500 and head at 800, `FindLogs` throws `ResourceNotFoundException` when the filter's `FromBlock` is below the floor and returns a `Transfer` log otherwise. The test asserts the token is detected and the entry is `complete: true` with `scannedFrom: 0`. Verified it **fails on the pre-fix code** (token lost to the underflowing first chunk) and passes with the fix. Full `DetectionScanner` class (14 tests) and the whole plugin test project (86 tests) pass; `dotnet format whitespace` reports no changes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

cc @Marchhill
