### PR TITLE
refactor(evm): make IGasPolicy.GetColdAccountAccessCost static virtual with default

### DIFF
--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -30,7 +30,9 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static abstract ulong GetRemainingGas(in TSelf gas);
 
     /// <summary>Cold account-access cost (EIP-2929), repriced by EIP-8038.</summary>
-    static abstract ulong GetColdAccountAccessCost(IReleaseSpec spec);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static virtual ulong GetColdAccountAccessCost(IReleaseSpec spec) =>
+        spec.IsEip8038Enabled ? Eip8038Constants.ColdAccountAccess : GasCostOf.ColdAccountAccess;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong CombineBlockGas(ulong blockExecutionGas, ulong blockStateGas) => Math.Max(blockExecutionGas, blockStateGas);


### PR DESCRIPTION
## What

Makes `IGasPolicy<TSelf>.GetColdAccountAccessCost(IReleaseSpec)` a `static virtual` member with a default body instead of `static abstract`, aligning it with the sibling additions on the same interface (`FromFrameLimits`, `CombineBlockGas`), which are already `static virtual` with defaults.

The default body is the standard EIP-2929 cost, repriced under EIP-8038:

```csharp
spec.IsEip8038Enabled ? Eip8038Constants.ColdAccountAccess : GasCostOf.ColdAccountAccess
```

## Why

The cold account-access cost has a single, well-defined default that every current policy shares. Requiring each implementer to supply it as an abstract member forces boilerplate on policies that do not reprice cold access. Providing the default on the interface lets an implementer override only when it genuinely reprices cold access, matching how the other 2D-gas seam members are already exposed.

## Behavior

No behavior change. `EthereumGasPolicy` retains its own `GetColdAccountAccessCost` (identical value) as the concrete implementation used by its internal call sites and by the generic `TGasPolicy.GetColdAccountAccessCost` dispatch on the frame path, so the computed cost is unchanged.

## Verification

- `Nethermind.Evm` builds clean (0 errors).
- Targeted tests green: `EthereumGasPolicy*`, `GasPolicyContract*` (30) and `FrameTx*` / `Eip8037*` / `Eip8038*` (486).
