### PR TITLE
Use unbound generic types in nameof

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Transactions/FilteredTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/FilteredTxSource.cs
@@ -44,5 +44,5 @@ public class FilteredTxSource<T>(ITxSource innerSource, ITxFilter txFilter, ILog
         }
     }
 
-    public override string ToString() => $"{nameof(FilteredTxSource<T>)} [ {innerSource} ]";
+    public override string ToString() => $"{nameof(FilteredTxSource<>)} [ {innerSource} ]";
 }

--- a/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BlockAccessListItemCountTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/BlockAccessLists/BlockAccessListItemCountTests.cs
@@ -121,9 +121,9 @@ public class BlockAccessListItemCountTests
             "_accountChanges",
             BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(bal)!;
         MethodInfo ensureCapacity = accountChanges.GetType().GetMethod(
-            nameof(Dictionary<int, int>.EnsureCapacity),
+            nameof(Dictionary<,>.EnsureCapacity),
             [typeof(int)])!;
-        PropertyInfo capacity = accountChanges.GetType().GetProperty(nameof(Dictionary<int, int>.Capacity))!;
+        PropertyInfo capacity = accountChanges.GetType().GetProperty(nameof(Dictionary<,>.Capacity))!;
         ensureCapacity.Invoke(accountChanges, [OversizedCapacity]);
         int capacityBeforeReset = (int)capacity.GetValue(accountChanges)!;
 

--- a/src/Nethermind/Nethermind.Core.Test/Caching/AssociativeCacheTestsBase.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Caching/AssociativeCacheTestsBase.cs
@@ -323,8 +323,8 @@ public class AssociativeCacheDeterministicHashTests
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(cacheInserted, Is.True, $"{nameof(AssociativeCache<DeterministicHashKey, TestValue>)} key {i}");
-                Assert.That(keyCacheInserted, Is.True, $"{nameof(AssociativeKeyCache<DeterministicHashKey>)} key {i}");
+                Assert.That(cacheInserted, Is.True, $"{nameof(AssociativeCache<,>)} key {i}");
+                Assert.That(keyCacheInserted, Is.True, $"{nameof(AssociativeKeyCache<>)} key {i}");
             }
         }
 
@@ -335,8 +335,8 @@ public class AssociativeCacheDeterministicHashTests
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(actualValue, Is.SameAs(values[i]), $"{nameof(AssociativeCache<DeterministicHashKey, TestValue>)} key {i}");
-                Assert.That(keyFound, Is.True, $"{nameof(AssociativeKeyCache<DeterministicHashKey>)} key {i}");
+                Assert.That(actualValue, Is.SameAs(values[i]), $"{nameof(AssociativeCache<,>)} key {i}");
+                Assert.That(keyFound, Is.True, $"{nameof(AssociativeKeyCache<>)} key {i}");
             }
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/BlockAccessListDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/BlockAccessListDecoderTests.cs
@@ -140,7 +140,7 @@ public class BlockAccessListDecoderTests
             GC.Collect();
             GC.WaitForPendingFinalizers();
 
-            Assert.That(error.ToString(), Does.Not.Contain(nameof(ArrayPoolList<byte>)));
+            Assert.That(error.ToString(), Does.Not.Contain(nameof(ArrayPoolList<>)));
         }
         finally
         {

--- a/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruCache.cs
@@ -293,7 +293,7 @@ namespace Nethermind.Core.Caching
 
             [DoesNotReturn]
             static void ThrowInvalidOperationException() => throw new InvalidOperationException(
-                    $"{nameof(LruCache<TKey, TValue>)} called {nameof(Replace)} when empty.");
+                    $"{nameof(LruCache<,>)} called {nameof(Replace)} when empty.");
         }
 
         private void NotifyEvictedValues(TValue[]? evictedValues)

--- a/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
+++ b/src/Nethermind/Nethermind.Core/Caching/LruKeyCache.cs
@@ -101,7 +101,7 @@ namespace Nethermind.Core.Caching
 
             [DoesNotReturn]
             static void ThrowInvalidOperation() => throw new InvalidOperationException(
-                                    $"{nameof(LruKeyCache<TKey>)} called {nameof(Replace)} when empty.");
+                                    $"{nameof(LruKeyCache<>)} called {nameof(Replace)} when empty.");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/ArrayPoolList.cs
@@ -78,7 +78,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
 
         [DoesNotReturn]
         [StackTraceHidden]
-        static void ThrowObjectDisposed() => throw new ObjectDisposedException(nameof(ArrayPoolList<T>));
+        static void ThrowObjectDisposed() => throw new ObjectDisposedException(nameof(ArrayPoolList<>));
     }
 
     IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
@@ -267,7 +267,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
     {
         if (_capacity != 0 && !_disposed)
         {
-            Console.Error.WriteLine($"Warning: {nameof(ArrayPoolList<T>)} was not disposed. Created at: {_creationStackTrace}");
+            Console.Error.WriteLine($"Warning: {nameof(ArrayPoolList<>)} was not disposed. Created at: {_creationStackTrace}");
         }
     }
 #endif
@@ -306,7 +306,7 @@ public sealed class ArrayPoolList<T> : IList<T>, IList, IOwnedReadOnlyList<T>
         [DoesNotReturn]
         [StackTraceHidden]
         static void ThrowUnsupportedPool() => throw new InvalidOperationException(
-            $"{nameof(ToRef)} is only supported when {nameof(ArrayPoolList<T>)} uses {nameof(SafeArrayPool<T>)}.Shared.");
+            $"{nameof(ToRef)} is only supported when {nameof(ArrayPoolList<>)} uses {nameof(SafeArrayPool<>)}.Shared.");
     }
     public Memory<T> AsMemory()
     {

--- a/src/Nethermind/Nethermind.Core/Collections/JournalCollection.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/JournalCollection.cs
@@ -33,7 +33,7 @@ namespace Nethermind.Core.Collections
 
         [DoesNotReturn, StackTraceHidden]
         private void ThrowInvalidRestore(int snapshot)
-            => throw new InvalidOperationException($"{nameof(JournalCollection<T>)} tried to restore snapshot {snapshot} beyond current position {Count}");
+            => throw new InvalidOperationException($"{nameof(JournalCollection<>)} tried to restore snapshot {snapshot} beyond current position {Count}");
 
         public IEnumerator<T> GetEnumerator() => _list.GetEnumerator();
         IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_list).GetEnumerator();

--- a/src/Nethermind/Nethermind.Core/Collections/JournalSet.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/JournalSet.cs
@@ -44,7 +44,7 @@ namespace Nethermind.Core.Collections
 
         [DoesNotReturn, StackTraceHidden]
         private void ThrowInvalidRestore(int snapshot)
-            => throw new InvalidOperationException($"{nameof(JournalSet<T>)} tried to restore snapshot {snapshot} beyond current position {Count}");
+            => throw new InvalidOperationException($"{nameof(JournalSet<>)} tried to restore snapshot {snapshot} beyond current position {Count}");
 
         public bool Add(T item)
         {

--- a/src/Nethermind/Nethermind.Core/Collections/NativeMemoryList.cs
+++ b/src/Nethermind/Nethermind.Core/Collections/NativeMemoryList.cs
@@ -68,7 +68,7 @@ public sealed unsafe class NativeMemoryList<T> : IList<T>, IList, IOwnedReadOnly
 
         [DoesNotReturn]
         [StackTraceHidden]
-        static void ThrowObjectDisposed() => throw new ObjectDisposedException(nameof(NativeMemoryList<T>));
+        static void ThrowObjectDisposed() => throw new ObjectDisposedException(nameof(NativeMemoryList<>));
     }
 
     public Enumerator GetEnumerator()
@@ -265,7 +265,7 @@ public sealed unsafe class NativeMemoryList<T> : IList<T>, IList, IOwnedReadOnly
         if (_capacity != 0 && !_disposed)
         {
 #if DEBUG
-            Console.Error.WriteLine($"Warning: {nameof(NativeMemoryList<T>)} was not disposed. Created at: {_creationStackTrace}");
+            Console.Error.WriteLine($"Warning: {nameof(NativeMemoryList<>)} was not disposed. Created at: {_creationStackTrace}");
 #endif
             // Always free unmanaged memory / return pooled array in the finalizer to avoid
             // process-lifetime native leaks or starvation of the ArrayPool.

--- a/src/Nethermind/Nethermind.Core/Extensions/MemberInfoExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/MemberInfoExtensions.cs
@@ -89,8 +89,8 @@ public static class MemberInfoExtensions
         Type? underlying = Nullable.GetUnderlyingType(body.Type);
         if (underlying != null)
         {
-            MethodInfo getValueOrDefault = body.Type.GetMethod(nameof(Nullable<int>.GetValueOrDefault), Type.EmptyTypes)
-                ?? throw new NotSupportedException($"{body.Type} is nullable but {nameof(Nullable<int>.GetValueOrDefault)}() not found.");
+            MethodInfo getValueOrDefault = body.Type.GetMethod(nameof(Nullable<>.GetValueOrDefault), Type.EmptyTypes)
+                ?? throw new NotSupportedException($"{body.Type} is nullable but {nameof(Nullable<>.GetValueOrDefault)}() not found.");
             body = Expression.Call(body, getValueOrDefault);
         }
 

--- a/src/Nethermind/Nethermind.Evm/EvmObjectPool.std.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectPool.std.cs
@@ -56,7 +56,7 @@ internal static class EvmPoolTiers
     [DoesNotReturn, StackTraceHidden]
     private static void ThrowTooManyPools() =>
         throw new InvalidOperationException(
-            $"More than {MaxPools} {nameof(EvmObjectPool<object>)} instances were constructed; raise the slot count.");
+            $"More than {MaxPools} {nameof(EvmObjectPool<>)} instances were constructed; raise the slot count.");
 }
 
 /// <summary>
@@ -219,6 +219,6 @@ internal sealed class EvmObjectPool<T>
     [DoesNotReturn, StackTraceHidden]
     private static void ThrowDuplicatePool() =>
         throw new InvalidOperationException(
-            $"{typeof(T).Name} is pooled by more than one {nameof(EvmObjectPool<T>)}; each would keep its own " +
+            $"{typeof(T).Name} is pooled by more than one {nameof(EvmObjectPool<>)}; each would keep its own " +
             "per-thread free list, halving reuse and doubling retention. Hoist the pool to a single instance.");
 }

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -242,7 +242,7 @@ public class VmState<TGasPolicy> : IDisposable
     {
         if (!_isDisposed)
         {
-            Console.Error.WriteLine($"Warning: {nameof(VmState<TGasPolicy>)} was not disposed. Created at: {_creationStackTrace}");
+            Console.Error.WriteLine($"Warning: {nameof(VmState<>)} was not disposed. Created at: {_creationStackTrace}");
         }
     }
 #endif

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/SingletonModulePool.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/SingletonModulePool.cs
@@ -33,7 +33,7 @@ namespace Nethermind.JsonRpc.Modules
         {
             if (!canBeShared && !_allowExclusive)
             {
-                throw new InvalidOperationException($"{nameof(SingletonModulePool<T>)} can only return shareable modules");
+                throw new InvalidOperationException($"{nameof(SingletonModulePool<>)} can only return shareable modules");
             }
 
             return _onlyInstanceAsTask;

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv5/WireTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv5/WireTests.cs
@@ -420,7 +420,7 @@ public class WireTests
     {
         foreach (NSubstitute.Core.ICall call in kademlia.ReceivedCalls())
         {
-            if (call.GetMethodInfo().Name == nameof(IKademlia<PublicKey, Node>.AddOrRefresh) &&
+            if (call.GetMethodInfo().Name == nameof(IKademlia<,>.AddOrRefresh) &&
                 call.GetArguments()[0] is Node node &&
                 node.Id.Equals(publicKey) &&
                 HasEnrSequence(node, sequence))

--- a/src/Nethermind/Nethermind.Network/MessageSerializationService.cs
+++ b/src/Nethermind/Nethermind.Network/MessageSerializationService.cs
@@ -121,7 +121,7 @@ public class MessageSerializationService : IMessageSerializationService
 
     [DoesNotReturn, StackTraceHidden]
     private static void ThrowNoSerializerRegistered<T>() where T : MessageBase
-        => throw new InvalidOperationException($"No {nameof(IZeroMessageSerializer<T>)} registered for {typeof(T).Name}.");
+        => throw new InvalidOperationException($"No {nameof(IZeroMessageSerializer<>)} registered for {typeof(T).Name}.");
 
     [DoesNotReturn, StackTraceHidden]
     private static void ThrowInvalidSerializerType<T>(object? serializerObject)

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszTypeConverterInfo.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszTypeConverterInfo.cs
@@ -198,28 +198,28 @@ internal sealed class SszTypeConverterInfo
             .OfType<IMethodSymbol>()
             .Any(m => m is { DeclaredAccessibility: Accessibility.Public, IsStatic: true, Parameters.Length: 1 }
                 && SymbolEqualityComparer.Default.Equals(m.ReturnType, targetType)
-                && IsSpanOfByte(m.Parameters[0].Type, nameof(ReadOnlySpan<byte>)));
+                && IsSpanOfByte(m.Parameters[0].Type, nameof(ReadOnlySpan<>)));
 
     private static bool HasCollectionFromSpanMethod(INamedTypeSymbol converterType, ITypeSymbol targetType) =>
         converterType.GetMembers("FromSpan")
             .OfType<IMethodSymbol>()
             .Any(m => m is { DeclaredAccessibility: Accessibility.Public, IsStatic: true, ReturnsVoid: true, Parameters.Length: 2 }
-                && IsSpanOfByte(m.Parameters[0].Type, nameof(ReadOnlySpan<byte>))
-                && IsSpanOfType(m.Parameters[1].Type, nameof(Span<byte>), targetType));
+                && IsSpanOfByte(m.Parameters[0].Type, nameof(ReadOnlySpan<>))
+                && IsSpanOfType(m.Parameters[1].Type, nameof(Span<>), targetType));
 
     private static bool HasToSpanMethod(INamedTypeSymbol converterType, ITypeSymbol targetType) =>
         converterType.GetMembers("ToSpan")
             .OfType<IMethodSymbol>()
             .Any(m => m is { DeclaredAccessibility: Accessibility.Public, IsStatic: true, ReturnsVoid: true, Parameters.Length: 2 }
-                && IsSpanOfByte(m.Parameters[0].Type, nameof(Span<byte>))
+                && IsSpanOfByte(m.Parameters[0].Type, nameof(Span<>))
                 && SymbolEqualityComparer.Default.Equals(m.Parameters[1].Type, targetType));
 
     private static bool HasCollectionToSpanMethod(INamedTypeSymbol converterType, ITypeSymbol targetType) =>
         converterType.GetMembers("ToSpan")
             .OfType<IMethodSymbol>()
             .Any(m => m is { DeclaredAccessibility: Accessibility.Public, IsStatic: true, ReturnsVoid: true, Parameters.Length: 2 }
-                && IsSpanOfByte(m.Parameters[0].Type, nameof(Span<byte>))
-                && IsSpanOfType(m.Parameters[1].Type, nameof(ReadOnlySpan<byte>), targetType));
+                && IsSpanOfByte(m.Parameters[0].Type, nameof(Span<>))
+                && IsSpanOfType(m.Parameters[1].Type, nameof(ReadOnlySpan<>), targetType));
 
     private static bool HasFeedMethod(INamedTypeSymbol converterType, ITypeSymbol targetType) =>
         converterType.GetMembers("Feed")

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -142,7 +142,7 @@ public class StorageProviderTests(bool useFlat)
     private static int GetCapacity(object collection)
     {
         object dictionary = GetDictionary(collection);
-        return (int)dictionary.GetType().GetProperty(nameof(System.Collections.Generic.Dictionary<int, int>.Capacity))!.GetValue(dictionary)!;
+        return (int)dictionary.GetType().GetProperty(nameof(System.Collections.Generic.Dictionary<,>.Capacity))!.GetValue(dictionary)!;
     }
 
     private static object GetDictionary(object collection)
@@ -157,10 +157,10 @@ public class StorageProviderTests(bool useFlat)
         owner.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(owner)!;
 
     private static void EnsureCapacity(object collection, int capacity) =>
-        collection.GetType().GetMethod(nameof(System.Collections.Generic.Dictionary<int, int>.EnsureCapacity), [typeof(int)])!.Invoke(collection, [capacity]);
+        collection.GetType().GetMethod(nameof(System.Collections.Generic.Dictionary<,>.EnsureCapacity), [typeof(int)])!.Invoke(collection, [capacity]);
 
     private static int GetCollectionCapacity(object collection) =>
-        (int)collection.GetType().GetProperty(nameof(System.Collections.Generic.Dictionary<int, int>.Capacity))!.GetValue(collection)!;
+        (int)collection.GetType().GetProperty(nameof(System.Collections.Generic.Dictionary<,>.Capacity))!.GetValue(collection)!;
 
     [TestCase(-1)]
     [TestCase(0)]

--- a/src/Nethermind/Nethermind.State/OverridableEnv/ShareableOverridableEnvSource.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/ShareableOverridableEnvSource.cs
@@ -60,7 +60,7 @@ public sealed class ShareableOverridableEnvSource<T>(
 
     private IOverridableEnv<T> Rent()
     {
-        if (_disposed) throw new ObjectDisposedException(nameof(ShareableOverridableEnvSource<T>));
+        if (_disposed) throw new ObjectDisposedException(nameof(ShareableOverridableEnvSource<>));
 
         int active = Interlocked.Increment(ref _activeCount);
         if (active > maxConcurrent)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/NoopSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/NoopSyncFeed.cs
@@ -37,5 +37,5 @@ public class NoopSyncFeed<T> : ISyncFeed<T>
     }
 
     public bool IsFinished { get; } = true;
-    public string FeedName => nameof(NoopSyncFeed<T>);
+    public string FeedName => nameof(NoopSyncFeed<>);
 }

--- a/tools/DocGen/JsonRpcGenerator.cs
+++ b/tools/DocGen/JsonRpcGenerator.cs
@@ -485,7 +485,7 @@ internal static class JsonRpcGenerator
     {
         JsonConverter converter = (JsonConverter)Activator.CreateInstance(converterType)!;
         MethodInfo write = converterType.GetMethod(
-            nameof(JsonConverter<object>.Write),
+            nameof(JsonConverter<>.Write),
             [typeof(Utf8JsonWriter), valueType, typeof(JsonSerializerOptions)])!;
 
         write.Invoke(converter, [writer, sample, EthereumJsonSerializer.JsonOptions]);


### PR DESCRIPTION
## Changes

- Replace 38 constructed generic operands in nameof expressions with C# 14 unbound generic types.
- Apply the syntax consistently to both type names and member access while preserving every resulting string.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: Description

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

- Formatted the 21 changed files and ran git diff --check.
- Nethermind.Core.Test targeted tests: 79 passed.
- Nethermind.State.Test targeted tests: 128 passed.
- Nethermind.Network.Discovery.Test targeted tests: 8 passed.
- DocGen compiled with 0 errors using --no-dependencies.
- The solution build compiled all affected projects before the aggregate build encountered locked Nethermind.Runner output files held by a locally running node.

No new tests are needed because nameof remains a compile-time constant and the existing reflection/member-name tests exercise the changed paths.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No