### PR TITLE
fix(consensus): frame-tx exec-gas cap independent of EIP-8037 gate

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -1174,6 +1174,27 @@ public class TxValidatorTests
         Assert.That(FrameTxFieldsTxValidator.Instance.IsWellFormed(tx, Eip8141Prototype.Instance).AsBool(), Is.False);
     }
 
+    [Test]
+    public void IsWellFormed_FrameTxExecutionReservationIsBoundedByEip7825_WhenEip8037Disabled()
+    {
+        OverridableReleaseSpec spec = new(Amsterdam.NoEip8037Instance) { IsEip8141Enabled = true };
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            SenderAddress = TestItem.AddressA,
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null,
+                    Eip7825Constants.DefaultTxGasLimitCap, stateGasLimit: 0, UInt256.Zero, default),
+            ],
+            FrameSignatures = [],
+            DecodedMaxFeePerGas = 1,
+        };
+
+        Assert.That(FrameTxFieldsTxValidator.Instance.IsWellFormed(tx, spec).AsBool(), Is.False);
+    }
+
     private static IEnumerable<TestCaseData> NonceKeysEnvelopeCases()
     {
         yield return new TestCaseData(null, false, true).SetName("IsWellFormed_FrameTxLegacyNonce_BeforeEip8250_ReturnTrue");

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -220,7 +220,7 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
             return FrameTxValidation.FrameGasOverflow;
         }
 
-        if (releaseSpec.IsEip8037Enabled && executionReservation > Eip7825Constants.DefaultTxGasLimitCap)
+        if ((releaseSpec.IsEip8037Enabled || releaseSpec.IsEip8141Enabled) && executionReservation > Eip7825Constants.DefaultTxGasLimitCap)
         {
             return FrameTxValidation.FrameExecutionGasExceedsCap(executionReservation, Eip7825Constants.DefaultTxGasLimitCap);
         }


### PR DESCRIPTION
## Changes

- `FrameTxFieldsTxValidator` applies the EIP-7825 frame execution-gas cap whenever the frame-tx path is active, gating on `IsEip8037Enabled || IsEip8141Enabled` instead of `IsEip8037Enabled` alone.
- Added a regression test that enables EIP-8141 with EIP-8037 disabled and asserts a frame tx whose execution reservation exceeds `Eip7825Constants.DefaultTxGasLimitCap` is rejected.

## Rationale

The frozen spec (ethereum/EIPs@3ceef8d, eip-8141.md L10) declares `requires: ...7825, 8037`, and the cap assertion (eip-8141.md L196-200) is unconditional once frame transactions are active. The prior gate tied the cap to `IsEip8037Enabled` only.

Every valid fork bundles EIP-8037 with EIP-8141 (`Eip8141Prototype` extends `Amsterdam.Instance`, which sets `IsEip8037Enabled = true`), so behavior is byte-identical in every shipped configuration. This change only closes a defense-in-depth hole: a spec-forbidden misconfiguration (8141 on, 8037 off) would otherwise silently drop the cap.

The 1D `GetTxGasLimitCap` path (`Eip7825Constants.cs`) caps only when `IsEip7825Enabled && !IsEip8037Enabled`, so no double cap is introduced in any valid configuration.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Added `IsWellFormed_FrameTxExecutionReservationIsBoundedByEip7825_WhenEip8037Disabled` alongside the existing frame validation tests. `dotnet test` on `Nethermind.Blockchain.Test` filtered to `TxValidatorTests` is green (153 passed).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
