### PR TITLE
Bound frame-tx validation-prefix simulation by wall clock

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
 using Nethermind.Consensus.Processing;
@@ -163,12 +164,12 @@ public class FrameTxPrefixSimulatorTests
     public void Simulate_ExceedsWallClockBudget_LeavesUndecidedInsteadOfBlocking()
     {
         FrameTxPrefixSimulator simulator = CreateSimulator(out _, out ITransactionProcessor processor, wallClockBudget: TimeSpan.FromMilliseconds(20));
+        bool tracerCancelled = false;
         processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
             .Returns(callInfo =>
             {
                 ITxTracer tracer = callInfo.ArgAt<ITxTracer>(1);
-                bool cancelled = SpinWait.SpinUntil(() => tracer.IsCancelled, TimeSpan.FromSeconds(5));
-                Assert.That(cancelled, Is.True, "the budget did not cancel the tracer");
+                tracerCancelled = SpinWait.SpinUntil(() => tracer.IsCancelled, TimeSpan.FromSeconds(5));
                 throw new OperationCanceledException();
             });
 
@@ -176,8 +177,37 @@ public class FrameTxPrefixSimulatorTests
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(tracerCancelled, Is.True, "the budget did not cancel the tracer");
             Assert.That(result.Outcome, Is.EqualTo(FrameTxSimulationOutcome.Undecided));
             Assert.That(result.Reason, Does.Contain("budget"));
+        }
+    }
+
+    [Test]
+    public void Simulate_BlockedBehindAnotherSimulation_TimesOutWaitingInsteadOfBlocking()
+    {
+        FrameTxPrefixSimulator simulator = CreateSimulator(out _, out ITransactionProcessor processor, wallClockBudget: TimeSpan.FromMilliseconds(100));
+        using ManualResetEventSlim holding = new();
+        using ManualResetEventSlim release = new();
+        processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
+            .Returns(_ =>
+            {
+                holding.Set();
+                release.Wait(TimeSpan.FromSeconds(5));
+                return TransactionResult.Ok;
+            });
+
+        Task<FrameTxSimulationResult> first = Task.Run(() => simulator.Simulate(Tx()));
+        Assert.That(holding.Wait(TimeSpan.FromSeconds(5)), Is.True, "the first simulation never entered");
+
+        FrameTxSimulationResult second = simulator.Simulate(Tx());
+        release.Set();
+        first.Wait(TimeSpan.FromSeconds(5));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(second.Outcome, Is.EqualTo(FrameTxSimulationOutcome.Undecided));
+            Assert.That(second.Reason, Does.Contain("waiting"));
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
@@ -160,14 +160,15 @@ public class FrameTxPrefixSimulatorTests
     }
 
     [Test]
-    public void Simulate_ExceedsWallClockBudget_RejectsInsteadOfBlocking()
+    public void Simulate_ExceedsWallClockBudget_LeavesUndecidedInsteadOfBlocking()
     {
         FrameTxPrefixSimulator simulator = CreateSimulator(out _, out ITransactionProcessor processor, wallClockBudget: TimeSpan.FromMilliseconds(20));
         processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
             .Returns(callInfo =>
             {
                 ITxTracer tracer = callInfo.ArgAt<ITxTracer>(1);
-                SpinWait.SpinUntil(() => tracer.IsCancelled, TimeSpan.FromSeconds(5));
+                bool cancelled = SpinWait.SpinUntil(() => tracer.IsCancelled, TimeSpan.FromSeconds(5));
+                Assert.That(cancelled, Is.True, "the budget did not cancel the tracer");
                 throw new OperationCanceledException();
             });
 
@@ -175,7 +176,7 @@ public class FrameTxPrefixSimulatorTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result.Outcome, Is.EqualTo(FrameTxSimulationOutcome.Rejected));
+            Assert.That(result.Outcome, Is.EqualTo(FrameTxSimulationOutcome.Undecided));
             Assert.That(result.Reason, Does.Contain("budget"));
         }
     }

--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
@@ -159,11 +159,33 @@ public class FrameTxPrefixSimulatorTests
         processor.Received(1).Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), expected);
     }
 
+    [Test]
+    public void Simulate_ExceedsWallClockBudget_RejectsInsteadOfBlocking()
+    {
+        FrameTxPrefixSimulator simulator = CreateSimulator(out _, out ITransactionProcessor processor, wallClockBudget: TimeSpan.FromMilliseconds(20));
+        processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
+            .Returns(callInfo =>
+            {
+                ITxTracer tracer = callInfo.ArgAt<ITxTracer>(1);
+                SpinWait.SpinUntil(() => tracer.IsCancelled, TimeSpan.FromSeconds(5));
+                throw new OperationCanceledException();
+            });
+
+        FrameTxSimulationResult result = simulator.Simulate(Tx());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Outcome, Is.EqualTo(FrameTxSimulationOutcome.Rejected));
+            Assert.That(result.Reason, Does.Contain("budget"));
+        }
+    }
+
     private static FrameTxPrefixSimulator CreateSimulator(
         out IReadOnlyTxProcessorSource source,
         out ITransactionProcessor processor,
         bool hasHead = true,
-        InterfaceLogger? logSink = null)
+        InterfaceLogger? logSink = null,
+        TimeSpan? wallClockBudget = null)
     {
         processor = Substitute.For<ITransactionProcessor>();
         IReadOnlyTxProcessingScope scope = Substitute.For<IReadOnlyTxProcessingScope>();
@@ -180,7 +202,10 @@ public class FrameTxPrefixSimulatorTests
         blockFinder.Head.Returns(hasHead ? Build.A.Block.WithNumber(1).TestObject : null);
 
         ILogManager logManager = logSink is null ? LimboLogs.Instance : new OneLoggerLogManager(new ILogger(logSink));
-        return new FrameTxPrefixSimulator(envFactory, blockFinder, new TestSpecProvider(Eip8141Prototype.Instance), logManager);
+        TestSpecProvider specProvider = new(Eip8141Prototype.Instance);
+        return wallClockBudget is null
+            ? new FrameTxPrefixSimulator(envFactory, blockFinder, specProvider, logManager)
+            : new FrameTxPrefixSimulator(envFactory, blockFinder, specProvider, logManager, wallClockBudget.Value);
     }
 
     private static Transaction Tx() => Build.A.Transaction.WithSenderAddress(TestItem.AddressA).TestObject;

--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
@@ -202,12 +202,13 @@ public class FrameTxPrefixSimulatorTests
 
         FrameTxSimulationResult second = simulator.Simulate(Tx());
         release.Set();
-        first.Wait(TimeSpan.FromSeconds(5));
+        Assert.That(first.Wait(TimeSpan.FromSeconds(5)), Is.True, "the first simulation never completed");
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(second.Outcome, Is.EqualTo(FrameTxSimulationOutcome.Undecided));
             Assert.That(second.Reason, Does.Contain("waiting"));
+            processor.Received(1).Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>());
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/FrameTxPrefixSimulator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/FrameTxPrefixSimulator.cs
@@ -26,11 +26,22 @@ public sealed class FrameTxPrefixSimulator(
     ISpecProvider specProvider,
     ILogManager logManager) : IFrameTxPrefixSimulator, IDisposable
 {
+    private static readonly TimeSpan DefaultWallClockBudget = TimeSpan.FromMilliseconds(500);
+
     private readonly ILogger _logger = logManager.GetClassLogger<FrameTxPrefixSimulator>();
     private readonly object _lock = new();
+    private readonly TimeSpan _wallClockBudget = DefaultWallClockBudget;
     private IReadOnlyTxProcessorSource? _source;
     private bool _disposed;
     private bool _nodeFaultReported;
+
+    internal FrameTxPrefixSimulator(
+        IReadOnlyTxProcessingEnvFactory envFactory,
+        IBlockFinder blockFinder,
+        ISpecProvider specProvider,
+        ILogManager logManager,
+        TimeSpan wallClockBudget) : this(envFactory, blockFinder, specProvider, logManager) =>
+        _wallClockBudget = wallClockBudget;
 
     public FrameTxSimulationResult Simulate(Transaction tx, bool signaturesPreValidated = false, CancellationToken token = default)
     {
@@ -55,6 +66,8 @@ public sealed class FrameTxPrefixSimulator(
             }
 
             IReadOnlyTxProcessorSource source = _source ??= envFactory.Create();
+            using CancellationTokenSource budget = CancellationTokenSource.CreateLinkedTokenSource(token);
+            budget.CancelAfter(_wallClockBudget);
             try
             {
                 using IReadOnlyTxProcessingScope scope = source.Build(head);
@@ -62,7 +75,7 @@ public sealed class FrameTxPrefixSimulator(
                 processor.SetBlockExecutionContext(head);
 
                 IReleaseSpec spec = specProvider.GetSpec(head);
-                FrameTxValidationTracer tracer = new(tx.SenderAddress, Eip8141Constants.ExpiryVerifierAddress, scope.WorldState, spec);
+                FrameTxValidationTracer tracer = new(tx.SenderAddress, Eip8141Constants.ExpiryVerifierAddress, scope.WorldState, spec, budget.Token);
                 ExecutionOptions opts = ExecutionOptions.FrameValidationPrefixOnly;
                 if (signaturesPreValidated) opts |= ExecutionOptions.FrameSignaturesPreValidated;
                 TransactionResult result = processor.Process(tx, tracer, opts);
@@ -81,6 +94,11 @@ public sealed class FrameTxPrefixSimulator(
                 }
 
                 return FrameTxSimulationResult.Accept(tracer.Payer);
+            }
+            catch (OperationCanceledException) when (budget.IsCancellationRequested && !token.IsCancellationRequested)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Frame transaction {tx.Hash} validation-prefix simulation exceeded its {_wallClockBudget.TotalMilliseconds}ms budget; rejecting.");
+                return FrameTxSimulationResult.Reject("validation-prefix simulation exceeded its time budget");
             }
             catch (OperationCanceledException)
             {

--- a/src/Nethermind/Nethermind.Consensus/Processing/FrameTxPrefixSimulator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/FrameTxPrefixSimulator.cs
@@ -97,8 +97,8 @@ public sealed class FrameTxPrefixSimulator(
             }
             catch (OperationCanceledException) when (budget.IsCancellationRequested && !token.IsCancellationRequested)
             {
-                if (_logger.IsDebug) _logger.Debug($"Frame transaction {tx.Hash} validation-prefix simulation exceeded its {_wallClockBudget.TotalMilliseconds}ms budget; rejecting.");
-                return FrameTxSimulationResult.Reject("validation-prefix simulation exceeded its time budget");
+                if (_logger.IsDebug) _logger.Debug($"Frame transaction {tx.Hash} validation-prefix simulation exceeded its {_wallClockBudget.TotalMilliseconds}ms budget; leaving it unjudged.");
+                return FrameTxSimulationResult.Undecided("validation-prefix simulation exceeded its time budget");
             }
             catch (OperationCanceledException)
             {

--- a/src/Nethermind/Nethermind.Consensus/Processing/FrameTxPrefixSimulator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/FrameTxPrefixSimulator.cs
@@ -58,7 +58,12 @@ public sealed class FrameTxPrefixSimulator(
             return FrameTxSimulationResult.Undecided("no chain head to simulate against");
         }
 
-        lock (_lock)
+        if (!Monitor.TryEnter(_lock, _wallClockBudget))
+        {
+            return FrameTxSimulationResult.Undecided("validation-prefix simulation timed out waiting for the simulator");
+        }
+
+        try
         {
             if (_disposed)
             {
@@ -128,6 +133,10 @@ public sealed class FrameTxPrefixSimulator(
                 if (_logger.IsDebug) _logger.Debug($"Frame transaction {tx.Hash} validation-prefix simulation threw; rejecting. {e}");
                 return FrameTxSimulationResult.Reject("validation-prefix simulation error");
             }
+        }
+        finally
+        {
+            Monitor.Exit(_lock);
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 using Nethermind.Blockchain;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
@@ -382,14 +383,25 @@ public class FrameTxValidationPrefixSimulationTests
         return data;
     }
 
-    private (TransactionResult, FrameTxValidationTracer) Simulate(Transaction tx, ulong? slotNumber = null, ExecutionOptions extraOptions = ExecutionOptions.None)
+    [Test]
+    public void Simulate_TracerTokenCancelled_TheEvmAbortsThePrefix()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => Simulate(tx, token: cts.Token));
+    }
+
+    private (TransactionResult, FrameTxValidationTracer) Simulate(Transaction tx, ulong? slotNumber = null, ExecutionOptions extraOptions = ExecutionOptions.None, CancellationToken token = default)
     {
         Block block = Build.A.Block.WithNumber(1)
             .WithBaseFeePerGas(0)
             .WithTransactions(tx)
             .WithSlotNumber(slotNumber)
             .WithGasLimit(30_000_000).TestObject;
-        FrameTxValidationTracer tracer = new(tx.SenderAddress!, Eip8141Constants.ExpiryVerifierAddress, _stateProvider, Spec);
+        FrameTxValidationTracer tracer = new(tx.SenderAddress!, Eip8141Constants.ExpiryVerifierAddress, _stateProvider, Spec, token);
         _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(block.Header, Spec));
         TransactionResult result = _transactionProcessor.Process(tx, tracer, ExecutionOptions.FrameValidationPrefixOnly | extraOptions);
         return (result, tracer);

--- a/src/Nethermind/Nethermind.Evm/Tracing/FrameTxValidationTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/FrameTxValidationTracer.cs
@@ -14,7 +14,7 @@ namespace Nethermind.Evm.Tracing;
 /// and captures the resolved payer.</summary>
 /// <remarks>EIP8141-GAP: deploy-frame carve-outs unhandled, so the processor declines any prefix containing one.</remarks>
 public sealed class FrameTxValidationTracer(Address sender, Address expiryVerifier, IReadOnlyStateProvider state, IReleaseSpec spec, CancellationToken token = default)
-    : TxTracer, IFrameTxReceiptTracer
+    : TxTracer, ITxTracer, IFrameTxReceiptTracer
 {
     // Stack slot holding the current CALL*/EXTCODE* target, or -1. Set in StartOperation and consumed in
     // SetOperationStack, as the operands aren't available any earlier.

--- a/src/Nethermind/Nethermind.Evm/Tracing/FrameTxValidationTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/FrameTxValidationTracer.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
@@ -12,12 +13,15 @@ namespace Nethermind.Evm.Tracing;
 /// <summary>Enforces the EIP-8141 validation-prefix opcode rules during mempool prefix simulation,
 /// and captures the resolved payer.</summary>
 /// <remarks>EIP8141-GAP: deploy-frame carve-outs unhandled, so the processor declines any prefix containing one.</remarks>
-public sealed class FrameTxValidationTracer(Address sender, Address expiryVerifier, IReadOnlyStateProvider state, IReleaseSpec spec)
+public sealed class FrameTxValidationTracer(Address sender, Address expiryVerifier, IReadOnlyStateProvider state, IReleaseSpec spec, CancellationToken token = default)
     : TxTracer, IFrameTxReceiptTracer
 {
     // Stack slot holding the current CALL*/EXTCODE* target, or -1. Set in StartOperation and consumed in
     // SetOperationStack, as the operands aren't available any earlier.
     private int _targetStackIndex = -1;
+
+    public bool IsCancelable => token.CanBeCanceled;
+    public bool IsCancelled => token.IsCancellationRequested;
 
     public override bool IsTracingInstructions => true;
     public override bool IsTracingOpLevelStorage => true;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSimulationFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSimulationFilter.cs
@@ -10,8 +10,9 @@ namespace Nethermind.TxPool.Filters;
 /// <summary>Simulates the validation prefix of opaque EIP-8141 frame transactions
 /// (<see cref="FrameTxPayerOutcome.RequiresSimulation"/>), rejecting those that do not validate.</summary>
 /// <remarks>Must run after <see cref="FrameTxPayerFilter"/>, whose resolved payer is the EVM-free fast
-/// path here. Runs inside the pool's head read lock, so the simulator has to bound its own wait. The
-/// simulation re-verifies the frame signatures unless <see cref="FrameTxSignatureFilter"/> already has.</remarks>
+/// path here. Runs inside the pool's head read lock; the simulator applies a best-effort wall-clock budget
+/// over its EVM run and leaves a transaction that exceeds it undecided rather than blocking. The simulation
+/// re-verifies the frame signatures unless <see cref="FrameTxSignatureFilter"/> already has.</remarks>
 internal sealed class FrameTxSimulationFilter(IFrameTxPrefixSimulator? simulator, ILogger logger) : IIncomingTxFilter
 {
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSimulationFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSimulationFilter.cs
@@ -10,9 +10,11 @@ namespace Nethermind.TxPool.Filters;
 /// <summary>Simulates the validation prefix of opaque EIP-8141 frame transactions
 /// (<see cref="FrameTxPayerOutcome.RequiresSimulation"/>), rejecting those that do not validate.</summary>
 /// <remarks>Must run after <see cref="FrameTxPayerFilter"/>, whose resolved payer is the EVM-free fast
-/// path here. Runs inside the pool's head read lock; the simulator applies a best-effort wall-clock budget
-/// over its EVM run and leaves a transaction that exceeds it undecided rather than blocking. The simulation
-/// re-verifies the frame signatures unless <see cref="FrameTxSignatureFilter"/> already has.</remarks>
+/// path here. Runs inside the pool's head read lock; the simulator bounds both the wait for its shared
+/// executor and the EVM run by a best-effort wall-clock budget, so a caller holds the read lock for at most
+/// about twice the budget, and a transaction that exceeds either bound is left undecided rather than blocking.
+/// An undecided frame transaction is admitted without a payer, so it takes no exposure reservation. The
+/// simulation re-verifies the frame signatures unless <see cref="FrameTxSignatureFilter"/> already has.</remarks>
 internal sealed class FrameTxSimulationFilter(IFrameTxPrefixSimulator? simulator, ILogger logger) : IIncomingTxFilter
 {
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)

--- a/src/Nethermind/Nethermind.TxPool/IFrameTxPrefixSimulator.cs
+++ b/src/Nethermind/Nethermind.TxPool/IFrameTxPrefixSimulator.cs
@@ -13,8 +13,10 @@ public interface IFrameTxPrefixSimulator
     /// <param name="signaturesPreValidated">Assert only if this exact transaction has already passed
     /// <c>validate_signature</c> at chain head; the simulation then trusts its signatures. The two sides read
     /// the head separately, so a head change between them can only mis-admit, never mis-reject.</param>
-    /// <param name="token">Checked at entry and, once cancelled, aborts a running simulation. Independently,
-    /// the implementation bounds each simulation by a wall-clock budget and rejects one that exceeds it.</param>
+    /// <param name="token">Checked at entry and, once cancelled, aborts a running simulation at the next EVM
+    /// cancellation checkpoint. Independently, the implementation applies a best-effort wall-clock budget over
+    /// the EVM run and leaves a transaction that exceeds it undecided; the budget is opcode-granular, not a hard
+    /// deadline.</param>
     FrameTxSimulationResult Simulate(Transaction tx, bool signaturesPreValidated = false, CancellationToken token = default);
 }
 

--- a/src/Nethermind/Nethermind.TxPool/IFrameTxPrefixSimulator.cs
+++ b/src/Nethermind/Nethermind.TxPool/IFrameTxPrefixSimulator.cs
@@ -16,7 +16,8 @@ public interface IFrameTxPrefixSimulator
     /// <param name="token">Checked at entry and, once cancelled, aborts a running simulation at the next EVM
     /// cancellation checkpoint. Independently, the implementation applies a best-effort wall-clock budget over
     /// the EVM run and leaves a transaction that exceeds it undecided; the budget is opcode-granular, not a hard
-    /// deadline.</param>
+    /// deadline. The same budget bounds the wait for the shared executor, so contention alone can return
+    /// undecided before the EVM runs.</param>
     FrameTxSimulationResult Simulate(Transaction tx, bool signaturesPreValidated = false, CancellationToken token = default);
 }
 

--- a/src/Nethermind/Nethermind.TxPool/IFrameTxPrefixSimulator.cs
+++ b/src/Nethermind/Nethermind.TxPool/IFrameTxPrefixSimulator.cs
@@ -13,7 +13,8 @@ public interface IFrameTxPrefixSimulator
     /// <param name="signaturesPreValidated">Assert only if this exact transaction has already passed
     /// <c>validate_signature</c> at chain head; the simulation then trusts its signatures. The two sides read
     /// the head separately, so a head change between them can only mis-admit, never mis-reject.</param>
-    /// <param name="token">Honored at entry only; a started simulation runs to its <c>MAX_VERIFY_GAS</c> bound.</param>
+    /// <param name="token">Checked at entry and, once cancelled, aborts a running simulation. Independently,
+    /// the implementation bounds each simulation by a wall-clock budget and rejects one that exceeds it.</param>
     FrameTxSimulationResult Simulate(Transaction tx, bool signaturesPreValidated = false, CancellationToken token = default);
 }
 


### PR DESCRIPTION
## What

Bound the EIP-8141 frame-tx validation-prefix simulation by a per-simulation wall-clock budget, so a simulation cannot run — or wait for the shared simulator — unboundedly while the pool holds its head read lock.

## Why

`FrameTxSimulationFilter` runs inside `TxPool`'s `_newHeadLock` read lock, and its `<remarks>` already conceded the simulator must bound its own wait. But `IFrameTxPrefixSimulator.Simulate` only honored the caller token at entry: once started, a simulation ran to its `MAX_VERIFY_GAS` gas cap, and callers queued on the simulator's serialization lock waited unbounded. The gas cap bounds compute deterministically, but not non-compute stalls (cold trie reads, a GC pause), nor the queue behind the single shared executor. A stall or a backlog holds the read lock and can delay a new-head update.

## How

- `FrameTxValidationTracer` becomes cancelable and **re-implements `ITxTracer`** so its `IsCancelable`/`IsCancelled` reach the EVM through interface dispatch (as class members on a type that only inherited the interface they were shadowed by the `=> false` default interface members, and the VM never polled them). It reports `IsCancelable` only when its token `CanBeCanceled`, so callers that pass no token keep the non-cancelable EVM fast path.
- `FrameTxPrefixSimulator` links the caller token with a per-simulation wall-clock budget and passes it to the tracer; the EVM's periodic cancellation check aborts a run that exceeds the budget. It also acquires the shared executor lock with `Monitor.TryEnter(_lock, budget)`, so a queued caller holds the read lock for at most about twice the budget.
- The budget is a fixed internal backstop (500 ms), not a new operator config surface. Caller-token cancellation propagates as shutdown; a budget overrun or a lock-wait timeout is left **undecided**.

## Attribution and the undecided trade-off

A wall-clock overrun and a lock-wait timeout are node-attributable (IO pressure, GC, a saturated executor), not properties of the transaction, so they return `Undecided` rather than `Rejected` — matching how the simulator already treats node-side faults, and avoiding feeding the peer flood counter and disconnecting honest peers.

`Undecided` admits the transaction with no resolved payer, which takes **no payer-exposure reservation** — the same outcome as running with no simulator wired (a supported configuration). This PR makes that outcome reachable per-transaction under load: an actor saturating the single serialized executor can push concurrent opaque frame transactions onto the undecided path and have them admitted unpriced. This is the deliberate, conservative choice here: the alternative attributions (rejecting, which charges honest peers under node-side pressure) are worse, and a stricter policy for unpriced admissions — reserving conservatively against `tx.SenderAddress`, or rate-limiting undecided admissions — changes the payer-exposure gate's admission behavior and is left as a separate decision for the frame-tx admission owners.

## Tests

- `FrameTxPrefixSimulatorTests.Simulate_ExceedsWallClockBudget_LeavesUndecidedInsteadOfBlocking`: a simulation that exceeds the budget is aborted and left undecided (not blocking, not charged as a rejection).
- `FrameTxPrefixSimulatorTests.Simulate_BlockedBehindAnotherSimulation_TimesOutWaitingInsteadOfBlocking`: a caller that cannot acquire the shared executor within the budget returns undecided; the busy caller is the only one that reaches the processor.
- `FrameTxValidationPrefixSimulationTests.Simulate_TracerTokenCancelled_TheEvmAbortsThePrefix`: drives the real `TransactionProcessor` with an already-cancelled token and asserts it aborts — this fails if the `ITxTracer` re-implementation is removed, guarding the interface-dispatch fix.
- Existing `FrameTxPrefixSimulatorTests`, `FrameTxValidationPrefixSimulationTests`, and `FrameTxSimulationFilterTests` stay green.
