### PR TITLE
perf(zkevm): stop copying witness elements into the guest databases

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
@@ -53,7 +53,6 @@ public static class WitnessExtensions
             foreach (byte[] code in witness.Codes)
             {
                 ReadOnlySpan<byte> hash = ValueKeccak.Compute(code).Bytes;
-                // See CreateNodeStorage: Set stores the array as-is, PutSpan would copy it.
                 db.Set(hash, code);
             }
 

--- a/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
@@ -41,8 +41,6 @@ public static class WitnessExtensions
             foreach (byte[] stateElement in witness.State)
             {
                 ReadOnlySpan<byte> hash = ValueKeccak.Compute(stateElement).Bytes;
-                // Set, not PutSpan: the element is already an owned array, and PutSpan's default
-                // implementation would copy it.
                 db.Set(hash, stateElement);
             }
 

--- a/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
@@ -41,7 +41,9 @@ public static class WitnessExtensions
             foreach (byte[] stateElement in witness.State)
             {
                 ReadOnlySpan<byte> hash = ValueKeccak.Compute(stateElement).Bytes;
-                db.PutSpan(hash, stateElement);
+                // Set, not PutSpan: the element is already an owned array, and PutSpan's default
+                // implementation would copy it.
+                db.Set(hash, stateElement);
             }
 
             return new NodeStorage(db, INodeStorage.KeyScheme.Hash);
@@ -53,7 +55,8 @@ public static class WitnessExtensions
             foreach (byte[] code in witness.Codes)
             {
                 ReadOnlySpan<byte> hash = ValueKeccak.Compute(code).Bytes;
-                db.PutSpan(hash, code);
+                // See CreateNodeStorage: Set stores the array as-is, PutSpan would copy it.
+                db.Set(hash, code);
             }
 
             return db;


### PR DESCRIPTION
## Changes

- `Witness.CreateNodeStorage` and `Witness.CreateCodeDb` store the witness arrays directly via
  `Set` instead of `PutSpan`, whose default implementation copies the value.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

`IWriteOnlyKeyValueStore.PutSpan`'s default implementation is `Set(key, value.ToArray())`, so this
is the same store operation with the copy removed. Covered by `stateless-tests.yml`, which asserts
the guest output hash for nine blocks.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Both loops already hold each witness element as an owned `byte[]` straight from the SSZ decode, and
never mutate it, so re-allocating and copying it into the in-memory database is pure waste. For
block 25,532,382 that is 26,025 state nodes and 403 code blobs, roughly 19 MB.

Measured on `ziskemu` 1.2.0-alpha over the CI input `25532382.ssz`, stacked on top of
`perf/zkevm-trie-metrics`:

| | steps |
|---|---|
| with trie-metrics gate | 683,177,483 |
| + this PR | 678,986,031 |
| | **−0.60 %** |

Output is byte-identical to the CI expectation, success flag included.

The saving is smaller than 19 MB of copying suggests because `memcpy` and `memset` are DMA
precompiles on ZisK — 337,272 `dma_memcpy` calls across the whole run cost 0.20 % of the proving
bill. Bulk movement is cheap there; the win here is the allocation and loop overhead around it.
