### PR TITLE
fix(evm): fail loud when a BAL source omits the POST_TX diff setter

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -3225,16 +3225,14 @@ public class FrameTxProcessorTests
         Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
     }
 
-    // A source written against the single-property contract must still satisfy the interface, so an
-    // upgrade cannot fail at type load; it just never installs a slice and offers no diff.
     [Test]
-    public void SetGeneratingBlockAccessList_SourceWithoutTheOverride_StaysIdle()
+    public void SetGeneratingBlockAccessList_SourceWithoutTheOverride_ThrowsRatherThanSilentlyDisablingDiffs()
     {
-        IBlockAccessListSource legacy = new SinglePropertyBlockAccessListSource();
+        IBlockAccessListSource readOnly = new SinglePropertyBlockAccessListSource();
 
-        legacy.SetGeneratingBlockAccessList(new BlockAccessListAtIndex());
-
-        Assert.That(legacy.GeneratedBlockAccessList, Is.Null);
+        Assert.That(() => readOnly.SetGeneratingBlockAccessList(new BlockAccessListAtIndex()),
+            Throws.TypeOf<NotSupportedException>());
+        Assert.That(readOnly.GeneratedBlockAccessList, Is.Null);
     }
 
     private sealed class SinglePropertyBlockAccessListSource : IBlockAccessListSource

--- a/src/Nethermind/Nethermind.Evm/State/IBlockAccessListSource.cs
+++ b/src/Nethermind/Nethermind.Evm/State/IBlockAccessListSource.cs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+
 using Nethermind.Core.BlockAccessLists;
 
 namespace Nethermind.Evm.State;
@@ -16,7 +18,9 @@ public interface IBlockAccessListSource
     /// <summary>Starts recording into <paramref name="bal"/>, or stops recording when it is null.</summary>
     /// <remarks>Block processing installs one per block; simulation installs one per transaction that
     /// reads its own diff, and stays idle otherwise. Defaulted so a source written against the
-    /// single-property contract still loads: it keeps reporting no slice, and callers that check
-    /// <see cref="GeneratedBlockAccessList"/> fall back to offering no diff at all.</remarks>
-    void SetGeneratingBlockAccessList(BlockAccessListAtIndex? bal) { }
+    /// single-property contract still loads, but the default throws rather than silently no-opping:
+    /// this hook drives the EIP-7906 POST_TX diff, so a source that reaches recording without
+    /// supplying it is a wiring gap that must fail loud, not quietly disable a consensus behaviour.</remarks>
+    void SetGeneratingBlockAccessList(BlockAccessListAtIndex? bal)
+        => throw new NotSupportedException($"{GetType().Name} does not implement {nameof(SetGeneratingBlockAccessList)}; a source that records the EIP-7906 POST_TX diff must override it.");
 }


### PR DESCRIPTION
## What

`IBlockAccessListSource.SetGeneratingBlockAccessList` had an empty default body. Replace it with a `throw new NotSupportedException(...)` so the hook cannot degrade quietly.

## Why

The setter installs the recording slice that the EIP-7906 POST_TX diff opcodes read. A source that implements only `GeneratedBlockAccessList` (the read side) and inherits the empty default would:

1. load and satisfy the interface, then
2. silently never install a slice, so `GeneratedBlockAccessList` stays null,
3. so `TryGetPostTxView` returns false and `TXTRACE` / `TXDIFF` / `EVENTDATACOPY` all return `BadInstruction`, reverting the POST_TX frame.

That is a consensus-visible outcome produced by a wiring gap, delivered as a silent no-op rather than a loud failure. For a consensus-relevant hook that is the wrong default.

## What changes

- The default now throws `NotSupportedException`. **Type-load forward-compat is preserved**: the default method still exists, so a source written against the single-property contract still satisfies the interface and still loads. What changes is that a source which actually reaches recording without supplying the setter now fails loud instead of quietly disabling the diff.
- The sole production implementation, `TracedAccessWorldState`, overrides the setter, so no live path changes; this is defensive.
- The existing unit test that asserted the silent no-op is updated to assert the new loud-failure contract (the read-only fixture still instantiates, proving type-load compat, and now the setter call throws).

## Test

- `Nethermind.Evm.Test`: `FrameTxProcessorTests` 244/244, `Eip7928Tests` 204/204.
- `Nethermind.State.Test`: `TracedAccessWorldState` 65/66 (1 pre-existing skip).
- Builds: `Nethermind.Evm`, `Nethermind.Evm.Test`, `Nethermind.State.Test` all 0 errors.
