### PR TITLE
refactor(evm): single RIPEMD-preserving post-frame approval helper

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -286,18 +286,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             bool frameSucceeded = !substate.ShouldRevert && !substate.IsError;
             if (frameSucceeded && frameContext.ApprovalScopeSignal != 0)
             {
-                long remainingStateGas = (frame.StateGasLimit > long.MaxValue ? long.MaxValue : (long)frame.StateGasLimit) - frameStateGas;
-                if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
+                if (!TryApplyPostFrameApproval(frameContext, frame, resolvedTarget, spec, in accessTracker, tracer, ref substate, ref frameGasUsed, ref frameStateGas))
                 {
                     frameSucceeded = false;
-                    substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
-                    frameGasUsed = frame.ExecutionGasLimit;
-                    frameStateGas = 0;
-                }
-                else
-                {
-                    frameGasUsed += (ulong)approvalStateGas;
-                    frameStateGas += approvalStateGas;
                 }
             }
             else if (!frameSucceeded)
@@ -617,18 +608,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
                 if (!substate.ShouldRevert && !substate.IsError && frameContext.ApprovalScopeSignal != 0)
                 {
-                    long remainingStateGas = (boundedFrame.StateGasLimit > long.MaxValue ? long.MaxValue : (long)boundedFrame.StateGasLimit) - frameStateGas;
-                    if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
-                    {
-                        substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
-                        frameGasUsed = boundedFrame.ExecutionGasLimit;
-                        frameStateGas = 0;
-                    }
-                    else
-                    {
-                        frameGasUsed += (ulong)approvalStateGas;
-                        frameStateGas += approvalStateGas;
-                    }
+                    TryApplyPostFrameApproval(frameContext, boundedFrame, resolvedTarget, spec, in accessTracker, tracer, ref substate, ref frameGasUsed, ref frameStateGas);
                 }
 
                 verifyGasUsed += frameGasUsed - (ulong)frameStateGas;
@@ -748,6 +728,28 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         && i + 1 < frames.Length
         && FrameTxValidation.IsDeployFrame(frames[i])
         && frames[i + 1].Mode == TxFrame.ModeVerify;
+
+    /// <summary>Applies a succeeded frame's pending approval scope, charging its state gas or, on failure,
+    /// replacing the substate with an out-of-gas halt.</summary>
+    private bool TryApplyPostFrameApproval(FrameTxContext frameContext, TxFrame frame, Address resolvedTarget, IReleaseSpec spec, in StackAccessTracker accessTracker, ITxTracer tracer, ref TransactionSubstate substate, ref ulong frameGasUsed, ref long frameStateGas)
+    {
+        long stateLimit = frame.StateGasLimit > long.MaxValue ? long.MaxValue : (long)frame.StateGasLimit;
+        long remainingStateGas = stateLimit - frameStateGas;
+        if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
+        {
+            substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions)
+            {
+                ShouldRestoreRipemdTouch = substate.ShouldRestoreRipemdTouch,
+            };
+            frameGasUsed = frame.ExecutionGasLimit;
+            frameStateGas = 0;
+            return false;
+        }
+
+        frameGasUsed += (ulong)approvalStateGas;
+        frameStateGas += approvalStateGas;
+        return true;
+    }
 
     private TransactionSubstate ExecuteFrame(TxFrame frame, Address resolvedTarget, Address caller, bool isStatic, FrameTxContext frameContext, in StackAccessTracker accessTracker, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed, out long stateGasUsed)
     {
@@ -891,23 +893,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         if (!substate.ShouldRevert && !substate.IsError && frameContext.ApprovalScopeSignal != 0)
         {
-            long remainingStateGas = stateReservoirSeed - stateGasUsed;
-            if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
-            {
-                // The replacement is the substate the caller sees, so it has to carry the RIPEMD touch
-                // the frame recorded; the rollback below and the transaction accumulator both read it.
-                substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions)
-                {
-                    ShouldRestoreRipemdTouch = substate.ShouldRestoreRipemdTouch,
-                };
-                gasUsed = frame.ExecutionGasLimit;
-                stateGasUsed = 0;
-            }
-            else
-            {
-                gasUsed += (ulong)approvalStateGas;
-                stateGasUsed += approvalStateGas;
-            }
+            TryApplyPostFrameApproval(frameContext, frame, resolvedTarget, spec, in accessTracker, tracer, ref substate, ref gasUsed, ref stateGasUsed);
         }
 
         if (substate.ShouldRevert || substate.IsError)


### PR DESCRIPTION
## Changes

The post-frame approval-application block (frame succeeded and an approval scope is pending: charge the approval's state gas against the frame's remaining state limit, or on `TryApplyApproval` failure replace the substate with an out-of-gas halt, pin `gas_used` to the execution limit and zero the state gas) was copied three times in `TransactionProcessorBase.FrameTx.cs`:

- main execution loop, `ExecuteFrameTransaction` (was lines ~287-302)
- validation-prefix simulation, `SimulateFrameValidationPrefix` (was lines ~618-632)
- per-frame execution, `ExecuteFrame` (was lines ~892-911)

They were byte-identical except for one asymmetry: only the `ExecuteFrame` copy preserved the incoming substate's `ShouldRestoreRipemdTouch` into the replacement OOG substate; the other two omitted it.

This PR folds the three copies into a single private helper `TryApplyPostFrameApproval(...)` and replaces each site with a call. The `frame`/`boundedFrame` used for the state-limit clamp and the execution-limit fallback, and the `ref` gas outputs, are passed per call site so each keeps its own operands.

### RIPEMD-touch asymmetry rationale

The helper preserves the RIPEMD touch unconditionally. This is behavior-preserving at all three sites:

- `ExecuteFrame`: the rollback right after the block reads `substate.ShouldRestoreRipemdTouch` (`RestoreRipemdTouch`), so preservation is required here and already existed.
- main loop: the frame's `substate.ShouldRestoreRipemdTouch` is OR-ed into the transaction-level `shouldRestoreRipemdTouch` flag before the block runs; that flag (not the substate) drives every later `RestoreRipemdTouch`, and the substate field is never read again in the loop. Preserving it is a no-op.
- prefix simulation: the whole simulation runs inside a `try/finally` that restores the transaction snapshot; the substate's RIPEMD field is never read for a restore. Preserving it is a no-op.

So making preservation unconditional cannot change any observable state; it only removes the divergence risk of three copies that must be edited in lockstep.

No behavior change, no reformatting of surrounding code.

## Types of changes

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] No

#### Notes on testing

Existing suites pass unchanged, built and run in release:

- `FullyQualifiedName~FrameTxProcessor`: 244 passed, 0 failed
- `FullyQualifiedName~Eip8141Scenario`: 27 passed, 0 failed

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
