### PR TITLE
refactor(evm): remove ArrayPool return try/finally (robustness.md)

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
@@ -132,18 +132,12 @@ public static class FrameTxSignatureValidator
 
         const int InputLength = Hash256.Size + TxFrameSignature.P256SignatureLength;
         byte[] input = ArrayPool<byte>.Shared.Rent(InputLength);
-        try
-        {
-            message.Bytes.CopyTo(input);
-            raw.CopyTo(input.AsSpan(Hash256.Size));
+        message.Bytes.CopyTo(input);
+        raw.CopyTo(input.AsSpan(Hash256.Size));
 
-            Result<byte[]> result = p256Precompile.Run(input.AsMemory(0, InputLength), spec);
-            return result && result.Data.Length > 0 || Fail(InvalidSignature, out error);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(input);
-        }
+        Result<byte[]> result = p256Precompile.Run(input.AsMemory(0, InputLength), spec);
+        ArrayPool<byte>.Shared.Return(input);
+        return result && result.Data.Length > 0 || Fail(InvalidSignature, out error);
     }
 
     private static bool Fail(string message, out string? error)


### PR DESCRIPTION
## Changes

- Remove the `try`/`finally` in `ValidateP256` (src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs:134-146) that existed solely to guarantee `ArrayPool<byte>.Shared.Return(input)` after an unexpected exception from `p256Precompile.Run`.
- The rented buffer is now returned on the normal path, immediately after `Run`. Buffer sizing (`InputLength`) and the inputs to `Run` are unchanged, so signature-verification semantics are byte-identical (zero behavior change).

This follows `.agents/rules/robustness.md:15`, which forbids adding or retaining a `try`/`finally` solely to guarantee `ArrayPool<T>.Shared.Return` after an unexpected exception aborts the operation: the abandoned array remains GC-reclaimable. `Run` is not expected to throw on the validated, canonical, fixed-length input, and a rented array leaking on an unexpected throw is acceptable per the rule.

## Types of changes

- [x] Refactoring

## Testing

#### Requires testing

- [x] No

#### Notes on testing

`Nethermind.Evm.Test` FrameTxSignatureValidator suite (20 tests) passes; project builds clean in release.

## Documentation

#### Requires documentation update

- [x] No
