### PR TITLE
fix(rlp): realign LegacyStorage receipt object decode to receiptEnd under AllowExtraBytes

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -68,12 +68,14 @@ public class FrameTxReceiptDecoderTests
             "the stored union must stay the union, not get rebuilt from frame logs");
     }
 
-    /// <summary>The object-path array decode must realign a frame-tx receipt to its own end under AllowExtraBytes,
-    /// mirroring the struct-ref path; otherwise the unconsumed [payer, per-frame receipts] tail is read as the next
-    /// element and corrupts it. The frame receipt sits between two distinct regulars so realigning onto the trailing
-    /// one is provably not the leading one.</summary>
+    /// <summary>The object-path array decode over LegacyStorage receipts must both decode a frame-tx receipt's
+    /// [payer, per-frame receipts] extension and realign to its own end, mirroring the compact object path; otherwise
+    /// under AllowExtraBytes the extension is read as the next element and corrupts it. The frame receipt sits between
+    /// two distinct regulars so realigning onto the trailing one is provably not the leading one, and the asserted
+    /// Payer/FrameReceipts prove the extension is decoded rather than skipped.</summary>
     [Test]
-    public void ArrayDecode_ObjectPath_FrameTxReceiptUnderAllowExtraBytes_StaysAligned()
+    public void ArrayDecode_ObjectPath_FrameTxReceiptBetweenRegulars_DecodesExtensionAndStaysAligned(
+        [Values(RlpBehaviors.Storage, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes)] RlpBehaviors decodeBehaviors)
     {
         LogEntry frameLog = Log(0x01);
         TxReceipt frameReceipt = CreateStorageFrameReceipt(
@@ -90,7 +92,7 @@ public class FrameTxReceiptDecoderTests
         byte[] encoded = decoder.Encode([before, frameReceipt, after], RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts).Bytes;
 
         RlpReader reader = new(encoded);
-        TxReceipt[] decoded = decoder.DecodeArray(ref reader, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes);
+        TxReceipt[] decoded = decoder.DecodeArray(ref reader, decodeBehaviors);
 
         Assert.That(decoded, Has.Length.EqualTo(3), "every receipt must decode, including the neighbour after the frame extension");
 
@@ -100,6 +102,8 @@ public class FrameTxReceiptDecoderTests
 
         Assert.That(decoded[1].TxType, Is.EqualTo(TxType.FrameTx), "the frame-tx receipt must be typed FrameTx");
         Assert.That(decoded[1].GasUsedTotal, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
+        Assert.That(decoded[1].Payer, Is.EqualTo(frameReceipt.Payer), "the payer must be decoded, not skipped by realignment");
+        AssertFrameReceiptsEqual(decoded[1].FrameReceipts!, frameReceipt.FrameReceipts!);
 
         Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender), "trailing receipt sender proves realignment past the frame extension");
         Assert.That(decoded[2].GasUsedTotal, Is.EqualTo(after.GasUsedTotal), "trailing receipt gas used total");

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -68,6 +68,44 @@ public class FrameTxReceiptDecoderTests
             "the stored union must stay the union, not get rebuilt from frame logs");
     }
 
+    /// <summary>The object-path array decode must realign a frame-tx receipt to its own end under AllowExtraBytes,
+    /// mirroring the struct-ref path; otherwise the unconsumed [payer, per-frame receipts] tail is read as the next
+    /// element and corrupts it. The frame receipt sits between two distinct regulars so realigning onto the trailing
+    /// one is provably not the leading one.</summary>
+    [Test]
+    public void ArrayDecode_ObjectPath_FrameTxReceiptUnderAllowExtraBytes_StaysAligned()
+    {
+        LogEntry frameLog = Log(0x01);
+        TxReceipt frameReceipt = CreateStorageFrameReceipt(
+            [frameLog],
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 5_000, [frameLog]),
+            new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, 0, [Log(0x02)]));
+
+        TxReceipt before = Build.A.Receipt.WithAllFieldsFilled
+            .WithSender(TestItem.AddressD).WithGasUsedTotal(1000).WithCalculatedBloom().TestObject;
+        TxReceipt after = Build.A.Receipt.WithAllFieldsFilled
+            .WithSender(TestItem.AddressE).WithGasUsedTotal(2000).WithCalculatedBloom().TestObject;
+
+        ReceiptStorageDecoder decoder = new();
+        byte[] encoded = decoder.Encode([before, frameReceipt, after], RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts).Bytes;
+
+        RlpReader reader = new(encoded);
+        TxReceipt[] decoded = decoder.DecodeArray(ref reader, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes);
+
+        Assert.That(decoded, Has.Length.EqualTo(3), "every receipt must decode, including the neighbour after the frame extension");
+
+        Assert.That(decoded[0].Sender, Is.EqualTo(before.Sender), "leading receipt sender");
+        Assert.That(decoded[0].GasUsedTotal, Is.EqualTo(before.GasUsedTotal), "leading receipt gas used total");
+        Assert.That(decoded[0].TxType, Is.EqualTo(TxType.Legacy), "a receipt without the extension must not be labelled FrameTx");
+
+        Assert.That(decoded[1].TxType, Is.EqualTo(TxType.FrameTx), "the frame-tx receipt must be typed FrameTx");
+        Assert.That(decoded[1].GasUsedTotal, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
+
+        Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender), "trailing receipt sender proves realignment past the frame extension");
+        Assert.That(decoded[2].GasUsedTotal, Is.EqualTo(after.GasUsedTotal), "trailing receipt gas used total");
+        Assert.That(decoded[2].TxType, Is.EqualTo(TxType.Legacy));
+    }
+
     // ReceiptsIterator (eth_getLogs) loops DecodeStructRef over stored receipts, so a frame-tx receipt must leave
     // the reader at its own end or corrupt the next one; it sits between two regulars here.
     [Test]

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -78,32 +78,27 @@ namespace Nethermind.Serialization.Rlp
                 decoderContext.Check(lastCheck);
             }
 
-            if (!allowExtraBytes)
+            if (isStorage && supportTxHash && decoderContext.Position < receiptEnd)
             {
-                if (isStorage && supportTxHash && decoderContext.Position < receiptEnd)
+                if (decoderContext.PeekByte() == MarkTxHashByte)
                 {
-                    // since txHash was added later and may not be in rlp, we provide special mark byte that it will be next
-                    if (decoderContext.PeekByte() == MarkTxHashByte)
-                    {
-                        decoderContext.ReadByte();
-                        txReceipt.TxHash = decoderContext.DecodeKeccakOrNull();
-                    }
-                }
-
-                // since error was added later we can only rely on it in cases where we read receipt only and no data follows, empty errors might not be serialized
-                if (decoderContext.Position < receiptEnd)
-                {
-                    txReceipt.Error = decoderContext.DecodeString();
-                }
-
-                if (txReceipt.TxType == TxType.FrameTx && decoderContext.Position < receiptEnd)
-                {
-                    txReceipt.Payer = decoderContext.DecodeAddress();
-                    txReceipt.FrameReceipts = DecodeFrameReceipts(ref decoderContext);
+                    decoderContext.ReadByte();
+                    txReceipt.TxHash = decoderContext.DecodeKeccakOrNull();
                 }
             }
 
             if (decoderContext.Position < receiptEnd)
+            {
+                txReceipt.Error = decoderContext.DecodeString();
+            }
+
+            if (txReceipt.TxType == TxType.FrameTx && decoderContext.Position < receiptEnd)
+            {
+                txReceipt.Payer = decoderContext.DecodeAddress();
+                txReceipt.FrameReceipts = DecodeFrameReceipts(ref decoderContext);
+            }
+
+            if (decoderContext.Position < receiptEnd && allowExtraBytes)
             {
                 decoderContext.Position = receiptEnd;
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -103,6 +103,11 @@ namespace Nethermind.Serialization.Rlp
                 }
             }
 
+            if (decoderContext.Position < receiptEnd)
+            {
+                decoderContext.Position = receiptEnd;
+            }
+
             txReceipt.Logs = logEntries.ToArray();
             return txReceipt;
         }


### PR DESCRIPTION
## What

The object-path `ReceiptStorageDecoder.DecodeInternal` decodes the EIP-8141 frame-tx receipt extension (`[payer, per-frame receipts]`) **only inside the `if (!allowExtraBytes)` block**. When `AllowExtraBytes` is set, that tail is never consumed and `Position` is left at the end of the logs sequence, short of the receipt's end. An array decode over `LegacyStorage` receipts in extra-bytes mode then reads the unconsumed frame extension as the start of the next element and misaligns.

The struct-ref path (`DecodeStructRef`) already repositions unconditionally to `receiptEnd`. This change adds the identical realignment tail to the object path so both realign the same way:

```csharp
if (decoderContext.Position < receiptEnd)
{
    decoderContext.Position = receiptEnd;
}
```

## Why it is reachable, not speculative

The misalignment is exercisable through the decoder's own public array API. `ReceiptStorageDecoder.DecodeArray(ref ctx, Storage | AllowExtraBytes)` over `[regular, frameTx, regular]` throws `RlpException: Invalid length of length` on the element after the frame receipt, because decoding resumes inside the frame extension. The regression test reproduces exactly this and passes only with the realign in place. The struct-ref path was already given this treatment; leaving the object path asymmetric is a latent trap for any caller that batches object-path `LegacyStorage` receipts with `AllowExtraBytes`.

## Cost

One integer comparison per receipt decode; the assignment fires only when a shorter path left the reader early (frame-tx extension or future trailing fields). No behavioural change for the common `!allowExtraBytes` case, where the reader already sits at `receiptEnd`.

## Tests

Added `ArrayDecode_ObjectPath_FrameTxReceiptUnderAllowExtraBytes_StaysAligned` in `FrameTxReceiptDecoderTests`: encodes `[before, frameReceipt, after]` with distinct senders/gas, decodes the array via the object path under `Storage | AllowExtraBytes`, and asserts all three receipts decode with the trailing neighbour landing on its own fields (proving realignment past the frame extension). Verified RED without the fix, GREEN with it. Full receipt-decoder suite (63 cases) passes.

Base: `eip8141-frame-txs-devnet7`.
