### PR TITLE
Add Plataberget archive config and CI support

### DIFF
--- a/.github/workflows/run-a-single-node-from-branch.yml
+++ b/.github/workflows/run-a-single-node-from-branch.yml
@@ -7,6 +7,10 @@ on:
         description: "Ref of the nethermind repo to build/use. Leave blank to use the workflow's own ref. For arbitrum-* networks, this is treated as the NethermindEth/nethermind-arbitrum ref (default 'main' if left blank)."
         default: ""
         required: false
+      smoke_tests_ref:
+        description: "Ref of the post-merge-smoke-tests repository to run the node from. Use a branch to validate smoke-tests changes before they merge."
+        default: "main"
+        required: false
       network:
         description: "Select a network on which You want to run a node"
         default: "mainnet"
@@ -18,6 +22,7 @@ on:
           - sepolia
           - chiado
           - hoodi
+          - plataberget
           - op-mainnet
           - op-sepolia
           - world-sepolia
@@ -74,7 +79,7 @@ on:
         required: false
       additional_options:
         description: "A Json property which allows to customize node even more"
-        default: '{"timeout":"24", "default_dockerfile":"Dockerfile", "default_dockerfile_build_type":"release", "ssh_keys":"", "allowed_ips":"", "custom_machine_type": ""}'
+        default: '{"timeout":"24", "default_dockerfile":"Dockerfile", "default_dockerfile_build_type":"release", "ssh_keys":"", "allowed_ips":"", "custom_machine_type": "", "sedge_repo": "", "sedge_branch": ""}'
       additional_l2_options:
         description: "Extra options to configure L2 node"
         default: '{"l1_nethermind_image":"", "l2_node_image":"", "l2_el_image":"", "l2_el_extra_flags":"", "l2_cl_extra_flags":"", "layer1_el_endpoint":"", "layer1_cl_endpoint":""}'
@@ -136,7 +141,7 @@ on:
       additional_options:
         type: string
         description: "A Json property which allows to customize node even more"
-        default: '{"timeout":"24", "default_dockerfile":"Dockerfile", "default_dockerfile_build_type":"release", "ssh_keys":"", "allowed_ips":"", "custom_machine_type": ""}'
+        default: '{"timeout":"24", "default_dockerfile":"Dockerfile", "default_dockerfile_build_type":"release", "ssh_keys":"", "allowed_ips":"", "custom_machine_type": "", "sedge_repo": "", "sedge_branch": ""}'
         required: false
       additional_l2_options:
         type: string
@@ -318,6 +323,10 @@ jobs:
           echo "ssh_keys=$(echo '${{ inputs.additional_options }}' | jq -r .ssh_keys)" >> $GITHUB_OUTPUT
           echo "allowed_ips=$(echo '${{ inputs.additional_options }}' | jq -r .allowed_ips)" >> $GITHUB_OUTPUT
           echo "custom_machine_type=$(echo '${{ inputs.additional_options }}' | jq -r .custom_machine_type)" >> $GITHUB_OUTPUT
+          # Both default to empty rather than jq's "null" so the smoke-tests side falls back to
+          # NethermindEth/sedge@core. Set them to build sedge from a fork/PR branch instead.
+          echo "sedge_repo=$(echo '${{ inputs.additional_options }}' | jq -r '.sedge_repo // ""')" >> $GITHUB_OUTPUT
+          echo "sedge_branch=$(echo '${{ inputs.additional_options }}' | jq -r '.sedge_branch // ""')" >> $GITHUB_OUTPUT
           echo "l1_nethermind_image=$(echo '${{ inputs.additional_l2_options }}' | jq -r .l1_nethermind_image)" >> $GITHUB_OUTPUT
           echo "l2_node_image=$(echo '${{ inputs.additional_l2_options }}' | jq -r .l2_node_image)" >> $GITHUB_OUTPUT
           echo "l2_el_image=$(echo '${{ inputs.additional_l2_options }}' | jq -r .l2_el_image)" >> $GITHUB_OUTPUT
@@ -332,7 +341,7 @@ jobs:
         with:
           workflow: run-single-node.yml
           repo: NethermindEth/post-merge-smoke-tests
-          ref: "main"
+          ref: "${{ inputs.smoke_tests_ref || 'main' }}"
           token: "${{ steps.gh-app.outputs.token }}"
           inputs: '{
             "github_username": "${{ github.actor }}",
@@ -341,7 +350,7 @@ jobs:
             "nethermind_branch": "${{ env.CLEAN_REF }}",
             "network": "${{ inputs.network }}",
             "cl_client": "${{ inputs.cl_client }}",
-            "additional_options": "{\"cl_custom_image\":\"${{ inputs.cl_custom_image }}\", \"timeout\":\"${{ steps.extract_variables.outputs.timeout }}\", \"non_validator_mode\":${{ steps.extract_variables.outputs.NON_VALIDATOR_MODE }}, \"additional_nethermind_flags\":\"${{ inputs.additional_nethermind_flags }}\", \"additional_cl_flags\":\"${{ inputs.additional_cl_flags }}\", \"ssh_keys\":\"${{ steps.extract_variables.outputs.ssh_keys }}\", \"allowed_ips\":\"${{ steps.extract_variables.outputs.allowed_ips }}\", \"custom_machine_type\":\"${{ steps.extract_variables.outputs.custom_machine_type }}\", \"convert_to_paprika\": \"${{ inputs.convert_to_paprika }}\"}",
+            "additional_options": "{\"cl_custom_image\":\"${{ inputs.cl_custom_image }}\", \"timeout\":\"${{ steps.extract_variables.outputs.timeout }}\", \"non_validator_mode\":${{ steps.extract_variables.outputs.NON_VALIDATOR_MODE }}, \"additional_nethermind_flags\":\"${{ inputs.additional_nethermind_flags }}\", \"additional_cl_flags\":\"${{ inputs.additional_cl_flags }}\", \"ssh_keys\":\"${{ steps.extract_variables.outputs.ssh_keys }}\", \"allowed_ips\":\"${{ steps.extract_variables.outputs.allowed_ips }}\", \"custom_machine_type\":\"${{ steps.extract_variables.outputs.custom_machine_type }}\", \"convert_to_paprika\": \"${{ inputs.convert_to_paprika }}\", \"sedge_repo\":\"${{ steps.extract_variables.outputs.sedge_repo }}\", \"sedge_branch\":\"${{ steps.extract_variables.outputs.sedge_branch }}\"}",
             "additional_l2_options": "{\"l1_nethermind_image\":\"${{ steps.extract_variables.outputs.l1_nethermind_image}}\", \"l2_node_image\":\"${{ steps.extract_variables.outputs.l2_node_image}}\", \"l2_el_image\":\"${{ steps.extract_variables.outputs.l2_el_image}}\", \"l2_el_extra_flags\":\"${{ steps.extract_variables.outputs.l2_el_extra_flags}}\", \"l2_cl_extra_flags\":\"${{ steps.extract_variables.outputs.l2_cl_extra_flags}}\", \"layer1_el_endpoint\":\"${{ steps.extract_variables.outputs.layer1_el_endpoint}}\", \"layer1_cl_endpoint\":\"${{ steps.extract_variables.outputs.layer1_cl_endpoint}}\"}"
             }'
 
@@ -356,7 +365,9 @@ jobs:
           ORG_NAME: "NethermindEth"
           REPO_NAME: "post-merge-smoke-tests"
           NAME_FILTER: ${{ env.BASE_TAG }}
-          REF: "main"
+          # Must track the ref the run was dispatched to: wait-for-workflow.sh matches on
+          # head_branch, so a mismatch here times out even though the run started.
+          REF: "${{ inputs.smoke_tests_ref || 'main' }}"
         run: |
           chmod +x scripts/wait-for-workflow.sh
           ./scripts/wait-for-workflow.sh | tee script-output.txt

--- a/src/Nethermind/Nethermind.Runner/configs/plataberget_archive.json
+++ b/src/Nethermind/Nethermind.Runner/configs/plataberget_archive.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://raw.githubusercontent.com/NethermindEth/core-scripts/refs/heads/main/schemas/config.json",
+  "Init": {
+    "ChainSpecPath": "chainspec/plataberget.json",
+    "GenesisHash": "0xee33ef92bbabcf07bcf44fea1d18a7925c5f7f9da8f81334ea19b0f3cb892b31",
+    "BaseDbPath": "nethermind_db/plataberget_archive",
+    "LogFileName": "plataberget_archive.log"
+  },
+  "TxPool": {
+    "Size": 1024
+  },
+  "Metrics": {
+    "NodeName": "Plataberget Archive"
+  },
+  "Blocks": {
+    "TargetBlockGasLimit": 60000000
+  },
+  "Receipt": {
+    "TxLookupLimit": 0
+  },
+  "Pruning": {
+    "Mode": "None"
+  },
+  "JsonRpc": {
+    "Enabled": true,
+    "Timeout": 20000,
+    "Host": "127.0.0.1",
+    "Port": 8545,
+    "EngineHost": "127.0.0.1",
+    "EnginePort": 8551,
+    "EngineEnabledModules": [ "net", "eth", "subscribe", "engine", "web3", "client" ]
+  },
+  "Merge": {
+    "Enabled": true
+  },
+  "Discovery": {
+    "DiscoveryVersion": "V5"
+  },
+  "FlatDb": {
+    "Enabled": true,
+    "HistoryEnabled": true,
+    "PersistenceWriteBufferFloor": 67108864
+  }
+}


### PR DESCRIPTION
## Changes

Plataberget support landed in #12807 (chainspec + `plataberget.json`), but there was no archive config, and the network could not be selected in CI.

- **Add `plataberget_archive.json`**, following `hoodi_archive.json` field for field and in key order: `Pruning.Mode: None`, `Receipt.TxLookupLimit: 0`, no `Sync` block, and the `FlatDb` history block. `EngineEnabledModules` omits `flashbots`, matching its `plataberget.json` sibling rather than hoodi's.
- **Add `plataberget` to the `network` dropdown** of *Run a node with selected configuration*.
- **Wire up `smoke_tests_ref`.** It was declared but referenced nowhere, with the dispatch hard-pinned to `ref: "main"`. It now selects the post-merge-smoke-tests ref, so a smoke-tests change can be validated before it merges. The `Wait for creation of node` step tracks the same ref — `scripts/wait-for-workflow.sh` matches candidate runs on `head_branch`, so leaving it pinned to `main` times out after 5 minutes even though the run started and the VM was created.
- **Forward `sedge_repo` and `sedge_branch`** through `additional_options`, so a run can build sedge from a fork or PR branch. Both default to empty, leaving the smoke-tests side on `NethermindEth/sedge@core` exactly as before. This is what allows a new network to be validated before the sedge change merges.

**No chainspec bootnodes.** An earlier revision of this PR added a `nodes` array to `Chains/plataberget.json` plus `GethGenesisLoader` support for it. That was unnecessary and has been dropped — see the measurement in the comments. discv5 is a single global DHT, so a node bootstraps onto this network from the embedded default ENRs without any network-specific seed. `sepolia.json` and `hoodi.json` ship no `nodes` either.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Config-only plus workflow changes, so covered by the existing directory-walking tests rather than new ones:

```
dotnet test --project src/Nethermind/Nethermind.Runner.Test/Nethermind.Runner.Test.csproj -c release \
  -- --filter "FullyQualifiedName~ConfigFilesTests"      # 125/125 passed
```

Validated end to end on the live network through *Run a node with selected configuration* — both a snap-synced and an archive node, plus a third control run. Details and run links in the comments.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Nethermind can now run an archive node on the Plataberget testnet with `--config plataberget_archive`.

## Remarks

- `Blocks.TargetBlockGasLimit` is 60000000 in both Plataberget configs while the live network runs at ~200M (measured 199,999,809). The field only matters when producing blocks, so it is inert for a syncing node — flagging rather than changing it here.
- The two workflow fixes are not Plataberget-specific; this network just happened to be the first thing to exercise them.
