### PR TITLE
test(rlp): pin frame-tx storage receipt log duplication size

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -129,6 +129,43 @@ public class FrameTxReceiptDecoderTests
         Assert.That(decoded[2].Type, Is.EqualTo(TxType.Legacy));
     }
 
+    /// <summary>The on-disk storage encoding persists each log twice — in the top-level union sequence and again
+    /// inside its frame receipt — so a frame-tx receipt is a full logs copy larger than the wire form, the trade-off
+    /// that lets the zero-alloc <c>DecodeStructRef</c> path slice the top-level logs without rebuilding them from the
+    /// frames. The literal length pins that on-disk size so a second duplication cannot land unnoticed.</summary>
+    [Test]
+    public void StorageEncoding_MultiFrameReceiptWithLogs_StoresLogsTwiceAtPinnedSizeAndRoundtrips(
+        [Values(true, false)] bool compact)
+    {
+        TxFrameReceipt[] frameReceipts =
+        [
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 5_000, [Log(0x01), Log(0x02)]),
+            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, 0, [Log(0x03)]),
+            new TxFrameReceipt(TxFrameReceipt.StatusSkipped, 0, 0, []),
+        ];
+        LogEntry[] unionLogs = frameReceipts.SelectMany(static frame => frame.Logs).ToArray();
+        TxReceipt receipt = CreateStorageFrameReceipt(unionLogs, frameReceipts);
+
+        RlpDecoder<TxReceipt> decoder = compact ? new CompactReceiptStorageDecoder() : new ReceiptStorageDecoder();
+        RlpBehaviors behaviors = RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts;
+        byte[] encoded = decoder.EncodeAsBytes(receipt, behaviors);
+
+        int expectedLength = compact ? 435 : 701;
+        Assert.That(encoded.Length, Is.EqualTo(expectedLength),
+            "the stored size counts every log twice; a change here means a copy was added or removed");
+
+        RlpReader reader = new(encoded);
+        TxReceipt decoded = decoder.Decode(ref reader, RlpBehaviors.Storage)!;
+        Assert.That(decoded.TxType, Is.EqualTo(TxType.FrameTx));
+        Assert.That(decoded.Payer, Is.EqualTo(receipt.Payer));
+        Assert.That(decoded.GasUsedTotal, Is.EqualTo(receipt.GasUsedTotal));
+        Assert.That(decoded.StatusCode, Is.EqualTo(receipt.StatusCode));
+        AssertLogsEqual(decoded.Logs!, unionLogs, "the top-level union copy of the logs must survive the round-trip");
+        AssertFrameReceiptsEqual(decoded.FrameReceipts!, frameReceipts);
+        AssertLogsEqual(decoded.FrameReceipts!.SelectMany(static frame => frame.Logs).ToArray(), unionLogs,
+            "the per-frame copy holds the same logs as the top-level union, the duplication this size pins");
+    }
+
     private static LogEntry[] DecodeLogs(scoped ReadOnlySpan<byte> logsRlp, bool compact)
     {
         RlpReader reader = new(logsRlp);


### PR DESCRIPTION
## What

Adds one test-only characterization test to `FrameTxReceiptDecoderTests`, parameterized over both storage decoders (`CompactReceiptStorageDecoder` and `ReceiptStorageDecoder`), pinning the on-disk encoded size of a multi-frame `FrameTx` receipt that carries logs.

No production code changes.

## Why

For a frame transaction the wire receipt (`ReceiptMessageDecoder`) stores logs **once**, per frame — the top-level `StatusCode` and union `Logs` are derived at decode time. The on-disk storage form persists logs **twice**: once in the top-level union logs sequence and again inside each frame receipt's own logs. This is a deliberate speed-vs-size trade-off — the zero-alloc `DecodeStructRef` fast path slices the top-level `LogsRlp` directly and jumps past the trailing `[payer, per-frame receipts]` extension, so it never has to reconstruct the union from the frames.

The redundancy is invisible to the round-trip tests, which is exactly how it could silently grow: a change could add a third copy, or drop the top-level copy and quietly regress the fast path, without any existing test noticing.

## What the test asserts

For a receipt with three frames (two carrying logs, union `Logs` = the frame logs):

- the encoded storage length equals a recorded literal byte count (435 compact, 701 legacy) — a real oracle that breaks if a log copy is added or removed;
- the larger encoding round-trips: `TxType`, `Payer`, `GasUsedTotal`, `StatusCode` and the top-level union `Logs` are preserved, and the per-frame receipts decode back holding the same logs as the top-level union — the two independent on-disk copies the size pins.

The literal-constant oracle follows the existing precedent in this file (`OldSingleCompactHex` and friends) rather than re-deriving `GetContentLength` in the test.

## Verification

- `dotnet build Nethermind.Core.Test -c release` — 0 errors.
- `Nethermind.Core.Test --filter FullyQualifiedName~FrameTxReceiptDecoderTests` — 18/18 pass.
- Positive control: encoding the same fixture with the top-level union logs removed drops the compact size from 435 to 256 bytes, confirming the pinned length is driven by the duplicated copy.
