### PR TITLE
test(zkevm): lock the guest metric-primitive no-op contract

### DIFF
--- a/src/Nethermind/Nethermind.Core.ZkEvm.Test/Threading/ZkEvmMetricPrimitivesTests.cs
+++ b/src/Nethermind/Nethermind.Core.ZkEvm.Test/Threading/ZkEvmMetricPrimitivesTests.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Threading;
+using NUnit.Framework;
+
+namespace Nethermind.Core.ZkEvm.Test.Threading;
+
+/// <remarks>
+/// Locks the two guest-only folds that let every <c>Metrics.Increment*</c> in Trie, Trie.Pruning,
+/// Db and Evm compile away. Flipping either one silently reinstates the counters, and flipping
+/// <see cref="ProcessingThread.IsBlockProcessingThread"/> to <c>true</c> would also switch on the
+/// work callers gate behind it, such as <c>BlockProcessor.SetAccountChanges</c>.
+/// </remarks>
+public class ZkEvmMetricPrimitivesTests
+{
+    [Test]
+    public void Block_processing_thread_flag_stays_false_when_set()
+    {
+        ProcessingThread.IsBlockProcessingThread = true;
+
+        Assert.That(ProcessingThread.IsBlockProcessingThread, Is.False);
+    }
+
+    [Test]
+    public void Striped_long_stays_empty_when_incremented()
+    {
+        StripedLong counter = new();
+
+        counter.Increment();
+        counter.Add(41);
+
+        Assert.That(counter.Sum, Is.Zero);
+    }
+}


### PR DESCRIPTION
Follow-up to #13077, from review feedback that arrived after it merged.

## Changes

- Add `Nethermind.Core.ZkEvm.Test/Threading/ZkEvmMetricPrimitivesTests.cs`, asserting the two
  guest-only folds introduced in #13077: `ProcessingThread.IsBlockProcessingThread` stays `false`
  even after a write, and `StripedLong.Sum` stays `0` after `Increment()` / `Add(n)`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: test-only

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.Core.ZkEvm.Test` with `EnableZkEvm=true`: 3 passed, 0 failed. The project only compiles
under that flag and already runs on every `pull_request` via `stateless-tests.yml`, so this needs no
workflow change. Modelled on the existing `Collections/SafeArrayPoolZkEvmTests.cs`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

#13077 folded `ProcessingThread.IsBlockProcessingThread` to a constant `false` and made
`StripedLong` a no-op in the guest, which is what lets every `Metrics.Increment*` in Trie,
Trie.Pruning, Db and Evm compile away (−2.99% guest steps). Nothing asserted either invariant — the
only evidence was that the stateless guest output hash still matched.

Both matter beyond the metrics. `BlockProcessor.SetAccountChanges` is gated on
`BlockchainProcessor.IsMainProcessingThread`, which reads that flag, so folding it to `true` instead
would silently switch that work on in the guest. These two assertions state the contract directly
and fail loudly if either fold is later flipped.
