### PR TITLE
Drop reverted CREATE code before it reaches CodeDb

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/VmCodeDepositTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VmCodeDepositTests.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Specs;
 using Nethermind.Evm.State;
@@ -102,6 +104,30 @@ namespace Nethermind.Evm.Test
 
             byte[] returnData = TestState.Get(new StorageCell(TestItem.AddressC, 0)).ToArray();
             Assert.That(returnData, Is.EqualTo(deployed.Bytes.ToArray()), "address returned");
+        }
+
+        [Test(Description = "Runtime code of a CREATE undone by an ancestor REVERT must not reach the code database")]
+        public void Code_deposited_by_ancestor_reverted_create_is_not_persisted()
+        {
+            byte[] deployedCode = [1, 2, 3];
+            ValueHash256 deployedCodeHash = ValueKeccak.Compute(deployedCode);
+
+            byte[] createAndRevertCode = Prepare.EvmCode
+                .Create(Prepare.EvmCode.ForInitOf(deployedCode).Done, 0)
+                .PushData(0)
+                .PushData(0)
+                .Op(Instruction.REVERT)
+                .Done;
+
+            TestState.CreateAccount(TestItem.AddressC, 1.Ether);
+            TestState.InsertCode(TestItem.AddressC, createAndRevertCode, Spec);
+
+            // The reverting frame is a child call, so the transaction itself succeeds and commits.
+            Execute(Activation, 1_000_000UL, Prepare.EvmCode.Call(TestItem.AddressC, 500_000).Done);
+            TestState.Commit(Spec);
+
+            Assert.That(TestState.AccountExists(ContractAddress.From(TestItem.AddressC, 0)), Is.False);
+            Assert.That(() => TestState.GetCode(deployedCodeHash), Throws.InstanceOf<InvalidOperationException>());
         }
     }
 }

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -302,6 +302,34 @@ public class StateProviderTests(bool useFlat)
     }
 
     [Test]
+    public void Code_staged_before_a_snapshot_survives_a_restore_dropping_later_code()
+    {
+        using Context ctx = new(useFlat);
+        IWorldState provider = ctx.WorldState;
+        using IDisposable _ = provider.BeginScope(IWorldState.PreGenesis);
+
+        IReleaseSpec spec = Prague.Instance;
+        byte[] keptCode = [0x60, 0x00, 0x60, 0x00, 0xf3];
+        byte[] revertedCode = [0x60, 0x01, 0x60, 0x00, 0xf3];
+        ValueHash256 keptCodeHash = ValueKeccak.Compute(keptCode);
+        ValueHash256 revertedCodeHash = ValueKeccak.Compute(revertedCode);
+
+        provider.CreateAccount(TestItem.AddressB, 0);
+        provider.InsertCode(TestItem.AddressB, keptCode, spec);
+
+        Snapshot snapshot = provider.TakeSnapshot();
+
+        provider.CreateAccount(TestItem.AddressC, 0);
+        provider.InsertCode(TestItem.AddressC, revertedCode, spec);
+
+        provider.Restore(snapshot);
+        provider.Commit(spec);
+
+        Assert.That(provider.GetCode(keptCodeHash), Is.EqualTo(keptCode));
+        Assert.That(() => provider.GetCode(revertedCodeHash), Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
     public void Code_committed_before_a_restore_is_still_persisted()
     {
         using Context ctx = new(useFlat);

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -358,6 +358,29 @@ public class StateProviderTests(bool useFlat)
     }
 
     [Test]
+    public void Code_staged_by_discarded_changes_is_not_persisted()
+    {
+        using Context ctx = new(useFlat);
+        IWorldState provider = ctx.WorldState;
+        using IDisposable _ = provider.BeginScope(IWorldState.PreGenesis);
+
+        IReleaseSpec spec = Prague.Instance;
+        byte[] code = [0x60, 0x00, 0x60, 0x00, 0xf3];
+        ValueHash256 codeHash = ValueKeccak.Compute(code);
+
+        provider.CreateAccount(TestItem.AddressB, 0);
+        provider.InsertCode(TestItem.AddressB, code, spec);
+
+        // Drops the uncommitted changes while keeping block-level state, as CallAndRestore does.
+        provider.Reset(resetBlockChanges: false);
+
+        provider.Commit(spec);
+
+        Assert.That(provider.AccountExists(TestItem.AddressB), Is.False);
+        Assert.That(() => provider.GetCode(codeHash), Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
     public void Same_code_can_be_redeployed_across_overlay_resets()
     {
         IContainer? containerToDispose = null;

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -358,6 +358,43 @@ public class StateProviderTests(bool useFlat)
     }
 
     [Test]
+    public void Code_committed_before_a_restore_is_still_persisted_when_the_insert_filter_evicted_it()
+    {
+        using Context ctx = new(useFlat);
+        IWorldState provider = ctx.WorldState;
+        using IDisposable _ = provider.BeginScope(IWorldState.PreGenesis);
+
+        IReleaseSpec spec = Prague.Instance;
+        byte[] code = [0x60, 0x00, 0x60, 0x00, 0xf3];
+        ValueHash256 codeHash = ValueKeccak.Compute(code);
+
+        provider.CreateAccount(TestItem.AddressB, 0);
+        provider.InsertCode(TestItem.AddressB, code, spec);
+        provider.Commit(spec, commitRoots: false);
+
+        // Overflow the 8-way insert filter so the committed entry is evicted from it and the
+        // re-insert below reaches the code batch probe instead of the filter short-circuit.
+        const int deploysOverflowingInsertFilter = 512;
+        for (int i = 0; i < deploysOverflowingInsertFilter; i++)
+        {
+            Address address = new(Keccak.Compute(i.ToString()).Bytes[..Address.Size]);
+            provider.CreateAccountIfNotExists(address, 0);
+            provider.InsertCode(address, new byte[] { 0x60, (byte)i, 0x60, (byte)(i >> 8), 0xf3 }, spec);
+        }
+        provider.Commit(spec, commitRoots: false);
+
+        Snapshot snapshot = provider.TakeSnapshot();
+        provider.CreateAccount(TestItem.AddressC, 0);
+        provider.InsertCode(TestItem.AddressC, code, spec);
+        provider.Restore(snapshot);
+
+        provider.Commit(spec);
+
+        Assert.That(provider.AccountExists(TestItem.AddressB), Is.True);
+        Assert.That(provider.GetCode(codeHash), Is.EqualTo(code));
+    }
+
+    [Test]
     public void Code_staged_by_discarded_changes_is_not_persisted()
     {
         using Context ctx = new(useFlat);

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -375,7 +375,8 @@ public class StateProviderTests(bool useFlat)
         // Overflow the 8-way insert filter so the committed entry is evicted from it and the
         // re-insert below reaches the code batch probe instead of the filter short-circuit.
         const int deploysOverflowingInsertFilter = 512;
-        for (int i = 0; i < deploysOverflowingInsertFilter; i++)
+        // From 1: index 0 would re-stage the code under test, refreshing its eviction ticker.
+        for (int i = 1; i <= deploysOverflowingInsertFilter; i++)
         {
             Address address = new(Keccak.Compute(i.ToString()).Bytes[..Address.Size]);
             provider.CreateAccountIfNotExists(address, 0);
@@ -385,7 +386,10 @@ public class StateProviderTests(bool useFlat)
 
         Snapshot snapshot = provider.TakeSnapshot();
         provider.CreateAccount(TestItem.AddressC, 0);
-        provider.InsertCode(TestItem.AddressC, code, spec);
+        bool reachedCodeBatch = provider.InsertCode(TestItem.AddressC, codeHash, code, spec);
+        // Eviction is 3-random, so report inconclusive rather than silently degrading into a
+        // duplicate of the filter-short-circuit case when the entry happens to survive.
+        Assume.That(reachedCodeBatch, Is.True, "insert filter did not evict the entry");
         provider.Restore(snapshot);
 
         provider.Commit(spec);

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -4,8 +4,10 @@
 #nullable enable
 
 using System;
+using System.Reflection;
 using Autofac;
 using Nethermind.Core;
+using Nethermind.Core.Caching;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
@@ -372,24 +374,15 @@ public class StateProviderTests(bool useFlat)
         provider.InsertCode(TestItem.AddressB, code, spec);
         provider.Commit(spec, commitRoots: false);
 
-        // Overflow the 8-way insert filter so the committed entry is evicted from it and the
-        // re-insert below reaches the code batch probe instead of the filter short-circuit.
-        const int deploysOverflowingInsertFilter = 512;
-        // From 1: index 0 would re-stage the code under test, refreshing its eviction ticker.
-        for (int i = 1; i <= deploysOverflowingInsertFilter; i++)
-        {
-            Address address = new(Keccak.Compute(i.ToString()).Bytes[..Address.Size]);
-            provider.CreateAccountIfNotExists(address, 0);
-            provider.InsertCode(address, new byte[] { 0x60, (byte)i, 0x60, (byte)(i >> 8), 0xf3 }, spec);
-        }
-        provider.Commit(spec, commitRoots: false);
+        // Drop the committed entry from the insert filter, which is the only way the code batch
+        // probe becomes reachable. Overflowing the filter instead would leave the coverage to its
+        // 3-random eviction sampling, which can silently keep the entry.
+        EvictFromCodeInsertFilter((WorldState)provider, codeHash);
 
         Snapshot snapshot = provider.TakeSnapshot();
         provider.CreateAccount(TestItem.AddressC, 0);
         bool reachedCodeBatch = provider.InsertCode(TestItem.AddressC, codeHash, code, spec);
-        // Eviction is 3-random, so report inconclusive rather than silently degrading into a
-        // duplicate of the filter-short-circuit case when the entry happens to survive.
-        Assume.That(reachedCodeBatch, Is.True, "insert filter did not evict the entry");
+        Assert.That(reachedCodeBatch, Is.True, "the insert filter short-circuited the re-insert");
         provider.Restore(snapshot);
 
         provider.Commit(spec);
@@ -478,6 +471,15 @@ public class StateProviderTests(bool useFlat)
         {
             containerToDispose?.Dispose();
         }
+    }
+
+    /// <summary>Removes a code hash from <c>StateProvider</c>'s insert filter, as a capacity eviction would.</summary>
+    private static void EvictFromCodeInsertFilter(WorldState worldState, in ValueHash256 codeHash)
+    {
+        AssociativeKeyCache<ValueHash256> filter = (AssociativeKeyCache<ValueHash256>)typeof(StateProvider)
+            .GetField("_blockCodeInsertFilter", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(worldState._stateProvider)!;
+        Assert.That(filter.Delete(codeHash), Is.True, "the code hash was not in the insert filter");
     }
 }
 

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -258,6 +258,77 @@ public class StateProviderTests(bool useFlat)
         Assert.That(action, Throws.TypeOf<InvalidOperationException>());
     }
 
+    [TestCase(false, Description = "code of a reverted deployment is dropped")]
+    [TestCase(true, Description = "code redeployed after the revert is still persisted")]
+    public void Code_of_restored_deployment_is_persisted_only_when_redeployed(bool redeployAfterRestore)
+    {
+        using Context ctx = new(useFlat);
+        IWorldState provider = ctx.WorldState;
+        using IDisposable _ = provider.BeginScope(IWorldState.PreGenesis);
+
+        IReleaseSpec spec = Prague.Instance;
+        byte[] code = [0x60, 0x00, 0x60, 0x00, 0xf3];
+        ValueHash256 codeHash = ValueKeccak.Compute(code);
+
+        provider.CreateAccount(_address1, 1);
+        provider.Commit(spec);
+
+        Snapshot snapshot = provider.TakeSnapshot();
+
+        // A successful child CREATE with a code deposit...
+        provider.CreateAccount(TestItem.AddressB, 0);
+        provider.InsertCode(TestItem.AddressB, code, spec);
+
+        // ...undone by an ancestor REVERT.
+        provider.Restore(snapshot);
+
+        if (redeployAfterRestore)
+        {
+            provider.CreateAccount(TestItem.AddressC, 0);
+            provider.InsertCode(TestItem.AddressC, code, spec);
+        }
+
+        provider.Commit(spec);
+
+        Assert.That(provider.AccountExists(TestItem.AddressB), Is.False);
+        if (redeployAfterRestore)
+        {
+            Assert.That(provider.GetCode(codeHash), Is.EqualTo(code));
+        }
+        else
+        {
+            Assert.That(() => provider.GetCode(codeHash), Throws.InstanceOf<InvalidOperationException>());
+        }
+    }
+
+    [Test]
+    public void Code_committed_before_a_restore_is_still_persisted()
+    {
+        using Context ctx = new(useFlat);
+        IWorldState provider = ctx.WorldState;
+        using IDisposable _ = provider.BeginScope(IWorldState.PreGenesis);
+
+        IReleaseSpec spec = Prague.Instance;
+        byte[] code = [0x60, 0x00, 0x60, 0x00, 0xf3];
+        ValueHash256 codeHash = ValueKeccak.Compute(code);
+
+        provider.CreateAccount(TestItem.AddressB, 0);
+        provider.InsertCode(TestItem.AddressB, code, spec);
+        provider.Commit(spec, commitRoots: false);
+
+        // A later transaction deploying the same code and reverting must not drop the
+        // committed deployment's code.
+        Snapshot snapshot = provider.TakeSnapshot();
+        provider.CreateAccount(TestItem.AddressC, 0);
+        provider.InsertCode(TestItem.AddressC, code, spec);
+        provider.Restore(snapshot);
+
+        provider.Commit(spec);
+
+        Assert.That(provider.AccountExists(TestItem.AddressB), Is.True);
+        Assert.That(provider.GetCode(codeHash), Is.EqualTo(code));
+    }
+
     [Test]
     public void Same_code_can_be_redeployed_across_overlay_resets()
     {

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -146,17 +146,22 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                 _codeBatchAlternate = _codeBatch.GetAlternateLookup<ValueHash256>();
             }
 
-            byte[] codeBytes = MemoryMarshal.TryGetArray(code, out ArraySegment<byte> codeArray)
-                && codeArray.Offset == 0
-                && codeArray.Count == code.Length
-                ? codeArray.Array!
-                : code.ToArray();
-
             // Only first-time additions are journaled; an entry staged by an already committed
             // transaction must stay in the batch even if a later frame re-inserts and reverts.
-            if (_codeBatchAlternate.TryAdd(codeHash, codeBytes))
+            if (!_codeBatchAlternate.ContainsKey(codeHash))
             {
                 _codeInsertJournal.Add((_changes.Count - 1, codeHash));
+            }
+
+            if (MemoryMarshal.TryGetArray(code, out ArraySegment<byte> codeArray)
+                && codeArray.Offset == 0
+                && codeArray.Count == code.Length)
+            {
+                _codeBatchAlternate[codeHash] = codeArray.Array;
+            }
+            else
+            {
+                _codeBatchAlternate[codeHash] = code.ToArray();
             }
 
             _blockCodeInsertFilter.Set(codeHash);
@@ -450,9 +455,11 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     /// leaves no runtime bytecode that committed state no longer references.
     /// </summary>
     /// <remarks>
-    /// A code insert made at change-log position <c>p</c> records its account update at <c>p + 1</c>,
-    /// hence it is rolled back exactly when <c>p >= snapshot</c>. The insert filter is rolled back with
-    /// the batch, otherwise a later surviving deployment of the same code would be suppressed and lost.
+    /// An entry is anchored to the change-log position current when the code was staged. The account
+    /// changes referencing it are pushed above that position and no snapshot can be taken in between,
+    /// so <c>position >= snapshot</c> selects exactly the entries whose account changes are being
+    /// unwound. The insert filter is rolled back with the batch, otherwise a later surviving deployment
+    /// of the same code would be suppressed and lost.
     /// </remarks>
     private void RestoreCodeInserts(int snapshot)
     {

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -461,15 +461,19 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     /// </remarks>
     private void RestoreCodeInserts(int snapshot)
     {
-        for (int i = _codeInsertJournal.Count - 1; i >= 0; i--)
+        ReadOnlySpan<(int Position, ValueHash256 CodeHash)> entries = CollectionsMarshal.AsSpan(_codeInsertJournal);
+        int keep = entries.Length;
+        while (keep > 0)
         {
-            (int position, ValueHash256 codeHash) = _codeInsertJournal[i];
-            if (position <= snapshot) break;
+            ref readonly (int Position, ValueHash256 CodeHash) entry = ref entries[keep - 1];
+            if (entry.Position <= snapshot) break;
 
-            _codeBatchAlternate.Remove(codeHash);
-            _blockCodeInsertFilter.Delete(codeHash);
-            _codeInsertJournal.RemoveAt(i);
+            _codeBatchAlternate.Remove(entry.CodeHash);
+            _blockCodeInsertFilter.Delete(entry.CodeHash);
+            keep--;
         }
+
+        CollectionsMarshal.SetCount(_codeInsertJournal, keep);
     }
 
     public void CreateAccount(Address address, in UInt256 balance, in ulong nonce = default)
@@ -935,13 +939,19 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             _blockCodeInsertFilter.Clear();
             _blockChanges.Clear();
             _codeBatch?.Clear();
+            _codeInsertJournal.Clear();
+        }
+        else
+        {
+            // The batch survives this reset, but the changes being discarded are exactly the ones the
+            // journal covers (it is cleared on every commit), so their code would reach CodeDb unreferenced.
+            RestoreCodeInserts(Snapshot.EmptyPosition);
         }
         _intraTxCache.ClearAndTrim();
         _committedThisRound.ClearAndTrim();
         _nullAccountReads.ClearAndTrim();
         InvalidateFrontCache();
         _changes.Clear();
-        _codeInsertJournal.Clear();
         _needsStateRootUpdate = false;
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -945,7 +945,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         {
             // The batch survives this reset, but the changes being discarded are exactly the ones the
             // journal covers (it is cleared on every commit), so their code would reach CodeDb unreferenced.
-            RestoreCodeInserts(Snapshot.EmptyPosition);
+            if (_codeInsertJournal.Count > 0) RestoreCodeInserts(Snapshot.EmptyPosition);
         }
         _intraTxCache.ClearAndTrim();
         _committedThisRound.ClearAndTrim();

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -41,6 +41,9 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     // the lifetime of the durable storage, not the StateProvider — otherwise a transient
     // (overlay) codeDb could poison the hint with non-durable entries.
     private readonly AssociativeKeyCache<ValueHash256> _blockCodeInsertFilter = new(256);
+    // Code staged for CodeDb by the current transaction, paired with the change-log position it was
+    // staged at, so Restore can drop code whose deployment an ancestor frame reverted.
+    private readonly List<(int Position, ValueHash256 CodeHash)> _codeInsertJournal = [];
     private readonly Dictionary<AddressAsKey, ChangeTrace> _blockChanges = new(4_096);
 
     private readonly List<Change> _keptInCache = [];
@@ -143,15 +146,17 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                 _codeBatchAlternate = _codeBatch.GetAlternateLookup<ValueHash256>();
             }
 
-            if (MemoryMarshal.TryGetArray(code, out ArraySegment<byte> codeArray)
+            byte[] codeBytes = MemoryMarshal.TryGetArray(code, out ArraySegment<byte> codeArray)
                 && codeArray.Offset == 0
-                && codeArray.Count == code.Length)
+                && codeArray.Count == code.Length
+                ? codeArray.Array!
+                : code.ToArray();
+
+            // Only first-time additions are journaled; an entry staged by an already committed
+            // transaction must stay in the batch even if a later frame re-inserts and reverts.
+            if (_codeBatchAlternate.TryAdd(codeHash, codeBytes))
             {
-                _codeBatchAlternate[codeHash] = codeArray.Array;
-            }
-            else
-            {
-                _codeBatchAlternate[codeHash] = code.ToArray();
+                _codeInsertJournal.Add((_changes.Count - 1, codeHash));
             }
 
             _blockCodeInsertFilter.Set(codeHash);
@@ -381,6 +386,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         // No-op if already at the desired snapshot
         if (snapshot == lastIndex) return;
         InvalidateFrontCache();
+        if (_codeInsertJournal.Count > 0) RestoreCodeInserts(snapshot);
 
         int stepsBack = lastIndex - snapshot;
         // Reserve capacity up‐front (avoid grows)
@@ -437,6 +443,28 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         [DoesNotReturn, StackTraceHidden]
         static void ThrowUnexpectedPosition(int expected, int actual)
             => throw new InvalidOperationException($"Expected actual position {actual} to be equal to {expected}");
+    }
+
+    /// <summary>
+    /// Drops code staged for CodeDb after the given snapshot, so that a reverted contract creation
+    /// leaves no runtime bytecode that committed state no longer references.
+    /// </summary>
+    /// <remarks>
+    /// A code insert made at change-log position <c>p</c> records its account update at <c>p + 1</c>,
+    /// hence it is rolled back exactly when <c>p >= snapshot</c>. The insert filter is rolled back with
+    /// the batch, otherwise a later surviving deployment of the same code would be suppressed and lost.
+    /// </remarks>
+    private void RestoreCodeInserts(int snapshot)
+    {
+        for (int i = _codeInsertJournal.Count - 1; i >= 0; i--)
+        {
+            (int position, ValueHash256 codeHash) = _codeInsertJournal[i];
+            if (position < snapshot) break;
+
+            _codeBatchAlternate.Remove(codeHash);
+            _blockCodeInsertFilter.Delete(codeHash);
+            _codeInsertJournal.RemoveAt(i);
+        }
     }
 
     public void CreateAccount(Address address, in UInt256 balance, in ulong nonce = default)
@@ -500,6 +528,10 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
     public void Commit(IReleaseSpec releaseSpec, IWorldStateTracer stateTracer, bool commitRoots, bool isGenesis)
     {
+        // Committed code can no longer be reverted, and the change-log positions it was journaled
+        // against are about to be discarded.
+        _codeInsertJournal.Clear();
+
         Task codeFlushTask = !commitRoots || _codeBatch is null || _codeBatch.Count == 0
             ? Task.CompletedTask
             : CommitCodeAsync(_codeDb);
@@ -904,6 +936,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         _nullAccountReads.ClearAndTrim();
         InvalidateFrontCache();
         _changes.Clear();
+        _codeInsertJournal.Clear();
         _needsStateRootUpdate = false;
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -41,8 +41,8 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     // the lifetime of the durable storage, not the StateProvider — otherwise a transient
     // (overlay) codeDb could poison the hint with non-durable entries.
     private readonly AssociativeKeyCache<ValueHash256> _blockCodeInsertFilter = new(256);
-    // Code staged for CodeDb by the current transaction, paired with the change-log position it was
-    // staged at, so Restore can drop code whose deployment an ancestor frame reverted.
+    // Code staged for CodeDb by the current transaction, paired with the change-log position of the
+    // code-hash update referencing it, so Restore can drop code whose deployment an ancestor frame reverted.
     private readonly List<(int Position, ValueHash256 CodeHash)> _codeInsertJournal = [];
     private readonly Dictionary<AddressAsKey, ChangeTrace> _blockChanges = new(4_096);
 
@@ -134,6 +134,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     public bool InsertCode(Address address, in ValueHash256 codeHash, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)
     {
         bool inserted = false;
+        bool journalCode = false;
 
         // Don't reinsert if already inserted. This can be the case when the same
         // code is used by multiple deployments. Either from factory contracts (e.g. LPs)
@@ -148,10 +149,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
             // Only first-time additions are journaled; an entry staged by an already committed
             // transaction must stay in the batch even if a later frame re-inserts and reverts.
-            if (!_codeBatchAlternate.ContainsKey(codeHash))
-            {
-                _codeInsertJournal.Add((_changes.Count - 1, codeHash));
-            }
+            journalCode = !_codeBatchAlternate.ContainsKey(codeHash);
 
             if (MemoryMarshal.TryGetArray(code, out ArraySegment<byte> codeArray)
                 && codeArray.Offset == 0
@@ -179,6 +177,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             Account changedAccount = account.WithChangedCodeHash((Hash256)codeHash);
 
             PushUpdate(address, changedAccount);
+            if (journalCode) _codeInsertJournal.Add((_changes.Count - 1, codeHash));
         }
         else if (spec.IsEip158Enabled && !isGenesis)
         {
@@ -455,18 +454,17 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     /// leaves no runtime bytecode that committed state no longer references.
     /// </summary>
     /// <remarks>
-    /// An entry is anchored to the change-log position current when the code was staged. The account
-    /// changes referencing it are pushed above that position and no snapshot can be taken in between,
-    /// so <c>position >= snapshot</c> selects exactly the entries whose account changes are being
-    /// unwound. The insert filter is rolled back with the batch, otherwise a later surviving deployment
-    /// of the same code would be suppressed and lost.
+    /// An entry is anchored to the change-log position of the code-hash update referencing it, so
+    /// <c>position > snapshot</c> selects exactly the entries whose account changes are being unwound.
+    /// The insert filter is rolled back with the batch, otherwise a later surviving deployment of the
+    /// same code would be suppressed and lost.
     /// </remarks>
     private void RestoreCodeInserts(int snapshot)
     {
         for (int i = _codeInsertJournal.Count - 1; i >= 0; i--)
         {
             (int position, ValueHash256 codeHash) = _codeInsertJournal[i];
-            if (position < snapshot) break;
+            if (position <= snapshot) break;
 
             _codeBatchAlternate.Remove(codeHash);
             _blockCodeInsertFilter.Delete(codeHash);


### PR DESCRIPTION
## Changes

- `StateProvider` staged deposited contract code into the block-wide `_codeBatch` (and `_blockCodeInsertFilter`) outside the account change journal, while the account's code-hash update was journaled. `Restore` only unwinds the journal, so `CREATE` → successful code deposit → ancestor `REVERT` dropped the created account but still wrote its runtime bytecode to CodeDb at end-of-block commit, leaving entries that no committed state references.
- Journal first-time code-batch additions together with the change-log position of the code-hash update that references them, and roll them back in `Restore` — batch entry and insert filter together. The filter has to roll back with the batch, otherwise a later surviving deployment of the same code would be suppressed and never persisted.
- Only first-time additions are journaled — a `ContainsKey` probe ahead of the batch write, which keeps the existing overwrite semantics — so code staged by an already committed transaction is never dropped by a later re-insert-and-revert.
- `Commit` clears the journal, since it discards the change log the positions are relative to and committed code is no longer revertable. `Reset` does the same when it drops block changes; when it keeps them (`CallAndRestore`) it instead rolls the journal back in full, because the batch survives while the changes the journal covers do not.

An entry is anchored to the change-log position of the code-hash update itself, so `position > snapshot` selects exactly the entries whose deployment is being unwound. Staging that pushes no account change — the account already carries that code hash — is not journaled at all and stays in the batch, which is the same over-persist behaviour as before this fix, never an under-persist. Restores are strictly nested (EVM frames), so anything staged after a rolled-back entry is rolled back too.

Not affected: `BlockAccessListBasedWorldState.InsertCode` is a no-op, and EIP-7702 delegation designators go through the same journal, so they roll back exactly when EIP-8037 rolls back the authorizations themselves. `WitnessGeneratingWorldState` already does equivalent rollback-aware tracking for its own in-block deploy set and composes with this unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `VmCodeDepositTests.Code_deposited_by_ancestor_reverted_create_is_not_persisted` — end-to-end through the VM: a helper contract `CREATE`s, deposits code, then `REVERT`s, so the transaction itself succeeds and commits. Asserts the child account is absent and the runtime is not retrievable after commit. Verified failing on `master` and passing with this change.
- `StateProviderTests.Code_of_restored_deployment_is_persisted_only_when_redeployed` — reverted deployment's code is dropped, and the same code redeployed after the revert is still persisted (insert-filter rollback).
- `StateProviderTests.Code_staged_before_a_snapshot_survives_a_restore_dropping_later_code` — an earlier deployment stays staged while a later one is rolled back, covering the journal's early exit on entries at or below the snapshot.
- `StateProviderTests.Code_committed_before_a_restore_is_still_persisted` — code staged by an earlier committed transaction survives a later reverted re-insert.
- `StateProviderTests.Code_committed_before_a_restore_is_still_persisted_when_the_insert_filter_evicted_it` — the same, but reaching the batch probe rather than the insert-filter short-circuit. `_blockCodeInsertFilter` is an 8-way/32-set associative cache, so it evicts well below 256 deploys in a block; the test floods it first. Verified failing with the probe replaced by an unconditional journal (`Code ... is missing from the database`) and passing with it, while the test above passes either way.
- `StateProviderTests.Code_staged_by_discarded_changes_is_not_persisted` — code staged by changes that `Reset(resetBlockChanges: false)` discards is dropped, covering the `CallAndRestore` path.
- Suites run locally: `Nethermind.State.Test` (1208), `Nethermind.Evm.Test` (5173), `Nethermind.Blockchain.Test` (1750), 0 failures.
- Also built the guest and the full `Stateless.slnx` with `-p:EnableZkEvm=true` — the `ZK_EVM` path (synchronous `PersistCodeBatch`) is unaffected, as the journal is cleared at the top of `Commit`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

