### PR TITLE
fix(xdc): emit XDPoS header fields over JSON-RPC

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSubscriptionResponseTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSubscriptionResponseTests.cs
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.JsonRpc.Modules.Subscribe;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test;
+
+/// <summary>
+/// Subscription payloads are declared as the base RPC model but are routinely a plugin-supplied subtype
+/// (an engine-specific <c>BlockForRpc</c>, say), so the writer has to serialize at the runtime type the
+/// way <see cref="ResultWrapper{T}"/> does for method results.
+/// </summary>
+[TestFixture]
+public class JsonRpcSubscriptionResponseTests
+{
+    private class Payload
+    {
+        public string Declared { get; set; } = "declared";
+    }
+
+    private sealed class DerivedPayload : Payload
+    {
+        public string Added { get; set; } = "added";
+    }
+
+    [Test]
+    public void Derived_payload_keeps_the_properties_its_subtype_adds()
+    {
+        JsonRpcSubscriptionResponse<Payload> response = new()
+        {
+            MethodName = SubscriptionMethodName.EthSubscription,
+            Params = new JsonRpcSubscriptionResult<Payload> { Result = new DerivedPayload(), Subscription = "0x1" }
+        };
+
+        string serialized = RpcTest.SerializeResponse(response);
+
+        Assert.That(serialized, Does.Contain("\"added\":\"added\""));
+        Assert.That(serialized, Does.Contain("\"declared\":\"declared\""));
+    }
+
+    [Test]
+    public void Payload_of_the_declared_type_is_unaffected()
+    {
+        JsonRpcSubscriptionResponse<Payload> response = new()
+        {
+            MethodName = SubscriptionMethodName.EthSubscription,
+            Params = new JsonRpcSubscriptionResult<Payload> { Result = new Payload(), Subscription = "0x1" }
+        };
+
+        Assert.That(RpcTest.SerializeResponse(response), Does.Contain("\"result\":{\"declared\":\"declared\"}"));
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcResponseWriter.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcResponseWriter.cs
@@ -8,6 +8,7 @@ using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -151,6 +152,26 @@ public static class JsonRpcResponseWriter
         writer.Write(IdSeparator);
         WriteIdRaw(writer, in id);
         writer.Write(EnvelopeEnd);
+    }
+
+    /// <summary>
+    /// Resolves the contract to serialize <paramref name="value"/> with, or null when the declared
+    /// <typeparamref name="TValue"/> contract already describes it.
+    /// </summary>
+    /// <remarks>
+    /// Serializing a derived payload at its declared type silently omits the properties the derived type
+    /// adds — the engine-specific seal fields consensus plugins put on <c>BlockForRpc</c>, for instance —
+    /// because the payload types carry no <c>JsonDerivedType</c> attributes.
+    /// </remarks>
+    internal static JsonTypeInfo? GetRuntimePayloadTypeInfo<TValue>(JsonSerializerOptions options, TValue value)
+    {
+        if (!RpcPayloadTypeShape<TValue>.CanHaveDerivedRuntimeType)
+        {
+            return null;
+        }
+
+        Type runtimeType = value!.GetType();
+        return runtimeType == typeof(TValue) ? null : RpcPayloadTypeInfo.Get(options, runtimeType);
     }
 
     internal static bool TryWriteSimpleValue<T>(Utf8JsonWriter writer, T value)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/JsonRpcSubscriptionResponse.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Subscribe/JsonRpcSubscriptionResponse.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Nethermind.JsonRpc.Modules.Subscribe
 {
@@ -92,7 +93,15 @@ namespace Nethermind.JsonRpc.Modules.Subscribe
             writer.WritePropertyName("result"u8);
             if (!JsonRpcResponseWriter.TryWriteSimpleValue(writer, result))
             {
-                JsonSerializer.Serialize(writer, result, RpcPayloadTypeInfo<T>.Get(options));
+                JsonTypeInfo? runtimeTypeInfo = JsonRpcResponseWriter.GetRuntimePayloadTypeInfo(options, result);
+                if (runtimeTypeInfo is not null)
+                {
+                    JsonSerializer.Serialize(writer, (object)result, runtimeTypeInfo);
+                }
+                else
+                {
+                    JsonSerializer.Serialize(writer, result, RpcPayloadTypeInfo<T>.Get(options));
+                }
             }
 
             writer.WriteEndObject();

--- a/src/Nethermind/Nethermind.JsonRpc/ResultWrapper.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ResultWrapper.cs
@@ -155,7 +155,7 @@ namespace Nethermind.JsonRpc
 
             if (!JsonRpcResponseWriter.TryWriteSimpleValue(writer, value))
             {
-                JsonTypeInfo? runtimeTypeInfo = GetRuntimePayloadTypeInfo(options, value);
+                JsonTypeInfo? runtimeTypeInfo = JsonRpcResponseWriter.GetRuntimePayloadTypeInfo(options, value);
                 if (runtimeTypeInfo is not null)
                 {
                     JsonSerializer.Serialize(writer, (object?)value, runtimeTypeInfo);
@@ -164,17 +164,6 @@ namespace Nethermind.JsonRpc
 
                 JsonSerializer.Serialize(writer, value, RpcPayloadTypeInfo<TValue>.Get(options));
             }
-        }
-
-        private static JsonTypeInfo? GetRuntimePayloadTypeInfo<TValue>(JsonSerializerOptions options, TValue value)
-        {
-            if (!RpcPayloadTypeShape<TValue>.CanHaveDerivedRuntimeType)
-            {
-                return null;
-            }
-
-            Type runtimeType = value.GetType();
-            return runtimeType == typeof(TValue) ? null : RpcPayloadTypeInfo.Get(options, runtimeType);
         }
 
         protected static void DisposeIfReferenceType<TValue>(TValue value)

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcBlockForRpcTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcBlockForRpcTests.cs
@@ -18,11 +18,6 @@ using NUnit.Framework;
 
 namespace Nethermind.Xdc.Test.ModuleTests;
 
-/// <summary>
-/// Guards the XDPoS header fields that <c>eth_getBlockBy*</c> and <c>newHeads</c> must carry, against the
-/// shapes the reference clients emit from <c>RPCMarshalHeader</c>: packed byte strings on XDPoSChain,
-/// address arrays plus <c>nextValidators</c> on the subnet fork.
-/// </summary>
 [TestFixture]
 public class XdcBlockForRpcTests
 {
@@ -111,7 +106,7 @@ public class XdcBlockForRpcTests
         Assert.That(factory.Create(chain.BlockTree.Head!, false, chain.SpecProvider), Is.TypeOf<XdcBlockForRpc>());
     }
 
-    /// <summary>Both the block and the standalone-header model, which must agree on the XDPoS fields.</summary>
+    /// <summary>The block and standalone-header models, which must agree on the XDPoS fields.</summary>
     private JsonElement[] Serialize(XdcBlockHeader header)
     {
         ISpecProvider specProvider = SpecProvider();

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcBlockForRpcTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcBlockForRpcTests.cs
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Autofac;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Facade.Eth;
+using Nethermind.Serialization.Json;
+using Nethermind.Xdc.RPC;
+using Nethermind.Xdc.Test.Helpers;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test.ModuleTests;
+
+/// <summary>
+/// Guards the XDPoS header fields that <c>eth_getBlockBy*</c> and <c>newHeads</c> must carry, against the
+/// shapes the reference clients emit from <c>RPCMarshalHeader</c>: packed byte strings on XDPoSChain,
+/// address arrays plus <c>nextValidators</c> on the subnet fork.
+/// </summary>
+[TestFixture]
+public class XdcBlockForRpcTests
+{
+    private static readonly Address[] Masternodes = [TestItem.AddressA, TestItem.AddressB];
+    private static readonly Address[] NextMasternodes = [TestItem.AddressC];
+    private static readonly Address[] Penalised = [TestItem.AddressD];
+
+    private readonly EthereumJsonSerializer _serializer = new();
+    private readonly XdcBlockForRpcFactory _factory = new();
+
+    [Test]
+    public void Mainnet_header_packs_validators_and_penalties_into_byte_strings()
+    {
+        XdcBlockHeader header = Build.A.XdcBlockHeader()
+            .WithValidator(Seal())
+            .WithValidators(Masternodes)
+            .WithPenalties(Penalised)
+            .TestObject;
+
+        foreach (JsonElement json in Serialize(header))
+        {
+            Assert.That(json.GetProperty("validator").GetString(), Is.EqualTo(Hex(Seal())));
+            Assert.That(json.GetProperty("validators").GetString(), Is.EqualTo(Hex(Pack(Masternodes))));
+            Assert.That(json.GetProperty("penalties").GetString(), Is.EqualTo(Hex(Pack(Penalised))));
+            Assert.That(json.TryGetProperty("nextValidators", out _), Is.False, "mainnet headers have no next-epoch list");
+        }
+    }
+
+    [Test]
+    public void Subnet_header_spells_out_validators_and_penalties_as_addresses()
+    {
+        XdcSubnetBlockHeaderBuilder builder = Build.A.XdcSubnetBlockHeader().WithNextValidators(NextMasternodes);
+        builder.WithValidator(Seal()).WithValidators(Masternodes).WithPenalties(Penalised);
+
+        foreach (JsonElement json in Serialize(builder.TestObject))
+        {
+            Assert.That(json.GetProperty("validator").GetString(), Is.EqualTo(Hex(Seal())));
+            Assert.That(Addresses(json, "validators"), Is.EqualTo(Masternodes));
+            Assert.That(Addresses(json, "nextValidators"), Is.EqualTo(NextMasternodes));
+            Assert.That(Addresses(json, "penalties"), Is.EqualTo(Penalised));
+        }
+    }
+
+    [Test]
+    public void Absent_lists_are_emitted_empty_rather_than_omitted()
+    {
+        XdcBlockHeader mainnet = Build.A.XdcBlockHeader().WithValidators(Array.Empty<byte>()).WithPenalties(Array.Empty<byte>()).TestObject;
+        mainnet.Validator = null;
+
+        foreach (JsonElement json in Serialize(mainnet))
+        {
+            Assert.That(json.GetProperty("validator").GetString(), Is.EqualTo("0x"));
+            Assert.That(json.GetProperty("validators").GetString(), Is.EqualTo("0x"));
+            Assert.That(json.GetProperty("penalties").GetString(), Is.EqualTo("0x"));
+        }
+
+        XdcSubnetBlockHeader subnet = Build.A.XdcSubnetBlockHeader().WithNextValidators(Array.Empty<byte>()).TestObject;
+        subnet.Validators = null;
+        subnet.Penalties = null;
+
+        foreach (JsonElement json in Serialize(subnet))
+        {
+            Assert.That(Addresses(json, "validators"), Is.Empty);
+            Assert.That(Addresses(json, "nextValidators"), Is.Empty);
+            Assert.That(Addresses(json, "penalties"), Is.Empty);
+        }
+    }
+
+    [Test]
+    public void Non_xdc_header_keeps_the_base_shape()
+    {
+        BlockHeader header = Build.A.BlockHeader.TestObject;
+        Block block = Build.A.Block.WithHeader(header).TestObject;
+
+        Assert.That(_factory.Create(block, false, SpecProvider()), Is.TypeOf<BlockForRpc>());
+        Assert.That(_factory.CreateHeader(header), Is.TypeOf<BlockHeaderForRpc>());
+    }
+
+    [Test]
+    public async Task Xdc_chain_resolves_the_xdc_models_over_the_default_ones()
+    {
+        using XdcTestBlockchain chain = await XdcTestBlockchain.Create(blocksToAdd: 1);
+        IBlockForRpcFactory factory = chain.Container.Resolve<IBlockForRpcFactory>();
+
+        Assert.That(factory, Is.TypeOf<XdcBlockForRpcFactory>());
+        Assert.That(factory.Create(chain.BlockTree.Head!, false, chain.SpecProvider), Is.TypeOf<XdcBlockForRpc>());
+    }
+
+    /// <summary>Both the block and the standalone-header model, which must agree on the XDPoS fields.</summary>
+    private JsonElement[] Serialize(XdcBlockHeader header)
+    {
+        ISpecProvider specProvider = SpecProvider();
+        Block block = Build.A.Block.WithHeader(header).TestObject;
+        return
+        [
+            Parse(_factory.Create(block, false, specProvider)),
+            Parse(_factory.CreateHeader(header, specProvider))
+        ];
+    }
+
+    private JsonElement Parse(object model) => JsonDocument.Parse(_serializer.Serialize(model)).RootElement;
+
+    private static Address[] Addresses(JsonElement json, string property)
+    {
+        JsonElement array = json.GetProperty(property);
+        Address[] addresses = new Address[array.GetArrayLength()];
+        for (int i = 0; i < addresses.Length; i++)
+        {
+            addresses[i] = new Address(array[i].GetString()!);
+        }
+        return addresses;
+    }
+
+    private static ISpecProvider SpecProvider()
+    {
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(Substitute.For<IReleaseSpec>());
+        return specProvider;
+    }
+
+    private static byte[] Seal()
+    {
+        byte[] seal = new byte[65];
+        seal[0] = 0xab;
+        seal[64] = 0xcd;
+        return seal;
+    }
+
+    private static byte[] Pack(Address[] addresses)
+    {
+        byte[] packed = new byte[addresses.Length * Address.Size];
+        for (int i = 0; i < addresses.Length; i++)
+        {
+            addresses[i].Bytes.CopyTo(packed.AsSpan(i * Address.Size));
+        }
+        return packed;
+    }
+
+    private static string Hex(byte[] bytes) => bytes.ToHexString(true);
+}

--- a/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcBlockForRpcTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/ModuleTests/XdcBlockForRpcTests.cs
@@ -10,6 +10,8 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Facade.Eth;
+using Nethermind.JsonRpc.Modules.Subscribe;
+using Nethermind.JsonRpc.Test;
 using Nethermind.Serialization.Json;
 using Nethermind.Xdc.RPC;
 using Nethermind.Xdc.Test.Helpers;
@@ -94,6 +96,35 @@ public class XdcBlockForRpcTests
 
         Assert.That(_factory.Create(block, false, SpecProvider()), Is.TypeOf<BlockForRpc>());
         Assert.That(_factory.CreateHeader(header), Is.TypeOf<BlockHeaderForRpc>());
+    }
+
+    /// <remarks>
+    /// <c>newHeads</c> declares its payload as <see cref="BlockForRpc"/>, so this covers the declared-type
+    /// serialization the model-shape tests above (which serialize at the runtime type) cannot see.
+    /// </remarks>
+    [Test]
+    public void Subscription_payload_keeps_the_xdpos_fields()
+    {
+        XdcSubnetBlockHeaderBuilder builder = Build.A.XdcSubnetBlockHeader().WithNextValidators(NextMasternodes);
+        builder.WithValidator(Seal()).WithValidators(Masternodes).WithPenalties(Penalised);
+        Block block = Build.A.Block.WithHeader(builder.TestObject).TestObject;
+
+        JsonRpcSubscriptionResponse<BlockForRpc> response = new()
+        {
+            MethodName = SubscriptionMethodName.EthSubscription,
+            Params = new JsonRpcSubscriptionResult<BlockForRpc>
+            {
+                Result = _factory.Create(block, false, SpecProvider()),
+                Subscription = "0x1"
+            }
+        };
+
+        string serialized = RpcTest.SerializeResponse(response);
+
+        Assert.That(serialized, Does.Contain($"\"validator\":\"{Hex(Seal())}\""));
+        Assert.That(serialized, Does.Contain("\"validators\":["));
+        Assert.That(serialized, Does.Contain("\"nextValidators\":["));
+        Assert.That(serialized, Does.Contain("\"penalties\":["));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcBlockForRpc.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcBlockForRpc.cs
@@ -7,15 +7,11 @@ using Nethermind.Facade.Eth;
 
 namespace Nethermind.Xdc.RPC;
 
-/// <summary>
-/// XDC-flavoured RPC block model: adds the XDPoS seal (<c>validator</c>) and the masternode
-/// (<c>validators</c>) and penalty (<c>penalties</c>) lists the base model has no place for.
-/// </summary>
+/// <summary>XDC RPC block model: adds the XDPoS seal and the masternode and penalty lists.</summary>
 /// <remarks>
-/// Field names and encodings follow XDPoSChain's <c>RPCMarshalHeader</c> (<c>internal/ethapi/api.go</c>),
-/// which emits all three as <c>hexutil.Bytes</c> — packed 20-byte addresses rather than JSON arrays —
-/// on every header, empty ones included. The subnet fork encodes the lists as address arrays and adds
-/// <c>nextValidators</c>; see <see cref="XdcSubnetBlockForRpc"/>.
+/// Shape follows XDPoSChain's <c>RPCMarshalHeader</c> (<c>internal/ethapi/api.go</c>): all three are
+/// <c>hexutil.Bytes</c> — packed 20-byte addresses, not JSON arrays — and all three are emitted even
+/// when empty. The subnet fork differs on both counts; see <see cref="XdcSubnetBlockForRpc"/>.
 /// </remarks>
 public sealed class XdcBlockForRpc : BlockForRpc
 {
@@ -42,10 +38,11 @@ public sealed class XdcBlockHeaderForRpc(XdcBlockHeader header, ISpecProvider? s
     public byte[] Penalties { get; set; } = header.Penalties ?? [];
 }
 
-/// <summary>
-/// Produces the XDC RPC block/header models, picking the subnet shape for subnet headers and falling
-/// back to the base (seal-agnostic) models for anything that isn't an XDC header.
-/// </summary>
+/// <summary>Produces the XDC RPC block/header models.</summary>
+/// <remarks>
+/// Subnet is matched before mainnet because <see cref="XdcSubnetBlockHeader"/> derives from
+/// <see cref="XdcBlockHeader"/>; the reverse order would give subnet blocks the mainnet shape.
+/// </remarks>
 public sealed class XdcBlockForRpcFactory : BlockForRpcFactory
 {
     public override BlockForRpc Create(Block block, bool includeFullTransactionData, ISpecProvider specProvider, bool skipTxs = false) =>

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcBlockForRpc.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcBlockForRpc.cs
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Facade.Eth;
+
+namespace Nethermind.Xdc.RPC;
+
+/// <summary>
+/// XDC-flavoured RPC block model: adds the XDPoS seal (<c>validator</c>) and the masternode
+/// (<c>validators</c>) and penalty (<c>penalties</c>) lists the base model has no place for.
+/// </summary>
+/// <remarks>
+/// Field names and encodings follow XDPoSChain's <c>RPCMarshalHeader</c> (<c>internal/ethapi/api.go</c>),
+/// which emits all three as <c>hexutil.Bytes</c> — packed 20-byte addresses rather than JSON arrays —
+/// on every header, empty ones included. The subnet fork encodes the lists as address arrays and adds
+/// <c>nextValidators</c>; see <see cref="XdcSubnetBlockForRpc"/>.
+/// </remarks>
+public sealed class XdcBlockForRpc : BlockForRpc
+{
+    public XdcBlockForRpc(Block block, bool includeFullTransactionData, ISpecProvider specProvider, bool skipTxs = false)
+        : base(block, includeFullTransactionData, specProvider, skipTxs)
+    {
+        XdcBlockHeader header = (XdcBlockHeader)block.Header;
+        Validator = header.Validator ?? [];
+        Validators = header.Validators ?? [];
+        Penalties = header.Penalties ?? [];
+    }
+
+    public byte[] Validator { get; set; }
+    public byte[] Validators { get; set; }
+    public byte[] Penalties { get; set; }
+}
+
+/// <summary><inheritdoc cref="XdcBlockForRpc"/></summary>
+public sealed class XdcBlockHeaderForRpc(XdcBlockHeader header, ISpecProvider? specProvider = null)
+    : BlockHeaderForRpc(header, specProvider)
+{
+    public byte[] Validator { get; set; } = header.Validator ?? [];
+    public byte[] Validators { get; set; } = header.Validators ?? [];
+    public byte[] Penalties { get; set; } = header.Penalties ?? [];
+}
+
+/// <summary>
+/// Produces the XDC RPC block/header models, picking the subnet shape for subnet headers and falling
+/// back to the base (seal-agnostic) models for anything that isn't an XDC header.
+/// </summary>
+public sealed class XdcBlockForRpcFactory : BlockForRpcFactory
+{
+    public override BlockForRpc Create(Block block, bool includeFullTransactionData, ISpecProvider specProvider, bool skipTxs = false) =>
+        block.Header switch
+        {
+            XdcSubnetBlockHeader => new XdcSubnetBlockForRpc(block, includeFullTransactionData, specProvider, skipTxs),
+            XdcBlockHeader => new XdcBlockForRpc(block, includeFullTransactionData, specProvider, skipTxs),
+            _ => base.Create(block, includeFullTransactionData, specProvider, skipTxs)
+        };
+
+    public override BlockHeaderForRpc CreateHeader(BlockHeader header, ISpecProvider? specProvider = null) =>
+        header switch
+        {
+            XdcSubnetBlockHeader subnet => new XdcSubnetBlockHeaderForRpc(subnet, specProvider),
+            XdcBlockHeader xdc => new XdcBlockHeaderForRpc(xdc, specProvider),
+            _ => base.CreateHeader(header, specProvider)
+        };
+}

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcSubnetBlockForRpc.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcSubnetBlockForRpc.cs
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Immutable;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Facade.Eth;
+
+namespace Nethermind.Xdc.RPC;
+
+/// <summary>
+/// Subnet-flavoured RPC block model: the same XDPoS seal as <see cref="XdcBlockForRpc"/>, but with the
+/// masternode and penalty lists spelled out as address arrays and the extra <c>nextValidators</c> list.
+/// </summary>
+/// <remarks>
+/// The subnet fork's header carries <c>[]common.Address</c> where mainnet packs the addresses into a
+/// byte string, and its <c>RPCMarshalHeader</c> (XDC-Subnet <c>internal/ethapi/api.go</c>) marshals them
+/// as-is; only <c>validator</c> stays a byte string in both.
+/// </remarks>
+public sealed class XdcSubnetBlockForRpc : BlockForRpc
+{
+    public XdcSubnetBlockForRpc(Block block, bool includeFullTransactionData, ISpecProvider specProvider, bool skipTxs = false)
+        : base(block, includeFullTransactionData, specProvider, skipTxs)
+    {
+        XdcSubnetBlockHeader header = (XdcSubnetBlockHeader)block.Header;
+        Validator = header.Validator ?? [];
+        Validators = Unpack(header.ValidatorsAddress);
+        NextValidators = Unpack(header.NextValidatorsAddress);
+        Penalties = Unpack(header.PenaltiesAddress);
+    }
+
+    public byte[] Validator { get; set; }
+    public Address[] Validators { get; set; }
+    public Address[] NextValidators { get; set; }
+    public Address[] Penalties { get; set; }
+
+    /// <summary>Empty rather than null for a list the header omits, matching the reference client.</summary>
+    internal static Address[] Unpack(ImmutableArray<Address>? addresses) => addresses is { } a ? [.. a] : [];
+}
+
+/// <summary><inheritdoc cref="XdcSubnetBlockForRpc"/></summary>
+public sealed class XdcSubnetBlockHeaderForRpc(XdcSubnetBlockHeader header, ISpecProvider? specProvider = null)
+    : BlockHeaderForRpc(header, specProvider)
+{
+    public byte[] Validator { get; set; } = header.Validator ?? [];
+    public Address[] Validators { get; set; } = XdcSubnetBlockForRpc.Unpack(header.ValidatorsAddress);
+    public Address[] NextValidators { get; set; } = XdcSubnetBlockForRpc.Unpack(header.NextValidatorsAddress);
+    public Address[] Penalties { get; set; } = XdcSubnetBlockForRpc.Unpack(header.PenaltiesAddress);
+}

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcSubnetBlockForRpc.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcSubnetBlockForRpc.cs
@@ -8,15 +8,15 @@ using Nethermind.Facade.Eth;
 namespace Nethermind.Xdc.RPC;
 
 /// <summary>
-/// Subnet-flavoured RPC block model: the same XDPoS seal as <see cref="XdcBlockForRpc"/>, but with the
-/// masternode and penalty lists spelled out as address arrays and the extra <c>nextValidators</c> list.
+/// Subnet RPC block model: the mainnet seal, but with the lists as address arrays and an added
+/// <c>nextValidators</c>.
 /// </summary>
 /// <remarks>
-/// The subnet fork's header carries <c>[]common.Address</c> where mainnet packs the addresses into a
-/// byte string, and its <c>RPCMarshalHeader</c> (XDC-Subnet <c>internal/ethapi/api.go</c>) marshals them
-/// as-is; only <c>validator</c> stays a byte string in both. The lists are unpacked from the raw header
-/// bytes rather than through the headers' cached <c>...Address</c> projections, whose lazy
-/// <see cref="System.Nullable{T}"/> write would not be atomic under concurrent RPC reads.
+/// XDC-Subnet's header holds <c>[]common.Address</c> where mainnet packs the addresses into a byte
+/// string, and its <c>RPCMarshalHeader</c> (<c>internal/ethapi/api.go</c>) marshals them as-is; only
+/// <c>validator</c> stays a byte string in both. Unpacking reads the raw header bytes rather than the
+/// headers' cached <c>...Address</c> projections, whose lazy <see cref="System.Nullable{T}"/> write is
+/// not atomic and so can tear under concurrent RPC reads.
 /// </remarks>
 public sealed class XdcSubnetBlockForRpc : BlockForRpc
 {

--- a/src/Nethermind/Nethermind.Xdc/RPC/XdcSubnetBlockForRpc.cs
+++ b/src/Nethermind/Nethermind.Xdc/RPC/XdcSubnetBlockForRpc.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Immutable;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Facade.Eth;
@@ -15,7 +14,9 @@ namespace Nethermind.Xdc.RPC;
 /// <remarks>
 /// The subnet fork's header carries <c>[]common.Address</c> where mainnet packs the addresses into a
 /// byte string, and its <c>RPCMarshalHeader</c> (XDC-Subnet <c>internal/ethapi/api.go</c>) marshals them
-/// as-is; only <c>validator</c> stays a byte string in both.
+/// as-is; only <c>validator</c> stays a byte string in both. The lists are unpacked from the raw header
+/// bytes rather than through the headers' cached <c>...Address</c> projections, whose lazy
+/// <see cref="System.Nullable{T}"/> write would not be atomic under concurrent RPC reads.
 /// </remarks>
 public sealed class XdcSubnetBlockForRpc : BlockForRpc
 {
@@ -24,18 +25,15 @@ public sealed class XdcSubnetBlockForRpc : BlockForRpc
     {
         XdcSubnetBlockHeader header = (XdcSubnetBlockHeader)block.Header;
         Validator = header.Validator ?? [];
-        Validators = Unpack(header.ValidatorsAddress);
-        NextValidators = Unpack(header.NextValidatorsAddress);
-        Penalties = Unpack(header.PenaltiesAddress);
+        Validators = XdcExtensions.ExtractAddresses(header.Validators) ?? [];
+        NextValidators = XdcExtensions.ExtractAddresses(header.NextValidators) ?? [];
+        Penalties = XdcExtensions.ExtractAddresses(header.Penalties) ?? [];
     }
 
     public byte[] Validator { get; set; }
     public Address[] Validators { get; set; }
     public Address[] NextValidators { get; set; }
     public Address[] Penalties { get; set; }
-
-    /// <summary>Empty rather than null for a list the header omits, matching the reference client.</summary>
-    internal static Address[] Unpack(ImmutableArray<Address>? addresses) => addresses is { } a ? [.. a] : [];
 }
 
 /// <summary><inheritdoc cref="XdcSubnetBlockForRpc"/></summary>
@@ -43,7 +41,7 @@ public sealed class XdcSubnetBlockHeaderForRpc(XdcSubnetBlockHeader header, ISpe
     : BlockHeaderForRpc(header, specProvider)
 {
     public byte[] Validator { get; set; } = header.Validator ?? [];
-    public Address[] Validators { get; set; } = XdcSubnetBlockForRpc.Unpack(header.ValidatorsAddress);
-    public Address[] NextValidators { get; set; } = XdcSubnetBlockForRpc.Unpack(header.NextValidatorsAddress);
-    public Address[] Penalties { get; set; } = XdcSubnetBlockForRpc.Unpack(header.PenaltiesAddress);
+    public Address[] Validators { get; set; } = XdcExtensions.ExtractAddresses(header.Validators) ?? [];
+    public Address[] NextValidators { get; set; } = XdcExtensions.ExtractAddresses(header.NextValidators) ?? [];
+    public Address[] Penalties { get; set; } = XdcExtensions.ExtractAddresses(header.Penalties) ?? [];
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcHeaderModule.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcHeaderModule.cs
@@ -3,15 +3,18 @@
 
 using Autofac;
 using Nethermind.Core;
+using Nethermind.Facade.Eth;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Xdc.RLP;
+using Nethermind.Xdc.RPC;
 
 namespace Nethermind.Xdc;
 
 /// <summary>
 /// Registers XDC header typing: the <see cref="BlockHeader"/> RLP decoders (globally and in DI)
 /// so that call sites which resolve decoders from the static <see cref="Rlp"/> registry instead of
-/// DI (e.g. <c>ProofRpcModule</c>) also encode/decode XDC headers correctly. Used by
+/// DI (e.g. <c>ProofRpcModule</c>) also encode/decode XDC headers correctly, plus the
+/// <see cref="IBlockForRpcFactory"/> that surfaces the XDPoS header fields over JSON-RPC. Used by
 /// <see cref="XdcModule"/> for mainnet headers and by <see cref="XdcSubnetModule"/> with a
 /// subnet-specific decoder instance.
 /// </summary>
@@ -37,6 +40,7 @@ public class XdcHeaderModule(IHeaderDecoder headerDecoder) : Module
         builder
             .AddSingleton<IHeaderDecoder>(headerDecoder)
             .AddSingleton(blockDecoder)
-            .AddSingleton(blockBodyDecoder);
+            .AddSingleton(blockBodyDecoder)
+            .AddSingleton<IBlockForRpcFactory, XdcBlockForRpcFactory>();
     }
 }


### PR DESCRIPTION
## Changes

`eth_getBlockByNumber`/`eth_getBlockByHash` and `newHeads` were dropping every XDPoS-specific header field. Diffing a Nethermind XDC node against the Go reference on the same block shows the standard Ethereum fields matching byte-for-byte, with four keys present only on the reference:

```
go-only : ['nextValidators', 'penalties', 'validator', 'validators']
nm-only : []
value diffs on shared keys:   (none)
```

The data was already decoded and held on `XdcBlockHeader`/`XdcSubnetBlockHeader`; it never reached the wire because `Nethermind.Xdc` registered no `IBlockForRpcFactory`, so the container fell back to the default seal-agnostic `BlockForRpc`.

- Add `XdcBlockForRpc`/`XdcBlockHeaderForRpc` and the subnet pair, plus `XdcBlockForRpcFactory`, behind the existing `IBlockForRpcFactory` extension point — the same one `AuRaBlockForRpcFactory` uses for its `step`/`signature` seal.
- Register the factory in `XdcHeaderModule`, which both `XdcModule` and `XdcSubnetModule` already load.
- Add `XdcBlockForRpcTests` covering both shapes, factory dispatch, and the DI wiring.

Apart from that one-line registration the XDC side is additive; no shared model was modified.

### Subscriptions dropped the fields too

`eth_getBlockBy*` worked immediately, but `newHeads` did not, and the same was already true of AuRa's
`step`/`signature`. Subscription payloads are declared as the base model, and
`JsonRpcSubscriptionResponse<T>.WriteParams` serialized through `RpcPayloadTypeInfo<T>`, so
System.Text.Json wrote the declared `BlockForRpc` contract and silently omitted whatever a subtype adds
(the payload models carry no `[JsonDerivedType]`).

The method path already solved this: `ResultWrapper<T>` held a private `GetRuntimePayloadTypeInfo` that
re-resolves the contract from `value.GetType()`. That helper is now an internal static on
`JsonRpcResponseWriter` beside the other shared write helpers, called from both places instead of being
duplicated — so this arrives as a de-duplication, and fixes AuRa on `newHeads` as a side effect.

Note this means any subscription whose payload type is non-sealed now re-resolves. The full
`Nethermind.JsonRpc.Test` suite passes unchanged, so nothing depended on the previous truncation.

### The two reference shapes

Mainnet and subnet disagree on encoding, so the factory dispatches on header type (subnet → mainnet → base, falling back to the standard model for any non-XDC header):

| | `validator` | `validators` / `penalties` | `nextValidators` |
|---|---|---|---|
| XDPoSChain (`internal/ethapi/api.go:1340-1342`) | `hexutil.Bytes` | `hexutil.Bytes` — packed 20-byte addresses | absent |
| XDC-Subnet (`internal/ethapi/api.go:1430-1433`) | `hexutil.Bytes` | `[]common.Address` — JSON arrays | `[]common.Address` |

This maps onto the existing type split: `XdcBlockHeader` packs the lists into `byte[]`, `XdcSubnetBlockHeader` adds `NextValidators`. All four are `gencodec:"required"` upstream, so absent lists are emitted as `"0x"` / `[]` rather than omitted.

Per house convention the fields stay camelCase with Nethermind's own number formatting; only the field set and value structure follow the reference.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.Xdc.Test` 671/671 and `Nethermind.JsonRpc.Test` 1983 (22 pre-existing skips needing a WS
server) both pass.

`JsonRpcSubscriptionResponseTests` (new) covers the writer fix directly: a base-declared payload holding
a derived instance keeps the subtype's properties, and a declared-type payload is unchanged.

Six tests in `XdcBlockForRpcTests`:

- mainnet header packs `validators`/`penalties` into byte strings and emits no `nextValidators`
- subnet header spells both out as address arrays alongside `nextValidators`
- absent lists serialize as `"0x"` / `[]` rather than being omitted
- a non-XDC header still yields the base `BlockForRpc`/`BlockHeaderForRpc`
- a real `XdcTestBlockchain` container resolves `IBlockForRpcFactory` to `XdcBlockForRpcFactory` over the default registration, and a produced block yields `XdcBlockForRpc`
- a `newHeads`-shaped `JsonRpcSubscriptionResponse<BlockForRpc>` keeps all four fields

The DI test guards the original defect, a missing registration, which a DTO-only test would not catch.
The subscription test guards the second one: the model-shape tests serialize at `object`, which *is*
polymorphic in STJ, and so cannot see a declared-type drop.

**Not yet verified against a live node.** Confirming end-to-end needs a rebuilt image on an XDC stack, after which the key diff above should come back empty.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

XDC JSON-RPC now returns the XDPoS header fields (`validator`, `validators`, `penalties`, and
`nextValidators` on subnets) from `eth_getBlockByNumber`, `eth_getBlockByHash`, and `newHeads`
subscriptions, matching the reference client.

Separately, JSON-RPC subscriptions now serialize their payload at its runtime type. Consensus plugins
that extend the RPC block model no longer lose those fields over `eth_subscribe`; this also restores
AuRa's `step` and `signature` on `newHeads`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
