### PR TITLE
fix(txpool): frame-tx MAX_VERIFY_GAS 300k -> spec 100k

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
@@ -22,7 +22,7 @@ public static class Eip8141Constants
 
     // Bounds mempool validation work only, never block execution; ITxPoolConfig.FrameTxMaxVerifyGas is the
     // operator-configurable mirror.
-    public const ulong MaxVerifyGas = 300_000;
+    public const ulong MaxVerifyGas = 100_000;
 
     /// <summary>
     /// <c>MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER</c>: the public-mempool cap on the pending frame

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -2539,6 +2539,27 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public void Frame_transaction_prefix_within_the_former_ceiling_is_rejected_by_the_default_bound()
+        {
+            _txPool = CreatePool(new TxPoolConfig(), new TestSpecProvider(Eip8141Prototype.Instance));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+            ITxPoolPeer peer = Substitute.For<ITxPoolPeer>();
+            peer.Id.Returns(TestItem.PublicKeyA);
+            _txPool.AddPeer(peer);
+
+            Transaction frameTx = BuildFrameTx(nonce: 0, TestItem.PrivateKeyA.Address, deadline: null, verifyGasLimit: 200_000);
+
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(AcceptTxResult.FrameTxVerifyGasTooHigh));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(0));
+                peer.DidNotReceive().SendNewTransaction(frameTx);
+            }
+        }
+
+        [Test]
         public void Frame_transaction_verify_gas_limit_of_zero_lifts_the_bound()
         {
             _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance));

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -37,7 +37,7 @@ public interface ITxPoolConfig : IConfig
     [ConfigItem(DefaultValue = "0", Description = "The max number of pending transactions per single sender. `0` to lift the limit.")]
     int MaxPendingTxsPerSender { get; set; }
 
-    [ConfigItem(DefaultValue = "300000", Description = "EIP-8141 `MAX_VERIFY_GAS`: the max gas a frame transaction's validation prefix and signature verification may cost for the transaction to be accepted into the public mempool. `0` to lift the limit. It bounds the declared-gas check only: an opaque prefix that has to be simulated is additionally capped, frame by frame, at the fixed `Eip8141Constants.MaxVerifyGas`, which raising this value does not move. Raise it only on a test network.")]
+    [ConfigItem(DefaultValue = "100000", Description = "EIP-8141 `MAX_VERIFY_GAS`: the max gas a frame transaction's validation prefix and signature verification may cost for the transaction to be accepted into the public mempool. `0` to lift the limit. It bounds the declared-gas check only: an opaque prefix that has to be simulated is additionally capped, frame by frame, at the fixed `Eip8141Constants.MaxVerifyGas`, which raising this value does not move. Raise it only on a test network.")]
     ulong FrameTxMaxVerifyGas { get; set; }
 
     [ConfigItem(DefaultValue = "500000", Description = "EIP-8141 `MAX_VERIFY_STATE_GAS`: the max state gas a frame transaction's validation prefix may budget across its `limits.state` for the transaction to be accepted into the public mempool. `0` to lift the limit. Raise it only on a test network.")]

--- a/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolConfig.cs
@@ -19,7 +19,7 @@ public class TxPoolConfig : ITxPoolConfig
     public int BlobCacheSize { get; set; } = 256;
     public int InMemoryBlobPoolSize { get; set; } = 512; // it is used when persistent pool is disabled
     public int MaxPendingTxsPerSender { get; set; } = 0;
-    public ulong FrameTxMaxVerifyGas { get; set; } = 300_000;
+    public ulong FrameTxMaxVerifyGas { get; set; } = 100_000;
     public ulong FrameTxMaxVerifyStateGas { get; set; } = 500_000;
     public int MaxPendingBlobTxsPerSender { get; set; } = 16;
     public int HashCacheSize { get; set; } = 512 * 1024;


### PR DESCRIPTION
## Changes

Lowers the EIP-8141 frame-transaction `MAX_VERIFY_GAS` public-mempool ceiling from `300_000` to the frozen-spec value `100_000`.

- `Nethermind.Core/Eip8141Constants.cs`: `MaxVerifyGas` `300_000` -> `100_000` (the per-frame cap applied during mempool prefix simulation in `TransactionProcessorBase.FrameTx.SimulateFrameValidationPrefix`).
- `Nethermind.TxPool/TxPoolConfig.cs`: `FrameTxMaxVerifyGas` default `300_000` -> `100_000` (the declared-gas admission bound in `FrameTxVerifyGasFilter`).
- `Nethermind.TxPool/ITxPoolConfig.cs`: `ConfigItem.DefaultValue` `"300000"` -> `"100000"` to keep the documented default in step with the property default (`StandardConfigTests.ValidateDefaultValues`).
- `Nethermind.TxPool.Test/TxPoolTests.cs`: regression test asserting a frame-tx validation prefix declaring `200_000` verify gas, in the former admit band `(100_000, 300_000]`, is now rejected with `FrameTxVerifyGasTooHigh` and not propagated to peers under the default config.

### Rationale

The frozen EIP-8141 spec (`ethereum/EIPs@3ceef8d37092c5b13a614746dbce5b1fc3c2dfab`, `EIPS/eip-8141.md` L868) fixes `MAX_VERIFY_GAS = 100_000` in the Public Mempool Validation table. Nethermind shipped `300_000`, a 3x deviation that admits and propagates prefixes the spec bars from the public mempool. `MAX_VERIFY_STATE_GAS` already matches the spec (`500_000`, L869) and is left untouched.

This is a public-mempool propagation and interop fix, not a consensus change. `MAX_VERIFY_GAS` bounds mempool admission and prefix simulation only; both call sites live inside `SimulateFrameValidationPrefix`, which runs against read-only head state for admission. Block validity is unaffected: a block carrying a frame tx whose prefix exceeds the bound stays consensus-valid.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Built `Nethermind.TxPool` and ran the targeted suites (release):

- `Nethermind.TxPool.Test` frame-tx filter: 126 passed, 0 failed.
- `Nethermind.Config.Test` default-value validation: 5 passed, 0 failed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

The default `TxPool.FrameTxMaxVerifyGas` drops from `300000` to `100000` to match the frozen EIP-8141 spec.
