### PR TITLE
feat(txpool): bound frame-tx signature verification when MAX_VERIFY_GAS is lifted

### DIFF
--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -281,6 +281,17 @@ public static class FrameTxValidation
             total = Saturating(total, frames[i].ExecutionGasLimit);
         }
 
+        return Saturating(total, SignatureVerificationWorkGas(transaction));
+    }
+
+    /// <summary>
+    /// The gas <c>validate_signature</c> spends verifying a frame transaction's signatures, saturating at
+    /// <see cref="ulong.MaxValue"/>. Scheme-weighted, so it reflects the elliptic-curve work each entry costs;
+    /// an ARBITRARY entry contributes only its cheap structural-check cost, its witness being verified by frame code.
+    /// </summary>
+    public static ulong SignatureVerificationWorkGas(Transaction transaction)
+    {
+        ulong total = 0;
         foreach (TxFrameSignature signature in transaction.FrameSignatures ?? [])
         {
             total = Saturating(total, SignatureVerificationGas(signature.Scheme));

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyGasFilterTest.cs
@@ -64,6 +64,50 @@ internal class FrameTxVerifyGasFilterTest
         Assert.That(filter.Accept(tx, ref state, TxHandlingOptions.None), Is.EqualTo(expected));
     }
 
+    private static TxFrameSignature[] Signatures(int count, byte scheme)
+    {
+        TxFrameSignature[] signatures = new TxFrameSignature[count];
+        for (int i = 0; i < count; i++)
+        {
+            signatures[i] = scheme switch
+            {
+                TxFrameSignature.SchemeSecp256k1 => Secp256k1Signature(TestItem.AddressA),
+                TxFrameSignature.SchemeP256 => new TxFrameSignature(TxFrameSignature.SchemeP256, TestItem.AddressA, default, new byte[TxFrameSignature.P256SignatureLength]),
+                _ => new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, default),
+            };
+        }
+
+        return signatures;
+    }
+
+    private static readonly int Secp256k1AtCeiling = (int)(Eip8141Constants.MaxVerifyGas / Eip8141Constants.Secp256k1VerificationGasCost);
+    private static readonly int P256AtCeiling = (int)(Eip8141Constants.MaxVerifyGas / Eip8141Constants.P256VerificationGasCost);
+    private const int DecoderSignatureCap = 1024;
+
+    private static IEnumerable<TestCaseData> LiftedCeilingCases()
+    {
+        yield return new TestCaseData(Secp256k1AtCeiling, TxFrameSignature.SchemeSecp256k1, AcceptTxResult.Accepted)
+            .SetName("secp256k1 verification at the fixed MAX_VERIFY_GAS is accepted with the ceiling lifted");
+        yield return new TestCaseData(Secp256k1AtCeiling + 1, TxFrameSignature.SchemeSecp256k1, AcceptTxResult.FrameTxVerifyGasTooHigh)
+            .SetName("secp256k1 verification over the fixed MAX_VERIFY_GAS is rejected with the ceiling lifted");
+        yield return new TestCaseData(P256AtCeiling, TxFrameSignature.SchemeP256, AcceptTxResult.Accepted)
+            .SetName("P256 verification at the fixed MAX_VERIFY_GAS is accepted with the ceiling lifted");
+        yield return new TestCaseData(P256AtCeiling + 1, TxFrameSignature.SchemeP256, AcceptTxResult.FrameTxVerifyGasTooHigh)
+            .SetName("P256 verification over the fixed MAX_VERIFY_GAS is rejected with the ceiling lifted");
+        yield return new TestCaseData(DecoderSignatureCap, TxFrameSignature.SchemeArbitrary, AcceptTxResult.Accepted)
+            .SetName("a decoder-cap run of arbitrary entries stays under the fixed MAX_VERIFY_GAS with the ceiling lifted");
+    }
+
+    [TestCaseSource(nameof(LiftedCeilingCases))]
+    public void Accept_BoundsSignatureVerificationGasAtTheFixedCeiling_WhenVerifyGasIsLifted(int signatureCount, byte scheme, AcceptTxResult expected)
+    {
+        Transaction tx = FrameTx(TestItem.AddressA, Signatures(signatureCount, scheme), Execution());
+        FrameTxVerifyGasFilter filter = new(new TxPoolConfig { FrameTxMaxVerifyGas = 0, FrameTxMaxVerifyStateGas = 0 }, LimboLogs.Instance.GetClassLogger<FrameTxVerifyGasFilterTest>());
+        TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>());
+
+        Assert.That(filter.Accept(tx, ref state, TxHandlingOptions.None), Is.EqualTo(expected));
+    }
+
     // The account cache stores the empty account on a miss while the reader beneath may leave the out-value
     // zeroed, so filters reading the first and second probe must not see a different sender.
     [Test]

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxVerifyGasFilter.cs
@@ -12,8 +12,11 @@ namespace Nethermind.TxPool.Filters;
 /// </summary>
 /// <remarks>
 /// A public-mempool DoS bound, not a validity rule: a block carrying such a transaction stays valid. Must run after
-/// <see cref="MalformedTxFilter"/>, which guarantees the frame list is well-formed. A configured limit of 0 lifts the
-/// respective bound, matching the other per-sender pool limits.
+/// <see cref="MalformedTxFilter"/>, which guarantees the frame list is well-formed, and before
+/// <see cref="FrameTxSignatureFilter"/>, so the per-signature elliptic-curve recovery it gates stays bounded. A
+/// configured gas limit of 0 lifts the operator ceiling, matching the other per-sender pool limits; signature
+/// verification then falls back to the fixed <see cref="Eip8141Constants.MaxVerifyGas"/>, so lifting the ceiling
+/// cannot uncap per-signature recovery.
 /// </remarks>
 internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger logger) : IIncomingTxFilter
 {
@@ -34,6 +37,16 @@ internal sealed class FrameTxVerifyGasFilter(ITxPoolConfig txPoolConfig, ILogger
             {
                 Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
                 if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, validation prefix costs {verifyGas} gas (max {_maxVerifyGas}).");
+                return AcceptTxResult.FrameTxVerifyGasTooHigh;
+            }
+        }
+        else
+        {
+            ulong signatureGas = FrameTxValidation.SignatureVerificationWorkGas(tx);
+            if (signatureGas > Eip8141Constants.MaxVerifyGas)
+            {
+                Metrics.PendingTransactionsFrameTxVerifyGasTooHigh++;
+                if (logger.IsTrace) logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, signature verification costs {signatureGas} gas (max {Eip8141Constants.MaxVerifyGas}).");
                 return AcceptTxResult.FrameTxVerifyGasTooHigh;
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPoolConfig.cs
@@ -37,7 +37,7 @@ public interface ITxPoolConfig : IConfig
     [ConfigItem(DefaultValue = "0", Description = "The max number of pending transactions per single sender. `0` to lift the limit.")]
     int MaxPendingTxsPerSender { get; set; }
 
-    [ConfigItem(DefaultValue = "300000", Description = "EIP-8141 `MAX_VERIFY_GAS`: the max gas a frame transaction's validation prefix and signature verification may cost for the transaction to be accepted into the public mempool. `0` to lift the limit. It bounds the declared-gas check only: an opaque prefix that has to be simulated is additionally capped, frame by frame, at the fixed `Eip8141Constants.MaxVerifyGas`, which raising this value does not move. Raise it only on a test network.")]
+    [ConfigItem(DefaultValue = "300000", Description = "EIP-8141 `MAX_VERIFY_GAS`: the max gas a frame transaction's validation prefix and signature verification may cost for the transaction to be accepted into the public mempool. `0` to lift the limit. It bounds the declared-gas check only: an opaque prefix that has to be simulated is additionally capped, frame by frame, at the fixed `Eip8141Constants.MaxVerifyGas`, which raising this value does not move. Lifting this limit with `0` still caps signature verification at that same fixed `Eip8141Constants.MaxVerifyGas`, so per-signature recovery cannot be uncapped. Raise it only on a test network.")]
     ulong FrameTxMaxVerifyGas { get; set; }
 
     [ConfigItem(DefaultValue = "500000", Description = "EIP-8141 `MAX_VERIFY_STATE_GAS`: the max state gas a frame transaction's validation prefix may budget across its `limits.state` for the transaction to be accepted into the public mempool. `0` to lift the limit. Raise it only on a test network.")]


### PR DESCRIPTION
## What

Bounds the per-signature elliptic-curve recovery an EIP-8141 frame transaction can demand at admission, even when the configurable verify-gas ceiling is lifted (`FrameTxMaxVerifyGas = 0`).

## Why

`FrameTxVerifyGasFilter` is the admission filter that bounds validation work before `FrameTxSignatureFilter` performs per-signature EC recovery (up to the decoder's 1024-entry cap). It sums the scheme-weighted verification gas of every `frame_signatures` entry into `ValidationWorkGas` and compares that against `FrameTxMaxVerifyGas` — but the comparison sits behind a `FrameTxMaxVerifyGas != 0` gate. Setting the ceiling to `0` to lift the per-sender gas limit therefore also removes the only bound on how many signatures the downstream filter recovers, so one admitted transaction could demand up to 1024 EC recoveries.

## What changed

- When the operator ceiling is lifted (`= 0`), signature verification falls back to the fixed protocol constant `Eip8141Constants.MaxVerifyGas`: a transaction whose scheme-weighted signature-verification gas exceeds it is refused. This is scheme-accurate — a P256 entry (6700) costs more than a secp256k1 entry (2800) and is counted as such — and caps signature work at the same fixed budget the protocol already applies to opaque-prefix simulation.
- `FrameTxValidation.SignatureVerificationWorkGas` factors out the scheme-weighted signature-gas sum that `ValidationWorkGas` already computed, so both the declared-gas check and the lifted-ceiling fallback share one saturating implementation.
- The `FrameTxMaxVerifyGas` config doc now states that lifting the limit still caps signature verification at the fixed `MAX_VERIFY_GAS`.

## Behavior

No change whenever the ceiling is set. A configured ceiling — default or raised — still governs through the existing declared-gas check, which already includes signature gas; a raised ceiling admits proportionally more signature work, and the fixed fallback is only consulted at `0`. The rejection reason and metric are unchanged (`FrameTxVerifyGasTooHigh`), since the fallback enforces the same `MAX_VERIFY_GAS` budget.

A public-mempool propagation bound, not a validity rule: a block carrying such a transaction stays consensus-valid.

## Tests

`FrameTxVerifyGasFilterTest` gains cases proving that, with the ceiling lifted, signature verification is bounded scheme-accurately: secp256k1 and P256 runs at the fixed budget are accepted while one entry over it is rejected, and a decoder-cap run of ARBITRARY entries stays under the budget and is accepted.
