### PR TITLE
refactor(consensus): single dispatch entry point for frame-tx block-production picker

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -755,7 +755,7 @@ public class BlockProcessorTests
         Transaction? addedTransaction = null;
         txPicker.AddingTransaction += (s, e) => addedTransaction = e.Transaction;
 
-        txPicker.CanAddTransaction(newBlock, transactionWithNetworkForm, new HashSet<Transaction>(), WorldStateStab.GetUntrackedReader());
+        txPicker.CanAddTransaction(newBlock, transactionWithNetworkForm, new HashSet<Transaction>(), WorldStateStab.GetUntrackedReader(), newBlock.GasUsed, 0);
 
         Assert.That(addedTransaction, Is.EqualTo(transactionWithNetworkForm));
     }

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionPickerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionPickerTests.cs
@@ -55,7 +55,7 @@ public class FrameTxBlockProductionPickerTests
 
         Block block = Build.A.Block.WithGasLimit(30_000_000).TestObject;
 
-        BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, tx, new HashSet<Transaction>(), state);
+        BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, tx, new HashSet<Transaction>(), state, block.GasUsed, 0);
 
         using (Assert.EnterMultipleScope())
         {

--- a/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TransactionsExecutorTests.cs
@@ -443,7 +443,7 @@ namespace Nethermind.Blockchain.Test
             Block block = Build.A.Block.WithGasLimit(GasCostOf.Transaction * 2).TestObject;
             BlockProcessor.BlockProductionTransactionPicker picker = new(new TestSingleReleaseSpecProvider(spec));
 
-            BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, tx, new HashSet<Transaction>(), stateProvider);
+            BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, tx, new HashSet<Transaction>(), stateProvider, block.GasUsed, 0);
 
             Assert.That(args.Action, Is.EqualTo(expectedSkipReason is null ? BlockProcessor.TxAction.Add : BlockProcessor.TxAction.Skip));
             if (expectedSkipReason is not null) Assert.That(args.Reason, Is.EqualTo(expectedSkipReason));
@@ -476,7 +476,7 @@ namespace Nethermind.Blockchain.Test
             ISpecProvider specProvider = new TestSingleReleaseSpecProvider(Eip8141Prototype.Instance);
             BlockProcessor.BlockProductionTransactionPicker picker = new(specProvider);
 
-            BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, frameTx, new HashSet<Transaction>(), stateProvider);
+            BlockProcessor.AddingTxEventArgs args = picker.CanAddTransaction(block, frameTx, new HashSet<Transaction>(), stateProvider, block.GasUsed, 0);
 
             if (expectedSkipped)
             {
@@ -518,7 +518,7 @@ namespace Nethermind.Blockchain.Test
 
             BlockProcessor.BlockProductionTransactionPicker picker = new(specProvider);
             BlockProcessor.AddingTxEventArgs args =
-                picker.CanAddTransaction(block, frameBlobTx, new HashSet<Transaction>(), stateProvider);
+                picker.CanAddTransaction(block, frameBlobTx, new HashSet<Transaction>(), stateProvider, block.GasUsed, 0);
 
             Assert.That(args.Action, Is.EqualTo(BlockProcessor.TxAction.Add));
         }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionPicker.cs
@@ -36,13 +36,6 @@ namespace Nethermind.Consensus.Processing
                 Block block,
                 Transaction currentTx,
                 IReadOnlySet<Transaction> transactionsInBlock,
-                IReadOnlyStateProvider stateProvider) =>
-                CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider, block.GasUsed, 0);
-
-            public virtual AddingTxEventArgs CanAddTransaction(
-                Block block,
-                Transaction currentTx,
-                IReadOnlySet<Transaction> transactionsInBlock,
                 IReadOnlyStateProvider stateProvider,
                 ulong cumulativeBlockExecutionGas,
                 ulong cumulativeBlockStateGas)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.IBlockProductionTransactionPicker.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.IBlockProductionTransactionPicker.cs
@@ -15,11 +15,7 @@ public partial class BlockProcessor
         event EventHandler<AddingTxEventArgs>? AddingTransaction;
 
         AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx,
-            IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider);
-
-        AddingTxEventArgs CanAddTransaction(Block block, Transaction currentTx,
             IReadOnlySet<Transaction> transactionsInBlock, IReadOnlyStateProvider stateProvider,
-            ulong cumulativeBlockExecutionGas, ulong cumulativeBlockStateGas)
-            => CanAddTransaction(block, currentTx, transactionsInBlock, stateProvider);
+            ulong cumulativeBlockExecutionGas, ulong cumulativeBlockStateGas);
     }
 }


### PR DESCRIPTION
## What

Collapse the frame-tx block-production picker's two `CanAddTransaction` dispatch
entry points into one.

`IBlockProductionTransactionPicker` exposed both a 4-arg and a 6-arg
`CanAddTransaction`. The 6-arg was a default interface method delegating **down**
to the 4-arg, while the concrete base delegated the other way (4-arg → 6-arg).
That duplicate dispatch is a trap: an implementer overriding only the 4-arg would
silently drop the gas dimensions `cumulativeBlockExecutionGas` and
`cumulativeBlockStateGas`, disabling the block-level state/execution gas gates.

## Change

- Remove the 4-arg interface declaration and its default method; keep only the
  6-arg method on the interface.
- Remove the base class's 4-arg overload (the one that filled in
  `block.GasUsed, 0`).

All production callers already use the 6-arg form — the executor call site and
the Optimism override. Test call sites that used the convenience 4-arg overload
are migrated to pass `block.GasUsed, 0`, exactly reproducing the removed
overload's behavior.

## Behavior

No behavior change. There is now a single dispatch path, and no implementer can
accidentally ignore the gas dimensions.

## Verification

- `Nethermind.Optimism` and `Nethermind.Blockchain.Test` build clean (0 errors).
- Targeted block-production suites pass:
  `FrameTxBlockProductionPickerTests`, `TransactionsExecutorTests` (30/30) and
  `BlockProcessorTests` (56/56).
