### PR TITLE
perf(zkevm): stop incrementing trie metrics in the guest

### DIFF
--- a/src/Nethermind/Nethermind.Core/Threading/ProcessingThread.std.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ProcessingThread.std.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Core.Threading;
 /// Identifies the current thread as the main block processing path.
 /// Set by BlockchainProcessor before processing blocks.
 /// </summary>
-public static class ProcessingThread
+public static partial class ProcessingThread
 {
     [ThreadStatic]
     private static bool _isBlockProcessingThread;

--- a/src/Nethermind/Nethermind.Core/Threading/ProcessingThread.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ProcessingThread.zkevm.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core.Threading;
+
+/// <summary>
+/// Constant-false flag for the zkVM guest — see the std counterpart for the real one.
+/// </summary>
+/// <remarks>
+/// The guest never runs <c>BlockchainProcessor</c>, so the std flag is already false throughout.
+/// Folding it to a constant lets the metrics counters that branch on it compile away entirely,
+/// and keeps the callers that gate work on it (e.g. <c>SetAccountChanges</c>) behaving as before.
+/// </remarks>
+public static partial class ProcessingThread
+{
+    public static bool IsBlockProcessingThread { get => false; set { } }
+}

--- a/src/Nethermind/Nethermind.Core/Threading/StripedLong.std.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/StripedLong.std.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Core.Threading;
 /// existing slots). Reads are O(stripes) and torn only across slots: fine for metrics, not for
 /// invariants.
 /// </remarks>
-public sealed class StripedLong
+public sealed partial class StripedLong
 {
     // 16 longs = 128 bytes between live slots.
     private const int SlotStride = 16;

--- a/src/Nethermind/Nethermind.Core/Threading/StripedLong.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/StripedLong.zkevm.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.CompilerServices;
+
+namespace Nethermind.Core.Threading;
+
+/// <summary>
+/// No-op counter for the zkVM guest — see the std counterpart for the striped one.
+/// </summary>
+/// <remarks>
+/// Every use is a metrics counter the guest never reads, and the guest is single-threaded, so the
+/// striping the std type exists for buys nothing. Empty bodies inline away, taking the surrounding
+/// <c>Metrics.Increment*</c> calls with them.
+/// </remarks>
+public sealed partial class StripedLong
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add(long value) { }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Increment() { }
+
+    public long Sum => 0;
+}


### PR DESCRIPTION
## Changes

- Compile the three `Nethermind.Trie.Metrics` counter increments out of the zkVM guest build.
- Host builds are unaffected; the backing fields and the exported metric properties are unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

No behavioural change on the host — the increments are only compiled out under `ZK_EVM`. The guest
is covered by `stateless-tests.yml`, which asserts the output hash for nine blocks; it is unchanged.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The guest reads none of these counters, but every trie node decode, encode and hash still pays for
one. `ProcessingThread`'s `[ThreadStatic]` is rewritten to a plain static by
`NoopThreadStaticAttribute` in the guest build and nothing ever sets it, so each increment takes the
striped path: `Thread.GetCurrentProcessorId()`, a masked index into a 128-byte-strided array, and an
interlocked add.

Block 25,532,382 fires 82,875 of them — 34,789 RLP decodes, 24,043 encodes, 24,043 hash
calculations. Measured on `ziskemu` 1.2.0-alpha over the CI input `25532382.ssz`:

| | steps | cost |
|---|---|---|
| master | 704,310,247 | 75,659,327,021 |
| this PR | 683,177,483 | — |
| | **−3.00 %** | |

Output is byte-identical to the CI expectation, success flag included.

`Nethermind.Evm.Metrics` is already gated by `NO_EXEC_METRICS` and `Nethermind.Db.Metrics` has its
own `ZK_EVM` handling, so this closes the remaining gap rather than introducing a new pattern.
