### PR TITLE
test(eip8037): regression for state-gas rollback baseline (EIP-8037)

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -1981,12 +1981,22 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         }
     }
 
-    private TestAllTracerWithOutput ExecuteParentSetThenChildOverwriteAndRevert(ulong gasLimit, Address childAddress, int storageSlot, int childWrittenValue)
+    private TestAllTracerWithOutput ExecuteParentSetThenChildOverwriteAndRevert(ulong gasLimit, Address childAddress, int storageSlot, int childWrittenValue, int? childOwnSlot = null)
     {
-        byte[] childCode = Prepare.EvmCode
+        Prepare childBuilder = Prepare.EvmCode
             .PushData(childWrittenValue)
             .PushData(storageSlot)
-            .Op(Instruction.SSTORE)
+            .Op(Instruction.SSTORE);
+
+        if (childOwnSlot is not null)
+        {
+            childBuilder = childBuilder
+                .PushData(1)
+                .PushData(childOwnSlot.Value)
+                .Op(Instruction.SSTORE);
+        }
+
+        byte[] childCode = childBuilder
             .Revert(0, 0)
             .Done;
 
@@ -2006,53 +2016,26 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
     }
 
     [Test]
-    public void Eip8037_reverting_child_that_spilled_its_own_fresh_set_then_restored_parent_slot_must_restore_the_spill_debt_not_credit_a_refill()
+    public void Eip8037_reverting_child_that_consumed_its_advanced_state_gas_credit_must_reclaim_it_from_state_gas_used()
     {
         const ulong gasLimit = 16_777_216ul;
 
-        TestAllTracerWithOutput restoresPreTxOriginal = ExecuteParentSetThenChildSpillsOwnSetAfterTouchingParentSlot(gasLimit, TestItem.AddressC, parentSlot: 0, childOwnSlot: 2, parentOverwriteValue: 0);
-        TestAllTracerWithOutput writesNonOriginal = ExecuteParentSetThenChildSpillsOwnSetAfterTouchingParentSlot(gasLimit, TestItem.AddressD, parentSlot: 1, childOwnSlot: 3, parentOverwriteValue: 2);
+        TestAllTracerWithOutput restoresPreTxOriginal = ExecuteParentSetThenChildOverwriteAndRevert(gasLimit, TestItem.AddressC, storageSlot: 0, childWrittenValue: 0, childOwnSlot: 2);
+        TestAllTracerWithOutput writesNonOriginal = ExecuteParentSetThenChildOverwriteAndRevert(gasLimit, TestItem.AddressF, storageSlot: 1, childWrittenValue: 2, childOwnSlot: 3);
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(restoresPreTxOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the tx succeeds");
             Assert.That(writesNonOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the control tx succeeds");
             Assert.That(restoresPreTxOriginal.GasConsumedResult.SpentGas, Is.EqualTo(writesNonOriginal.GasConsumedResult.SpentGas),
-                "with reservoir 0 the child spills its own fresh set into gas_left; restoring the parent's pre-tx original advances that credit into the child reservoir, which the own set then consumes. On revert the amount>0 tail of RemoveStateGasRefundFromReservoir must reclaim the advance from state-gas-used so the spill debt is restored, leaving the same charge as the control that wrote a non-original value and never credited; a smaller charge means the reverted advance leaked back to the parent reservoir as an unbilled refill");
+                "with reservoir 0 the child's restore of the parent's pre-tx original credits a state-gas refund that is advanced into the child reservoir, and the child's own fresh set then consumes that advance. On revert the amount>0 tail of RemoveStateGasRefundFromReservoir must reclaim the advance from state-gas-used, leaving the same charge as the control that wrote a non-original value and never credited; a smaller charge means the reverted advance leaked back as an unbilled reservoir refill");
             Assert.That(restoresPreTxOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
-                "the only durable state change is the parent's single fresh slot set; the reverted child's own set and its restored-then-revoked credit add no block state gas");
+                "the only durable state change is the parent's single fresh slot set; the reverted child's own set and its advanced-then-reclaimed credit add no block state gas");
             Assert.That(writesNonOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
                 "the control must fund its own distinct fresh slot exactly like run A; collapsing the two runs onto one slot would turn the control's parent SSTORE into a no-op reset charging no state gas and this equality would fail, silently disarming the control");
             AssertStorage(new StorageCell(Recipient, UInt256.Zero), UInt256.One);
             Assert.That(TestState.Get(new StorageCell(Recipient, (UInt256)1)).ToArray(), Is.EqualTo(UInt256.One.ToBigEndian().WithoutLeadingZeros().ToArray()),
                 "the control's parent fresh set survives while the child's reverted own set and non-original overwrite are rolled back; a control that failed to revert would leave the child's written value here and go unnoticed");
         }
-    }
-
-    private TestAllTracerWithOutput ExecuteParentSetThenChildSpillsOwnSetAfterTouchingParentSlot(ulong gasLimit, Address childAddress, int parentSlot, int childOwnSlot, int parentOverwriteValue)
-    {
-        byte[] childCode = Prepare.EvmCode
-            .PushData(parentOverwriteValue)
-            .PushData(parentSlot)
-            .Op(Instruction.SSTORE)
-            .PushData(1)
-            .PushData(childOwnSlot)
-            .Op(Instruction.SSTORE)
-            .Revert(0, 0)
-            .Done;
-
-        TestState.CreateAccount(childAddress, 0);
-        TestState.InsertCode(childAddress, childCode, SpecProvider.GenesisSpec);
-
-        byte[] parentCode = Prepare.EvmCode
-            .PushData(1)
-            .PushData(parentSlot)
-            .Op(Instruction.SSTORE)
-            .DelegateCall(childAddress, 1_000_000)
-            .Op(Instruction.POP)
-            .Op(Instruction.STOP)
-            .Done;
-
-        return Execute(Activation, gasLimit, parentCode, blockGasLimit: DynamicStatePricingBlockGasLimit);
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -1967,18 +1967,22 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(restoresPreTxOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the tx succeeds");
-            Assert.That(writesNonOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the control tx succeeds");
-            Assert.That(restoresPreTxOriginal.GasConsumedResult.SpentGas, Is.EqualTo(writesNonOriginal.GasConsumedResult.SpentGas),
+            AssertRollbackChargedLikeControl(restoresPreTxOriginal, writesNonOriginal,
                 "both children take the identical dirty-slot SSTORE branch and then revert, so restoring the pre-tx original may only cost the same as writing a non-original value; a smaller charge means the reverted child was wrongly credited a reservoir refill for the parent-funded set");
-            Assert.That(restoresPreTxOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
-                "the only durable state change is the parent's single fresh slot set; the reverted child adds no block state gas");
-            Assert.That(writesNonOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
-                "the control must fund its own distinct fresh slot exactly like run A; if the two runs were collapsed onto one slot the control's parent SSTORE would become a no-op reset (newSameAsCurrent) charging no state gas and this equality would fail, silently disarming the control");
             AssertStorage(new StorageCell(Recipient, UInt256.Zero), UInt256.One);
-            Assert.That(TestState.Get(new StorageCell(Recipient, (UInt256)1)).ToArray(), Is.EqualTo(UInt256.One.ToBigEndian().WithoutLeadingZeros().ToArray()),
-                "the control's parent fresh set survives while the child's reverted non-original overwrite is rolled back; a control that failed to revert would leave the child's written value here and go unnoticed");
+            AssertStorage(new StorageCell(Recipient, UInt256.One), UInt256.One);
         }
+    }
+
+    private void AssertRollbackChargedLikeControl(TestAllTracerWithOutput restoresPreTxOriginal, TestAllTracerWithOutput writesNonOriginal, string spentGasReason)
+    {
+        Assert.That(restoresPreTxOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the tx succeeds");
+        Assert.That(writesNonOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the control tx succeeds");
+        Assert.That(restoresPreTxOriginal.GasConsumedResult.SpentGas, Is.EqualTo(writesNonOriginal.GasConsumedResult.SpentGas), spentGasReason);
+        Assert.That(restoresPreTxOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
+            "the only durable state change is the parent's single fresh slot set; the reverted child adds no block state gas");
+        Assert.That(writesNonOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
+            "the control must fund its own distinct fresh slot exactly like run A; if the two runs were collapsed onto one slot the control's parent SSTORE would become a no-op reset (newSameAsCurrent) charging no state gas and this equality would fail, silently disarming the control");
     }
 
     private TestAllTracerWithOutput ExecuteParentSetThenChildOverwriteAndRevert(ulong gasLimit, Address childAddress, int storageSlot, int childWrittenValue, int? childOwnSlot = null)
@@ -2018,24 +2022,19 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
     [Test]
     public void Eip8037_reverting_child_that_consumed_its_advanced_state_gas_credit_must_reclaim_it_from_state_gas_used()
     {
-        const ulong gasLimit = 16_777_216ul;
+        ulong gasLimit = Eip7825Constants.DefaultTxGasLimitCap;
 
         TestAllTracerWithOutput restoresPreTxOriginal = ExecuteParentSetThenChildOverwriteAndRevert(gasLimit, TestItem.AddressC, storageSlot: 0, childWrittenValue: 0, childOwnSlot: 2);
         TestAllTracerWithOutput writesNonOriginal = ExecuteParentSetThenChildOverwriteAndRevert(gasLimit, TestItem.AddressF, storageSlot: 1, childWrittenValue: 2, childOwnSlot: 3);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(restoresPreTxOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the tx succeeds");
-            Assert.That(writesNonOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the control tx succeeds");
-            Assert.That(restoresPreTxOriginal.GasConsumedResult.SpentGas, Is.EqualTo(writesNonOriginal.GasConsumedResult.SpentGas),
+            AssertRollbackChargedLikeControl(restoresPreTxOriginal, writesNonOriginal,
                 "with reservoir 0 the child's restore of the parent's pre-tx original credits a state-gas refund that is advanced into the child reservoir, and the child's own fresh set then consumes that advance. On revert the amount>0 tail of RemoveStateGasRefundFromReservoir must reclaim the advance from state-gas-used, leaving the same charge as the control that wrote a non-original value and never credited; a smaller charge means the reverted advance leaked back as an unbilled reservoir refill");
-            Assert.That(restoresPreTxOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
-                "the only durable state change is the parent's single fresh slot set; the reverted child's own set and its advanced-then-reclaimed credit add no block state gas");
-            Assert.That(writesNonOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
-                "the control must fund its own distinct fresh slot exactly like run A; collapsing the two runs onto one slot would turn the control's parent SSTORE into a no-op reset charging no state gas and this equality would fail, silently disarming the control");
             AssertStorage(new StorageCell(Recipient, UInt256.Zero), UInt256.One);
-            Assert.That(TestState.Get(new StorageCell(Recipient, (UInt256)1)).ToArray(), Is.EqualTo(UInt256.One.ToBigEndian().WithoutLeadingZeros().ToArray()),
-                "the control's parent fresh set survives while the child's reverted own set and non-original overwrite are rolled back; a control that failed to revert would leave the child's written value here and go unnoticed");
+            AssertStorage(new StorageCell(Recipient, UInt256.One), UInt256.One);
+            AssertStorage(new StorageCell(Recipient, (UInt256)2), UInt256.Zero);
+            AssertStorage(new StorageCell(Recipient, (UInt256)3), UInt256.Zero);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -1959,7 +1959,7 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
     }
 
     [TestCase(17_777_216ul, TestName = "Eip8037_reverting_child_restoring_parent_fresh_slot_credits_no_state_gas_reservoir_funded")]
-    [TestCase(16_777_216ul, TestName = "Eip8037_reverting_child_restoring_parent_fresh_slot_credits_no_state_gas_spill_tail")]
+    [TestCase(16_777_216ul, TestName = "Eip8037_reverting_child_restoring_parent_fresh_slot_credits_no_state_gas_parent_spill_funded")]
     public void Eip8037_reverting_child_restoring_parent_fresh_slot_to_pre_tx_original_must_charge_same_as_writing_a_non_original_value(ulong gasLimit)
     {
         TestAllTracerWithOutput restoresPreTxOriginal = ExecuteParentSetThenChildOverwriteAndRevert(gasLimit, TestItem.AddressC, storageSlot: 0, childWrittenValue: 0);
@@ -1973,7 +1973,11 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
                 "both children take the identical dirty-slot SSTORE branch and then revert, so restoring the pre-tx original may only cost the same as writing a non-original value; a smaller charge means the reverted child was wrongly credited a reservoir refill for the parent-funded set");
             Assert.That(restoresPreTxOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
                 "the only durable state change is the parent's single fresh slot set; the reverted child adds no block state gas");
+            Assert.That(writesNonOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
+                "the control must fund its own distinct fresh slot exactly like run A; if the two runs were collapsed onto one slot the control's parent SSTORE would become a no-op reset (newSameAsCurrent) charging no state gas and this equality would fail, silently disarming the control");
             AssertStorage(new StorageCell(Recipient, UInt256.Zero), UInt256.One);
+            Assert.That(TestState.Get(new StorageCell(Recipient, (UInt256)1)).ToArray(), Is.EqualTo(UInt256.One.ToBigEndian().WithoutLeadingZeros().ToArray()),
+                "the control's parent fresh set survives while the child's reverted non-original overwrite is rolled back; a control that failed to revert would leave the child's written value here and go unnoticed");
         }
     }
 
@@ -1992,6 +1996,57 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
         byte[] parentCode = Prepare.EvmCode
             .PushData(1)
             .PushData(storageSlot)
+            .Op(Instruction.SSTORE)
+            .DelegateCall(childAddress, 1_000_000)
+            .Op(Instruction.POP)
+            .Op(Instruction.STOP)
+            .Done;
+
+        return Execute(Activation, gasLimit, parentCode, blockGasLimit: DynamicStatePricingBlockGasLimit);
+    }
+
+    [Test]
+    public void Eip8037_reverting_child_that_spilled_its_own_fresh_set_then_restored_parent_slot_must_restore_the_spill_debt_not_credit_a_refill()
+    {
+        const ulong gasLimit = 16_777_216ul;
+
+        TestAllTracerWithOutput restoresPreTxOriginal = ExecuteParentSetThenChildSpillsOwnSetAfterTouchingParentSlot(gasLimit, TestItem.AddressC, parentSlot: 0, childOwnSlot: 2, parentOverwriteValue: 0);
+        TestAllTracerWithOutput writesNonOriginal = ExecuteParentSetThenChildSpillsOwnSetAfterTouchingParentSlot(gasLimit, TestItem.AddressD, parentSlot: 1, childOwnSlot: 3, parentOverwriteValue: 2);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(restoresPreTxOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the tx succeeds");
+            Assert.That(writesNonOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the control tx succeeds");
+            Assert.That(restoresPreTxOriginal.GasConsumedResult.SpentGas, Is.EqualTo(writesNonOriginal.GasConsumedResult.SpentGas),
+                "with reservoir 0 the child spills its own fresh set into gas_left; restoring the parent's pre-tx original advances that credit into the child reservoir, which the own set then consumes. On revert the amount>0 tail of RemoveStateGasRefundFromReservoir must reclaim the advance from state-gas-used so the spill debt is restored, leaving the same charge as the control that wrote a non-original value and never credited; a smaller charge means the reverted advance leaked back to the parent reservoir as an unbilled refill");
+            Assert.That(restoresPreTxOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
+                "the only durable state change is the parent's single fresh slot set; the reverted child's own set and its restored-then-revoked credit add no block state gas");
+            Assert.That(writesNonOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
+                "the control must fund its own distinct fresh slot exactly like run A; collapsing the two runs onto one slot would turn the control's parent SSTORE into a no-op reset charging no state gas and this equality would fail, silently disarming the control");
+            AssertStorage(new StorageCell(Recipient, UInt256.Zero), UInt256.One);
+            Assert.That(TestState.Get(new StorageCell(Recipient, (UInt256)1)).ToArray(), Is.EqualTo(UInt256.One.ToBigEndian().WithoutLeadingZeros().ToArray()),
+                "the control's parent fresh set survives while the child's reverted own set and non-original overwrite are rolled back; a control that failed to revert would leave the child's written value here and go unnoticed");
+        }
+    }
+
+    private TestAllTracerWithOutput ExecuteParentSetThenChildSpillsOwnSetAfterTouchingParentSlot(ulong gasLimit, Address childAddress, int parentSlot, int childOwnSlot, int parentOverwriteValue)
+    {
+        byte[] childCode = Prepare.EvmCode
+            .PushData(parentOverwriteValue)
+            .PushData(parentSlot)
+            .Op(Instruction.SSTORE)
+            .PushData(1)
+            .PushData(childOwnSlot)
+            .Op(Instruction.SSTORE)
+            .Revert(0, 0)
+            .Done;
+
+        TestState.CreateAccount(childAddress, 0);
+        TestState.InsertCode(childAddress, childCode, SpecProvider.GenesisSpec);
+
+        byte[] parentCode = Prepare.EvmCode
+            .PushData(1)
+            .PushData(parentSlot)
             .Op(Instruction.SSTORE)
             .DelegateCall(childAddress, 1_000_000)
             .Op(Instruction.POP)

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037RegressionTests.cs
@@ -1957,4 +1957,47 @@ public class Eip8037RegressionTests : VirtualMachineTestsBase
             "The parent SSTORE should run out of gas once the child CALL burns its own failed SSTORE gas.");
         Assert.That(tracer.Error, Is.EqualTo("OutOfGas"));
     }
+
+    [TestCase(17_777_216ul, TestName = "Eip8037_reverting_child_restoring_parent_fresh_slot_credits_no_state_gas_reservoir_funded")]
+    [TestCase(16_777_216ul, TestName = "Eip8037_reverting_child_restoring_parent_fresh_slot_credits_no_state_gas_spill_tail")]
+    public void Eip8037_reverting_child_restoring_parent_fresh_slot_to_pre_tx_original_must_charge_same_as_writing_a_non_original_value(ulong gasLimit)
+    {
+        TestAllTracerWithOutput restoresPreTxOriginal = ExecuteParentSetThenChildOverwriteAndRevert(gasLimit, TestItem.AddressC, storageSlot: 0, childWrittenValue: 0);
+        TestAllTracerWithOutput writesNonOriginal = ExecuteParentSetThenChildOverwriteAndRevert(gasLimit, TestItem.AddressE, storageSlot: 1, childWrittenValue: 2);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(restoresPreTxOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the tx succeeds");
+            Assert.That(writesNonOriginal.StatusCode, Is.EqualTo(StatusCode.Success), "the reverting child leaves the parent's committed fresh set intact, so the control tx succeeds");
+            Assert.That(restoresPreTxOriginal.GasConsumedResult.SpentGas, Is.EqualTo(writesNonOriginal.GasConsumedResult.SpentGas),
+                "both children take the identical dirty-slot SSTORE branch and then revert, so restoring the pre-tx original may only cost the same as writing a non-original value; a smaller charge means the reverted child was wrongly credited a reservoir refill for the parent-funded set");
+            Assert.That(restoresPreTxOriginal.GasConsumedResult.BlockStateGas, Is.EqualTo(GasCostOf.SSetState),
+                "the only durable state change is the parent's single fresh slot set; the reverted child adds no block state gas");
+            AssertStorage(new StorageCell(Recipient, UInt256.Zero), UInt256.One);
+        }
+    }
+
+    private TestAllTracerWithOutput ExecuteParentSetThenChildOverwriteAndRevert(ulong gasLimit, Address childAddress, int storageSlot, int childWrittenValue)
+    {
+        byte[] childCode = Prepare.EvmCode
+            .PushData(childWrittenValue)
+            .PushData(storageSlot)
+            .Op(Instruction.SSTORE)
+            .Revert(0, 0)
+            .Done;
+
+        TestState.CreateAccount(childAddress, 0);
+        TestState.InsertCode(childAddress, childCode, SpecProvider.GenesisSpec);
+
+        byte[] parentCode = Prepare.EvmCode
+            .PushData(1)
+            .PushData(storageSlot)
+            .Op(Instruction.SSTORE)
+            .DelegateCall(childAddress, 1_000_000)
+            .Op(Instruction.POP)
+            .Op(Instruction.STOP)
+            .Done;
+
+        return Execute(Activation, gasLimit, parentCode, blockGasLimit: DynamicStatePricingBlockGasLimit);
+    }
 }


### PR DESCRIPTION
## Changes

Adds one regression test in `Nethermind.Evm.Test` for EIP-8037 state-gas rollback. No production changes.

## Why

ethereum/EIPs#12256 (chfast) fixes a spec-level defect: because an `SSTORE`'s *original* value is the transaction-start value rather than the frame-entry value, a reverting frame can credit a state-gas refill it never funded, unless rollback restores to a per-frame baseline. This test pins the property on our side.

Nethermind already handles this correctly: the unfunded refill is booked as an advanced refund (`VmState.StateGasRefundAdvanced`) and revoked from the reservoir by `RemoveAdvancedStateGasRefund` on the child's revert, before `RestoreChildStateGas` returns it to the parent. This is the functional equivalent of #12256's `state_gas_baseline` restore.

Scenario: a parent frame `SSTORE`s a slot (funding a fresh `SSetState`), `DELEGATECALL`s a child that `SSTORE`s the same slot back to its pre-tx original and then reverts. Asserts the transaction still pays the parent-funded `SSetState` and does not credit the child an unfunded refill.

RED-control: commenting out `RemoveAdvancedStateGasRefund` makes the transaction underpay by exactly one `GasCostOf.SSetState`, and the test fails; restoring it passes. Green against current master.

## Type of change

- [x] New test

## Testing

`dotnet test src/Nethermind/Nethermind.Evm.Test -c release --filter FullyQualifiedName~Eip8037RollbackBaselineAudit` passes (1/1) on master.

## Documentation

Not required (test-only).