### PR TITLE
fix(jsonrpc): bound frame-tx receipt log count on debug_insertReceipts

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -527,4 +527,47 @@ public class FrameTransactionForRpcTests
 
         Assert.That(() => receiptForRpc.ToReceipt(), Throws.InstanceOf<JsonException>());
     }
+
+    private const int MaxAggregateLogs = 270_000;
+
+    /// <summary>The frame log union is admitted right up to the wire receipt decoder's log ceiling.</summary>
+    [Test]
+    public void ReceiptForRpc_FrameTx_AdmitsFrameLogsUpToTheWireCeiling()
+    {
+        ReceiptForRpc receiptForRpc = ToRpc(BuildFrameTxReceipt());
+        receiptForRpc.FrameReceipts =
+        [
+            new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = RepeatFrameLog(MaxAggregateLogs - 1) },
+            new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = RepeatFrameLog(1) },
+        ];
+
+        TxReceipt receipt = receiptForRpc.ToReceipt();
+
+        Assert.That(receipt.Logs, Has.Length.EqualTo(MaxAggregateLogs));
+    }
+
+    /// <summary>A frame log union above that ceiling is a caller error, rejected before the receipt store.</summary>
+    [Test]
+    public void ReceiptForRpc_FrameTx_RejectsFrameLogsAboveTheWireCeiling()
+    {
+        ReceiptForRpc receiptForRpc = ToRpc(BuildFrameTxReceipt());
+        receiptForRpc.FrameReceipts =
+        [
+            new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = RepeatFrameLog(MaxAggregateLogs) },
+            new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = RepeatFrameLog(1) },
+        ];
+
+        Assert.That(() => receiptForRpc.ToReceipt(), Throws.InstanceOf<JsonException>());
+    }
+
+    private static LogEntry[] RepeatFrameLog(int count)
+    {
+        LogEntry[] logs = new LogEntry[count];
+        for (int i = 0; i < count; i++)
+        {
+            logs[i] = FrameLog;
+        }
+
+        return logs;
+    }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
@@ -150,12 +150,21 @@ namespace Nethermind.JsonRpc.Data
             return logEntries;
         }
 
+        /// <summary>
+        /// The ceiling on the logs a frame-transaction receipt may carry across all of its frames. It reuses
+        /// the wire receipt decoder's 270k logs limit but applies it to the frame log union rather than per
+        /// frame, so this debug ingress is deliberately at least as strict as the P2P one: a 100M-gas
+        /// transaction emits on the order of 266k logs in total, so a receipt whose frames sum above this
+        /// cannot come from a valid block.
+        /// </summary>
+        private const int MaxLogs = 270_000;
+
         /// <summary>Binds the caller-supplied <see cref="FrameReceipts"/> to their core representation.</summary>
         /// <remarks>
         /// Reached with an unvalidated payload through <c>debug_insertReceipts</c>, so a shape EIP-8141
         /// cannot produce has to be rejected here rather than reaching the receipt store.
         /// </remarks>
-        /// <exception cref="JsonException">An entry is null, or there are more than EIP-8141's MAX_FRAMES of them.</exception>
+        /// <exception cref="JsonException">An entry is null, there are more than EIP-8141's MAX_FRAMES of them, or their logs exceed <see cref="MaxLogs"/> in aggregate.</exception>
         private TxFrameReceipt[] ToFrameReceipts()
         {
             if (FrameReceipts is not { Length: > 0 } frames)
@@ -169,12 +178,21 @@ namespace Nethermind.JsonRpc.Data
             }
 
             TxFrameReceipt[] frameReceipts = new TxFrameReceipt[frames.Length];
+            long logCount = 0;
             for (int i = 0; i < frames.Length; i++)
             {
                 // The element annotation does not bind the deserializer: "frameReceipts": [null] reaches here.
-                frameReceipts[i] = frames[i] is { } frame
+                TxFrameReceipt frameReceipt = frames[i] is { } frame
                     ? frame.ToFrameReceipt()
                     : throw new JsonException($"Frame receipt {i} is null.");
+
+                logCount += frameReceipt.Logs.Length;
+                if (logCount > MaxLogs)
+                {
+                    throw new JsonException($"A frame transaction receipt carries at most {MaxLogs} logs across all frames.");
+                }
+
+                frameReceipts[i] = frameReceipt;
             }
 
             return frameReceipts;


### PR DESCRIPTION
## What

`debug_insertReceipts` binds a frame-transaction receipt straight from JSON. `ReceiptForRpc.ToFrameReceipts` capped the frame **count** to `Eip8141Constants.MaxFrames`, but left the per-frame and aggregate **log count** unbounded — `FrameReceiptForRpc.Logs` was bound directly from the payload with no ceiling.

The wire receipt decoder (`ReceiptMessageDecoder`) guards every `logs` list against a 270k ceiling (`LogsRlpLimit`). The frame RPC ingress did not, so an over-limit frame receipt could be admitted into the receipt store through the debug path only to later fail a wire round trip.

## Change

`ToFrameReceipts` now rejects a frame-transaction receipt whose frame logs sum above the same 270k value, with `JsonException` (mapped to invalid params, as the sibling null-entry and MAX_FRAMES rejections already are). The check is cumulative across frames, so it bounds the aggregate log union and — because a single frame above the ceiling trips it on its own — every individual frame as well.

This is validation, not a resource-exhaustion guard: `System.Text.Json` has already materialized the payload by the time this runs (that bound is `JsonRpc.MaxRequestBodySize`). What it buys is keeping a receipt the wire path would reject out of the store.

The value is reused from the wire decoder but applied to the frame log **union** rather than per frame, so the debug ingress is deliberately at least as strict as the P2P one (a 100M-gas transaction emits ~266k logs in total, not per frame). Scope is confined to the frame RPC ingress; the wire decoders and the non-frame `logs` path are unchanged.

## Test

`FrameTransactionForRpcTests` gains two regression cases:

- a frame log union at exactly the ceiling is admitted and yields the full log set;
- a union one log above the ceiling is rejected with `JsonException`.

Verified RED/GREEN: the rejection case fails with the guard disabled while the acceptance case stays green, then both pass with the guard in place. Targeted suite: 38/38.
