### PR TITLE
perf(zkevm): compile the guest's metric counters away

### DIFF
--- a/src/Nethermind/Nethermind.Core/Threading/ProcessingThread.std.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ProcessingThread.std.cs
@@ -9,7 +9,7 @@ namespace Nethermind.Core.Threading;
 /// Identifies the current thread as the main block processing path.
 /// Set by BlockchainProcessor before processing blocks.
 /// </summary>
-public static class ProcessingThread
+public static partial class ProcessingThread
 {
     [ThreadStatic]
     private static bool _isBlockProcessingThread;

--- a/src/Nethermind/Nethermind.Core/Threading/ProcessingThread.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ProcessingThread.zkevm.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Core.Threading;
+
+/// <summary>
+/// Constant-false flag for the zkVM guest — see the std counterpart for the real one.
+/// </summary>
+/// <remarks>
+/// The guest never runs <c>BlockchainProcessor</c>, so the std flag is already false throughout.
+/// Folding it to a constant lets the metrics counters that branch on it compile away entirely,
+/// and keeps the callers that gate work on it (e.g. <c>SetAccountChanges</c>) behaving as before.
+/// </remarks>
+public static partial class ProcessingThread
+{
+    public static bool IsBlockProcessingThread { get => false; set { } }
+}

--- a/src/Nethermind/Nethermind.Core/Threading/StripedLong.std.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/StripedLong.std.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Core.Threading;
 /// existing slots). Reads are O(stripes) and torn only across slots: fine for metrics, not for
 /// invariants.
 /// </remarks>
-public sealed class StripedLong
+public sealed partial class StripedLong
 {
     // 16 longs = 128 bytes between live slots.
     private const int SlotStride = 16;

--- a/src/Nethermind/Nethermind.Core/Threading/StripedLong.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/StripedLong.zkevm.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.CompilerServices;
+
+namespace Nethermind.Core.Threading;
+
+/// <summary>
+/// No-op counter for the zkVM guest — see the std counterpart for the striped one.
+/// </summary>
+/// <remarks>
+/// Every use is a metrics counter the guest never reads, and the guest is single-threaded, so the
+/// striping the std type exists for buys nothing. Empty bodies inline away, taking the surrounding
+/// <c>Metrics.Increment*</c> calls with them.
+/// </remarks>
+public sealed partial class StripedLong
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Add(long value) { }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Increment() { }
+
+    public long Sum => 0;
+}


### PR DESCRIPTION
Supersedes #13075 (closed by a branch rename).

## Changes

- Split `ProcessingThread` into `.std.cs` / `.zkevm.cs`; the guest variant folds
  `IsBlockProcessingThread` to a constant `false`.
- Split `StripedLong` into `.std.cs` / `.zkevm.cs`; the guest variant is a no-op counter.
- No metrics file is touched: `Trie`, `Trie.Pruning`, `Db` and `Evm` counters all compile away in
  the guest as a consequence.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Host builds are unaffected — the `.std.cs` files are the existing implementations, moved and marked
`partial`, and `StripedLongTests` passes unchanged. The guest is covered by `stateless-tests.yml`,
which asserts the output hash for nine blocks; all runs below reproduce it byte for byte.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The guest reads none of these counters, but every trie node decode, encode and hash still pays for
one. `ProcessingThread`'s `[ThreadStatic]` is rewritten to a plain static by
`NoopThreadStaticAttribute` in the guest build and nothing ever sets it, so each increment takes the
striped path: `Thread.GetCurrentProcessorId()`, a masked index into a 128-byte-strided array, and an
interlocked add. Block 25,532,382 fires 82,875 trie increments alone — 34,789 RLP decodes, 24,043
encodes, 24,043 hash calculations.

Gating each call site with `#if !ZK_EVM` works but scales badly across four metrics classes.
Folding the two primitives the counters are built on removes the `if` *and* both of its branches, so
the increments disappear without those files changing.

`false` rather than `true` is deliberate: it is what the flag already evaluates to in the guest, so
callers that gate work on it keep their current behaviour — notably `SetAccountChanges`, which
`BlockProcessor` runs only when `BlockchainProcessor.IsMainProcessingThread`. `true` would have
switched that on. `false` selects the `StripedLong` branch, which is why the no-op counter is the
other half of the pair.

Measured on `ziskemu` 1.2.0-alpha over the CI input `25532382.ssz`:

| | steps | vs master |
|---|---|---|
| master | 704,310,247 | — |
| `#if !ZK_EVM` at each trie call site | 683,177,483 | −3.00 % |
| this PR | 683,279,081 | −2.99 % |

Same saving as the per-call-site version, from a smaller diff that also covers `Trie.Pruning`, `Db`
and `Evm`.
