### PR TITLE
chore: add svlachakis to CODEOWNERS for flat history and history pruning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /src/Nethermind/Nethermind.Evm @LukaszRozmej @benaadams
 /src/Nethermind/Nethermind.Facade @LukaszRozmej @benaadams @svlachakis
 /src/Nethermind/Nethermind.ExternalSigner.Plugin @ak88
-/src/Nethermind/Nethermind.History @LukaszRozmej @Marchhill
+/src/Nethermind/Nethermind.History @LukaszRozmej @Marchhill @svlachakis
 /src/Nethermind/Nethermind.Hive @flcl42 @marcindsobczak
 /src/Nethermind/Nethermind.Init @LukaszRozmej @asdacap
 /src/Nethermind/Nethermind.Init.Snapshot @svlachakis
@@ -38,6 +38,7 @@
 /src/Nethermind/Nethermind.Sockets @LukaszRozmej @benaadams
 /src/Nethermind/Nethermind.Specs @smartprogrammer93
 /src/Nethermind/Nethermind.State @LukaszRozmej @benaadams @asdacap @flcl42 @damian-orzechowski
+/src/Nethermind/Nethermind.State.Flat.History @svlachakis
 /src/Nethermind/Nethermind.StateDiff.Core @daniilankusin
 /src/Nethermind/Nethermind.StateDiffsWriter @daniilankusin
 /src/Nethermind/Nethermind.StateDiffsWriter.Test @daniilankusin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,6 +38,7 @@
 /src/Nethermind/Nethermind.Sockets @LukaszRozmej @benaadams
 /src/Nethermind/Nethermind.Specs @smartprogrammer93
 /src/Nethermind/Nethermind.State @LukaszRozmej @benaadams @asdacap @flcl42 @damian-orzechowski
+/src/Nethermind/Nethermind.State.Flat @asdacap @svlachakis
 /src/Nethermind/Nethermind.State.Flat.History @svlachakis
 /src/Nethermind/Nethermind.StateDiff.Core @daniilankusin
 /src/Nethermind/Nethermind.StateDiffsWriter @daniilankusin


### PR DESCRIPTION
Names owners for the flat database areas and the history pruner: a new entry for Nethermind.State.Flat (@asdacap @svlachakis) and one for Nethermind.State.Flat.History (@svlachakis) - both previously unowned, since the /Nethermind.State pattern does not match sibling directories - plus @svlachakis added to the existing Nethermind.History entry.