### PR TITLE
test(rlp): pin EIP-8141 decoder deviation caps (chain_id u64, 1024 sigs, 30MiB data)

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -27,6 +27,8 @@ namespace Nethermind.Core.Test.Encoding;
 public class FrameTxDecoderTests
 {
     private const int BlobVersionedHashesDecodeCap = ShardBlobNetworkWrapperRlp.BlobCountLimit;
+    private const int SignaturesDecodeCap = 1024;
+    private const int FrameDataDecodeCap = 30 * 1024 * 1024;
 
     private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
 
@@ -275,11 +277,12 @@ public class FrameTxDecoderTests
     /// <summary>
     /// Encodes the well-formed type-6 payload body that the hand-built payload tests start from.
     /// </summary>
+    /// <param name="chainId">Replaces the chain_id field; defaults to <see cref="TestBlockchainIds.ChainId"/>.</param>
     /// <param name="sender">Replaces the sender field; defaults to <see cref="TestItem.AddressA"/>.</param>
     /// <param name="trailing">Extra elements appended after <c>blob_versioned_hashes</c>.</param>
-    private static Rlp FrameTxBody(Rlp? sender = null, params Rlp[] trailing) =>
+    private static Rlp FrameTxBody(Rlp? chainId = null, Rlp? sender = null, params Rlp[] trailing) =>
         Rlp.Encode([
-            Rlp.Encode(TestBlockchainIds.ChainId),          // chain_id
+            chainId ?? Rlp.Encode(TestBlockchainIds.ChainId),
             Rlp.Encode(0L),                                 // nonce
             sender ?? Rlp.Encode(TestItem.AddressA.Bytes),  // sender
             Rlp.Encode(Array.Empty<Rlp>()),                 // frames
@@ -468,6 +471,54 @@ public class FrameTxDecoderTests
         else
         {
             Assert.That(EncodeDecode(tx).BlobVersionedHashes!.Length, Is.EqualTo(hashCount));
+        }
+    }
+
+    [TestCase(SignaturesDecodeCap, false)]
+    [TestCase(SignaturesDecodeCap + 1, true)]
+    public void Decode_BoundsTheSignatureCount(int signatureCount, bool rejected)
+    {
+        Transaction tx = CreateFrameTx(signatures:
+            [.. Enumerable.Range(0, signatureCount).Select(static _ =>
+                new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, default))]);
+
+        if (rejected)
+        {
+            Assert.That(() => EncodeDecode(tx), Throws.InstanceOf<RlpLimitException>());
+        }
+        else
+        {
+            Assert.That(EncodeDecode(tx).FrameSignatures!.Length, Is.EqualTo(signatureCount));
+        }
+    }
+
+    [Test]
+    public void Decode_ChainIdAtTwoToThe64_ThrowsRatherThanTruncatingToU64()
+    {
+        byte[] payload = TypedPayload(FrameTxBody(chainId: Rlp.Encode((UInt256)ulong.MaxValue + 1)));
+
+        void Decode()
+        {
+            RlpReader reader = new(payload);
+            _txDecoder.DecodeGuardNotNull(ref reader, RlpBehaviors.SkipTypedWrapping);
+        }
+
+        Assert.That(Decode, Throws.InstanceOf<RlpException>().With.Message.Contains("Unexpected length of integer"));
+    }
+
+    [TestCase(FrameDataDecodeCap, false)]
+    [TestCase(FrameDataDecodeCap + 1, true)]
+    public void Decode_BoundsTheFrameDataLength(int dataLength, bool rejected)
+    {
+        Transaction tx = CreateFrameTx(frames: [Frame(data: new byte[dataLength])]);
+
+        if (rejected)
+        {
+            Assert.That(() => EncodeDecode(tx), Throws.InstanceOf<RlpLimitException>());
+        }
+        else
+        {
+            Assert.That(EncodeDecode(tx).Frames![0].Data.Length, Is.EqualTo(dataLength));
         }
     }
 


### PR DESCRIPTION
## Changes

Adds decoder unit tests (test-only, no production change) pinning the three intentional EIP-8141 decode-side deviations that were self-labelled `EIP8141-DEVIATION` but had no regression test fixing the chosen bound:

- `src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs:22-23` `SignaturesDecodeCap = 1024` (spec does not cap the signature count). New `Decode_BoundsTheSignatureCount` asserts 1024 decodes and 1025 throws `RlpLimitException`.
- `src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs:120-121` chain_id decoded as u64 via `DecodeULong` though the spec allows chain_id < 2^256. New `Decode_ChainIdAtTwoToThe64_ThrowsRatherThanTruncatingToU64` asserts a chain_id of exactly 2^64 is rejected rather than silently truncated.
- `src/Nethermind/Nethermind.Serialization.Rlp/TxFrameDecoder.cs:21-22` frame `data` cap of 30 MiB (spec bounds frame data only through gas). New `Decode_BoundsTheFrameDataLength` asserts 30 MiB decodes and 30 MiB + 1 throws `RlpLimitException`.

These caps are correct decode-side hardening; the only gap was the missing test, so a future edit cannot silently move a bound. Each new rejection case was confirmed to fail if its cap is removed.

## Types of changes

- [x] Other: test-only, pins existing decoder behaviour

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`dotnet test` on `Nethermind.Core.Test` filtered to `FrameTxDecoder`: 42/42 green. Each rejection case was verified to fail when its cap is temporarily bumped, then the cap reverted.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
