### PR TITLE
Update release/2.0.0-rc with #13036, #13038, #13046

### DIFF
--- a/src/Nethermind/Nethermind.Api/INethermindApi.cs
+++ b/src/Nethermind/Nethermind.Api/INethermindApi.cs
@@ -20,6 +20,18 @@ namespace Nethermind.Api
 
     public static class NethermindApiExtensions
     {
+        /// <summary>
+        /// Registers the RPC decoder and transaction validator for a transaction type.
+        /// </summary>
+        /// <remarks>
+        /// A per-type validator may cover fewer rules than the default full validator. Chain plugins that register
+        /// one must ensure their <see cref="ISpecChangeTxValidator"/> validates any omitted fork-sensitive rules in
+        /// <see cref="ISpecChangeTxValidator.IsWellFormedAfterFullValidation"/>.
+        /// </remarks>
+        /// <typeparam name="T">The RPC transaction representation to register.</typeparam>
+        /// <param name="api">The Nethermind API receiving the registrations.</param>
+        /// <param name="decoder">The decoder for the transaction type.</param>
+        /// <param name="validator">The full validator for the transaction type.</param>
         public static void RegisterTxType<T>(this INethermindApi api, ITxDecoder decoder, ITxValidator validator) where T : TransactionForRpc, IFromTransaction<T>
         {
             ArgumentNullException.ThrowIfNull(api.TxValidator);

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockFinderExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockFinderExtensionsTests.cs
@@ -59,7 +59,7 @@ public class BlockFinderExtensionsTests
         BlockHeader head = Build.A.BlockHeader.WithNumber(1000).TestObject;
         Block headBlock = Build.A.Block.WithHeader(head).TestObject;
         blockFinder.Head.Returns(headBlock);
-        blockFinder.GetLowestBlock().Returns(100ul);
+        blockFinder.LowestServedBlock.Returns(100ul);
 
         // Mock the underlying method that will be called
         blockFinder.FindBlock(50ul, BlockTreeLookupOptions.None).Returns((Block?)null);
@@ -71,5 +71,32 @@ public class BlockFinderExtensionsTests
         Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.PrunedHistoryUnavailable));
         Assert.That(result.Error, Does.Contain("50"));
         Assert.That(result.Error, Does.Contain("Pruned history unavailable"));
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void SearchForBlock_reports_pruned_history_below_the_served_floor_not_the_published_boundary()
+    {
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.Head.Returns(Build.A.Block.WithNumber(200).TestObject);
+        blockFinder.GetLowestBlock().Returns(1UL);
+        blockFinder.LowestServedBlock.Returns(100UL);
+
+        SearchResult<Block> result = blockFinder.SearchForBlock(new BlockParameter(50));
+
+        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.PrunedHistoryUnavailable),
+            "the pruned-history check keys on the served floor the node advertises, not the published boundary");
+    }
+
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void SearchForBlock_stays_not_found_at_or_above_the_served_floor()
+    {
+        IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.Head.Returns(Build.A.Block.WithNumber(200).TestObject);
+        blockFinder.GetLowestBlock().Returns(1UL);
+        blockFinder.LowestServedBlock.Returns(100UL);
+
+        SearchResult<Block> result = blockFinder.SearchForBlock(new BlockParameter(150));
+
+        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.ResourceNotFound));
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockTreeTests.cs
@@ -38,6 +38,22 @@ namespace Nethermind.Blockchain.Test;
 [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 public class BlockTreeTests
 {
+    [Test, MaxTime(Timeout.MaxTestTime)]
+    public void Lowest_served_block_follows_the_latest_push_but_never_drops_below_the_published_boundary()
+    {
+        BlockTree tree = Build.A.BlockTree().OfChainLength(3).TestObject;
+        ulong published = tree.GetLowestBlock();
+
+        tree.UpdateLowestServedBlock(published + 500);
+        Assert.That(tree.LowestServedBlock, Is.EqualTo(published + 500));
+
+        tree.UpdateLowestServedBlock(published + 100);
+        Assert.That(tree.LowestServedBlock, Is.EqualTo(published + 100), "the served floor follows a descending frontier down");
+
+        tree.UpdateLowestServedBlock(0);
+        Assert.That(tree.LowestServedBlock, Is.EqualTo(published), "the served floor never reports below the published boundary");
+    }
+
     private TestMemDb _blocksInfosDb = null!;
     private TestMemDb _headersDb = null!;
     private TestMemDb _blocksDb = null!;

--- a/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Find/LogFinderTests.cs
@@ -20,6 +20,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.History;
 using Nethermind.Logging;
 using Nethermind.Db.LogIndex;
 using Nethermind.Facade.Find;
@@ -421,6 +422,206 @@ public class LogFinderTests
         receiptStorage.ClearCache();
 
         Assert.That(() => CreateLogFinder(_rawBlockTree, receiptStorage).FindLogs(FilterBuilder.New().FromBlock(1).ToBlock(1).Build()).ToArray(), Throws.TypeOf<InvalidOperationException>().With.Message.Contains(@"missing block data"));
+    }
+
+    private const ulong BoundaryOldestStored = 50;
+    private const int BoundaryFrom = 10;
+    private const int BoundaryTo = 200;
+
+    private static IndexedLogFinder CreateBoundaryFinder(out IBlockFinder blockFinder, out ILogIndexStorage index, IPrunedLogsRetention? retention = null, int? indexFrom = 0, ulong lowestStored = BoundaryOldestStored, IHistoryPruner? historyPruner = null)
+    {
+        blockFinder = Substitute.For<IBlockFinder>();
+        blockFinder.GetLowestBlock().Returns(lowestStored);
+        index = Substitute.For<ILogIndexStorage>();
+        index.Enabled.Returns(true);
+        index.MinBlockNumber.Returns(indexFrom);
+        index.MaxBlockNumber.Returns(indexFrom is null ? (int?)null : BoundaryTo);
+        return new IndexedLogFinder(
+            blockFinder, Substitute.For<IReceiptFinder>(), Substitute.For<IReceiptStorage>(), LimboLogs.Instance,
+            Substitute.For<IReceiptsRecovery>(), index, prunedLogsRetention: retention, historyPruner: historyPruner);
+    }
+
+    private static LogFilter BoundaryFilter(ulong from = BoundaryFrom) =>
+        FilterBuilder.New().FromBlock(from).ToBlock(BoundaryTo).WithAddress(TestItem.AddressA).Build();
+
+    private static BlockHeader BoundaryHeader(ulong number) => Build.A.BlockHeader.WithNumber(number).TestObject;
+
+    [Test]
+    public void Should_ServeBetweenTheReclaimCursorAndThePublishedBoundary_FromTheIndex()
+    {
+        IHistoryPruner pruner = Substitute.For<IHistoryPruner>();
+        pruner.OldestUnreclaimedBlockNumber.Returns(1UL);
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out ILogIndexStorage index, historyPruner: pruner);
+
+        FilterLog[] logs = finder.FindLogs(BoundaryFilter(), BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray();
+
+        Assert.That(logs, Is.Empty);
+        index.Received().GetEnumerator(TestItem.AddressA, BoundaryFrom, BoundaryTo);
+    }
+
+    [Test]
+    public void Should_ReportAnInvertedRangeAsInvalid_NotAsPrunedData()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out _);
+        LogFilter inverted = FilterBuilder.New().FromBlock(30UL).ToBlock(10UL).WithAddress(TestItem.AddressA).Build();
+
+        Assert.Throws<ArgumentException>(() =>
+            finder.FindLogs(inverted, BoundaryHeader(30), BoundaryHeader(10)).ToArray());
+    }
+
+    [Test]
+    public void Should_FailClosed_BelowTheReclaimCursor()
+    {
+        IHistoryPruner pruner = Substitute.For<IHistoryPruner>();
+        pruner.OldestUnreclaimedBlockNumber.Returns(BoundaryOldestStored);
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out _, historyPruner: pruner);
+
+        Assert.Throws<ResourceNotFoundException>(() =>
+            finder.FindLogs(BoundaryFilter(), BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray());
+    }
+
+    [Test]
+    public void Should_AnswerAWholeGenesisQuery_WhenTheBoundaryIsTheAncientBarrier()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out ILogIndexStorage index, indexFrom: 1, lowestStored: 24_600_000);
+        LogFilter genesisFilter = FilterBuilder.New().FromBlock(0UL).ToBlock(0UL).WithAddress(TestItem.AddressA).Build();
+
+        FilterLog[] logs = finder.FindLogs(genesisFilter, BoundaryHeader(0), BoundaryHeader(0)).ToArray();
+
+        Assert.That(logs, Is.Empty);
+        index.DidNotReceive().GetEnumerator(Arg.Any<Address>(), Arg.Any<int>(), Arg.Any<int>());
+    }
+
+    [Test]
+    public void Should_ServeBelowTheOldestStoredBlockFromTheIndex_WhenTheRetentionCoversTheFilter()
+    {
+        IPrunedLogsRetention retention = Substitute.For<IPrunedLogsRetention>();
+        retention.RetainsLogsFor(Arg.Any<IReadOnlyCollection<AddressAsKey>>(), Arg.Any<ulong>(), Arg.Any<ulong>()).Returns(true);
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out ILogIndexStorage index, retention);
+
+        FilterLog[] logs = finder.FindLogs(BoundaryFilter(), BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray();
+
+        Assert.That(logs, Is.Empty);
+        index.Received().GetEnumerator(TestItem.AddressA, BoundaryFrom, BoundaryTo);
+    }
+
+    [Test]
+    public void Should_FailClosedBelowTheOldestStoredBlock_WhenTheRetentionDoesNotCoverTheFilter()
+    {
+        IPrunedLogsRetention retention = Substitute.For<IPrunedLogsRetention>();
+        retention.RetainsLogsFor(Arg.Any<IReadOnlyCollection<AddressAsKey>>(), Arg.Any<ulong>(), Arg.Any<ulong>()).Returns(false);
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out _, retention);
+
+        Assert.Throws<ResourceNotFoundException>(() =>
+            finder.FindLogs(BoundaryFilter(), BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray());
+    }
+
+    [Test]
+    public void Should_FailClosedBelowTheOldestStoredBlock_WhenNoRetentionIsConfigured()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out _);
+
+        Assert.Throws<ResourceNotFoundException>(() =>
+            finder.FindLogs(BoundaryFilter(), BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray());
+    }
+
+    [Test]
+    public void Should_FailClosedBelowTheOldestStoredBlock_EvenWhenBothEndpointsCarryNoReceipts()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out _);
+        BlockHeader emptyFrom = BoundaryHeader(BoundaryFrom);
+        BlockHeader emptyTo = BoundaryHeader(BoundaryTo);
+
+        Assert.That(emptyFrom.ReceiptsRoot, Is.EqualTo(Keccak.EmptyTreeHash),
+            "the scenario needs endpoints the endpoint probe cannot see, so their receipt roots must be empty");
+
+        Assert.Throws<ResourceNotFoundException>(() =>
+            finder.FindLogs(BoundaryFilter(), emptyFrom, emptyTo).ToArray());
+    }
+
+    [Test]
+    public void Should_FailClosedBelowTheOldestStoredBlock_EvenWhenTheIndexStartsExactlyAtTheBoundary()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out _, indexFrom: (int)BoundaryOldestStored);
+
+        Assert.Throws<ResourceNotFoundException>(() =>
+            finder.FindLogs(BoundaryFilter(), BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray());
+    }
+
+    [Test]
+    public void Should_FailClosedBelowTheOldestStoredBlock_OnEveryPollOfAStoredFilter()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out _);
+        LogFilter stored = BoundaryFilter();
+
+        Assert.Throws<ResourceNotFoundException>(() =>
+            finder.FindLogs(stored, BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray());
+        Assert.That(stored.UseIndex, Is.True,
+            "eth_getFilterLogs reuses the stored LogFilter instance, so a throw must not leave UseIndex cleared and route the retry around the guard");
+        Assert.Throws<ResourceNotFoundException>(() =>
+            finder.FindLogs(stored, BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray());
+    }
+
+    [Test]
+    public void Should_FallBackToThePlainScan_ForAnAddressLessFilter()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out ILogIndexStorage index);
+        LogFilter addressLess = FilterBuilder.New().FromBlock((ulong)BoundaryFrom).ToBlock(BoundaryTo).Build();
+
+        FilterLog[] logs = finder.FindLogs(addressLess, BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray();
+
+        Assert.That(logs, Is.Empty);
+        index.DidNotReceiveWithAnyArgs().GetEnumerator(Arg.Any<Address>(), Arg.Any<int>(), Arg.Any<int>());
+    }
+
+    [Test]
+    public void Should_FailClosedBelowTheOldestStoredBlock_ForATopicOnlyFilter()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out _);
+        LogFilter topicOnly = FilterBuilder.New()
+            .FromBlock((ulong)BoundaryFrom).ToBlock(BoundaryTo)
+            .WithAnyAddress()
+            .WithTopicExpressions(TestTopicExpressions.Specific(TestItem.KeccakA))
+            .Build();
+
+        Assert.Throws<ResourceNotFoundException>(() =>
+            finder.FindLogs(topicOnly, BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray(),
+            "a sliced index holds fabricated empties below the boundary, so a topic-only filter there must refuse rather than answer silently short");
+    }
+
+    [Test]
+    public void Should_FallBackToThePlainScan_WhenNothingIsIndexedYet()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out ILogIndexStorage index, indexFrom: null);
+
+        FilterLog[] logs = finder.FindLogs(BoundaryFilter(), BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray();
+
+        Assert.That(logs, Is.Empty);
+        index.DidNotReceiveWithAnyArgs().GetEnumerator(Arg.Any<Address>(), Arg.Any<int>(), Arg.Any<int>());
+    }
+
+    [Test]
+    public void Should_UseTheFullIndexRange_WhenTheQueryDoesNotReachBelowTheOldestStoredBlock()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out _, out ILogIndexStorage index, lowestStored: 1UL);
+
+        FilterLog[] logs = finder.FindLogs(BoundaryFilter(), BoundaryHeader(BoundaryFrom), BoundaryHeader(BoundaryTo)).ToArray();
+
+        Assert.That(logs, Is.Empty);
+        index.Received().GetEnumerator(TestItem.AddressA, BoundaryFrom, BoundaryTo);
+    }
+
+    [Test]
+    public void Should_AnswerAFromGenesisQueryUnchanged_OnANodeThatNeverPrunedHistory()
+    {
+        IndexedLogFinder finder = CreateBoundaryFinder(out IBlockFinder blockFinder, out ILogIndexStorage index, lowestStored: 1UL);
+        BlockHeader genesis = BoundaryHeader(0);
+        blockFinder.FindHeader(0UL).Returns(genesis);
+
+        FilterLog[] logs = finder.FindLogs(BoundaryFilter(from: 0), genesis, BoundaryHeader(BoundaryTo)).ToArray();
+
+        Assert.That(logs, Is.Empty);
+        index.Received().GetEnumerator(TestItem.AddressA, 1, BoundaryTo);
     }
 
     private static FilterBuilder AllBlockFilter() => FilterBuilder.New().FromEarliestBlock().ToPendingBlock();

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -252,21 +252,23 @@ public class TxPoolSourceTests
     }
 
     [Test]
-    public void Default_pending_view_does_not_expose_a_mutable_shared_dictionary()
+    public void Default_pending_view_is_empty()
     {
         PendingTransactionsView view = default;
-
-        Action mutate = () => view.Transactions.Add(TestItem.AddressA, []);
+        IReadOnlyDictionary<AddressAsKey, Transaction[]> transactions = view.Transactions;
+        IReadOnlyDictionary<AddressAsKey, Transaction[]> blobTransactions = view.BlobTransactions;
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(mutate, Throws.TypeOf<NotSupportedException>());
-            Assert.That(default(PendingTransactionsView).Transactions, Is.Empty);
+            Assert.That(transactions, Is.Empty);
+            Assert.That(blobTransactions, Is.Empty);
         }
     }
 
-    [Test]
-    public void GetTransactions_should_not_let_an_invalid_blob_displace_a_valid_blob()
+    [TestCase(1, true)]
+    [TestCase(10, true)]
+    [TestCase(11, false)]
+    public void GetTransactions_should_bound_resolved_rejections(int invalidBlobCount, bool expectValidBlob)
     {
         TestSpecProvider specProvider = new(Osaka.Instance)
         {
@@ -275,39 +277,46 @@ public class TxPoolSourceTests
         };
         TransactionComparerProvider transactionComparerProvider = new(specProvider, Build.A.BlockTree().TestObject);
 
-        Transaction invalidBlob = Build.A.Transaction
-            .WithShardBlobTxTypeAndFields(spec: Amsterdam.Instance)
-            .WithAccessList(BuildUnderGassedAccessList())
-            .WithGasLimit(UnderGassedTransactionGasLimit)
-            .WithMaxFeePerGas(2.GWei)
-            .WithMaxPriorityFeePerGas(2.GWei)
-            .SignedAndResolved(TestItem.PrivateKeyA)
-            .TestObject;
+        Transaction[] invalidBlobs = new Transaction[invalidBlobCount];
+        Dictionary<AddressAsKey, Transaction[]> pendingBlobTransactions = new(invalidBlobCount + 1);
+        Dictionary<ValueHash256, Transaction> fullBlobTransactions = new(invalidBlobCount + 1);
+        for (int i = 0; i < invalidBlobs.Length; i++)
+        {
+            UInt256 fee = 2.GWei + (UInt256)(invalidBlobCount - i);
+            Transaction invalidBlob = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(spec: Amsterdam.Instance)
+                .WithAccessList(BuildUnderGassedAccessList())
+                .WithGasLimit(UnderGassedTransactionGasLimit)
+                .WithMaxFeePerGas(fee)
+                .WithMaxPriorityFeePerGas(fee)
+                .SignedAndResolved(TestItem.PrivateKeys[i])
+                .TestObject;
+            invalidBlobs[i] = invalidBlob;
+            pendingBlobTransactions[new AddressAsKey(invalidBlob.SenderAddress!)] = [new LightTransaction(invalidBlob)];
+            fullBlobTransactions[invalidBlob.Hash!.ValueHash256] = invalidBlob;
+        }
+
         Transaction validBlob = Build.A.Transaction
             .WithShardBlobTxTypeAndFields(spec: Amsterdam.Instance)
             .WithAccessList(BuildUnderGassedAccessList())
             .WithGasLimit(100_000)
             .WithMaxFeePerGas(1.GWei)
             .WithMaxPriorityFeePerGas(1.GWei)
-            .SignedAndResolved(TestItem.PrivateKeyB)
+            .SignedAndResolved(TestItem.PrivateKeys[invalidBlobCount])
             .TestObject;
+        pendingBlobTransactions[new AddressAsKey(validBlob.SenderAddress!)] = [new LightTransaction(validBlob)];
+        fullBlobTransactions[validBlob.Hash!.ValueHash256] = validBlob;
+
         ITxPool txPool = Substitute.For<ITxPool>();
-        SetPendingForProduction(txPool, blobTransactions: new Dictionary<AddressAsKey, Transaction[]>
-        {
-            { new AddressAsKey(invalidBlob.SenderAddress!), [new LightTransaction(invalidBlob)] },
-            { new AddressAsKey(validBlob.SenderAddress!), [new LightTransaction(validBlob)] }
-        });
-        txPool.TryGetPendingBlobTransaction(Arg.Is<Hash256>(h => h == invalidBlob.Hash), out Arg.Any<Transaction?>())
-            .Returns(x =>
+        SetPendingForProduction(txPool, blobTransactions: pendingBlobTransactions);
+        txPool.TryGetPendingBlobTransaction(Arg.Any<Hash256>(), out Arg.Any<Transaction?>())
+            .Returns(callInfo =>
             {
-                x[1] = invalidBlob;
-                return true;
-            });
-        txPool.TryGetPendingBlobTransaction(Arg.Is<Hash256>(h => h == validBlob.Hash), out Arg.Any<Transaction?>())
-            .Returns(x =>
-            {
-                x[1] = validBlob;
-                return true;
+                bool found = fullBlobTransactions.TryGetValue(
+                    callInfo.ArgAt<Hash256>(0).ValueHash256,
+                    out Transaction? fullBlobTransaction);
+                callInfo[1] = fullBlobTransaction;
+                return found;
             });
         txPool.SupportsBlobs.Returns(true);
 
@@ -329,12 +338,77 @@ public class TxPoolSourceTests
 
         Transaction[] result = txSource.GetTransactions(parent, targetBlock, long.MaxValue).ToArray();
 
+        Transaction[] expected = expectValidBlob ? [validBlob] : [];
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result, Is.EqualTo(new[] { validBlob }).UsingTransactionComparer());
-            txPool.Received(1).TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>());
-            txFilterPipeline.DidNotReceive().Execute(invalidBlob, parent, Amsterdam.Instance);
+            Assert.That(result, Is.EqualTo(expected).UsingTransactionComparer());
+            txPool.Received(expectValidBlob ? 1 : 0).TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>());
             txFilterPipeline.DidNotReceive().Execute(validBlob, parent, Amsterdam.Instance);
+        }
+
+        for (int i = 0; i < invalidBlobs.Length; i++)
+        {
+            txPool.Received(1).TryGetPendingBlobTransaction(invalidBlobs[i].Hash!, out Arg.Any<Transaction?>());
+            txFilterPipeline.DidNotReceive().Execute(invalidBlobs[i], parent, Amsterdam.Instance);
+        }
+    }
+
+    [TestCase(26)]
+    public void GetTransactions_should_skip_light_rejections_without_resolving_them(int invalidBlobCount)
+    {
+        TestSpecProvider specProvider = new(Osaka.Instance)
+        {
+            NextForkSpec = Amsterdam.Instance,
+            ForkOnBlockNumber = 1
+        };
+        TransactionComparerProvider transactionComparerProvider = new(specProvider, Build.A.BlockTree().TestObject);
+        Transaction validBlob = Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Amsterdam.Instance)
+            .WithMaxFeePerGas(1.GWei)
+            .WithMaxPriorityFeePerGas(1.GWei)
+            .SignedAndResolved(TestItem.PrivateKeys[invalidBlobCount])
+            .TestObject;
+        Dictionary<AddressAsKey, Transaction[]> pendingBlobTransactions = new(invalidBlobCount + 1);
+        LightTransaction[] invalidBlobs = new LightTransaction[invalidBlobCount];
+        for (int i = 0; i < invalidBlobs.Length; i++)
+        {
+            LightTransaction invalidBlob = new(validBlob)
+            {
+                Hash = TestItem.Keccaks[i],
+                SenderAddress = TestItem.Addresses[i],
+                GasPrice = 2.GWei,
+                DecodedMaxFeePerGas = 2.GWei,
+                GasBottleneck = 2.GWei,
+                ProofVersion = ProofVersion.V0
+            };
+            invalidBlobs[i] = invalidBlob;
+            pendingBlobTransactions[new AddressAsKey(invalidBlob.SenderAddress)] = [invalidBlob];
+        }
+
+        pendingBlobTransactions[new AddressAsKey(validBlob.SenderAddress!)] = [new LightTransaction(validBlob)];
+        ITxPool txPool = Substitute.For<ITxPool>();
+        SetPendingForProduction(txPool, blobTransactions: pendingBlobTransactions);
+        txPool.TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = validBlob;
+                return true;
+            });
+        txPool.SupportsBlobs.Returns(true);
+        ITxFilterPipeline txFilterPipeline = Substitute.For<ITxFilterPipeline>();
+        txFilterPipeline.Execute(Arg.Any<Transaction>(), Arg.Any<BlockHeader>(), Arg.Any<IReleaseSpec>()).Returns(true);
+        TxPoolTxSource txSource = new(txPool, specProvider, transactionComparerProvider, LimboLogs.Instance,
+            txFilterPipeline, new BlocksConfig { BlockProductionBlobLimit = 1 }, CreateSpecChangeTxValidator(specProvider));
+        BlockHeader parent = Build.A.BlockHeader.WithNumber(0).WithExcessBlobGas(0).TestObject;
+        BlockHeader targetBlock = Build.A.BlockHeader.WithNumber(1).WithExcessBlobGas(0).TestObject;
+
+        Transaction[] result = txSource.GetTransactions(parent, targetBlock, long.MaxValue).ToArray();
+
+        Assert.That(result, Is.EqualTo(new[] { validBlob }).UsingTransactionComparer());
+        txPool.Received(1).TryGetPendingBlobTransaction(validBlob.Hash!, out Arg.Any<Transaction?>());
+        for (int i = 0; i < invalidBlobs.Length; i++)
+        {
+            txPool.DidNotReceive().TryGetPendingBlobTransaction(invalidBlobs[i].Hash!, out Arg.Any<Transaction?>());
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -21,6 +21,7 @@ using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -496,6 +497,98 @@ public class TxValidatorTests
 
         Assert.That(() => result = txValidator.IsWellFormed(tx, Osaka.Instance).AsBool(), Throws.Nothing);
         Assert.That(result, Is.False);
+    }
+
+    private static IEnumerable<TestCaseData> SpecChangeValidationCases()
+    {
+        yield return new TestCaseData(
+                Berlin.Instance,
+                Build.A.Transaction
+                    .WithType(TxType.EIP1559)
+                    .WithAccessList(AccessList.Empty)
+                    .WithMaxFeePerGas(1)
+                    .WithMaxPriorityFeePerGas(1)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_release_activation_is_covered_by_full_validation");
+
+        yield return new TestCaseData(
+                Cancun.Instance,
+                Build.A.Transaction
+                    .WithShardBlobTxTypeAndFields((int)Cancun.Instance.MaxBlobCount + 1, isMempoolTx: false)
+                    .WithMaxFeePerGas(1)
+                    .WithMaxPriorityFeePerGas(1)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_blob_count_is_covered_by_full_validation");
+
+        yield return new TestCaseData(
+                Osaka.Instance,
+                Build.A.Transaction
+                    .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + 1)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_gas_limit_cap_is_covered_by_full_validation");
+
+        yield return new TestCaseData(
+                Osaka.Instance,
+                Build.A.Transaction
+                    .WithShardBlobTxTypeAndFields(spec: Cancun.Instance)
+                    .WithMaxFeePerGas(1)
+                    .WithMaxPriorityFeePerGas(1)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_proof_version_is_covered_by_full_validation");
+
+        yield return new TestCaseData(
+                Shanghai.Instance,
+                Build.A.Transaction
+                    .WithCode(new byte[(int)Shanghai.Instance.MaxInitCodeSize + 1])
+                    .WithGasLimit(int.MaxValue)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_contract_size_is_covered_by_full_validation");
+
+        yield return new TestCaseData(
+                Prague.Instance,
+                Build.A.Transaction
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .TestObject)
+            .SetName("Spec_change_signature_is_covered_by_full_validation");
+
+        yield return new TestCaseData(
+                Prague.Instance,
+                Build.A.Transaction
+                    .WithData([1])
+                    .WithGasLimit(Transaction.BaseTxGasCost)
+                    .WithChainId(TestBlockchainIds.ChainId)
+                    .SignedAndResolved()
+                    .TestObject)
+            .SetName("Spec_change_intrinsic_gas_is_covered_by_full_validation");
+    }
+
+    [TestCaseSource(nameof(SpecChangeValidationCases))]
+    public void Full_validation_covers_spec_change_validation(IReleaseSpec spec, Transaction transaction)
+    {
+        TxValidator fullValidator = new(TestBlockchainIds.ChainId);
+        SpecChangeTxValidator specChangeValidator = new(TestBlockchainIds.ChainId);
+        ValidationResult specChangeResult = specChangeValidator.IsWellFormed(transaction, spec);
+        ValidationResult fullValidationResult = fullValidator.IsWellFormed(
+            transaction,
+            spec,
+            blockGasLimit: 0,
+            TxValidationOptions.SkipBlobProofs);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(specChangeResult.AsBool, Is.False, "test case must exercise a spec-change rejection");
+            Assert.That(fullValidationResult.AsBool, Is.False);
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/BlockTree.cs
@@ -100,6 +100,7 @@ namespace Nethermind.Blockchain
         public bool CanAcceptNewBlocks => _canAcceptNewBlocksCounter == 0;
 
         private ulong _oldestBlock;
+        private ulong _lowestServedBlock;
 
         private TaskCompletionSource? _taskCompletionSource;
 
@@ -1903,6 +1904,10 @@ namespace Nethermind.Blockchain
         }
 
         public ulong GetLowestBlock() => _oldestBlock;
+
+        public ulong LowestServedBlock => Math.Max(_oldestBlock, Volatile.Read(ref _lowestServedBlock));
+
+        public void UpdateLowestServedBlock(ulong lowestServed) => Volatile.Write(ref _lowestServedBlock, lowestServed);
 
         public void NewOldestBlock(ulong oldestBlock) => _oldestBlock = oldestBlock;
     }

--- a/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/IBlockFinder.cs
@@ -143,5 +143,9 @@ namespace Nethermind.Blockchain.Find
         }
 
         public ulong GetLowestBlock();
+
+        /// <summary>The oldest block this node can actually serve - the published boundary floored by the
+        /// download frontier while a backfill is still descending. What eth/69 advertises as earliest.</summary>
+        public ulong LowestServedBlock => GetLowestBlock();
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/IBlockTree.cs
@@ -245,6 +245,10 @@ namespace Nethermind.Blockchain
         /// </summary>
         (ulong BlockNumber, Hash256 BlockHash) SyncPivot { get; set; }
 
+        /// <summary>Publishes the served-history floor surfaced by <see cref="IBlockFinder.LowestServedBlock"/>.
+        /// A no-op everywhere except the live tree - read-only and overlay trees never own the floor.</summary>
+        void UpdateLowestServedBlock(ulong lowestServed) { }
+
         public readonly struct ForkChoiceUpdateEventArgs(Block? head, ulong safe, ulong finalized)
         {
             public Block? Head => head;

--- a/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReadOnlyBlockTree.cs
@@ -207,6 +207,8 @@ namespace Nethermind.Blockchain
 
         public ulong GetLowestBlock() => _wrapped.GetLowestBlock();
 
+        public ulong LowestServedBlock => _wrapped.LowestServedBlock;
+
         public void NewOldestBlock(ulong oldestBlock) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(NewOldestBlock)} calls");
 
         public void DeleteOldBlockRange(ulong fromInclusive, ulong toExclusive) => throw new InvalidOperationException($"{nameof(ReadOnlyBlockTree)} does not expect {nameof(DeleteOldBlockRange)} calls");

--- a/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/InitializationSteps/InitializeBlockchainAuRa.cs
@@ -12,7 +12,6 @@ using Nethermind.Consensus.AuRa.Contracts.DataStore;
 using Nethermind.Consensus.AuRa.Transactions;
 using Nethermind.Consensus.Comparers;
 using Nethermind.Consensus.Transactions;
-using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Init.Steps;
 using Nethermind.Logging;
@@ -103,7 +102,7 @@ public class InitializeBlockchainAuRa(
             chainHeadInfoProvider,
             NethermindApi.Config<ITxPoolConfig>(),
             api.TxValidator!,
-            new SpecChangeTxValidator(api.SpecProvider.ChainId),
+            _specChangeTxValidator,
             api.LogManager,
             CreateTxPoolTxComparer(txPriorityContract, localDataSource),
             _txGossipPolicy,

--- a/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus.AuRa/Transactions/TxPriorityTxSource.cs
@@ -42,7 +42,7 @@ namespace Nethermind.Consensus.AuRa.Transactions
 
         public override string ToString() => $"{nameof(TxPriorityTxSource)}";
 
-        protected override IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit)
+        protected override IEnumerable<Transaction> GetOrderedTransactions(IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit)
         {
             if (_logger.IsTrace)
             {

--- a/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/TxPoolTxSource.cs
@@ -37,6 +37,9 @@ namespace Nethermind.Consensus.Producers
         [KeyFilter(ITxValidator.SpecChangeTxValidatorKey)] ITxValidator? specChangeTxValidator)
         : ITxSource
     {
+        private const ulong BlobConsiderationMultiplier = 5;
+        private const ulong RejectedBlobReadMultiplier = 10;
+
         private readonly ITxPool _transactionPool = transactionPool ?? throw new ArgumentNullException(nameof(transactionPool));
         private readonly ITransactionComparerProvider _transactionComparerProvider = transactionComparerProvider ?? throw new ArgumentNullException(nameof(transactionComparerProvider));
         private readonly ITxFilterPipeline _txFilterPipeline = txFilterPipeline ?? throw new ArgumentNullException(nameof(txFilterPipeline));
@@ -55,8 +58,8 @@ namespace Nethermind.Consensus.Producers
             UInt256 baseFee = BaseFeeCalculator.Calculate(parent, spec);
             PendingTransactionsView pending = _transactionPool.GetPendingForProduction(targetBlock, filterSource, baseFee);
             bool isRevalidatedForTarget = pending.IsRevalidated;
-            IDictionary<AddressAsKey, Transaction[]> pendingTransactions = pending.Transactions;
-            IDictionary<AddressAsKey, Transaction[]> pendingBlobTransactionsEquivalences = pending.BlobTransactions;
+            IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions = pending.Transactions;
+            IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingBlobTransactionsEquivalences = pending.BlobTransactions;
             IComparer<Transaction> comparer = GetComparer(parent, new BlockPreparationContext(baseFee, targetBlock.Number))
                 .ThenBy(ByHashTxComparer.Instance); // in order to sort properly and not lose transactions we need to differentiate on their identity which provided comparer might not be doing
 
@@ -68,8 +71,16 @@ namespace Nethermind.Consensus.Producers
                 : tx => filter(tx) && IsForkSensitiveStateValid(tx, spec);
 
             ulong maxBlobCount = spec.MaxProductionBlobCount(blocksConfig.BlockProductionBlobLimit);
-            IEnumerable<Transaction> transactions = GetOrderedTransactions(pendingTransactions, comparer, pendingTxFilter, gasLimit);
-            IEnumerable<(Transaction tx, ulong blobChain)> blobTransactions = GetOrderedBlobTransactions(pendingBlobTransactionsEquivalences, comparer, BlobFilter, maxBlobCount);
+            IEnumerable<Transaction> transactions = GetOrderedTransactions(
+                pendingTransactions,
+                comparer,
+                pendingTxFilter,
+                gasLimit);
+            IEnumerable<(Transaction tx, ulong blobChain)> blobTransactions = GetOrderedBlobTransactions(
+                pendingBlobTransactionsEquivalences,
+                comparer,
+                BlobFilter,
+                maxBlobCount);
             if (_logger.IsTrace) _logger.Trace($"Collecting pending transactions at block gas limit {gasLimit}.");
 
             int checkedTransactions = 0;
@@ -163,10 +174,15 @@ namespace Nethermind.Consensus.Producers
             ulong maxBlobs,
             bool validateForkSensitiveState)
         {
-            ulong maxBlobsToConsider = maxBlobs * 5ul;
+            // Allow more rejected sidecar loads than valid candidates, but keep storage work bounded. Light-only
+            // rejections do no I/O and are bounded by the pool size instead, so they do not consume this budget.
+            ulong maxBlobsToConsider = maxBlobs * BlobConsiderationMultiplier;
+            ulong maxRejectedBlobsToConsider = maxBlobs * RejectedBlobReadMultiplier;
             ulong countOfRemainingBlobs = 0UL;
             ulong consideredBlobCount = 0UL;
+            ulong rejectedBlobCount = 0UL;
             Dictionary<Hash256, Transaction>? fullBlobTxs = null;
+            ILightTxValidator? lightTxValidator = _specChangeTxValidator as ILightTxValidator;
 
             if (!TryUpdateFeePerBlobGas(parent, spec, out UInt256 feePerBlobGas))
             {
@@ -190,15 +206,20 @@ namespace Nethermind.Consensus.Producers
                     continue;
                 }
 
-                // Count before resolving sidecars so an invalid pool cannot make fork-transition validation unbounded.
-                consideredBlobCount += txBlobCount;
-                bool reachedConsiderationLimit = consideredBlobCount > maxBlobsToConsider;
                 if (validateForkSensitiveState)
                 {
+                    if (blobTx is LightTransaction lightTransaction
+                        && lightTxValidator is not null
+                        && !lightTxValidator.IsWellFormedLight(lightTransaction, spec))
+                    {
+                        continue;
+                    }
+
                     if (!TryResolveBlob(blobTx, spec, out Transaction? fullBlobTx)
                         || !IsForkSensitiveStateValid(fullBlobTx, spec))
                     {
-                        if (reachedConsiderationLimit)
+                        rejectedBlobCount += txBlobCount;
+                        if (rejectedBlobCount > maxRejectedBlobsToConsider)
                         {
                             break;
                         }
@@ -211,6 +232,9 @@ namespace Nethermind.Consensus.Producers
                         (fullBlobTxs ??= [])[hash] = fullBlobTx;
                     }
                 }
+
+                consideredBlobCount += txBlobCount;
+                bool reachedConsiderationLimit = consideredBlobCount > maxBlobsToConsider;
 
                 if (txBlobCount == 1UL && candidates is null)
                 {
@@ -463,20 +487,20 @@ namespace Nethermind.Consensus.Producers
             return true;
         }
 
-        protected virtual IEnumerable<Transaction> GetOrderedTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
+        protected virtual IEnumerable<Transaction> GetOrderedTransactions(IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
             Order(pendingTransactions, comparer, filter, gasLimit);
 
-        private static IEnumerable<(Transaction tx, ulong blobChain)> GetOrderedBlobTransactions(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong maxBlobs = 0ul) =>
+        private static IEnumerable<(Transaction tx, ulong blobChain)> GetOrderedBlobTransactions(IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong maxBlobs = 0ul) =>
             OrderCore(pendingTransactions, comparer, static tx => (ulong)tx.GetBlobCount(), filter, maxBlobs, enforceSequentialNonces: true);
 
         protected virtual IComparer<Transaction> GetComparer(BlockHeader parent, BlockPreparationContext blockPreparationContext)
             => _transactionComparerProvider.GetDefaultProducerComparer(blockPreparationContext);
 
-        internal static IEnumerable<Transaction> Order(IDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
+        internal static IEnumerable<Transaction> Order(IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions, IComparer<Transaction> comparer, Func<Transaction, bool> filter, ulong gasLimit) =>
             OrderCore(pendingTransactions, comparer, static tx => tx.BlockGasUsed, filter, gasLimit, enforceSequentialNonces: false).Select(static tx => tx.tx);
 
         private static IEnumerable<(Transaction tx, ulong resource)> OrderCore(
-            IDictionary<AddressAsKey, Transaction[]> pendingTransactions,
+            IReadOnlyDictionary<AddressAsKey, Transaction[]> pendingTransactions,
             IComparer<Transaction> comparer,
             Func<Transaction, ulong> resourceSelector,
             Func<Transaction, bool> filter,

--- a/src/Nethermind/Nethermind.Consensus/Validators/SpecChangeTxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/SpecChangeTxValidator.cs
@@ -4,6 +4,7 @@
 using System;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.GasPolicy;
 using Nethermind.TxPool;
 
 namespace Nethermind.Consensus.Validators;
@@ -22,7 +23,16 @@ public sealed class SpecChangeTxValidator(ulong chainId) :
     private static readonly HeadTxValidator LightTxValidator = new();
 
     public string PersistenceFingerprint { get; } =
-        FormattableString.Invariant($"1|{typeof(SpecChangeTxValidator).Module.ModuleVersionId:N}|{chainId}");
+        FormattableString.Invariant($"2|{typeof(SpecChangeTxValidator).Module.ModuleVersionId:N}|{typeof(EthereumGasPolicy).Module.ModuleVersionId:N}|{chainId}");
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// This follows a successful <see cref="TxValidator"/> pass with blob proofs skipped. That pass already covers
+    /// every rule in this validator, including blob count. Chain-specific validators only need to override this
+    /// when a registered transaction type bypasses part of the full validator.
+    /// </remarks>
+    public ValidationResult IsWellFormedAfterFullValidation(Transaction transaction, IReleaseSpec releaseSpec) =>
+        ValidationResult.Success;
 
     public ValidationResult IsWellFormedLight(LightTransaction transaction, IReleaseSpec releaseSpec) =>
         LightTxValidator.IsWellFormed(transaction, releaseSpec);

--- a/src/Nethermind/Nethermind.Db/MetadataDbKeys.cs
+++ b/src/Nethermind/Nethermind.Db/MetadataDbKeys.cs
@@ -28,5 +28,6 @@ namespace Nethermind.Db
         public const int HistoryPruningSliceCleanupCursor = 21;
         public const int RetiredHistorySliceLogsRetainedFrom = 22;
         public const int RetiredHistorySliceLogsSliceSet = 23;
+        public const int AncientBodiesDownloadComplete = 24;
     }
 }

--- a/src/Nethermind/Nethermind.Facade.Test/LogIndexBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Facade.Test/LogIndexBuilderTests.cs
@@ -2,20 +2,25 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Synchronization;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Events;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Db;
 using Nethermind.Db.LogIndex;
 using Nethermind.Facade.Find;
+using Nethermind.History;
 using Nethermind.Logging;
 using NSubstitute;
 using NUnit.Framework;
@@ -57,7 +62,7 @@ public class LogIndexBuilderTests
 
         public string GetDbSize() => 0L.SizeToString();
 
-        public LogIndexAggregate Aggregate(IReadOnlyList<BlockReceipts> batch, bool isBackwardSync, LogIndexUpdateStats? stats = null) =>
+        public virtual LogIndexAggregate Aggregate(IReadOnlyList<BlockReceipts> batch, bool isBackwardSync, LogIndexUpdateStats? stats = null) =>
             new(batch);
 
         public virtual Task AddReceiptsAsync(LogIndexAggregate aggregate, LogIndexUpdateStats? stats = null)
@@ -102,6 +107,33 @@ public class LogIndexBuilderTests
         public Task StopAsync() => Task.CompletedTask;
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private class RecordingLogIndexStorage : TestLogIndexStorage
+    {
+        private readonly ConcurrentDictionary<int, int> _receiptCounts = new();
+
+        public int ReceiptCountAt(int blockNumber) => _receiptCounts.TryGetValue(blockNumber, out int count) ? count : -1;
+
+        public override LogIndexAggregate Aggregate(IReadOnlyList<BlockReceipts> batch, bool isBackwardSync, LogIndexUpdateStats? stats = null)
+        {
+            foreach (BlockReceipts blockReceipts in batch)
+                _receiptCounts[blockReceipts.BlockNumber] = blockReceipts.Receipts.Length;
+            return base.Aggregate(batch, isBackwardSync, stats);
+        }
+    }
+
+    private sealed class GatedLogIndexStorage : RecordingLogIndexStorage
+    {
+        public TaskCompletionSource Gate { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int GateAtOrBelow { get; init; } = int.MinValue;
+
+        public override async Task AddReceiptsAsync(LogIndexAggregate aggregate, LogIndexUpdateStats? stats = null)
+        {
+            if (Math.Min(aggregate.FirstBlockNum, aggregate.LastBlockNum) <= GateAtOrBelow)
+                await Gate.Task;
+            await base.AddReceiptsAsync(aggregate, stats);
+        }
     }
 
     private class FailingLogIndexStorage(int failAfter, Exception exception) : TestLogIndexStorage
@@ -156,9 +188,32 @@ public class LogIndexBuilderTests
         }
     }
 
-    private LogIndexBuilder GetService(ILogIndexStorage logIndexStorage, IBlockTree? blockTree = null) => new LogIndexBuilder(
-            logIndexStorage, _config, blockTree ?? _blockTree, _syncConfig, _receiptStorage, _logManager
-        ).AddTo(_testDisposables);
+    private LogIndexBuilder GetService(ILogIndexStorage logIndexStorage, IBlockTree? blockTree = null, IFlatDbConfig? flatDbConfig = null, IPrunedLogsRetention? prunedLogsRetention = null, ISyncPointers? syncPointers = null, int stallTicksBeforeGivingUp = 1440) => new LogIndexBuilder(
+            logIndexStorage, _config, blockTree ?? _blockTree, _syncConfig, _receiptStorage, _logManager, flatDbConfig, prunedLogsRetention, syncPointers
+        )
+    { StallTicksBeforeGivingUp = stallTicksBeforeGivingUp }.AddTo(_testDisposables);
+
+    [TestCase(0UL, 12UL, 1440)]
+    [TestCase(8UL, 12UL, 1843)]
+    [TestCase(40UL, 12UL, 9216)]
+    [TestCase(40UL, 2UL, 1536)]
+    public void Stall_deadline_scales_with_the_pruning_interval_and_slot_time(ulong pruningInterval, ulong secondsPerSlot, int expectedTicks)
+    {
+        LogIndexBuilder builder = new(
+            Substitute.For<ILogIndexStorage>(), _config, _blockTree, _syncConfig, _receiptStorage, _logManager,
+            historyConfig: new HistoryConfig { PruningInterval = pruningInterval },
+            blocksConfig: new BlocksConfig { SecondsPerSlot = secondsPerSlot });
+        builder.AddTo(_testDisposables);
+
+        Assert.That(builder.StallTicksBeforeGivingUp, Is.EqualTo(expectedTicks));
+    }
+
+    private static ISyncPointers DownloadedToTheBarrier()
+    {
+        ISyncPointers pointers = Substitute.For<ISyncPointers>();
+        pointers.LowestInsertedBodyNumber.Returns(1UL);
+        return pointers;
+    }
 
     [Test]
     [CancelAfter(60_000)]
@@ -284,6 +339,361 @@ public class LogIndexBuilderTests
             Assert.That(builder.LastError, Is.Null);
             Assert.That(storage.MinBlockNumber, Is.EqualTo(oldestStored),
                 "receipts below the oldest stored block are pruned, not late - the backward sync must complete there rather than poll forever");
+        }
+    }
+
+    [Test]
+    [CancelAfter(60_000)]
+    public async Task Should_ContinueBackwardSyncThroughRetainedIslands_BelowTheOldestStoredBlock_WhenSlicesAreConfigured(CancellationToken cancellation)
+    {
+        const int oldestStored = 50;
+        const int islandLow = 20;
+        const int islandHigh = 21;
+        _syncConfig.AncientReceiptsBarrier = 1;
+
+        IBlockTree realTree = _blockTree;
+        IBlockTree prunedTree = Substitute.For<IBlockTree>();
+        prunedTree.SyncPivot.Returns(realTree.SyncPivot);
+        prunedTree.BestKnownNumber.Returns(realTree.BestKnownNumber);
+        prunedTree.GetLowestBlock().Returns((ulong)oldestStored);
+        prunedTree
+            .FindBlock(Arg.Any<ulong>(), Arg.Any<BlockTreeLookupOptions>())
+            .Returns(ci =>
+            {
+                ulong number = ci.ArgAt<ulong>(0);
+                if (number is islandLow or islandHigh)
+                    return Build.A.Block.WithNumber(number).WithTransactions(Build.A.Transaction.TestObject).TestObject;
+
+                bool pruned = number < oldestStored;
+                return pruned ? null : realTree.FindBlock(number, ci.ArgAt<BlockTreeLookupOptions>(1));
+            });
+        _receiptStorage
+            .Get(Arg.Is<Block>(b => b.Number == islandLow || b.Number == islandHigh))
+            .Returns([new TxReceipt()]);
+
+        RecordingLogIndexStorage storage = new();
+        LogIndexBuilder builder = GetService(
+            storage,
+            prunedTree,
+            new FlatDbConfig { HistorySliceAddresses = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
+            Substitute.For<IPrunedLogsRetention>(),
+            DownloadedToTheBarrier());
+
+        Task completion = WaitMinBlockAsync(storage, 0, cancellation);
+        await builder.StartAsync();
+        await completion;
+        await builder.BackwardSyncCompletion.WaitAsync(cancellation);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(builder.LastError, Is.Null);
+            Assert.That(storage.MinBlockNumber, Is.EqualTo(0),
+                "a sliced node keeps receipt islands below the pruned boundary, so the backward sync must descend past the boundary and index them instead of completing there");
+            Assert.That(storage.ReceiptCountAt(islandLow), Is.EqualTo(1),
+                "the island's real receipts must reach the index - fabricating an empty entry for a retained height serves a lie at match cost");
+            Assert.That(storage.ReceiptCountAt(islandHigh), Is.EqualTo(1));
+            Assert.That(storage.ReceiptCountAt(islandLow - 1), Is.Zero);
+            Assert.That(storage.ReceiptCountAt(islandHigh + 1), Is.Zero);
+        }
+    }
+
+    [Test]
+    [CancelAfter(60_000)]
+    public async Task Should_WaitInsteadOfCompletingOrFabricating_WhenABelowBoundaryHeightHasABodyButNoReceipts(CancellationToken cancellation)
+    {
+        const int oldestStored = 50;
+        const int stalledHeight = 30;
+        _syncConfig.AncientReceiptsBarrier = 1;
+
+        IBlockTree realTree = _blockTree;
+        IBlockTree prunedTree = Substitute.For<IBlockTree>();
+        prunedTree.SyncPivot.Returns(realTree.SyncPivot);
+        prunedTree.BestKnownNumber.Returns(realTree.BestKnownNumber);
+        prunedTree.GetLowestBlock().Returns((ulong)oldestStored);
+        prunedTree
+            .FindBlock(Arg.Any<ulong>(), Arg.Any<BlockTreeLookupOptions>())
+            .Returns(ci =>
+            {
+                ulong number = ci.ArgAt<ulong>(0);
+                if (number is stalledHeight)
+                    return Build.A.Block.WithNumber(number).WithTransactions(Build.A.Transaction.TestObject).TestObject;
+
+                bool pruned = number < oldestStored;
+                return pruned ? null : realTree.FindBlock(number, ci.ArgAt<BlockTreeLookupOptions>(1));
+            });
+
+        bool reclaimed = false;
+        _receiptStorage
+            .Get(Arg.Is<Block>(b => b.Number == stalledHeight))
+            .Returns(_ => Volatile.Read(ref reclaimed) ? [new TxReceipt()] : []);
+
+        RecordingLogIndexStorage storage = new();
+        LogIndexBuilder builder = GetService(
+            storage,
+            prunedTree,
+            new FlatDbConfig { HistorySliceAddresses = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
+            Substitute.For<IPrunedLogsRetention>(),
+            DownloadedToTheBarrier());
+
+        Task stalled = WaitMinBlockAsync(storage, stalledHeight + 1, cancellation);
+        await builder.StartAsync();
+        await stalled;
+
+        Assert.That(builder.BackwardSyncCompletion.IsCompleted, Is.False,
+            "a below-boundary height with a body but no readable receipts is either mid-reclaim or a retained height that lost its data - the descent must wait, not complete and not fabricate an empty entry");
+
+        Volatile.Write(ref reclaimed, true);
+
+        Task completion = WaitMinBlockAsync(storage, 0, cancellation);
+        await completion;
+        await builder.BackwardSyncCompletion.WaitAsync(cancellation);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(builder.LastError, Is.Null);
+            Assert.That(storage.MinBlockNumber, Is.EqualTo(0));
+            Assert.That(storage.ReceiptCountAt(stalledHeight), Is.EqualTo(1));
+        }
+    }
+
+    [Test]
+    [CancelAfter(60_000)]
+    public async Task Should_StopTheSlicedDescentAtTheLowestDownloadedBody_InsteadOfFabricatingToTheBarrier(CancellationToken cancellation)
+    {
+        const int oldestStored = 50;
+        const int lowestDownloadedBody = 30;
+        _syncConfig.AncientReceiptsBarrier = 1;
+
+        IBlockTree realTree = _blockTree;
+        IBlockTree prunedTree = Substitute.For<IBlockTree>();
+        prunedTree.SyncPivot.Returns(realTree.SyncPivot);
+        prunedTree.BestKnownNumber.Returns(realTree.BestKnownNumber);
+        prunedTree.GetLowestBlock().Returns((ulong)oldestStored);
+        prunedTree
+            .FindBlock(Arg.Any<ulong>(), Arg.Any<BlockTreeLookupOptions>())
+            .Returns(ci =>
+            {
+                ulong number = ci.ArgAt<ulong>(0);
+                return number < oldestStored ? null : realTree.FindBlock(number, ci.ArgAt<BlockTreeLookupOptions>(1));
+            });
+        ISyncPointers pointers = Substitute.For<ISyncPointers>();
+        pointers.LowestInsertedBodyNumber.Returns((ulong)lowestDownloadedBody);
+
+        RecordingLogIndexStorage storage = new();
+        LogIndexBuilder builder = GetService(
+            storage,
+            prunedTree,
+            new FlatDbConfig { HistorySliceAddresses = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
+            Substitute.For<IPrunedLogsRetention>(),
+            pointers);
+
+        Task completion = WaitMinBlockAsync(storage, lowestDownloadedBody, cancellation);
+        await builder.StartAsync();
+        await completion;
+        await builder.BackwardSyncCompletion.WaitAsync(cancellation);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(builder.LastError, Is.Null);
+            Assert.That(storage.MinBlockNumber, Is.EqualTo(lowestDownloadedBody),
+                "nothing below the lowest downloaded body can be a retained island, so the descent must stop there instead of fabricating to the barrier");
+            Assert.That(storage.ReceiptCountAt(lowestDownloadedBody - 1), Is.EqualTo(-1));
+        }
+    }
+
+    [Test]
+    [CancelAfter(60_000)]
+    public async Task Should_NotCompleteAtTheMovingDownloadFrontier_WhileThePrunerHoldsTheBoundary(CancellationToken cancellation)
+    {
+        const int firstFrontier = 40;
+        const int secondFrontier = 30;
+        _syncConfig.AncientReceiptsBarrier = 1;
+
+        int frontier = firstFrontier;
+        int publishedBoundary = 1;
+        IBlockTree realTree = _blockTree;
+        IBlockTree downloadingTree = Substitute.For<IBlockTree>();
+        downloadingTree.SyncPivot.Returns(realTree.SyncPivot);
+        downloadingTree.BestKnownNumber.Returns(realTree.BestKnownNumber);
+        downloadingTree.GetLowestBlock().Returns(_ => (ulong)Volatile.Read(ref publishedBoundary));
+        downloadingTree
+            .FindBlock(Arg.Any<ulong>(), Arg.Any<BlockTreeLookupOptions>())
+            .Returns(ci =>
+            {
+                ulong number = ci.ArgAt<ulong>(0);
+                return number >= (ulong)Volatile.Read(ref frontier)
+                    ? realTree.FindBlock(number, ci.ArgAt<BlockTreeLookupOptions>(1))
+                    : null;
+            });
+        ISyncPointers pointers = Substitute.For<ISyncPointers>();
+        pointers.LowestInsertedBodyNumber.Returns(_ => (ulong)Volatile.Read(ref frontier));
+
+        RecordingLogIndexStorage storage = new();
+        LogIndexBuilder builder = GetService(
+            storage,
+            downloadingTree,
+            new FlatDbConfig { HistorySliceAddresses = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
+            Substitute.For<IPrunedLogsRetention>(),
+            pointers);
+
+        Task firstStop = WaitMinBlockAsync(storage, firstFrontier, cancellation);
+        await builder.StartAsync();
+        await firstStop;
+
+        Assert.That(builder.BackwardSyncCompletion.IsCompleted, Is.False,
+            "the body pointer is a moving frontier while the pruner still holds the boundary at its barrier - the descent must wait there, not declare itself complete");
+
+        Volatile.Write(ref frontier, secondFrontier);
+
+        await WaitMinBlockAsync(storage, secondFrontier, cancellation);
+
+        Assert.That(builder.BackwardSyncCompletion.IsCompleted, Is.False);
+
+        Volatile.Write(ref publishedBoundary, secondFrontier);
+
+        await builder.BackwardSyncCompletion.WaitAsync(cancellation);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(builder.LastError, Is.Null);
+            Assert.That(storage.MinBlockNumber, Is.EqualTo(secondFrontier),
+                "once the pruner publishes the boundary at the parked frontier, the risen floor must complete the descent instead of leaving it polling forever");
+        }
+    }
+
+    [Test]
+    [CancelAfter(60_000)]
+    public async Task Should_CompleteTheBackwardSync_WhenTheFloorDropsAfterTheExit(CancellationToken cancellation)
+    {
+        const int latchedBoundary = 60;
+        const int firstFrontier = 30;
+        const int droppedFrontier = 10;
+        _syncConfig.AncientReceiptsBarrier = 1;
+
+        int frontier = firstFrontier;
+        IBlockTree realTree = _blockTree;
+        IBlockTree latchedTree = Substitute.For<IBlockTree>();
+        latchedTree.SyncPivot.Returns(realTree.SyncPivot);
+        latchedTree.BestKnownNumber.Returns(realTree.BestKnownNumber);
+        latchedTree.GetLowestBlock().Returns((ulong)latchedBoundary);
+        latchedTree
+            .FindBlock(Arg.Any<ulong>(), Arg.Any<BlockTreeLookupOptions>())
+            .Returns(ci =>
+            {
+                ulong number = ci.ArgAt<ulong>(0);
+                return number >= (ulong)Volatile.Read(ref frontier)
+                    ? realTree.FindBlock(number, ci.ArgAt<BlockTreeLookupOptions>(1))
+                    : null;
+            });
+        ISyncPointers pointers = Substitute.For<ISyncPointers>();
+        pointers.LowestInsertedBodyNumber.Returns(_ => (ulong)Volatile.Read(ref frontier));
+
+        GatedLogIndexStorage storage = new() { GateAtOrBelow = firstFrontier };
+        LogIndexBuilder builder = GetService(
+            storage,
+            latchedTree,
+            new FlatDbConfig { HistorySliceAddresses = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
+            Substitute.For<IPrunedLogsRetention>(),
+            pointers);
+
+        await builder.StartAsync();
+        while (builder.BackwardExitFloor != firstFrontier)
+            await Task.Delay(10, cancellation);
+
+        Volatile.Write(ref frontier, droppedFrontier);
+        storage.Gate.SetResult();
+
+        await builder.BackwardSyncCompletion.WaitAsync(cancellation);
+
+        Assert.That(storage.MinBlockNumber, Is.EqualTo(firstFrontier),
+            "the completion fires against the floor the exit recorded, not the floor that dropped after it");
+    }
+
+    [Test]
+    [CancelAfter(60_000)]
+    public async Task Should_NotFabricateOverNeverDownloadedHeights_WhenTheBodyPointerWasNeverWritten(CancellationToken cancellation)
+    {
+        const int oldestStored = 50;
+        _syncConfig.AncientReceiptsBarrier = 1;
+
+        IBlockTree realTree = _blockTree;
+        IBlockTree prunedTree = Substitute.For<IBlockTree>();
+        prunedTree.SyncPivot.Returns(realTree.SyncPivot);
+        prunedTree.BestKnownNumber.Returns(realTree.BestKnownNumber);
+        prunedTree.GetLowestBlock().Returns((ulong)oldestStored);
+        prunedTree
+            .FindBlock(Arg.Any<ulong>(), Arg.Any<BlockTreeLookupOptions>())
+            .Returns(ci =>
+            {
+                ulong number = ci.ArgAt<ulong>(0);
+                return number < oldestStored ? null : realTree.FindBlock(number, ci.ArgAt<BlockTreeLookupOptions>(1));
+            });
+
+        RecordingLogIndexStorage storage = new();
+        LogIndexBuilder builder = GetService(
+            storage,
+            prunedTree,
+            new FlatDbConfig { HistorySliceAddresses = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
+            Substitute.For<IPrunedLogsRetention>(),
+            Substitute.For<ISyncPointers>());
+
+        Task completion = WaitMinBlockAsync(storage, oldestStored, cancellation);
+        await builder.StartAsync();
+        await completion;
+        await builder.BackwardSyncCompletion.WaitAsync(cancellation);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(builder.LastError, Is.Null);
+            Assert.That(storage.MinBlockNumber, Is.EqualTo(oldestStored),
+                "an unwritten body pointer on a fast-synced node means nothing below the pivot was ever downloaded - heights below the boundary are undownloaded, not reclaimed, and must not be fabricated");
+            Assert.That(storage.ReceiptCountAt(oldestStored - 1), Is.EqualTo(-1));
+        }
+    }
+
+    [Test]
+    [CancelAfter(60_000)]
+    public async Task Should_GiveUpTheDescentAlone_WhenABelowBoundaryHeightNeverYieldsItsReceipts(CancellationToken cancellation)
+    {
+        const int oldestStored = 50;
+        const int stalledHeight = 30;
+        _syncConfig.AncientReceiptsBarrier = 1;
+
+        IBlockTree realTree = _blockTree;
+        IBlockTree prunedTree = Substitute.For<IBlockTree>();
+        prunedTree.SyncPivot.Returns(realTree.SyncPivot);
+        prunedTree.BestKnownNumber.Returns(realTree.BestKnownNumber);
+        prunedTree.GetLowestBlock().Returns((ulong)oldestStored);
+        prunedTree
+            .FindBlock(Arg.Any<ulong>(), Arg.Any<BlockTreeLookupOptions>())
+            .Returns(ci =>
+            {
+                ulong number = ci.ArgAt<ulong>(0);
+                if (number is stalledHeight)
+                    return Build.A.Block.WithNumber(number).WithTransactions(Build.A.Transaction.TestObject).TestObject;
+
+                bool pruned = number < oldestStored;
+                return pruned ? null : realTree.FindBlock(number, ci.ArgAt<BlockTreeLookupOptions>(1));
+            });
+
+        RecordingLogIndexStorage storage = new();
+        LogIndexBuilder builder = GetService(
+            storage,
+            prunedTree,
+            new FlatDbConfig { HistorySliceAddresses = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" },
+            Substitute.For<IPrunedLogsRetention>(),
+            DownloadedToTheBarrier(),
+            stallTicksBeforeGivingUp: 2);
+
+        await builder.StartAsync();
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => builder.BackwardSyncCompletion.WaitAsync(cancellation),
+            "a height that never yields its receipts must end the descent in a hard error, not an invisible infinite poll");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(builder.LastError, Is.InstanceOf<InvalidOperationException>());
+            Assert.That(builder.IsRunning, Is.True,
+                "the give-up is scoped to the backward direction - the live forward index must keep running");
         }
     }
 

--- a/src/Nethermind/Nethermind.Facade/Filters/LogIndexFilterVisitor.cs
+++ b/src/Nethermind/Nethermind.Facade/Filters/LogIndexFilterVisitor.cs
@@ -12,6 +12,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Db.LogIndex;
 
 [assembly: InternalsVisibleTo("Nethermind.Blockchain.Test")]
+[assembly: InternalsVisibleTo("Nethermind.Facade.Test")]
 
 namespace Nethermind.Facade.Filters;
 

--- a/src/Nethermind/Nethermind.Facade/Find/IndexedLogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Find/IndexedLogFinder.cs
@@ -10,6 +10,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Core;
 using Nethermind.Db.LogIndex;
+using Nethermind.History;
 using Nethermind.Logging;
 using Autofac.Features.AttributeFilters;
 
@@ -29,10 +30,14 @@ public class IndexedLogFinder(
     ILogIndexStorage logIndexStorage,
     int minBlocksToUseIndex = 32,
     IReceiptConfig? receiptConfig = null,
-    IPrunedLogsRetention? prunedLogsRetention = null)
+    IPrunedLogsRetention? prunedLogsRetention = null,
+    IHistoryPruner? historyPruner = null)
     : LogFinder(blockFinder, receiptFinder, receiptStorage, logManager, receiptsRecovery, receiptConfig, prunedLogsRetention)
 {
     private readonly ILogIndexStorage _logIndexStorage = logIndexStorage ?? throw new ArgumentNullException(nameof(logIndexStorage));
+    // CS9107: a primary-ctor parameter that also flows to the base ctor cannot be used in a method body.
+    private readonly IBlockFinder _blockFinder = blockFinder;
+    private readonly IHistoryPruner? _historyPruner = historyPruner;
 
     public override IEnumerable<FilterLog> FindLogs(LogFilter filter, BlockHeader fromBlock, BlockHeader toBlock, CancellationToken cancellationToken = default) =>
         GetLogIndexRange(filter, fromBlock, toBlock) is not { } indexRange
@@ -78,10 +83,31 @@ public class IndexedLogFinder(
         if (_logIndexStorage.MinBlockNumber is not { } indexFrom || _logIndexStorage.MaxBlockNumber is not { } indexTo)
             return null;
 
+        // Rejected eagerly once the index is in play: the endpoint probe only sees the two endpoint headers,
+        // so it cannot notice reclaimed receipts in the interior. Keyed on the reclaim cursor, not the
+        // published boundary - the boundary jumps ahead of the physical reclaim by design, and everything
+        // between the two is declared absent but still readable, so refusing it would fail closed over data
+        // that is on disk for the months the reclaim takes. Genesis carries no receipts on any chain, so a
+        // query confined to it (or reaching below on a never-pruned node) has nothing to lose. A topic-only
+        // filter is held to this too - retention can never vouch for it, and a sliced index holds fabricated
+        // empties below the reclaimed line, so answering it from the index would be silently short.
+        ulong lowestStored = _historyPruner?.OldestUnreclaimedBlockNumber ?? _blockFinder.GetLowestBlock();
+        bool uncoveredBelowBoundary = fromBlock.Number < lowestStored
+            && !RetainsLogsForFilter(filter, fromBlock.Number, toBlock.Number);
+        if (uncoveredBelowBoundary && fromBlock.Number <= toBlock.Number && toBlock.Number != 0 && (fromBlock.Number != 0 || lowestStored != 1))
+        {
+            filter.UseIndex = tryUseIndex;
+            throw new ResourceNotFoundException($"Receipt not available for From block {fromBlock.Number}.");
+        }
+
         (int from, int to) range = (
             Math.Max((int)fromBlock.Number, indexFrom),
             Math.Min((int)toBlock.Number, indexTo)
         );
+
+        // Only the genesis carve-out reaches here uncovered; lift block 0 out of the index range.
+        if (uncoveredBelowBoundary && range.from == 0)
+            range.from = 1;
 
         if (range.from > range.to)
             return null;

--- a/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
+++ b/src/Nethermind/Nethermind.Facade/Find/LogFinder.cs
@@ -87,7 +87,7 @@ namespace Nethermind.Facade.Find
             return FilterLogsIteratively(filter, fromBlock, toBlock, cancellationToken);
         }
 
-        private bool RetainsLogsForFilter(LogFilter filter, ulong fromBlock, ulong toBlock) =>
+        protected bool RetainsLogsForFilter(LogFilter filter, ulong fromBlock, ulong toBlock) =>
             prunedLogsRetention is not null
             && filter.AddressFilter.Addresses.Count != 0
             && prunedLogsRetention.RetainsLogsFor(filter.AddressFilter.Addresses, fromBlock, toBlock);

--- a/src/Nethermind/Nethermind.Facade/Find/LogIndexBuilder.cs
+++ b/src/Nethermind/Nethermind.Facade/Find/LogIndexBuilder.cs
@@ -11,8 +11,12 @@ using System.Threading.Tasks.Dataflow;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
+using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Synchronization;
+using Nethermind.Db;
 using Nethermind.Db.LogIndex;
+using Nethermind.History;
 using Nethermind.Logging;
 using Timer = System.Timers.Timer;
 using static System.Threading.Tasks.TaskCreationOptions;
@@ -70,6 +74,16 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
     private ref DirectionState Direction(bool isForward) => ref _directions[isForward ? 1 : 0];
 
     private LogIndexUpdateStats _stats;
+    private readonly bool _indexRetainedSlices;
+    private readonly ISyncPointers? _syncPointers;
+    // Three pruning intervals, floored at two hours: the next pruning pass is what clears the
+    // receipts-reclaimed/body-not-yet transient this stall waits on, and the interval is operator-tunable.
+    internal int StallTicksBeforeGivingUp { get; init; }
+    private int _stalledBelowBoundary = -1;
+    private volatile int _backwardExitFloor = -1;
+    internal int BackwardExitFloor => _backwardExitFloor;
+    private int _stallTicks;
+    private bool _stallWarned;
 
     public string Description => "log index builder";
 
@@ -77,7 +91,8 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
 
     public LogIndexBuilder(ILogIndexStorage logIndexStorage, ILogIndexConfig config,
         IBlockTree blockTree, ISyncConfig syncConfig, IReceiptStorage receiptStorage,
-        ILogManager logManager)
+        ILogManager logManager, IFlatDbConfig? flatDbConfig = null, IPrunedLogsRetention? prunedLogsRetention = null,
+        ISyncPointers? syncPointers = null, IHistoryConfig? historyConfig = null, IBlocksConfig? blocksConfig = null)
     {
         ArgumentNullException.ThrowIfNull(logIndexStorage);
         ArgumentNullException.ThrowIfNull(blockTree);
@@ -92,6 +107,12 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
         _receiptStorage = receiptStorage;
         _logManager = logManager;
         _logger = logManager.GetClassLogger<LogIndexBuilder>();
+        bool slicesConfigured = prunedLogsRetention is not null && SliceScopeConfig.Parse(flatDbConfig?.HistorySliceAddresses).Count != 0;
+        _indexRetainedSlices = slicesConfigured && syncPointers is not null;
+        _syncPointers = syncPointers;
+        if (slicesConfigured && syncPointers is null && _logger.IsWarn)
+            _logger.Warn("History slices are configured but sync pointers are unavailable - the below-boundary log index descent is disabled.");
+        StallTicksBeforeGivingUp = StallDeadlineTicks(historyConfig, blocksConfig);
         _pivotTask = _pivotSource.Task;
         _stats = new(_logIndexStorage);
 
@@ -99,11 +120,22 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
         Direction(isForward: true) = new();
     }
 
+    private static int StallDeadlineTicks(IHistoryConfig? historyConfig, IBlocksConfig? blocksConfig)
+    {
+        const ulong FloorTicks = 1440;
+        const ulong SlotsPerEpoch = 32;
+        ulong secondsPerSlot = ulong.Max(blocksConfig?.SecondsPerSlot ?? 12, 1);
+        ulong overflowCeiling = ulong.MaxValue / (SlotsPerEpoch * secondsPerSlot * 3);
+        ulong intervalEpochs = ulong.Min(historyConfig?.PruningInterval ?? 0, overflowCeiling);
+        ulong deadline = intervalEpochs * SlotsPerEpoch * secondsPerSlot * 3 / (ulong)NewBlockWaitTimeout.TotalSeconds;
+        return (int)ulong.Min(ulong.Max(FloorTicks, deadline), int.MaxValue);
+    }
+
     private void StartProcessing(bool isForward)
     {
         // Skip backward sync if storage already reached the target. Null MinBlockNumber
         // means nothing indexed yet — must not skip.
-        if (!isForward && _logIndexStorage.MinBlockNumber is { } minStored && (ulong)minStored <= MinTargetBlockNumber)
+        if (!isForward && _logIndexStorage.MinBlockNumber is { } minStored && (ulong)minStored <= BackwardTargetBlockNumber)
         {
             MarkCompleted(false);
             return;
@@ -231,7 +263,7 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
         if (number is 0)
             return false;
 
-        if (!TryGetBlockReceipts(number, out _))
+        if (!TryGetBlockReceipts(number, out _, fabricateReclaimed: false))
             return false;
 
         if (!_pivotSource.TrySetResult(number))
@@ -255,6 +287,27 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
     public ulong MinTargetBlockNumber => _syncConfig.AncientReceiptsBarrierCalc <= 1
         ? 0UL
         : _syncConfig.AncientReceiptsBarrierCalc;
+
+    // Nothing below the lowest body the node ever downloaded can be a retained island, so the sliced
+    // descent stops there instead of fabricating down to the barrier. Clamped by the published boundary:
+    // while the ancient feeds are still descending the pointer is a moving frontier, and the pruner holds
+    // the boundary at its initial barrier until the backfill is done, so the floor is inert until then.
+    private ulong BackwardTargetBlockNumber => _indexRetainedSlices
+        ? ulong.Max(MinTargetBlockNumber, ulong.Min(LowestDownloadedBody, _blockTree.GetLowestBlock()))
+        : MinTargetBlockNumber;
+
+    // An absent pointer means no ancient body was ever inserted: on a fast-synced node the pivot is the floor,
+    // on a full-sync node everything was downloaded and the floor is genesis. The tree pivot rises to the
+    // finalized head on a running node - the boundary clamp above is what turns that into stop-at-the-boundary.
+    // A pointer at the barrier means everything above genesis was downloaded, and block 0 is always present.
+    private ulong LowestDownloadedBody
+    {
+        get
+        {
+            ulong lowest = _syncPointers?.LowestInsertedBodyNumber ?? (_syncConfig.FastSync ? _blockTree.SyncPivot.BlockNumber : 0UL);
+            return lowest <= 1 ? 0UL : lowest;
+        }
+    }
 
     public bool IsRunning { get; private set; }
     public DateTimeOffset? LastUpdate { get; private set; }
@@ -328,7 +381,7 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
 
         UpdateProgress();
 
-        if (_logIndexStorage.MinBlockNumber <= (int)MinTargetBlockNumber)
+        if (_logIndexStorage.MinBlockNumber <= Math.Max((int)BackwardTargetBlockNumber, _backwardExitFloor))
             MarkCompleted(false);
     }
 
@@ -345,17 +398,28 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
             BlockReceipts[] buffer = new BlockReceipts[_config.MaxBatchSize];
             while (!CancellationToken.IsCancellationRequested)
             {
-                if (!isForward && start < (int)MinTargetBlockNumber)
+                // One read per iteration: the exit decision, the recorded floor and the completion test must
+                // all see the same value, or a drop between two reads of the moving property re-opens the hang.
+                int backwardFloor = isForward ? 0 : (int)BackwardTargetBlockNumber;
+                if (!isForward && start < backwardFloor)
                 {
                     if (_logger.IsTrace)
                         _logger.Trace($"{GetLogPrefix(isForward)}: queued last block");
 
+                    // The floor can rise when the pruner publishes; a batch checked against the old floor never
+                    // fires the completion, so the exit marks it too - but only once storage has caught up, so a
+                    // still-queued final batch fires it from AddReceiptsAsync instead of completing early. On a
+                    // latched-boundary database the floor can also DROP after this exit, so the floor it left
+                    // against is recorded for the still-queued batches - without it the completion never fires.
+                    _backwardExitFloor = backwardFloor;
+                    if (_logIndexStorage.MinBlockNumber <= backwardFloor)
+                        MarkCompleted(isForward: false);
                     return;
                 }
 
                 int batchSize = _config.MaxBatchSize;
                 int end = isForward ? start + batchSize - 1 : start - batchSize + 1;
-                end = Math.Max(end, (int)MinTargetBlockNumber);
+                end = Math.Max(end, (int)(isForward ? MinTargetBlockNumber : BackwardTargetBlockNumber));
                 end = Math.Min(end, (int)MaxTargetBlockNumber);
 
                 // from - inclusive, to - exclusive
@@ -372,10 +436,36 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
                     ulong lowestStored = _blockTree.GetLowestBlock();
                     if (!isForward && (ulong)start < lowestStored)
                     {
-                        if (_logger.IsDebug) _logger.Debug(
-                            $"{GetLogPrefix(isForward)}: stopping at block {start} - everything below the oldest stored block {lowestStored} is pruned, so its receipts are not late, they are gone.");
-                        MarkCompleted(isForward: false);
-                        return;
+                        if (!_indexRetainedSlices)
+                        {
+                            if (_logger.IsDebug) _logger.Debug(
+                                $"{GetLogPrefix(isForward)}: stopping at block {start} - everything below the oldest stored block {lowestStored} is pruned, so its receipts are not late, they are gone.");
+                            MarkCompleted(isForward: false);
+                            return;
+                        }
+
+                        if (start != _stalledBelowBoundary)
+                        {
+                            _stalledBelowBoundary = start;
+                            _stallTicks = 0;
+                        }
+                        else if (++_stallTicks >= StallTicksBeforeGivingUp)
+                        {
+                            // Fails only this direction: the live forward index keeps running.
+                            InvalidOperationException stall = new(
+                                $"{GetLogPrefix(isForward)}: block {start} below the oldest stored block {lowestStored} kept a body with no readable receipts for {StallTicksBeforeGivingUp} polls - a retained height lost its receipts, history pruning passes run less often than this deadline, or an ancient receipts backfill is still descending below a latched boundary.");
+                            if (_logger.IsError) _logger.Error($"{GetLogPrefix(isForward)}: giving up.", stall);
+                            LastError = stall;
+                            Direction(isForward: false).Completion.TrySetException(stall);
+                            Direction(isForward: false).Progress?.MarkEnd();
+                            return;
+                        }
+                        else if (!_stallWarned)
+                        {
+                            _stallWarned = true;
+                            if (_logger.IsWarn) _logger.Warn(
+                                $"{GetLogPrefix(isForward)}: block {start} below the oldest stored block {lowestStored} still has a body but no readable receipts - the descent is stalled until it is reclaimed.");
+                        }
                     }
 
                     // TODO: stop waiting immediately when receipts become available
@@ -384,6 +474,14 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
                 }
 
                 _stats.LoadingReceipts.Include(Stopwatch.GetElapsedTime(timestamp));
+
+                if (!isForward && _stallWarned)
+                {
+                    _stallWarned = false;
+                    if (_logger.IsInfo) _logger.Info(
+                        $"{GetLogPrefix(isForward)}: the descent moved past block {_stalledBelowBoundary}.");
+                    _stalledBelowBoundary = -1;
+                }
 
                 start = GetNextBlockNumber(batch[^1].BlockNumber, isForward);
                 await queue.WriteAsync(batch.ToArray(), CancellationToken);
@@ -419,8 +517,8 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
         ref DirectionState backward = ref Direction(isForward: false);
         if (backward.Progress is { HasEnded: false } backwardProgress)
         {
-            backwardProgress.TargetValue = pivotNumber >= MinTargetBlockNumber
-                ? pivotNumber - MinTargetBlockNumber
+            backwardProgress.TargetValue = pivotNumber >= BackwardTargetBlockNumber
+                ? pivotNumber - BackwardTargetBlockNumber
                 : 0UL;
             backwardProgress.Update(_logIndexStorage.MinBlockNumber is { } min && pivotNumber >= (ulong)min
                 ? pivotNumber - (ulong)min
@@ -475,12 +573,22 @@ public sealed class LogIndexBuilder : ILogIndexBuilder
     }
 
     // TODO: move to IReceiptStorage?
-    private bool TryGetBlockReceipts(ulong blockNumber, out BlockReceipts blockReceipts)
+    private bool TryGetBlockReceipts(ulong blockNumber, out BlockReceipts blockReceipts, bool fabricateReclaimed = true)
     {
         blockReceipts = default;
 
         if (_blockTree.FindBlock(blockNumber, BlockTreeLookupOptions.ExcludeTxHashes) is not { Hash: not null } block)
         {
+            // A height absent below the published boundary and above the lowest downloaded body was reclaimed -
+            // not late, not undownloaded - so an empty entry is the truth. A boundary persisted by an older
+            // release can over-report; healing it must invalidate the below-boundary index range first.
+            if (fabricateReclaimed && _indexRetainedSlices
+                && blockNumber < _blockTree.GetLowestBlock() && blockNumber >= BackwardTargetBlockNumber)
+            {
+                blockReceipts = new((int)blockNumber, []);
+                return true;
+            }
+
             return false;
         }
 

--- a/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
+++ b/src/Nethermind/Nethermind.Facade/Nethermind.Facade.csproj
@@ -13,6 +13,7 @@
     <ProjectReference Include="..\Nethermind.Consensus\Nethermind.Consensus.csproj" />
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />
+    <ProjectReference Include="..\Nethermind.History\Nethermind.History.csproj" />
     <ProjectReference Include="..\Nethermind.Synchronization\Nethermind.Synchronization.csproj" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -16,9 +16,11 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Blockchain;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
 using Nethermind.Specs;
@@ -300,6 +302,258 @@ public class HistoryPrunerTests
             Assert.Throws<HistoryPruner.HistoryPrunerException>(action);
         else
             Assert.DoesNotThrow(action);
+    }
+
+    [TestCase(null, false, TestName = "SetDeletePointerToOldestBlock_never_searches_while_no_body_was_inserted")]
+    [TestCase(7000UL, false, TestName = "SetDeletePointerToOldestBlock_holds_above_the_static_barrier")]
+    [TestCase(1UL, true, TestName = "SetDeletePointerToOldestBlock_releases_at_the_static_barrier")]
+    public void SetDeletePointerToOldestBlock_holds_while_the_ancient_bodies_feed_is_descending(ulong? bodyPointer, bool searches)
+    {
+        TestMemDb metadataDb = new();
+        if (bodyPointer is not null)
+            metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(bodyPointer.Value).Bytes);
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels);
+
+        for (int i = 0; i < 3; i++)
+        {
+            pruner.SetDeletePointerToOldestBlock();
+        }
+
+        if (searches)
+            chainLevels.Received().LoadLevel(Arg.Any<ulong>());
+        else
+            chainLevels.DidNotReceive().LoadLevel(Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void SetDeletePointerToOldestBlock_releases_when_the_feed_marked_its_backfill_complete()
+    {
+        TestMemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(7000UL).Bytes);
+        metadataDb.Set(MetadataDbKeys.AncientBodiesDownloadComplete, [1]);
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels);
+
+        pruner.SetDeletePointerToOldestBlock();
+        chainLevels.Received().LoadLevel(Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void SetDeletePointerToOldestBlock_releases_a_pointer_parked_at_the_barrier_the_feed_last_started_with()
+    {
+        TestMemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(5000UL).Bytes);
+        metadataDb.Set(MetadataDbKeys.BodiesBarrierWhenStarted, ((long)5000).ToBigEndianByteArrayWithoutLeadingZeros());
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels);
+
+        pruner.SetDeletePointerToOldestBlock();
+        chainLevels.Received().LoadLevel(Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void OldestUnreclaimedBlockNumber_reads_the_persisted_boundary_before_the_pointers_load()
+    {
+        TestMemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.HistoryPruningDeletePointer, Rlp.Encode(5_000_000UL).Bytes);
+        metadataDb.Set(MetadataDbKeys.HistoryPruningReclaimCursor, Rlp.Encode(4_000_000UL).Bytes);
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels);
+
+        Assert.That(pruner.OldestUnreclaimedBlockNumber, Is.EqualTo(4_000_000UL),
+            "before the pointers load, the persisted cursors are the truth, not the config barrier");
+    }
+
+    [Test]
+    public void OldestUnreclaimedBlockNumber_floors_at_the_configured_barrier_before_the_pointers_load()
+    {
+        TestMemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.HistoryPruningDeletePointer, Rlp.Encode(5_000UL).Bytes);
+        metadataDb.Set(MetadataDbKeys.HistoryPruningReclaimCursor, Rlp.Encode(4_000UL).Bytes);
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels, lowestBlock: 9_000UL);
+
+        Assert.That(pruner.OldestUnreclaimedBlockNumber, Is.EqualTo(9_000UL),
+            "a barrier raised above the persisted cursors refuses more than necessary, transiently");
+    }
+
+    [Test]
+    public void OldestUnreclaimedBlockNumber_is_the_configured_barrier_when_nothing_was_persisted()
+    {
+        TestMemDb metadataDb = new();
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels, lowestBlock: 9_000UL);
+
+        Assert.That(pruner.OldestUnreclaimedBlockNumber, Is.EqualTo(9_000UL),
+            "with no persisted state the barrier is the whole answer, matching a never-pruned node");
+    }
+
+    [Test]
+    public void SetDeletePointerToOldestBlock_holds_when_the_barrier_dropped_below_the_one_the_feed_last_started_with()
+    {
+        TestMemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(7000UL).Bytes);
+        metadataDb.Set(MetadataDbKeys.BodiesBarrierWhenStarted, ((long)7000).ToBigEndianByteArrayWithoutLeadingZeros());
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels);
+
+        Assert.That(pruner.SetDeletePointerToOldestBlock(), Is.False,
+            "a recorded barrier above the current one describes a finished descent the config since reopened");
+        chainLevels.DidNotReceive().LoadLevel(Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void SetDeletePointerToOldestBlock_never_releases_a_written_pointer_above_the_barrier_without_the_marker()
+    {
+        TestMemDb metadataDb = new();
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels);
+
+        for (ulong frontier = 9000; frontier > 8995; frontier--)
+        {
+            metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(frontier).Bytes);
+            Assert.That(pruner.SetDeletePointerToOldestBlock(), Is.False);
+            Assert.That(pruner.SetDeletePointerToOldestBlock(), Is.False,
+                "a written pointer above the static barrier must hold until the completion marker releases it");
+        }
+
+        chainLevels.DidNotReceive().LoadLevel(Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void SetDeletePointerToOldestBlock_releases_a_written_pointer_when_synchronization_is_disabled()
+    {
+        TestMemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(9000UL).Bytes);
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels, synchronizationEnabled: false);
+
+        pruner.SetDeletePointerToOldestBlock();
+
+        chainLevels.Received().LoadLevel(Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void A_frontier_frozen_by_disabled_synchronization_is_not_persisted_by_a_pruning_pass()
+    {
+        (HistoryPruner pruner, TestMemDb metadataDb, IPrunedReceiptRetention retention) = CreateFrontierFixture(synchronizationEnabled: false);
+
+        Assert.That(pruner.OldestBlockHeader?.Number, Is.EqualTo(9_000UL));
+        pruner.TryPruneHistory(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(metadataDb.KeyExists(MetadataDbKeys.HistoryPruningDeletePointer), Is.False,
+                "a frozen frontier must not reach disk through a pruning-path save");
+            Assert.That(metadataDb.KeyExists(MetadataDbKeys.HistoryPruningReclaimCursor), Is.False,
+                "the frontier-seeded reclaim cursor must not reach disk either");
+            Assert.That(metadataDb.KeyExists(MetadataDbKeys.HistoryPruningSliceCleanupCursor), Is.False,
+                "the first-save sentinel of the cleanup cursor is pinned on the frozen path too");
+            Assert.That(metadataDb.KeyExists(MetadataDbKeys.BlockAccessListPruningDeletePointer), Is.True,
+                "the pass itself persists normally");
+        }
+        retention.DidNotReceive().OnPruningPassStarting(Arg.Any<ulong>(), Arg.Any<ulong>(), Arg.Any<ulong>());
+    }
+
+    [Test]
+    public void A_discovered_boundary_is_persisted_by_a_pruning_pass_when_synchronization_is_enabled()
+    {
+        (HistoryPruner pruner, TestMemDb metadataDb, IPrunedReceiptRetention retention) = CreateFrontierFixture(synchronizationEnabled: true, markerPresent: true);
+
+        Assert.That(pruner.OldestBlockHeader?.Number, Is.EqualTo(9_000UL));
+        pruner.TryPruneHistory(CancellationToken.None);
+
+        Assert.That(metadataDb.KeyExists(MetadataDbKeys.HistoryPruningDeletePointer), Is.True,
+            "the suppression is scoped to the frozen path, not persistence outright");
+        retention.Received().OnPruningPassStarting(Arg.Any<ulong>(), Arg.Any<ulong>(), Arg.Any<ulong>());
+    }
+
+    private static (HistoryPruner Pruner, TestMemDb MetadataDb, IPrunedReceiptRetention Retention) CreateFrontierFixture(bool synchronizationEnabled, bool markerPresent = false)
+    {
+        TestMemDb metadataDb = new();
+        metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(9000UL).Bytes);
+        if (markerPresent)
+        {
+            metadataDb.Set(MetadataDbKeys.AncientBodiesDownloadComplete, [1]);
+        }
+        IDbProvider dbProvider = Substitute.For<IDbProvider>();
+        dbProvider.MetadataDb.Returns(metadataDb);
+        dbProvider.BlocksDb.Returns(new TestMemDb());
+        dbProvider.ReceiptsDb.GetColumnDb(Arg.Any<ReceiptsColumns>()).Returns(new TestMemDb());
+        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
+        Block oldest = Build.A.Block.WithNumber(9_000UL).TestObject;
+        chainLevels.LoadLevel(Arg.Is<ulong>(static n => n >= 9_000)).Returns(new ChainLevelInfo(true, new BlockInfo(oldest.Hash!, 0)));
+        IPrunedReceiptRetention retention = Substitute.For<IPrunedReceiptRetention>();
+
+        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels, synchronizationEnabled: synchronizationEnabled, oldestBlock: oldest, balRetentionEpochs: 1, retention: retention);
+        return (pruner, metadataDb, retention);
+    }
+
+    private static HistoryPruner CreateDetachedPruner(IDbProvider dbProvider, IChainLevelInfoRepository chainLevels, bool synchronizationEnabled = true, Block oldestBlock = null, uint balRetentionEpochs = 3533, IPrunedReceiptRetention retention = null, ulong lowestBlock = 0)
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.SyncPivot.Returns((10_000UL, Keccak.Zero));
+        blockTree.Head.Returns(Build.A.Block.WithNumber(10_000UL).TestObject);
+        blockTree.GetLowestBlock().Returns(lowestBlock);
+        if (oldestBlock is not null)
+        {
+            blockTree.FindBlock(Arg.Any<Hash256>(), Arg.Any<ulong?>()).Returns(oldestBlock);
+            blockTree.FindHeader(Arg.Any<ulong>(), Arg.Any<BlockTreeLookupOptions>()).Returns(oldestBlock.Header);
+        }
+
+        return new HistoryPruner(
+            blockTree,
+            Substitute.For<IReceiptStorage>(),
+            Substitute.For<IBlockAccessListStore>(),
+            new TestSpecProvider(new ReleaseSpec()),
+            chainLevels,
+            Substitute.For<IHeaderStore>(),
+            dbProvider,
+            new HistoryConfig { Pruning = PruningModes.Rolling, RetentionEpochs = 100, PruningInterval = 0, BalRetentionEpochs = balRetentionEpochs },
+            BlocksConfig,
+            new SyncConfig { FastSync = true, PivotNumber = 10_000, DownloadBodiesInFastSync = true, SynchronizationEnabled = synchronizationEnabled },
+            new ProcessExitSource(new()),
+            Substitute.For<IBackgroundTaskScheduler>(),
+            Substitute.For<IBlockProcessingQueue>(),
+            retention ?? NullPrunedReceiptRetention.Instance,
+            LimboLogs.Instance);
     }
 
     [TestCase(5u)]
@@ -769,6 +1023,7 @@ public class HistoryPrunerTests
         IBackgroundTaskScheduler scheduler = null)
     {
         BasicTestBlockchain bc = await BasicTestBlockchain.Create(BuildContainer(historyConfig, scheduler));
+        bc.Container.Resolve<IDbProvider>().MetadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(1UL).Bytes);
         blockHashes?.Add(bc.BlockTree.Head!.Hash!);
         for (int i = 0; i < blocks; i++)
         {

--- a/src/Nethermind/Nethermind.History/HistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/HistoryPruner.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BlockAccessLists;
@@ -45,6 +46,9 @@ public class HistoryPruner : IHistoryPruner
     private readonly IChainLevelInfoRepository _chainLevelInfoRepository;
     private readonly IHeaderStore _headerStore;
     private readonly IDb _metadataDb;
+    private readonly IDb _blocksDb;
+    private static readonly byte[] LegacyLowestInsertedBodyNumberKey = ((long)0).ToBigEndianByteArrayWithoutLeadingZeros();
+    private readonly ulong _persistedUnreclaimedFloor;
     private readonly IProcessExitSource _processExitSource;
     private readonly IBackgroundTaskScheduler _backgroundTaskScheduler;
     private readonly IHistoryConfig _historyConfig;
@@ -56,6 +60,13 @@ public class HistoryPruner : IHistoryPruner
     private readonly ulong _ancientBarrier;
     private readonly ulong _ancientReceiptsBarrier;
     private readonly bool _fastSync;
+    private readonly ISyncConfig _syncConfig;
+    private static readonly TimeSpan AncientHoldRelogInterval = TimeSpan.FromMinutes(10);
+    private const int AncientHoldStaticRelogsBeforeWarn = 3;
+    private long _ancientHoldLastLogged;
+    private ulong? _ancientHoldLastLoggedPointer;
+    private int _ancientHoldStaticRelogs;
+    private bool _frontierFrozen;
     private readonly IDb _defaultReceiptsColumn;
     private readonly ulong _minDeletableBlockNumber;
 
@@ -106,6 +117,7 @@ public class HistoryPruner : IHistoryPruner
         _chainLevelInfoRepository = chainLevelInfoRepository;
         _headerStore = headerStore;
         _metadataDb = dbProvider.MetadataDb;
+        _blocksDb = dbProvider.BlocksDb;
         _processExitSource = processExitSource;
         _backgroundTaskScheduler = backgroundTaskScheduler;
         _historyConfig = historyConfig;
@@ -116,8 +128,15 @@ public class HistoryPruner : IHistoryPruner
         _minBalRetentionEpochs = specProvider.GenesisSpec.MinBalRetentionEpochs;
         _ancientReceiptsBarrier = syncConfig.AncientReceiptsBarrierCalc;
         _fastSync = syncConfig.FastSync;
+        _syncConfig = syncConfig;
         _defaultReceiptsColumn = dbProvider.ReceiptsDb.GetColumnDb(ReceiptsColumns.Default);
         _minDeletableBlockNumber = (_blockTree.Genesis?.Number ?? 0) + 1; // do not remove genesis
+
+        (ulong? persistedPointer, ulong? persistedCursor) = ReadPersistedPointers(_metadataDb);
+        ulong snapshotPointer = persistedPointer ?? 0;
+        ulong barrierFloor = _blockTree.GetLowestBlock(); // still the config barrier here - nothing has raised it yet
+        // An absent cursor defaults to the pointer, as at load: on a per-block-pruned database everything below the boundary is gone.
+        _persistedUnreclaimedFloor = ulong.Max(ulong.Min(persistedCursor ?? snapshotPointer, snapshotPointer), barrierFloor);
 
         CheckConfig();
 
@@ -182,6 +201,14 @@ public class HistoryPruner : IHistoryPruner
             return _oldestBlockHeader;
         }
     }
+
+    // Deliberately lock-free - this sits on the eth_getLogs path, and the first pruning pass or
+    // OldestBlockHeader access drives the load, which the ancient-bodies hold can defer for the whole
+    // backfill. Until then the answer is the later of the constructor's snapshot of the persisted cursors
+    // - exact, since nothing moves them in this process before the load - and the configured barrier:
+    // refusing more than necessary beats serving a reclaimed height silently short.
+    public ulong OldestUnreclaimedBlockNumber =>
+        _hasLoadedDeletePointers ? ulong.Min(_blocksReclaimCursor, _blocksDeletePointer) : _persistedUnreclaimedFloor;
 
     private ulong? CalculateRollingCutoff(uint retentionEpochs)
     {
@@ -274,8 +301,13 @@ public class HistoryPruner : IHistoryPruner
                 // Before the interval gate: the read side refuses every sliced address until this has validated
                 // the stamps, and the first interval boundary can be most of an hour away. The flag keeps the
                 // uncontended fast path honest - another caller loading the pointers must not skip this tick.
-                _receiptRetention.OnPruningPassStarting(OldestStoredReceipts(), _blocksReclaimCursor, _sliceCleanupCursor);
-                _stampsValidated = true;
+                // A frozen frontier must not stamp: the stamp never lowers, and this one would cap slice
+                // coverage at a mid-backfill depth forever.
+                if (!_frontierFrozen)
+                {
+                    _receiptRetention.OnPruningPassStarting(OldestStoredReceipts(), _blocksReclaimCursor, _sliceCleanupCursor);
+                    _stampsValidated = true;
+                }
 
                 if (!ShouldPruneHistory())
                 {
@@ -331,6 +363,21 @@ public class HistoryPruner : IHistoryPruner
 
     internal bool SetDeletePointerToOldestBlock()
     {
+        // While the ancient bodies feed is still descending, the oldest existing body is the download
+        // frontier, not the truth - a pointer latched from it would over-report forever.
+        bool frontierFrozen = false;
+        if (AncientBodiesStillDownloading())
+        {
+            if (_syncConfig.SynchronizationEnabled)
+            {
+                return false;
+            }
+
+            // With synchronization disabled no feed can move the frontier, so it is the truth for this
+            // process - but it is never persisted, so the next syncing process re-derives the boundary.
+            frontierFrozen = true;
+        }
+
         ulong? oldestBlockNumber = BlockTree.BinarySearchBlockNumber(
             _minDeletableBlockNumber,
             _blockTree.SyncPivot.BlockNumber,
@@ -340,11 +387,87 @@ public class HistoryPruner : IHistoryPruner
         if (oldestBlockNumber is not null)
         {
             UpdateBlocksDeletePointer(oldestBlockNumber.Value);
-            SaveDeletePointers();
+            if (frontierFrozen)
+            {
+                _frontierFrozen = true;
+                _lastSavedBlocksDeletePointer = _blocksDeletePointer;
+            }
+            else
+            {
+                SaveDeletePointers();
+            }
             return true;
         }
 
         return false;
+    }
+
+    private bool AncientBodiesStillDownloading()
+    {
+        // Keyed on the tree pivot, like the feed itself: a CL-discovered pivot never reaches the sync config.
+        ulong pivot = _blockTree.SyncPivot.BlockNumber;
+        if (!_fastSync || pivot == 0 || !_syncConfig.DownloadBodiesInFastSync)
+        {
+            return false;
+        }
+
+        // The feed persists a completion marker when it reaches its own latched barrier, so the release
+        // never has to reconstruct a barrier that drifts with the pruning cutoff. The static barrier is a
+        // term of the feed's ComputeBarrier and so always releasable, and a pointer parked at the barrier
+        // the feed recorded when it last started is a finished descent even if the marker predates this
+        // build - only for a descent whose barrier never moved, since a rolling cutoff climbs during a
+        // long descent and parks the pointer above the recorded value; a legacy database self-heals
+        // regardless, because the feed activates once and writes the marker. A written pointer above
+        // those with no marker is a descent in progress - the persisted pointer only moves every flush
+        // interval, so its quietness proves nothing and the hold stays; an absent pointer is a feed that
+        // has not run yet, which a synchronizing process eventually runs.
+        if (_metadataDb.KeyExists(MetadataDbKeys.AncientBodiesDownloadComplete))
+        {
+            return false;
+        }
+
+        byte[]? pointerBytes = _metadataDb.Get(MetadataDbKeys.LowestInsertedBodyNumber) ?? _blocksDb.Get(LegacyLowestInsertedBodyNumberKey);
+        ulong? pointer = pointerBytes is null ? null : new RlpReader(pointerBytes).DecodeULong();
+        ulong barrier = ulong.Max(1UL, ulong.Min(pivot, _syncConfig.AncientBodiesBarrier));
+        if (pointer <= barrier)
+        {
+            return false;
+        }
+
+        byte[]? barrierWhenStartedBytes = _metadataDb.Get(MetadataDbKeys.BodiesBarrierWhenStarted);
+        if (pointer is not null && barrierWhenStartedBytes is not null)
+        {
+            ulong barrierWhenStarted = barrierWhenStartedBytes.AsSpan().ToULongFromBigEndianByteArrayWithoutLeadingZeros();
+            // Only while the feed still targets at least that barrier: a config edit that lowered it reopens
+            // the descent, and the recorded value then describes the descent that finished, not the current one.
+            if (barrierWhenStarted <= ulong.Max(barrier, CutoffBlockNumber ?? 0) && pointer <= barrierWhenStarted)
+            {
+                return false;
+            }
+        }
+
+        bool firstHoldLog = _ancientHoldLastLogged == 0;
+        if (_syncConfig.SynchronizationEnabled && (firstHoldLog || Stopwatch.GetElapsedTime(_ancientHoldLastLogged) >= AncientHoldRelogInterval))
+        {
+            _ancientHoldLastLogged = Stopwatch.GetTimestamp();
+            // Info while the frontier moved since the last relog - a descending backfill is the healthy shape
+            // in every pruning mode - and Warn once it sat still for several intervals: that is the stuck hold
+            // worth alerting on, in-memory movement over a ten-minute window being a fair progress signal even
+            // though the persisted pointer's flush resolution makes it useless as a release signal.
+            _ancientHoldStaticRelogs = !firstHoldLog && pointer == _ancientHoldLastLoggedPointer ? _ancientHoldStaticRelogs + 1 : 0;
+            _ancientHoldLastLoggedPointer = pointer;
+            string holdMessage = $"Holding the history boundary while the ancient bodies backfill is descending (currently #{pointer?.ToString() ?? "none"}).";
+            if (_ancientHoldStaticRelogs >= AncientHoldStaticRelogsBeforeWarn)
+            {
+                if (_logger.IsWarn) _logger.Warn(holdMessage);
+            }
+            else if (_logger.IsInfo)
+            {
+                _logger.Info(holdMessage);
+            }
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -874,6 +997,14 @@ public class HistoryPruner : IHistoryPruner
         return ulong.Max(_blocksDeletePointer, ulong.Max(_ancientReceiptsBarrier, receiptsFloor));
     }
 
+    private static (ulong? Pointer, ulong? Cursor) ReadPersistedPointers(IDb metadataDb)
+    {
+        byte[]? pointerBytes = metadataDb.Get(MetadataDbKeys.HistoryPruningDeletePointer);
+        byte[]? cursorBytes = metadataDb.Get(MetadataDbKeys.HistoryPruningReclaimCursor);
+        return (pointerBytes is null ? null : new RlpReader(pointerBytes).DecodeULong(),
+            cursorBytes is null ? null : new RlpReader(cursorBytes).DecodeULong());
+    }
+
     private bool TryLoadDeletePointers()
     {
         if (_hasLoadedDeletePointers)
@@ -881,8 +1012,8 @@ public class HistoryPruner : IHistoryPruner
             return true;
         }
 
-        byte[]? blocksVal = _metadataDb.Get(MetadataDbKeys.HistoryPruningDeletePointer);
-        if (blocksVal is null)
+        (ulong? persistedPointer, ulong? persistedCursor) = ReadPersistedPointers(_metadataDb);
+        if (persistedPointer is null)
         {
             if (!SetDeletePointerToOldestBlock())
             {
@@ -891,16 +1022,15 @@ public class HistoryPruner : IHistoryPruner
         }
         else
         {
-            UpdateBlocksDeletePointer(ulong.Max(new RlpReader(blocksVal).DecodeULong(), _minDeletableBlockNumber));
+            UpdateBlocksDeletePointer(ulong.Max(persistedPointer.Value, _minDeletableBlockNumber));
             _lastSavedBlocksDeletePointer = _blocksDeletePointer;
         }
 
-        byte[]? reclaimVal = _metadataDb.Get(MetadataDbKeys.HistoryPruningReclaimCursor);
         // Absent on a database pruned by the per-block code, where everything below the boundary is already gone.
-        _blocksReclaimCursor = reclaimVal is null
+        _blocksReclaimCursor = persistedCursor is null
             ? _blocksDeletePointer
-            : ulong.Max(new RlpReader(reclaimVal).DecodeULong(), _minDeletableBlockNumber);
-        _lastSavedBlocksReclaimCursor = reclaimVal is null ? ulong.MaxValue : _blocksReclaimCursor;
+            : ulong.Max(persistedCursor.Value, _minDeletableBlockNumber);
+        _lastSavedBlocksReclaimCursor = persistedCursor is null ? ulong.MaxValue : _blocksReclaimCursor;
 
         byte[]? balsVal = _metadataDb.Get(MetadataDbKeys.BlockAccessListPruningDeletePointer);
         // Until BAL pruning runs once, the BAL pointer trails the blocks pointer because BALs are
@@ -917,6 +1047,14 @@ public class HistoryPruner : IHistoryPruner
             ? _minDeletableBlockNumber
             : ulong.Max(new RlpReader(cleanupVal).DecodeULong(), _minDeletableBlockNumber);
         _lastSavedSliceCleanupCursor = cleanupVal is null ? ulong.MaxValue : _sliceCleanupCursor;
+
+        // A frozen frontier must not leak to disk through the first-save sentinels either.
+        if (_frontierFrozen)
+        {
+            _lastSavedBlocksReclaimCursor = _blocksReclaimCursor;
+            _lastSavedBalsDeletePointer = _balsDeletePointer;
+            _lastSavedSliceCleanupCursor = _sliceCleanupCursor;
+        }
 
         // Loaded here rather than lazily in the sweep, because ShouldPruneHistory has to see it: a sweep left
         // half-finished is work owed, and if nothing else were owed the pass would never run to notice.
@@ -941,33 +1079,37 @@ public class HistoryPruner : IHistoryPruner
         // both directions, only a shared batch could.
         _receiptRetention.OnPruningProgress(_blocksReclaimCursor, _sliceCleanupCursor);
 
-        // Cursor first, and load-bearing: these are independent writes, and a restart that finds a boundary with no
-        // cursor reads it as "already level" and treats an unreclaimed backlog as finished, forever.
-        if (_blocksReclaimCursor != _lastSavedBlocksReclaimCursor)
+        // One batch, and a boundary write carries the cursors with it: a boundary that lands without its
+        // cursor reads an unreclaimed backlog as "already level" on the next load, forever.
+        bool boundaryDirty = _blocksDeletePointer != _lastSavedBlocksDeletePointer;
+        bool cursorDirty = boundaryDirty || _blocksReclaimCursor != _lastSavedBlocksReclaimCursor;
+        bool cleanupDirty = _sliceCleanupCursor != _lastSavedSliceCleanupCursor;
+        bool balsDirty = boundaryDirty || _balsDeletePointer != _lastSavedBalsDeletePointer;
+        if (!cursorDirty && !cleanupDirty && !balsDirty)
         {
-            _metadataDb.Set(MetadataDbKeys.HistoryPruningReclaimCursor, Rlp.Encode(_blocksReclaimCursor).Bytes);
-            _lastSavedBlocksReclaimCursor = _blocksReclaimCursor;
+            return;
         }
 
-        if (_blocksDeletePointer != _lastSavedBlocksDeletePointer)
+        ulong cursorToSave = _blocksReclaimCursor;
+        ulong boundaryToSave = _blocksDeletePointer;
+        ulong cleanupToSave = _sliceCleanupCursor;
+        ulong balsToSave = _balsDeletePointer;
+        using (IWriteBatch batch = _metadataDb.StartWriteBatch())
         {
-            _metadataDb.Set(MetadataDbKeys.HistoryPruningDeletePointer, Rlp.Encode(_blocksDeletePointer).Bytes);
-            _lastSavedBlocksDeletePointer = _blocksDeletePointer;
-            if (_logger.IsDebug) _logger.Debug($"Persisting oldest block stored = #{_blocksDeletePointer} to disk.");
+            if (cursorDirty) batch.Set(MetadataDbKeys.HistoryPruningReclaimCursor, Rlp.Encode(cursorToSave).Bytes);
+            if (boundaryDirty) batch.Set(MetadataDbKeys.HistoryPruningDeletePointer, Rlp.Encode(boundaryToSave).Bytes);
+            if (cleanupDirty) batch.Set(MetadataDbKeys.HistoryPruningSliceCleanupCursor, Rlp.Encode(cleanupToSave).Bytes);
+            if (balsDirty) batch.Set(MetadataDbKeys.BlockAccessListPruningDeletePointer, Rlp.Encode(balsToSave).Bytes);
         }
 
-        if (_sliceCleanupCursor != _lastSavedSliceCleanupCursor)
-        {
-            _metadataDb.Set(MetadataDbKeys.HistoryPruningSliceCleanupCursor, Rlp.Encode(_sliceCleanupCursor).Bytes);
-            _lastSavedSliceCleanupCursor = _sliceCleanupCursor;
-        }
+        // Only after the batch committed: a throwing commit must leave these claiming unsaved.
+        if (cursorDirty) _lastSavedBlocksReclaimCursor = cursorToSave;
+        if (boundaryDirty) _lastSavedBlocksDeletePointer = boundaryToSave;
+        if (cleanupDirty) _lastSavedSliceCleanupCursor = cleanupToSave;
+        if (balsDirty) _lastSavedBalsDeletePointer = balsToSave;
 
-        if (_balsDeletePointer != _lastSavedBalsDeletePointer)
-        {
-            _metadataDb.Set(MetadataDbKeys.BlockAccessListPruningDeletePointer, Rlp.Encode(_balsDeletePointer).Bytes);
-            _lastSavedBalsDeletePointer = _balsDeletePointer;
-            if (_logger.IsDebug) _logger.Debug($"Persisting oldest BAL stored = #{_balsDeletePointer} to disk.");
-        }
+        if (_logger.IsDebug && boundaryDirty) _logger.Debug($"Persisting oldest block stored = #{boundaryToSave} to disk.");
+        if (_logger.IsDebug && balsDirty) _logger.Debug($"Persisting oldest BAL stored = #{balsToSave} to disk.");
     }
 
     private void UpdateBlocksDeletePointer(ulong newDeletePointer)

--- a/src/Nethermind/Nethermind.History/IHistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/IHistoryPruner.cs
@@ -16,6 +16,10 @@ public interface IHistoryPruner
 
     public BlockHeader? OldestBlockHeader { get; }
 
+    /// <summary>Oldest block the reclaim has not physically deleted yet - the published boundary moves
+    /// ahead of the reclaim by design, so data between the two is declared absent but still readable.</summary>
+    public ulong OldestUnreclaimedBlockNumber { get; }
+
     event EventHandler<OnNewOldestBlockArgs> NewOldestBlock;
 
     void SchedulePruneHistory();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/BlockFinderExtensions.cs
@@ -23,7 +23,9 @@ namespace Nethermind.JsonRpc.Modules
                     requestedBlock = headerResult.Object.Number;
                 }
             }
-            return requestedBlock < blockFinder.GetLowestBlock();
+            // The served floor, not the published boundary: during a backfill the two differ, and this check
+            // must agree with what the node advertises as earliest over eth/69.
+            return requestedBlock < blockFinder.LowestServedBlock;
         }
 
         public static SearchResult<BlockHeader> SearchForHeader(this IBlockFinder blockFinder, BlockParameter? blockParameter, bool allowNulls = false)

--- a/src/Nethermind/Nethermind.Kademlia/LookupKNearestNeighbour.cs
+++ b/src/Nethermind/Nethermind.Kademlia/LookupKNearestNeighbour.cs
@@ -47,7 +47,7 @@ public class LookupKNearestNeighbour<TKey, TNode, TKadKey>(
         Func<TNode, CancellationToken, Task<TNode[]?>> findNeighbourOp,
         CancellationToken token
     )
-        => await LookupCore(targetHash, k, findNeighbourOp, null, token);
+        => await LookupCore(targetHash, k, findNeighbourOp, null, token, callerToken: token);
 
     public async IAsyncEnumerable<TNode> LookupNodes(
         TKadKey targetHash,
@@ -97,7 +97,7 @@ public class LookupKNearestNeighbour<TKey, TNode, TKadKey>(
             Exception? error = null;
             try
             {
-                _ = await LookupCore(targetHash, maxResults, findNeighbourOp, Publish, cts.Token);
+                _ = await LookupCore(targetHash, maxResults, findNeighbourOp, Publish, cts.Token, callerToken: token);
             }
             catch (OperationCanceledException) when (cts.IsCancellationRequested)
             {
@@ -135,11 +135,16 @@ public class LookupKNearestNeighbour<TKey, TNode, TKadKey>(
         int k,
         Func<TNode, CancellationToken, Task<TNode[]?>> findNeighbourOp,
         Func<TNode, bool>? publishNode,
-        CancellationToken token
+        CancellationToken token,
+        CancellationToken callerToken
     )
     {
         if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace($"Initiate lookup for hash {targetHash}");
 
+        // `token` drives this lookup and is shadowed below by a linked source cancelled on normal
+        // completion — the drain after a worker finishes, and (via LookupNodes) on reaching maxResults.
+        // `callerToken` is the real caller/shutdown token, used to tell an expected teardown failure from
+        // a genuine one; it is never cancelled by normal completion.
         using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(token);
         token = cts.Token;
 
@@ -275,11 +280,17 @@ public class LookupKNearestNeighbour<TKey, TNode, TKadKey>(
             catch (Exception e)
             {
                 nodeHealthTracker.OnRequestFailed(node);
-                // Transport failures (e.g. unreachable host) are expected during discovery, so log them quietly.
-                bool shouldWarn = e is not SocketException && e.InnerException is not SocketException;
-                if (shouldWarn)
+                // Expected-and-quiet: a failure after the caller's token is cancelled (teardown, in whatever
+                // shape DotNetty raises), or a transport failure (unreachable host, torn-down channel —
+                // ClosedChannelException derives from IOException). Anything else is a genuine fault and
+                // warrants a warning. Use the caller's token, not the internal one, which is also cancelled
+                // on the normal drain after the first worker returns and on reaching maxResults.
+                bool isExpectedFailure = callerToken.IsCancellationRequested
+                    || e is SocketException or IOException
+                    || e.InnerException is SocketException or IOException;
+                if (!isExpectedFailure)
                 {
-                    if (_logger.IsEnabled(LogLevel.Debug)) _logger.LogWarning($"Find neighbour op failed: {e}");
+                    if (_logger.IsEnabled(LogLevel.Warning)) _logger.LogWarning($"Find neighbour op failed: {e}");
                 }
                 else if (_logger.IsEnabled(LogLevel.Trace)) _logger.LogTrace($"Find neighbour op failed: {e.Message}");
                 return null;

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/LookupKNearestNeighbourTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/LookupKNearestNeighbourTests.cs
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Nethermind.Kademlia;
 using NSubstitute;
 using NUnit.Framework;
@@ -21,7 +25,7 @@ public class LookupKNearestNeighbourTests
     private const int N1 = 4;
     private const int N2 = 5;
 
-    private static (LookupKNearestNeighbour<int, int, int> Lookup, IRoutingTable<int, int> Routing, INodeHealthTracker<int> Health) CreateLookup(int alpha, TimeSpan hardTimeout, int[] seeds)
+    private static (LookupKNearestNeighbour<int, int, int> Lookup, IRoutingTable<int, int> Routing, INodeHealthTracker<int> Health) CreateLookup(int alpha, TimeSpan hardTimeout, int[] seeds, ILoggerFactory? loggerFactory = null)
     {
         IRoutingTable<int, int> routing = Substitute.For<IRoutingTable<int, int>>();
         routing.GetKNearestNeighbour(Arg.Any<int>(), Arg.Any<bool>()).Returns(seeds);
@@ -39,7 +43,8 @@ public class LookupKNearestNeighbourTests
                 Alpha = alpha,
                 KSize = 8,
                 LookupFindNeighbourHardTimeout = hardTimeout,
-            });
+            },
+            loggerFactory ?? NullLoggerFactory.Instance);
 
         return (lookup, routing, health);
     }
@@ -234,5 +239,126 @@ public class LookupKNearestNeighbourTests
             token);
 
         Assert.That(cancelledWorkerDrained.Task.IsCompleted, Is.True);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task Find_neighbour_transport_failure_is_not_logged_as_warning(CancellationToken token)
+    {
+        // A torn-down channel raises DotNetty's ClosedChannelException (: IOException); like a
+        // SocketException it is expected transport churn — logged at Trace, never at Warning.
+        CapturingLogger logger = new(LogLevel.Trace);
+        (LookupKNearestNeighbour<int, int, int> lookup, _, _) =
+            CreateLookup(1, TimeSpan.FromSeconds(10), [Seed1], new CapturingLoggerFactory(logger));
+
+        _ = await lookup.Lookup(Self, 8, (_, _) => throw new IOException("channel closed"), token);
+
+        Assert.That(logger.Entries.Any(e => e.Level == LogLevel.Warning), Is.False);
+        Assert.That(logger.Entries.Any(e => e.Level == LogLevel.Trace && e.Message.Contains("Find neighbour op failed")), Is.True);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task Find_neighbour_unexpected_failure_is_logged_as_warning(CancellationToken token)
+    {
+        // A non-transport failure is unexpected and should still be reported.
+        CapturingLogger logger = new();
+        (LookupKNearestNeighbour<int, int, int> lookup, _, _) =
+            CreateLookup(1, TimeSpan.FromSeconds(10), [Seed1], new CapturingLoggerFactory(logger));
+
+        _ = await lookup.Lookup(Self, 8, (_, _) => throw new InvalidOperationException("boom"), token);
+
+        Assert.That(logger.Entries.Any(e => e.Level == LogLevel.Warning), Is.True);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task Find_neighbour_failure_after_cancellation_is_not_logged_as_warning(CancellationToken token)
+    {
+        // After the lookup token is cancelled, a non-transport teardown failure (e.g. DotNetty's
+        // RejectedExecutionException from the disposed event loop) is expected and must stay quiet —
+        // otherwise a graceful restart floods WARN and trips the very detector this fix targets.
+        CapturingLogger logger = new();
+        (LookupKNearestNeighbour<int, int, int> lookup, _, _) =
+            CreateLookup(1, TimeSpan.FromSeconds(10), [Seed1], new CapturingLoggerFactory(logger));
+
+        using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+        _ = await lookup.Lookup(Self, 8, (_, _) =>
+        {
+            cts.Cancel();
+            throw new InvalidOperationException("torn down");
+        }, cts.Token);
+
+        Assert.That(logger.Entries.Any(e => e.Level == LogLevel.Warning), Is.False);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task Find_neighbour_unexpected_failure_during_drain_is_logged_as_warning(CancellationToken token)
+    {
+        // The other seeds return nothing, so the lookup finishes and drains — cancelling its internal
+        // token while the caller's token stays live. Seed1 is still in flight and then fails with a
+        // non-transport exception: a real fault that must warn, not be silenced as shutdown teardown.
+        CapturingLogger logger = new();
+        (LookupKNearestNeighbour<int, int, int> lookup, _, _) =
+            CreateLookup(2, TimeSpan.FromSeconds(10), [Seed1, Seed2, Seed3, N1], new CapturingLoggerFactory(logger));
+
+        // Gate the empty-returning ops on Seed1's op having started, so Seed1's worker has taken its round
+        // before the other worker consumes the Alpha*2 rounds that trip the no-better-result break —
+        // otherwise Seed1's worker could break without ever calling the op and the drain never happens.
+        TaskCompletionSource seed1Started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        _ = await lookup.Lookup(Self, 1, async (node, findToken) =>
+        {
+            if (node != Seed1)
+            {
+                await seed1Started.Task;
+                return [];
+            }
+
+            seed1Started.SetResult();
+            try
+            {
+                await Task.Delay(Timeout.Infinite, findToken);
+                return [];
+            }
+            catch (OperationCanceledException)
+            {
+                // The drain cancelled the internal token; the caller's token is still live.
+                throw new InvalidOperationException("failed during drain");
+            }
+        }, token);
+
+        Assert.That(logger.Entries.Any(e => e.Level == LogLevel.Warning && e.Message.Contains("Find neighbour op failed")), Is.True);
+    }
+
+    private readonly record struct LogEntry(LogLevel Level, string Message);
+
+    private sealed class CapturingLoggerFactory(ILogger logger) : ILoggerFactory
+    {
+        public ILogger CreateLogger(string categoryName) => logger;
+        public void AddProvider(ILoggerProvider provider) { }
+        public void Dispose() { }
+    }
+
+    private sealed class CapturingLogger(LogLevel minLevel = LogLevel.Information) : ILogger
+    {
+        private readonly ConcurrentQueue<LogEntry> _entries = new();
+        public IEnumerable<LogEntry> Entries => _entries;
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        // Default to a production node's Info floor (Trace/Debug disabled) so the warning-gate is
+        // actually exercised; a test that needs the Trace branch opts in with a lower minLevel.
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= minLevel;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            => _entries.Enqueue(new LogEntry(logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismBlockValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismBlockValidatorTests.cs
@@ -6,8 +6,11 @@ using System.Collections.Generic;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
 using Nethermind.Logging;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.Optimism.Test;
@@ -141,6 +144,40 @@ public class OptimismBlockValidatorTests(Fork fork)
         Assert.That(
             validator.ValidateSuggestedBlock(block, parentHeader, out string? error),
             Is.EqualTo(isValid.On(_timestamp)),
+            () => error!);
+    }
+
+    [Test]
+    public void ValidateSuggestedBlock_ValidatesLegacyTransactionGasLimitCap()
+    {
+        const ulong chainId = 10;
+        Transaction transaction = Build.A.Transaction
+            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + 1)
+            .SignedAndResolved(new EthereumEcdsa(chainId), TestItem.PrivateKeyA)
+            .TestObject;
+        (BlockHeader parentHeader, Block block) = BuildBlock(b => b
+            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap * 2)
+            .WithTransactions(transaction));
+        OptimismReleaseSpec spec = new()
+        {
+            IsEip1559Enabled = true,
+            IsEip7825Enabled = _timestamp >= Spec.KarstTimeStamp
+        };
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(block.Header).Returns(spec);
+        TxValidator txValidator = new(chainId);
+        txValidator.RegisterValidator(TxType.Legacy, new OptimismLegacyTxValidator(chainId));
+        OptimismBlockValidator validator = new(
+            txValidator,
+            Always.Valid,
+            Always.Valid,
+            specProvider,
+            Spec.Instance,
+            TestLogManager.Instance);
+
+        Assert.That(
+            validator.ValidateSuggestedBlock(block, parentHeader, out string? error),
+            Is.EqualTo(_timestamp < Spec.KarstTimeStamp),
             () => error!);
     }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismModuleTests.cs
@@ -7,6 +7,7 @@ using Autofac;
 using Nethermind.Api.Steps;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
+using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
@@ -66,13 +67,104 @@ public class OptimismModuleTests
         builder.RegisterInstance(specProvider).As<ISpecProvider>();
         using IContainer container = builder.Build();
         ITxValidator validator = container.ResolveKeyed<ITxValidator>(ITxValidator.SpecChangeTxValidatorKey);
+        string ethereumFingerprint = new SpecChangeTxValidator(chainId).PersistenceFingerprint;
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(validator, Is.TypeOf<OptimismSpecChangeTxValidator>());
             Assert.That(container.ResolveKeyed<ITxValidator>(ITxValidator.SpecChangeTxValidatorKey), Is.SameAs(validator));
+            Assert.That(((ISpecChangeTxValidator)validator).PersistenceFingerprint, Does.Contain(ethereumFingerprint));
             Assert.That(validator.IsWellFormed(transaction, preBedrock).AsBool(), Is.True);
             Assert.That(validator.IsWellFormed(transaction, postBedrock).AsBool(), Is.False);
+        }
+    }
+
+    [TestCase(TxType.Legacy, true, true, 1ul, false)]
+    [TestCase(TxType.DepositTx, true, true, 1ul, false)]
+    [TestCase(TxType.Legacy, true, true, 0ul, true)]
+    [TestCase(TxType.DepositTx, true, true, 0ul, true)]
+    [TestCase(TxType.Legacy, true, false, 1ul, true)]
+    [TestCase(TxType.DepositTx, true, false, 1ul, true)]
+    [TestCase(TxType.Legacy, false, true, 1ul, true)]
+    [TestCase(TxType.DepositTx, false, true, 1ul, false)]
+    public void Full_and_delta_validation_respect_optimism_gas_limit_cap(
+        TxType transactionType,
+        bool isEip1559Enabled,
+        bool isEip7825Enabled,
+        ulong gasLimitAboveCap,
+        bool expected)
+    {
+        const ulong chainId = 10;
+        OptimismReleaseSpec spec = new()
+        {
+            IsEip1559Enabled = isEip1559Enabled,
+            IsEip7825Enabled = isEip7825Enabled
+        };
+        TransactionBuilder<Transaction> transactionBuilder = Build.A.Transaction
+            .WithType(transactionType)
+            .WithGasLimit(Eip7825Constants.DefaultTxGasLimitCap + gasLimitAboveCap)
+            .WithSenderAddress(TestItem.AddressA);
+        Transaction transaction = transactionType == TxType.Legacy
+            ? transactionBuilder.SignedAndResolved(new EthereumEcdsa(chainId), TestItem.PrivateKeyA).TestObject
+            : transactionBuilder.TestObject;
+        ITxValidator fullValidator = transactionType == TxType.DepositTx
+            ? Always.Valid
+            : new OptimismLegacyTxValidator(chainId);
+        OptimismSpecChangeTxValidator specChangeValidator = new(chainId);
+        ValidationResult specChangeResult = specChangeValidator.IsWellFormed(transaction, spec);
+        ValidationResult admissionResult = fullValidator.IsWellFormed(transaction, spec);
+
+        if (admissionResult)
+        {
+            admissionResult = specChangeValidator.IsWellFormedAfterFullValidation(transaction, spec);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(specChangeResult.AsBool, Is.EqualTo(expected));
+            Assert.That(admissionResult.AsBool, Is.EqualTo(expected));
+        }
+    }
+
+    [TestCase(false, ulong.MaxValue, null)]
+    [TestCase(true, ulong.MaxValue - 1, null)]
+    [TestCase(true, ulong.MaxValue, TxErrorMessages.NonceTooHigh)]
+    public void Legacy_validation_respects_eip2681_nonce_cap_after_bedrock(
+        bool isEip1559Enabled,
+        ulong nonce,
+        string? expectedError)
+    {
+        const ulong chainId = 10;
+        OptimismReleaseSpec spec = new() { IsEip1559Enabled = isEip1559Enabled };
+        Transaction transaction = Build.A.Transaction
+            .WithNonce(nonce)
+            .SignedAndResolved(new EthereumEcdsa(chainId), TestItem.PrivateKeyA)
+            .TestObject;
+
+        ValidationResult result = new OptimismLegacyTxValidator(chainId).IsWellFormed(transaction, spec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.AsBool, Is.EqualTo(expectedError is null));
+            Assert.That(result.Error, Is.EqualTo(expectedError));
+        }
+    }
+
+    [Test]
+    public void Full_validation_prioritizes_sender_independent_errors_over_intrinsic_gas()
+    {
+        OptimismReleaseSpec spec = new() { IsEip1559Enabled = true };
+        Transaction transaction = Build.A.Transaction
+            .WithGasLimit(0)
+            .TestObject;
+
+        ValidationResult result = new OptimismLegacyTxValidator(10).IsWellFormed(transaction, spec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.AsBool, Is.False);
+            Assert.That(result.IsIntrinsicGasError, Is.False);
+            Assert.That(result.Error, Is.EqualTo(TxErrorMessages.InvalidTxSignature));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Optimism/Nethermind.Optimism.csproj
+++ b/src/Nethermind/Nethermind.Optimism/Nethermind.Optimism.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Nethermind.Optimism.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Nethermind.Libp2p" />
     <PackageReference Include="Nethermind.Libp2p.Protocols.PubsubPeerDiscovery" />
     <PackageReference Include="Google.Protobuf" />

--- a/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismLegacyTxDecoder.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Runtime.CompilerServices;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -10,8 +9,6 @@ using Nethermind.Core.Specs;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Serialization.Rlp.TxDecoders;
 using Nethermind.TxPool;
-
-[assembly: InternalsVisibleTo("Nethermind.Optimism.Test")]
 
 namespace Nethermind.Optimism;
 
@@ -31,11 +28,13 @@ public sealed class OptimismLegacyTxDecoder : LegacyTxDecoder<Transaction>
 public sealed class OptimismLegacyTxValidator(ulong chainId) : ITxValidator
 {
     private readonly ITxValidator _postBedrockValidator = new CompositeTxValidator([
-        IntrinsicGasTxValidator.Instance,
+        NonceCapTxValidator.Instance,
         new LegacySignatureTxValidator(chainId),
         ContractSizeTxValidator.Instance,
         NonBlobFieldsTxValidator.Instance,
-        NonSetCodeFieldsTxValidator.Instance
+        NonSetCodeFieldsTxValidator.Instance,
+        GasLimitCapTxValidator.Instance,
+        IntrinsicGasTxValidator.Instance
     ]);
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
@@ -55,17 +54,31 @@ public sealed class OptimismLegacyTxValidator(ulong chainId) : ITxValidator
     }
 }
 
-internal sealed class OptimismSpecChangeTxValidator(ulong chainId) : ITxValidator, ILightTxValidator, ISpecChangeTxValidator
+internal sealed class OptimismSpecChangeTxValidator : ITxValidator, ILightTxValidator, ISpecChangeTxValidator
 {
-    private readonly SpecChangeTxValidator _ethereumValidator = new(chainId);
+    private readonly SpecChangeTxValidator _ethereumValidator;
 
-    public string PersistenceFingerprint { get; } =
-        FormattableString.Invariant($"1|{typeof(OptimismSpecChangeTxValidator).Module.ModuleVersionId:N}|{chainId}");
+    public OptimismSpecChangeTxValidator(ulong chainId)
+    {
+        _ethereumValidator = new(chainId);
+        PersistenceFingerprint = FormattableString.Invariant(
+            $"2|{typeof(OptimismSpecChangeTxValidator).Module.ModuleVersionId:N}|{_ethereumValidator.PersistenceFingerprint}");
+    }
+
+    public string PersistenceFingerprint { get; }
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec) =>
         transaction.Type == TxType.Legacy && !releaseSpec.IsEip1559Enabled
             ? ValidationResult.Success
             : _ethereumValidator.IsWellFormed(transaction, releaseSpec);
+
+    public ValidationResult IsWellFormedAfterFullValidation(Transaction transaction, IReleaseSpec releaseSpec) =>
+        transaction.Type switch
+        {
+            TxType.Legacy when !releaseSpec.IsEip1559Enabled => ValidationResult.Success,
+            TxType.DepositTx => _ethereumValidator.IsWellFormed(transaction, releaseSpec),
+            _ => _ethereumValidator.IsWellFormedAfterFullValidation(transaction, releaseSpec)
+        };
 
     public ValidationResult IsWellFormedLight(LightTransaction transaction, IReleaseSpec releaseSpec) =>
         _ethereumValidator.IsWellFormedLight(transaction, releaseSpec);

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin.Test/DetectionScannerTests.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin.Test/DetectionScannerTests.cs
@@ -272,6 +272,88 @@ public class DetectionScannerTests
     }
 
     [Test]
+    public async Task Downward_walk_clamps_to_the_retained_history_floor_and_completes_there()
+    {
+        SeedHead(100);
+        _blockFinder.GetLowestBlock().Returns(50UL);
+        List<long> fromBlocks = [];
+        _logFinder.FindLogs(Arg.Any<LogFilter>(), Arg.Any<CancellationToken>())
+            .Returns(ci => { fromBlocks.Add((long)(ci.Arg<LogFilter>().FromBlock.BlockNumber ?? 0)); return (IEnumerable<FilterLog>)[]; });
+
+        _scanner.RequestScan(ChainId, Account);
+        await _scheduler.RunAll();
+
+        DetectionEntry? entry = _cache.Get(ChainId, Account.ToString());
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(fromBlocks, Has.All.GreaterThanOrEqualTo(50));
+            Assert.That(fromBlocks, Does.Contain(50));
+            Assert.That(entry!.Complete, Is.True, "reaching the floor completes the scan in one pass");
+            Assert.That(entry.ScannedFrom, Is.EqualTo(0));
+        }
+    }
+
+    [Test]
+    public async Task Forward_walk_clamps_to_the_retained_history_floor_instead_of_skipping_the_gap()
+    {
+        _cache.Put(ChainId, Account.ToString(), new DetectionEntry([], [], 0, 5, true, 0));
+        _blockFinder.Head.Returns(Build.A.Block.WithNumber(100_000).TestObject);
+        _blockFinder.GetLowestBlock().Returns(50UL);
+        List<long> fromBlocks = [];
+        _logFinder.FindLogs(Arg.Any<LogFilter>(), Arg.Any<CancellationToken>())
+            .Returns(ci => { fromBlocks.Add((long)(ci.Arg<LogFilter>().FromBlock.BlockNumber ?? 0)); return (IEnumerable<FilterLog>)[]; });
+
+        _scanner.RequestScan(ChainId, Account);
+        await _scheduler.RunAll();
+
+        DetectionEntry? entry = _cache.Get(ChainId, Account.ToString());
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(fromBlocks, Has.All.GreaterThanOrEqualTo(50), "no chunk asks below the floor, so the fail-closed guard is never tripped");
+            Assert.That(fromBlocks, Does.Contain(50), "the recoverable [floor, head] portion is scanned, not skipped");
+            Assert.That(entry!.Head, Is.EqualTo(100_000));
+        }
+    }
+
+    [Test]
+    public async Task Forward_walk_with_the_floor_above_the_head_resumes_from_the_head_without_querying()
+    {
+        _cache.Put(ChainId, Account.ToString(), new DetectionEntry([Token.ToString()], [], 0, 5, true, 0));
+        _blockFinder.Head.Returns(Build.A.Block.WithNumber(100).TestObject);
+        _blockFinder.GetLowestBlock().Returns(500UL);
+
+        _scanner.RequestScan(ChainId, Account);
+        await _scheduler.RunAll();
+
+        DetectionEntry? entry = _cache.Get(ChainId, Account.ToString());
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(entry!.Head, Is.EqualTo(100), "coverage resumes from the current head");
+            Assert.That(entry.Contracts, Does.Contain(Token.ToString()), "previously detected contracts retained");
+        }
+        _logFinder.DidNotReceive().FindLogs(Arg.Any<LogFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Scan_already_below_the_floor_completes_without_querying()
+    {
+        _cache.Put(ChainId, Account.ToString(), new DetectionEntry([Token.ToString()], [], 20, 100, false, 0));
+        _blockFinder.GetLowestBlock().Returns(50UL);
+
+        _scanner.RequestScan(ChainId, Account);
+        await _scheduler.RunAll();
+
+        DetectionEntry? entry = _cache.Get(ChainId, Account.ToString());
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(entry!.Complete, Is.True);
+            Assert.That(entry.ScannedFrom, Is.EqualTo(0));
+            Assert.That(entry.Contracts, Does.Contain(Token.ToString()), "previously detected contracts retained");
+        }
+        _logFinder.DidNotReceive().FindLogs(Arg.Any<LogFilter>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task Fresh_scan_reads_head_from_block_finder()
     {
         _blockFinder.Head.Returns(Build.A.Block.WithNumber(5).TestObject);

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin/DetectionScanner.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin/DetectionScanner.cs
@@ -8,6 +8,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Facade.Filters;
 using Nethermind.Facade.Filters.Topics;
+using Nethermind.History;
 using Nethermind.Facade.Find;
 using Nethermind.Logging;
 
@@ -26,7 +27,8 @@ public interface IDetectionScanner
 /// chunks chained until retained history is covered, so a deep scan can't affect validator performance.
 /// </remarks>
 public sealed class DetectionScanner(
-    IBackgroundTaskScheduler scheduler, ILogFinder logFinder, IBlockFinder blockFinder, IDetectionCache cache, ILogManager logManager, ulong localChainId)
+    IBackgroundTaskScheduler scheduler, ILogFinder logFinder, IBlockFinder blockFinder, IDetectionCache cache, ILogManager logManager, ulong localChainId,
+    IHistoryPruner? historyPruner = null)
     : IDetectionScanner
 {
     // ERC-20/ERC-721 Transfer, and ERC-1155 TransferSingle/TransferBatch event signatures
@@ -86,14 +88,24 @@ public sealed class DetectionScanner(
         {
             DetectionEntry? existing = cache.Get(chainId, account.ToString());
             long curHead = (long)(blockFinder.Head?.Number ?? 0);
+            // Clamped where the cursors and completion flags derive, so both walks stop at the floor in one pass.
+            // The floor is the reclaim line, not the published boundary - data between the two is still readable.
+            long floor = (long)(historyPruner?.OldestUnreclaimedBlockNumber ?? blockFinder.GetLowestBlock());
             int chunk = CurrentChunk(key);
 
             // Forward phase: cover blocks since the last scan first, so freshly-received tokens surface before
             // the downward history walk.
             if (existing is not null && curHead > existing.Head)
             {
-                long flo = Math.Max(0, existing.Head + 1 - ForwardReorgOverlapBlocks);
+                long flo = Math.Max(floor, existing.Head + 1 - ForwardReorgOverlapBlocks);
                 long fhi = Math.Min(curHead, flo + chunk - 1);
+                if (fhi < flo)
+                {
+                    // the whole remaining gap sits below the floor - resume from the current head
+                    Persist(chainId, account, existing.Contracts, existing.NftContracts, existing.ScannedFrom, curHead, existing.Complete);
+                    Schedule(req);
+                    return Task.CompletedTask;
+                }
                 HashSet<string> fErc20 = [.. existing.Contracts];
                 HashSet<string> fNfts = [.. existing.NftContracts];
                 try
@@ -110,8 +122,7 @@ public sealed class DetectionScanner(
                 }
                 catch (ResourceNotFoundException e)
                 {
-                    // forward gap is below retained receipts (node was offline past the floor) — skip it and
-                    // resume from the current head, since those blocks are pruned and can't be scanned
+                    // the floor rose past this range between our read and the finder's - resume from the current head
                     if (_logger.IsDebug) _logger.Debug($"Token detection forward gap unavailable for {account}: {e.Message}");
                     Persist(chainId, account, fErc20, fNfts, existing.ScannedFrom, curHead, existing.Complete);
                     Schedule(req);
@@ -129,8 +140,8 @@ public sealed class DetectionScanner(
 
             long priorScannedFrom = existing is { ScannedFrom: > 0 } ? existing.ScannedFrom : head + 1;
             long hi = priorScannedFrom - 1;
-            if (hi <= 0) { Persist(chainId, account, existing?.Contracts, existing?.NftContracts, 0, head, complete: true); _active.TryRemove(key, out _); return Task.CompletedTask; }
-            long lo = Math.Max(0, hi - chunk + 1);
+            if (hi <= 0 || hi < floor) { Persist(chainId, account, existing?.Contracts, existing?.NftContracts, 0, head, complete: true); _active.TryRemove(key, out _); return Task.CompletedTask; }
+            long lo = Math.Max(floor, hi - chunk + 1);
 
             HashSet<string> erc20 = existing is null ? [] : [.. existing.Contracts];
             HashSet<string> nfts = existing is null ? [] : [.. existing.NftContracts];
@@ -155,7 +166,7 @@ public sealed class DetectionScanner(
                 return Task.CompletedTask;
             }
 
-            bool complete = lo <= 0 || erc20.Count + nfts.Count >= MaxContractsPerScan;
+            bool complete = lo <= floor || erc20.Count + nfts.Count >= MaxContractsPerScan;
             Persist(chainId, account, erc20, nfts, complete ? 0 : lo, head, complete);
             if (complete) _active.TryRemove(key, out _);
             else { Grow(key); Schedule(req); } // chunk finished within the gap — go wider next time

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin/Nethermind.PortfolioViewer.Plugin.csproj
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin/Nethermind.PortfolioViewer.Plugin.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\Nethermind.Blockchain\Nethermind.Blockchain.csproj" />
     <ProjectReference Include="..\Nethermind.Consensus\Nethermind.Consensus.csproj" />
     <ProjectReference Include="..\Nethermind.Facade\Nethermind.Facade.csproj" />
+    <ProjectReference Include="..\Nethermind.History\Nethermind.History.csproj" />
     <ProjectReference Include="..\Nethermind.JsonRpc\Nethermind.JsonRpc.csproj" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin/PortfolioViewerConfigurer.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin/PortfolioViewerConfigurer.cs
@@ -14,6 +14,7 @@ using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Facade.Find;
+using Nethermind.History;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
 
@@ -26,7 +27,8 @@ namespace Nethermind.PortfolioViewer.Plugin;
 /// </remarks>
 public sealed class PortfolioViewerConfigurer(
     IPortfolioViewerConfig config, IInitConfig initConfig, IBackgroundTaskScheduler scheduler,
-    ILogFinder logFinder, IBlockFinder blockFinder, ISpecProvider specProvider, ILogManager logManager) : IJsonRpcServiceConfigurer
+    ILogFinder logFinder, IBlockFinder blockFinder, ISpecProvider specProvider, ILogManager logManager,
+    IHistoryPruner? historyPruner = null) : IJsonRpcServiceConfigurer
 {
     public void Configure(IServiceCollection services)
     {
@@ -36,7 +38,7 @@ public sealed class PortfolioViewerConfigurer(
         services.AddSingleton<ISiblingNodeRegistry, SiblingNodeRegistry>();
         services.AddSingleton<IDetectionCache>(cache);
         services.AddSingleton<IPinnedCidStore>(new PinnedCidStore(initConfig.BaseDbPath, logManager));
-        services.AddSingleton<IDetectionScanner>(new DetectionScanner(scheduler, logFinder, blockFinder, cache, logManager, specProvider.ChainId));
+        services.AddSingleton<IDetectionScanner>(new DetectionScanner(scheduler, logFinder, blockFinder, cache, logManager, specProvider.ChainId, historyPruner));
         services.AddTransient<IStartupFilter, PortfolioViewerStartupFilter>();
     }
 }

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -848,6 +848,7 @@
           "Nethermind.Consensus": "[1.40.0-unstable, )",
           "Nethermind.Core": "[1.40.0-unstable, )",
           "Nethermind.Crypto": "[1.40.0-unstable, )",
+          "Nethermind.History": "[1.40.0-unstable, )",
           "Nethermind.Synchronization": "[1.40.0-unstable, )",
           "NonBlocking": "[2.1.2, )"
         }
@@ -1104,6 +1105,7 @@
           "Nethermind.Blockchain": "[1.40.0-unstable, )",
           "Nethermind.Consensus": "[1.40.0-unstable, )",
           "Nethermind.Facade": "[1.40.0-unstable, )",
+          "Nethermind.History": "[1.40.0-unstable, )",
           "Nethermind.JsonRpc": "[1.40.0-unstable, )"
         }
       },

--- a/src/Nethermind/Nethermind.State.Test/VerifyTrieStarterTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/VerifyTrieStarterTests.cs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Config;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.State;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Store.Test;
+
+public class VerifyTrieStarterTests
+{
+    [Test]
+    public void Logs_cancellation_not_error_when_verify_trie_is_cancelled_as_aggregate()
+    {
+        // The parallel stats walk surfaces shutdown cancellation as an AggregateException of
+        // TaskCanceledExceptions; it must be reported as a cancellation, never as an error.
+        CapturingLogManager logManager = RunVerifyTrieThatThrows(
+            new AggregateException(new TaskCanceledException(), new TaskCanceledException()));
+
+        Assert.That(() => logManager.Infos, Has.Some.Contains("Verify trie cancelled").After(5000, 20));
+        Assert.That(logManager.Errors, Is.Empty);
+    }
+
+    [Test]
+    public void Logs_error_when_a_real_fault_is_aggregated_with_cancellations()
+    {
+        // A genuine failure alongside cancellations leaves a non-cancellation leaf and must
+        // still surface as an error, so a real divergence can never be silently swallowed.
+        CapturingLogManager logManager = RunVerifyTrieThatThrows(
+            new AggregateException(new TaskCanceledException(), new InvalidOperationException("boom")));
+
+        Assert.That(() => logManager.Errors, Has.Some.Contains("Error in verify trie").After(5000, 20));
+        Assert.That(logManager.Infos, Has.None.Contains("Verify trie cancelled"));
+    }
+
+    [Test]
+    public void Logs_error_when_cancelled_without_process_exit()
+    {
+        // A cancellation that did not originate from process exit is unexpected: the sweep never
+        // finished, so it must surface as an error rather than a benign "Verify trie cancelled".
+        CapturingLogManager logManager = RunVerifyTrieThatThrows(
+            new OperationCanceledException(), processExiting: false);
+
+        Assert.That(() => logManager.Errors, Has.Some.Contains("Error in verify trie").After(5000, 20));
+        Assert.That(logManager.Infos, Has.None.Contains("Verify trie cancelled"));
+    }
+
+    private static CapturingLogManager RunVerifyTrieThatThrows(Exception toThrow, bool processExiting = true)
+    {
+        IWorldStateManager worldStateManager = Substitute.For<IWorldStateManager>();
+        worldStateManager
+            .VerifyTrie(Arg.Any<BlockHeader>(), Arg.Any<CancellationToken>())
+            .Returns(_ => throw toThrow);
+
+        IProcessExitSource exitSource = Substitute.For<IProcessExitSource>();
+        exitSource.Token.Returns(new CancellationToken(processExiting));
+
+        CapturingLogManager logManager = new();
+        VerifyTrieStarter starter = new(worldStateManager, exitSource, logManager);
+
+        Assert.That(starter.TryStartVerifyTrie(Build.A.BlockHeader.TestObject), Is.True);
+        return logManager;
+    }
+
+    private sealed class CapturingLogManager : ILogManager
+    {
+        public ConcurrentQueue<string> Infos { get; } = new();
+        public ConcurrentQueue<string> Errors { get; } = new();
+
+        public ILogger GetClassLogger<T>() => new(new Logger(this));
+        public ILogger GetLogger(string loggerName) => new(new Logger(this));
+
+        private sealed class Logger(CapturingLogManager parent) : InterfaceLogger
+        {
+            public void Info(string text) => parent.Infos.Enqueue(text);
+            public void Warn(string text) { }
+            public void Debug(string text) { }
+            public void Trace(string text) { }
+            public void Error(string text, Exception? ex = null) => parent.Errors.Enqueue(text);
+            public bool IsInfo => true;
+            public bool IsWarn => true;
+            public bool IsDebug => true;
+            public bool IsTrace => true;
+            public bool IsError => true;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State/VerifyTrieStarter.cs
+++ b/src/Nethermind/Nethermind.State/VerifyTrieStarter.cs
@@ -41,7 +41,9 @@ public class VerifyTrieStarter(IWorldStateManager worldStateManager, IProcessExi
                     if (_logger.IsError) _logger!.Error($"Verify trie failed");
                 }
             }
-            catch (OperationCanceledException)
+            // Only a shutdown-driven cancellation is expected here; an OCE from any other token means the
+            // sweep never completed, so it is treated as a fault rather than a benign cancellation.
+            catch (Exception e) when (exitSource.Token.IsCancellationRequested && IsCancellation(e))
             {
                 if (_logger.IsInfo) _logger.Info($"Verify trie cancelled");
             }
@@ -53,6 +55,36 @@ public class VerifyTrieStarter(IWorldStateManager worldStateManager, IProcessExi
         }, TaskCreationOptions.LongRunning);
 
         return true;
+    }
+
+    /// <summary>Whether an exception thrown by the verify-trie run represents cancellation rather than a fault.</summary>
+    /// <remarks>
+    /// The stats walk runs in parallel (<c>BatchedTrieVisitor</c> / <c>FlatTrieVerifier</c> do
+    /// <c>Task.WaitAll</c>), so shutdown cancellation surfaces as an <see cref="AggregateException"/> of
+    /// <see cref="OperationCanceledException"/>s, not a single one. Only an aggregate whose leaves are
+    /// <em>all</em> cancellations counts as cancelled: a real fault raised alongside the cancellation
+    /// leaves a non-cancellation leaf and is still surfaced as an error.
+    /// </remarks>
+    private static bool IsCancellation(Exception exception) => exception switch
+    {
+        OperationCanceledException => true,
+        AggregateException aggregate => IsAllCancellation(aggregate),
+        _ => false,
+    };
+
+    private static bool IsAllCancellation(AggregateException exception)
+    {
+        bool any = false;
+        foreach (Exception leaf in exception.Flatten().InnerExceptions)
+        {
+            any = true;
+            if (leaf is not OperationCanceledException)
+            {
+                return false;
+            }
+        }
+
+        return any;
     }
 }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -266,6 +266,20 @@ public class BodiesSyncFeedTests
     }
 
     [Test]
+    public void Completion_marker_clears_when_the_barrier_drops_after_a_finished_download()
+    {
+        _historyPruner.CutoffBlockNumber.Returns((ulong?)60);
+        _syncPointers.LowestInsertedBodyNumber = 60;
+        _feed.InitializeFeed();
+        Assert.That(_metadataDb.KeyExists(MetadataDbKeys.AncientBodiesDownloadComplete), Is.True);
+
+        _historyPruner.CutoffBlockNumber.Returns((ulong?)null);
+        _feed.InitializeFeed();
+
+        Assert.That(_metadataDb.KeyExists(MetadataDbKeys.AncientBodiesDownloadComplete), Is.False);
+    }
+
+    [Test]
     public async Task ShouldLimitBatchSizeToPeerEstimate()
     {
         _feed.InitializeFeed();

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncServerTests.cs
@@ -610,7 +610,7 @@ public class SyncServerTests
         ctx.BlockTree.Genesis.Returns(Build.A.BlockHeader.WithNumber(0).TestObject);
         ctx.BlockTree.Head.Returns(Build.A.Block.WithNumber(200).TestObject);
         ctx.BlockTree.GetLowestBlock().Returns(100UL);
-        ctx.BlockTree.FindHeader(100UL, BlockTreeLookupOptions.None).Returns(Build.A.BlockHeader.WithNumber(100).TestObject);
+        ctx.BlockTree.FindHeader(100UL, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(Build.A.BlockHeader.WithNumber(100).TestObject);
         ctx.HistoryPruner.OldestBlockHeader.Returns((BlockHeader?)null);
 
         PeerInfo peer = new(Substitute.For<ISyncPeer>());
@@ -634,14 +634,149 @@ public class SyncServerTests
 
     [Test]
     [Parallelizable(ParallelScope.None)]
+    public void Broadcast_BlockRangeUpdate_floors_at_the_download_pointers_while_the_pruner_defers()
+    {
+        Context ctx = new();
+        ctx.BlockTree.Genesis.Returns(Build.A.BlockHeader.WithNumber(0).TestObject);
+        ctx.BlockTree.Head.Returns(Build.A.Block.WithNumber(200).TestObject);
+        ctx.BlockTree.GetLowestBlock().Returns(100UL);
+        ctx.BlockTree.FindHeader(120UL, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(Build.A.BlockHeader.WithNumber(120).TestObject);
+        ctx.HistoryPruner.OldestBlockHeader.Returns((BlockHeader?)null);
+        ctx.SyncPointers.LowestInsertedBodyNumber.Returns(110UL);
+        ctx.SyncPointers.LowestInsertedReceiptBlockNumber.Returns(120UL);
+
+        PeerInfo peer = new(Substitute.For<ISyncPeer>());
+        ConfigurePeers(ctx, [peer]);
+
+        using ManualResetEventSlim notified = new(false);
+        ulong notifiedEarliest = ulong.MaxValue;
+        peer.SyncPeer
+            .When(p => p.NotifyOfNewRange(Arg.Any<BlockHeader>(), Arg.Any<BlockHeader>()))
+            .Do(call =>
+            {
+                notifiedEarliest = call.ArgAt<BlockHeader>(0).Number;
+                notified.Set();
+            });
+
+        ctx.BlockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(128).TestObject));
+
+        Assert.That(notified.Wait(TimeSpan.FromSeconds(30)), Is.True, "Peer was not notified of the block range");
+        Assert.That(notifiedEarliest, Is.EqualTo(120UL),
+            "while the pruner defers, the advertised earliest must track the later of the body and receipt frontiers, not the config barrier");
+        Assert.That(ctx.SyncServer.LowestBlock, Is.EqualTo(120UL),
+            "the eth/69 status handshake reads LowestBlock directly, so it must carry the same floor as the range broadcast");
+    }
+
+    [TestCase(true, 150UL, 1UL, TestName = "LowestBlock_falls_back_to_the_config_pivot_while_no_ancient_body_was_inserted")]
+    [TestCase(false, 150UL, 1UL, TestName = "LowestBlock_ignores_the_pivot_on_a_node_with_no_descending_feed")]
+    [TestCase(true, 0UL, 1UL, TestName = "LowestBlock_ignores_the_pivot_on_a_genesis_following_node_without_a_config_pivot")]
+    [Parallelizable(ParallelScope.None)]
+    public void LowestBlock_floors_at_the_config_pivot_only_under_fast_sync(bool fastSync, ulong configPivot, ulong lowestStored)
+    {
+        ulong expected = fastSync && configPivot != 0 ? configPivot : lowestStored;
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.SyncPivot.Returns((5_000UL, Keccak.Zero));
+        blockTree.Genesis.Returns(Build.A.BlockHeader.WithNumber(0).TestObject);
+        blockTree.Head.Returns(Build.A.Block.WithNumber(200).TestObject);
+        blockTree.GetLowestBlock().Returns(lowestStored);
+
+        SyncServer syncServer = new(
+            Substitute.For<IWorldStateManager>(),
+            new MemDb(),
+            blockTree,
+            NullReceiptStorage.Instance,
+            Substitute.For<IBlockAccessListStore>(),
+            Always.Valid,
+            Always.Valid,
+            Substitute.For<ISyncPeerPool>(),
+            StaticSelector.Full,
+            new TestSyncConfig { FastSync = fastSync, PivotNumber = configPivot },
+            Policy.FullGossip,
+            Substitute.For<IHistoryPruner>(),
+            MainnetSpecProvider.Instance,
+            LimboLogs.Instance,
+            Substitute.For<ISyncPointers>());
+
+        Assert.That(syncServer.LowestBlock, Is.EqualTo(expected),
+            "the floor is the static config pivot, only under fast sync - the live tree pivot rises with finality and would withdraw held history on a genesis-following node");
+    }
+
+    [Test]
+    [Parallelizable(ParallelScope.None)]
+    public void Broadcast_BlockRangeUpdate_floors_above_a_published_boundary_while_receipts_descend()
+    {
+        Context ctx = new();
+        ctx.BlockTree.Genesis.Returns(Build.A.BlockHeader.WithNumber(0).TestObject);
+        ctx.BlockTree.Head.Returns(Build.A.Block.WithNumber(200).TestObject);
+        ctx.BlockTree.GetLowestBlock().Returns(100UL);
+        ctx.BlockTree.FindHeader(120UL, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(Build.A.BlockHeader.WithNumber(120).TestObject);
+        ctx.HistoryPruner.OldestBlockHeader.Returns(Build.A.BlockHeader.WithNumber(100).TestObject);
+        ctx.SyncPointers.LowestInsertedBodyNumber.Returns(110UL);
+        ctx.SyncPointers.LowestInsertedReceiptBlockNumber.Returns(120UL);
+
+        PeerInfo peer = new(Substitute.For<ISyncPeer>());
+        ConfigurePeers(ctx, [peer]);
+
+        using ManualResetEventSlim notified = new(false);
+        ulong notifiedEarliest = ulong.MaxValue;
+        peer.SyncPeer
+            .When(p => p.NotifyOfNewRange(Arg.Any<BlockHeader>(), Arg.Any<BlockHeader>()))
+            .Do(call =>
+            {
+                notifiedEarliest = call.ArgAt<BlockHeader>(0).Number;
+                notified.Set();
+            });
+
+        ctx.BlockTree.NewHeadBlock += Raise.EventWith(new BlockEventArgs(Build.A.Block.WithNumber(128).TestObject));
+
+        Assert.That(notified.Wait(TimeSpan.FromSeconds(30)), Is.True, "Peer was not notified of the block range");
+        Assert.That(notifiedEarliest, Is.EqualTo(120UL),
+            "the broadcast must carry the same floor as the status handshake even when the pruner has already published a lower boundary");
+    }
+
+    [Test]
+    [Parallelizable(ParallelScope.None)]
+    public void Broadcast_BlockRangeUpdate_floors_the_pruner_published_boundary_too()
+    {
+        Context ctx = new();
+        ctx.BlockTree.Genesis.Returns(Build.A.BlockHeader.WithNumber(0).TestObject);
+        ctx.BlockTree.Head.Returns(Build.A.Block.WithNumber(200).TestObject);
+        ctx.BlockTree.GetLowestBlock().Returns(100UL);
+        ctx.BlockTree.FindHeader(120UL, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(Build.A.BlockHeader.WithNumber(120).TestObject);
+        ctx.SyncPointers.LowestInsertedBodyNumber.Returns(110UL);
+        ctx.SyncPointers.LowestInsertedReceiptBlockNumber.Returns(120UL);
+
+        PeerInfo peer = new(Substitute.For<ISyncPeer>());
+        ConfigurePeers(ctx, [peer]);
+
+        using ManualResetEventSlim notified = new(false);
+        ulong notifiedEarliest = ulong.MaxValue;
+        peer.SyncPeer
+            .When(p => p.NotifyOfNewRange(Arg.Any<BlockHeader>(), Arg.Any<BlockHeader>()))
+            .Do(call =>
+            {
+                notifiedEarliest = call.ArgAt<BlockHeader>(0).Number;
+                notified.Set();
+            });
+
+        ctx.HistoryPruner.NewOldestBlock += Raise.EventWith(new OnNewOldestBlockArgs(Build.A.BlockHeader.WithNumber(100).TestObject));
+
+        Assert.That(notified.Wait(TimeSpan.FromSeconds(30)), Is.True, "Peer was not notified of the block range");
+        Assert.That(notifiedEarliest, Is.EqualTo(120UL),
+            "the pruner published path must carry the same floor as the head driven one, so one peer never sees two different earliest values");
+        ctx.BlockTree.Received().UpdateLowestServedBlock(120UL);
+    }
+
+    [Test]
+    [Parallelizable(ParallelScope.None)]
     public void Broadcast_BlockRangeUpdate_clamps_earliest_to_the_announced_block()
     {
         Context ctx = new();
         ctx.BlockTree.Genesis.Returns(Build.A.BlockHeader.WithNumber(0).TestObject);
         ctx.BlockTree.Head.Returns(Build.A.Block.WithNumber(200).TestObject);
         ctx.BlockTree.GetLowestBlock().Returns(100UL);
-        ctx.BlockTree.FindHeader(64UL, BlockTreeLookupOptions.None).Returns(Build.A.BlockHeader.WithNumber(64).TestObject);
-        ctx.BlockTree.FindHeader(100UL, BlockTreeLookupOptions.None).Returns(Build.A.BlockHeader.WithNumber(100).TestObject);
+        ctx.BlockTree.FindHeader(64UL, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(Build.A.BlockHeader.WithNumber(64).TestObject);
+        ctx.BlockTree.FindHeader(100UL, BlockTreeLookupOptions.TotalDifficultyNotNeeded).Returns(Build.A.BlockHeader.WithNumber(100).TestObject);
         ctx.HistoryPruner.OldestBlockHeader.Returns((BlockHeader?)null);
 
         PeerInfo peer = new(Substitute.For<ISyncPeer>());
@@ -819,6 +954,7 @@ public class SyncServerTests
             BlockTree = Substitute.For<IBlockTree>();
             WorldStateManager = Substitute.For<IWorldStateManager>();
             HistoryPruner = Substitute.For<IHistoryPruner>();
+            SyncPointers = Substitute.For<ISyncPointers>();
 
             StaticSelector selector = StaticSelector.Full;
             SyncServer = new SyncServer(
@@ -835,11 +971,13 @@ public class SyncServerTests
                 Policy.FullGossip,
                 HistoryPruner,
                 MainnetSpecProvider.Instance,
-                LimboLogs.Instance);
+                LimboLogs.Instance,
+                SyncPointers);
         }
 
         public IBlockTree BlockTree { get; }
         public IHistoryPruner HistoryPruner { get; }
+        public ISyncPointers SyncPointers { get; }
         public IWorldStateManager WorldStateManager { get; }
         public ISyncPeerPool PeerPool { get; }
         public SyncServer SyncServer { get; set; }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -108,6 +108,7 @@ namespace Nethermind.Synchronization.FastBlocks
                 InitializeMetadataDb();
             }
             base.InitializeFeed();
+            PersistCompletionMarker();
             _syncReport.FastBlocksBodies.Reset(0, _pivotNumber - _barrier);
         }
 
@@ -188,6 +189,21 @@ namespace Nethermind.Synchronization.FastBlocks
             ulong lowestInsertedAtPoint = _syncStatusList.LowestInsertWithoutGaps;
             _blocksDb.Flush();
             _syncPointers.LowestInsertedBodyNumber = lowestInsertedAtPoint;
+            PersistCompletionMarker();
+        }
+
+        // Consumers that must not act on a mid-descent frontier (history pruning discovery) key off this
+        // marker; it mirrors AllDownloaded both ways because a recomputed barrier can drop and reopen the descent.
+        private void PersistCompletionMarker()
+        {
+            if (AllDownloaded)
+            {
+                _metadataDb.Set(MetadataDbKeys.AncientBodiesDownloadComplete, [1]);
+            }
+            else
+            {
+                _metadataDb.Delete(MetadataDbKeys.AncientBodiesDownloadComplete);
+            }
         }
 
         public override SyncResponseHandlingResult HandleResponse(BodiesSyncBatch? batch, PeerInfo peer = null)

--- a/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SyncServer.cs
@@ -53,6 +53,8 @@ namespace Nethermind.Synchronization
         private readonly IGossipPolicy _gossipPolicy;
         private readonly ISpecProvider _specProvider;
         private readonly IHistoryPruner _historyPruner;
+        private readonly ISyncPointers? _syncPointers;
+        private readonly ISyncConfig _syncConfig;
         private bool _gossipStopped = false;
         private readonly Random _broadcastRandomizer = new();
 
@@ -80,9 +82,12 @@ namespace Nethermind.Synchronization
             IGossipPolicy gossipPolicy,
             IHistoryPruner historyPruner,
             ISpecProvider specProvider,
-            ILogManager logManager)
+            ILogManager logManager,
+            ISyncPointers? syncPointers = null)
         {
+            _syncPointers = syncPointers;
             ISyncConfig config = syncConfig ?? throw new ArgumentNullException(nameof(syncConfig));
+            _syncConfig = config;
             _gossipPolicy = gossipPolicy ?? throw new ArgumentNullException(nameof(gossipPolicy));
             _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
             _pool = pool ?? throw new ArgumentNullException(nameof(pool));
@@ -103,6 +108,9 @@ namespace Nethermind.Synchronization
             _blockTree.NewHeadBlock += OnNewRange;
             _pool.NotifyPeerBlock += OnNotifyPeerBlock;
             _historyPruner.NewOldestBlock += OnNewRange;
+            // Seed the served floor at startup so JSON-RPC's pruned-history check agrees with the eth/69
+            // advertisement before the first broadcast recomputes it.
+            _blockTree.UpdateLowestServedBlock(ulong.Max(_blockTree.GetLowestBlock(), DownloadPointerFloor));
         }
 
         public ulong NetworkId => _blockTree.NetworkId;
@@ -129,7 +137,26 @@ namespace Nethermind.Synchronization
             }
         }
 
-        public ulong LowestBlock => Math.Min(Head?.Number ?? 0UL, _blockTree.GetLowestBlock());
+        // The advertised range covers bodies and receipts, so the honest earliest is the later of the two
+        // download frontiers - the block tree's boundary is only the truth once the pruner has published one.
+        // An absent pointer under fast sync falls back to the static config pivot - bodies exist only from
+        // where full sync began, so the pivot is the honest earliest even when the feeds never run; the live
+        // tree pivot rises with finality, so a genesis-following node (CL-discovered pivot) falls back to zero.
+        private ulong DownloadPointerFloor
+        {
+            get
+            {
+                if (_syncPointers is null)
+                    return 0;
+
+                ulong fallback = _syncConfig.FastSync ? _syncConfig.PivotNumber : 0;
+                return ulong.Max(
+                    _syncPointers.LowestInsertedBodyNumber ?? fallback,
+                    _syncPointers.LowestInsertedReceiptBlockNumber ?? fallback);
+            }
+        }
+
+        public ulong LowestBlock => Math.Min(Head?.Number ?? 0UL, ulong.Max(_blockTree.GetLowestBlock(), DownloadPointerFloor));
 
         public int GetPeerCount() => _pool.PeerCount;
 
@@ -467,7 +494,18 @@ namespace Nethermind.Synchronization
             if (_blockTree.Head is null)
                 return;
 
-            OnNewRange(onNewOldestBlockArgs.OldestBlockHeader, _blockTree.Head.Header);
+            BlockHeader latest = _blockTree.Head.Header;
+            ulong servedFloor = ulong.Max(_blockTree.GetLowestBlock(), DownloadPointerFloor);
+            _blockTree.UpdateLowestServedBlock(servedFloor);
+            ulong floor = ulong.Min(servedFloor, latest.Number);
+            BlockHeader earliest = onNewOldestBlockArgs.OldestBlockHeader;
+            if (earliest.Number < floor)
+            {
+                // TotalDifficultyNotNeeded: ancient headers carry no TD, and a null here must not fall back below the floor.
+                earliest = _blockTree.FindHeader(floor, BlockTreeLookupOptions.TotalDifficultyNotNeeded) ?? latest;
+            }
+
+            OnNewRange(earliest, latest);
         }
 
         private void OnNewRange(object? sender, BlockEventArgs latestBlockEventArgs)
@@ -478,11 +516,14 @@ namespace Nethermind.Synchronization
             if (latestBlock.Number % NewHeadBlockRangeUpdateFrequency != 0)
                 return;
 
+            // The same floor the status handshake advertises, so a peer never sees two different earliest values.
+            ulong servedFloor = ulong.Max(_blockTree.GetLowestBlock(), DownloadPointerFloor);
+            _blockTree.UpdateLowestServedBlock(servedFloor);
+            ulong floor = ulong.Min(servedFloor, latestBlock.Number);
             BlockHeader? earliest = _historyPruner.OldestBlockHeader;
-            if (earliest is null || earliest.Number > latestBlock.Number)
+            if (earliest is null || earliest.Number > latestBlock.Number || earliest.Number < floor)
             {
-                ulong floor = ulong.Min(_blockTree.GetLowestBlock(), latestBlock.Number);
-                earliest = _blockTree.FindHeader(floor, BlockTreeLookupOptions.None) ?? latestBlock.Header;
+                earliest = _blockTree.FindHeader(floor, BlockTreeLookupOptions.TotalDifficultyNotNeeded) ?? latestBlock.Header;
             }
 
             OnNewRange(earliest, latestBlock.Header);

--- a/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/BlobTxStorageTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
@@ -225,6 +226,42 @@ public class BlobTxStorageTests
             Assert.That(blobTxStorage.TryGetWithoutBlobs(first.Hash, first.SenderAddress!, out _), Is.False);
             Assert.That(blobTxStorage.TryGetWithoutBlobs(second.Hash, second.SenderAddress!, out _), Is.False);
             Assert.That(blobTxStorage.GetAll(), Is.Empty);
+        }
+    }
+
+    [Test]
+    public void DeleteObsoleteFullBlobTransactions_should_skip_write_batches_for_live_entries()
+    {
+        const int transactionCount = 17;
+        TrackingColumnsDb columnsDb = new();
+        BlobTxStorage blobTxStorage = new(columnsDb);
+        Transaction[] transactions = new Transaction[transactionCount];
+        EthereumEcdsa ecdsa = new(BlockchainIds.Mainnet);
+        for (int i = 0; i < transactions.Length; i++)
+        {
+            transactions[i] = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields()
+                .WithNonce((ulong)i)
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .SignedAndResolved(ecdsa, TestItem.PrivateKeyA).TestObject;
+            blobTxStorage.Add(transactions[i]);
+        }
+
+        ((IBatchDeleteTxStorage)blobTxStorage).DeleteObsoleteFullBlobTransactions(CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(columnsDb.StartedWriteBatchCount, Is.Zero);
+            for (int i = 0; i < transactions.Length; i++)
+            {
+                Transaction transaction = transactions[i];
+                Assert.That(blobTxStorage.TryGet(
+                    transaction.Hash,
+                    transaction.SenderAddress!,
+                    transaction.Timestamp,
+                    out _), Is.True);
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -5,6 +5,7 @@ using System;
 using CkzgLib;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Comparers;
+using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -278,6 +279,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
         }
@@ -318,6 +320,7 @@ namespace Nethermind.TxPool.Test
             storage.DeletePersistedTransaction(transaction);
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             bool found = _txPool.TryGetPendingBlobTransaction(transaction.Hash!, out Transaction pendingTransaction);
             BlobCellMask pendingMask = found
@@ -382,6 +385,9 @@ namespace Nethermind.TxPool.Test
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
             await _txPool.DisposeAsync();
 
             storage.ResetFullReadCount();
@@ -552,6 +558,7 @@ namespace Nethermind.TxPool.Test
 
             EnsureSenderBalance(TestItem.AddressA, UInt256.Zero);
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
 
@@ -567,6 +574,417 @@ namespace Nethermind.TxPool.Test
                 .TestObject;
 
             Assert.That(_txPool.SubmitTx(newProofTransaction, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+        }
+
+        [Test]
+        public async Task should_flush_failed_revalidation_deletes_before_publishing_marker()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            (ChainSpecBasedSpecProvider provider, _) = TestSpecHelper.LoadChainSpec(new ChainSpecJson
+            {
+                Params = new ChainSpecParamsJson
+                {
+                    Eip4844TransitionTimestamp = head.Timestamp,
+                    Eip7594TransitionTimestamp = head.Timestamp + 1,
+                }
+            });
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                PersistentBlobStorageSize = 1
+            };
+            FailingBatchDeleteBlobTxStorage storage = new() { DeleteManyFailuresRemaining = 2 };
+            _txPool = CreatePool(txPoolConfig, provider, txStorage: storage);
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+            int recoveryCountBeforeFork = storage.ObsoleteRecoveryCount;
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
+            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            await AddEmptyBlock();
+            Assert.That(() => storage.DeleteBatchSizes.Count, Is.EqualTo(1).After(Timeout, 10));
+            Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+
+            await AddEmptyBlock();
+            Assert.That(() => storage.DeleteBatchSizes.Count, Is.EqualTo(2).After(Timeout, 10));
+            Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+
+            await AddEmptyBlock();
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1, 1 }));
+                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(recoveryCountBeforeFork));
+                Assert.That(storage.GetAll(), Is.Empty);
+                Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
+            }
+        }
+
+        [Test]
+        public void should_retry_batched_revalidation_deletes_after_storage_failure()
+        {
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+
+            Assert.That(
+                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
+                Throws.TypeOf<InvalidOperationException>());
+            Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions), Throws.Nothing);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(blobPool.Count, Is.Zero);
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1, 1 }));
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void should_not_retry_stale_revalidation_delete_after_transaction_is_reinserted(bool changeTimestamp)
+        {
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA);
+            UInt256 originalTimestamp = transaction.Timestamp;
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+
+            Assert.That(
+                () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
+                Throws.TypeOf<InvalidOperationException>());
+            if (changeTimestamp)
+            {
+                transaction.Timestamp += UInt256.One;
+            }
+
+            Assert.That(blobPool.TryInsert(transaction.Hash, transaction, out _), Is.True);
+            Assert.That(() => blobPool.UpdatePoolForRevalidation(accounts, KeepAllTransactions), Throws.Nothing);
+            bool persisted = storage.TryGet(transaction.Hash, transaction.SenderAddress!, transaction.Timestamp, out _);
+            bool obsoleteTransactionPersisted = storage.TryGet(transaction.Hash, transaction.SenderAddress!, originalTimestamp, out _);
+            bool elidedTransactionPersisted = storage.TryGetWithoutBlobs(transaction.Hash, transaction.SenderAddress!, out _);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(blobPool.Count, Is.EqualTo(1));
+                Assert.That(storage.DeleteBatchSizes, Is.EqualTo(new[] { 1 }));
+                Assert.That(storage.FullTransactionDeleteBatchSizes, Is.EqualTo(changeTimestamp ? new[] { 1 } : Array.Empty<int>()));
+                Assert.That(persisted, Is.True);
+                Assert.That(obsoleteTransactionPersisted, Is.EqualTo(!changeTimestamp));
+                Assert.That(elidedTransactionPersisted, Is.True);
+                Assert.That(storage.GetAll(), Is.Not.Empty);
+            }
+        }
+
+        [Test]
+        public async Task should_remove_obsolete_full_transaction_after_failed_delete_and_restart()
+        {
+            TestSpecProvider specProvider = new(Cancun.Instance);
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
+            UInt256 originalTimestamp = transaction.Timestamp;
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                BlobCacheSize = 1,
+                PersistentBlobStorageSize = 2
+            };
+            IComparer<Transaction> comparer = new TransactionComparerProvider(specProvider, _blockTree).GetDefaultComparer();
+            IAccountStateProvider accounts = Substitute.For<IAccountStateProvider>();
+
+            using (PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance))
+            {
+                Assert.That(
+                    () => blobPool.UpdatePoolForRevalidation(accounts, RemoveAllTransactions),
+                    Throws.TypeOf<InvalidOperationException>());
+
+                transaction.Timestamp += UInt256.One;
+                Assert.That(blobPool.TryInsert(transaction.Hash, transaction, out _), Is.True);
+                storage.FailNextFullTransactionDelete = true;
+                Assert.That(
+                    () => blobPool.UpdatePoolForRevalidation(accounts, KeepAllTransactions),
+                    Throws.TypeOf<InvalidOperationException>());
+            }
+
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            _txPool = CreatePool(txPoolConfig, specProvider, txStorage: storage);
+            await AddEmptyBlock();
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+
+            bool currentTransactionPersisted = storage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                transaction.Timestamp,
+                out _);
+            bool obsoleteTransactionPersisted = storage.TryGet(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                originalTimestamp,
+                out _);
+            bool elidedTransactionPersisted = storage.TryGetWithoutBlobs(
+                transaction.Hash,
+                transaction.SenderAddress!,
+                out _);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(currentTransactionPersisted, Is.True);
+                Assert.That(obsoleteTransactionPersisted, Is.False);
+                Assert.That(elidedTransactionPersisted, Is.True);
+                Assert.That(storage.GetAll(), Is.Not.Empty);
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task should_defer_obsolete_full_transaction_recovery_from_startup(bool validatorHasFingerprint)
+        {
+            TestSpecProvider specProvider = new(Cancun.Instance);
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
+            UInt256 obsoleteTimestamp = transaction.Timestamp;
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            transaction.Timestamp += UInt256.One;
+            storage.Add(transaction);
+            storage.Delete(transaction.Hash, transaction.Timestamp);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                PersistentBlobStorageSize = 1
+            };
+            TaskCompletionSource recoveryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRecovery = new(false);
+            storage.BeforeObsoleteRecovery = _ =>
+            {
+                if (storage.ObsoleteRecoveryCount != 1)
+                {
+                    return;
+                }
+
+                recoveryStarted.TrySetResult();
+                Assert.That(
+                    releaseRecovery.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "Timed out waiting to release obsolete blob-body recovery.");
+                throw new InvalidOperationException("Simulated interrupted obsolete blob-body recovery.");
+            };
+
+            ITxValidator specChangeTxValidator = validatorHasFingerprint
+                ? new SpecChangeTxValidator(specProvider.ChainId)
+                : Always.Valid;
+            Task<TxPool> poolCreation = RunOnDedicatedThread(() => CreatePool(
+                txPoolConfig,
+                specProvider,
+                txStorage: storage,
+                specChangeTxValidator: specChangeTxValidator));
+            await recoveryStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            TxPool createdPool = null;
+            bool constructionCompletedBeforeRecovery = true;
+            try
+            {
+                createdPool = await poolCreation.WaitAsync(TimeSpan.FromSeconds(5));
+                _txPool = createdPool;
+                Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+                await AddEmptyBlock();
+            }
+            catch (TimeoutException)
+            {
+                constructionCompletedBeforeRecovery = false;
+            }
+            finally
+            {
+                releaseRecovery.Set();
+            }
+
+            _txPool = createdPool ?? await poolCreation.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Assert.That(constructionCompletedBeforeRecovery, Is.True, "TxPool construction waited for the recovery scan.");
+            Assert.That(() => storage.ObsoleteRecoveryCount, Is.EqualTo(2).After(Timeout, 10));
+            if (validatorHasFingerprint)
+            {
+                Assert.That(
+                    () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                    Is.Not.Null.After(Timeout, 10));
+            }
+            else
+            {
+                Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
+            }
+
+            Assert.That(
+                storage.TryGet(transaction.Hash, transaction.SenderAddress!, obsoleteTimestamp, out _),
+                Is.False);
+        }
+
+        [TestCase(BlobsSupportMode.Disabled)]
+        [TestCase(BlobsSupportMode.InMemory)]
+        public async Task should_not_recover_obsolete_full_transactions_for_non_persistent_blob_pool(BlobsSupportMode blobsSupport)
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider specProvider = new(Prague.Instance)
+            {
+                NextForkSpec = Osaka.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            FailingBatchDeleteBlobTxStorage storage = new();
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = blobsSupport };
+            _txPool = CreatePool(txPoolConfig, specProvider, txStorage: storage);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            Transaction transaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+
+            Assert.That(storage.ObsoleteRecoveryCount, Is.Zero);
+        }
+
+        [Test]
+        public async Task should_recover_obsolete_full_transactions_before_revalidation_walk()
+        {
+            TestSpecProvider specProvider = new(Cancun.Instance);
+            Transaction transaction = CreateBlobTx(TestItem.PrivateKeyA, releaseSpec: Cancun.Instance);
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.Add(transaction);
+            TxPoolConfig txPoolConfig = new()
+            {
+                BlobsSupport = BlobsSupportMode.Storage,
+                PersistentBlobStorageSize = 1
+            };
+            TaskCompletionSource revalidationStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRevalidation = new(false);
+            ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
+            specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(_ =>
+            {
+                revalidationStarted.TrySetResult();
+                Assert.That(
+                    releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "Timed out waiting to release fork revalidation.");
+                return ValidationResult.Success;
+            });
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            _txPool = CreatePool(
+                txPoolConfig,
+                specProvider,
+                txStorage: storage,
+                specChangeTxValidator: specChangeTxValidator);
+            await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            try
+            {
+                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                releaseRevalidation.Set();
+            }
+
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+        }
+
+        [Test]
+        public async Task should_stop_retrying_obsolete_full_transaction_recovery_after_repeated_failures()
+        {
+            InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+            logger.IsError.Returns(true);
+            _logManager = new OneLoggerLogManager(new ILogger(logger));
+            FailingBatchDeleteBlobTxStorage storage = new() { ObsoleteRecoveryFailuresRemaining = 2 };
+            _txPool = CreatePool(
+                new TxPoolConfig
+                {
+                    BlobsSupport = BlobsSupportMode.Storage,
+                    PersistentBlobStorageSize = 1
+                },
+                GetCancunSpecProvider(),
+                txStorage: storage);
+            Assert.That(() => storage.ObsoleteRecoveryCount, Is.EqualTo(1).After(Timeout, 10));
+
+            await AddEmptyBlock();
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+            await AddEmptyBlock();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(2));
+                Assert.That(_txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True);
+            }
+
+            logger.Received(1).Error(
+                Arg.Is<string>(static message => message.Contains("Skipping obsolete full blob transaction recovery")),
+                Arg.Any<Exception>());
+        }
+
+        [Test]
+        [NonParallelizable]
+        public async Task should_cancel_obsolete_full_transaction_recovery_during_shutdown()
+        {
+            InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+            logger.IsWarn.Returns(true);
+            _logManager = new OneLoggerLogManager(new ILogger(logger));
+            TaskCompletionSource recoveryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> recoveryReleasedAfterCancellation = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRecovery = new(false);
+            FailingBatchDeleteBlobTxStorage storage = new();
+            storage.BeforeObsoleteRecovery = cancellationToken =>
+            {
+                recoveryStarted.TrySetResult();
+                bool released = releaseRecovery.Wait(TimeSpan.FromSeconds(10));
+                recoveryReleasedAfterCancellation.TrySetResult(released && cancellationToken.IsCancellationRequested);
+            };
+            _txPool = CreatePool(
+                new TxPoolConfig
+                {
+                    BlobsSupport = BlobsSupportMode.Storage,
+                    PersistentBlobStorageSize = 1
+                },
+                GetCancunSpecProvider(),
+                txStorage: storage);
+            await recoveryStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            ValueTask disposal = _txPool.DisposeAsync();
+            releaseRecovery.Set();
+
+            await disposal.AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(await recoveryReleasedAfterCancellation.Task.WaitAsync(TimeSpan.FromSeconds(10)), Is.True);
+                Assert.That(storage.ObsoleteRecoveryCount, Is.EqualTo(1));
+                Assert.That(storage.ObsoleteRecoveryCancellationCount, Is.EqualTo(1));
+            }
+
+            logger.DidNotReceive().Warn(Arg.Is<string>(static message =>
+                message.Contains("failed to revalidate transactions after a protocol change")));
         }
 
         [Test]
@@ -1581,6 +1999,9 @@ namespace Nethermind.TxPool.Test
                         break;
                     case TestAction.Fork:
                         await AddEmptyBlock();
+                        Assert.That(
+                            () => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader),
+                            Is.True.After(Timeout, 10));
                         break;
                     case TestAction.ResetNonce:
                         nonce = 0;
@@ -1667,6 +2088,124 @@ namespace Nethermind.TxPool.Test
             public void ResetFullReadCount() => FullReadCount = 0;
         }
 
+        private sealed class FailingBatchDeleteBlobTxStorage : IBlobTxStorage, IBatchDeleteTxStorage, ISpecChangeValidationStorage
+        {
+            private readonly BlobTxStorage _storage = new();
+            private int _obsoleteRecoveryCount;
+            private int _obsoleteRecoveryCancellationCount;
+
+            public List<int> DeleteBatchSizes { get; } = [];
+
+            public List<int> FullTransactionDeleteBatchSizes { get; } = [];
+
+            public int DeleteManyFailuresRemaining { get; set; } = 1;
+
+            public int ObsoleteRecoveryFailuresRemaining { get; set; }
+
+            public bool FailNextFullTransactionDelete { get; set; }
+
+            public Action<CancellationToken> BeforeObsoleteRecovery { get; set; }
+
+            public int ObsoleteRecoveryCount => Volatile.Read(ref _obsoleteRecoveryCount);
+
+            public int ObsoleteRecoveryCancellationCount => Volatile.Read(ref _obsoleteRecoveryCancellationCount);
+
+            public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
+                _storage.TryGet(hash, sender, timestamp, out transaction);
+
+            public bool TryGetWithoutBlobs(in ValueHash256 hash, Address sender, out Transaction transaction) =>
+                _storage.TryGetWithoutBlobs(hash, sender, out transaction);
+
+            public int TryGetMany(TxLookupKey[] keys, int count, Transaction[] results) =>
+                _storage.TryGetMany(keys, count, results);
+
+            public IEnumerable<LightTransaction> GetAll() => _storage.GetAll();
+
+            public void Add(Transaction transaction) => _storage.Add(transaction);
+
+            public void Delete(in ValueHash256 hash, in UInt256 timestamp) => _storage.Delete(hash, timestamp);
+
+            public bool TryGetBlobTransactionsFromBlock(ulong blockNumber, out Transaction[] blockBlobTransactions) =>
+                _storage.TryGetBlobTransactionsFromBlock(blockNumber, out blockBlobTransactions);
+
+            public void AddBlobTransactionsFromBlock(ulong blockNumber, in ArrayPoolListRef<Transaction> blockBlobTransactions) =>
+                _storage.AddBlobTransactionsFromBlock(blockNumber, blockBlobTransactions);
+
+            public void DeleteBlobTransactionsFromBlock(ulong blockNumber) =>
+                _storage.DeleteBlobTransactionsFromBlock(blockNumber);
+
+            string ISpecChangeValidationStorage.GetSpecChangeValidationMarker() =>
+                ((ISpecChangeValidationStorage)_storage).GetSpecChangeValidationMarker();
+
+            void ISpecChangeValidationStorage.SetSpecChangeValidationMarker(string marker) =>
+                ((ISpecChangeValidationStorage)_storage).SetSpecChangeValidationMarker(marker);
+
+            void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
+            {
+                DeleteBatchSizes.Add(keys.Length);
+                if (DeleteManyFailuresRemaining > 0)
+                {
+                    DeleteManyFailuresRemaining--;
+                    throw new InvalidOperationException();
+                }
+
+                ((IBatchDeleteTxStorage)_storage).DeleteMany(keys);
+            }
+
+            void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys)
+            {
+                FullTransactionDeleteBatchSizes.Add(keys.Length);
+                if (FailNextFullTransactionDelete)
+                {
+                    FailNextFullTransactionDelete = false;
+                    throw new InvalidOperationException();
+                }
+
+                ((IBatchDeleteTxStorage)_storage).DeleteFullBlobTransactions(keys);
+            }
+
+            void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _obsoleteRecoveryCount);
+                BeforeObsoleteRecovery?.Invoke(cancellationToken);
+                if (ObsoleteRecoveryFailuresRemaining > 0)
+                {
+                    ObsoleteRecoveryFailuresRemaining--;
+                    throw new InvalidOperationException("Simulated obsolete blob transaction recovery failure.");
+                }
+
+                try
+                {
+                    ((IBatchDeleteTxStorage)_storage).DeleteObsoleteFullBlobTransactions(cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    Interlocked.Increment(ref _obsoleteRecoveryCancellationCount);
+                    throw;
+                }
+            }
+        }
+
+        private static void RemoveAllTransactions(
+            in AccountStruct account,
+            EnhancedSortedSet<Transaction> transactions,
+            ref Transaction lastElement,
+            TxDistinctSortedPool.UpdateTransactionDelegate updateTransaction)
+        {
+            foreach (Transaction tx in transactions)
+            {
+                updateTransaction(transactions, tx, changedGasBottleneck: null, lastElement);
+            }
+        }
+
+        private static void KeepAllTransactions(
+            in AccountStruct account,
+            EnhancedSortedSet<Transaction> transactions,
+            ref Transaction lastElement,
+            TxDistinctSortedPool.UpdateTransactionDelegate updateTransaction)
+        {
+        }
+
         private sealed class NamedReleaseSpec(IReleaseSpec spec, string name) : ReleaseSpecDecorator(spec)
         {
             public override string Name => name;
@@ -1709,6 +2248,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
         }
@@ -1743,6 +2283,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
         }
@@ -3082,8 +3623,9 @@ namespace Nethermind.TxPool.Test
                 Size = 10
             };
             IComparer<Transaction> comparer = new TransactionComparerProvider(_specProvider, _blockTree).GetDefaultComparer();
+            ManualTimeProvider timeProvider = new();
             using BlockingBlobTxStorage storage = new(failedDeleteCount: failReinsertion ? 3 : 2);
-            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance);
+            using PersistentBlobTxDistinctSortedPool blobPool = new(storage, txPoolConfig, comparer, LimboLogs.Instance, timeProvider);
             Transaction fullBlobTx = Build.A.Transaction
                 .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
                 .WithMaxFeePerGas(1.GWei)
@@ -3131,6 +3673,8 @@ namespace Nethermind.TxPool.Test
                 Assert.That(blobPool.TryInsert(fullBlobTx.Hash, fullBlobTx, out _), Is.True);
             }
 
+            // Advance beyond the maximum backoff so every pending retry is due.
+            timeProvider.AdvanceAndFireTimer(TimeSpan.FromMinutes(1));
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(
@@ -3262,18 +3806,35 @@ namespace Nethermind.TxPool.Test
             Task<BlobCellMergeResult> merge = RunOnDedicatedThread(() =>
                 blobPool.MergeCells(sparseTx.Hash!.ValueHash256, updateMask, updateCells));
             Assert.That(storage.WaitForBlockedRead(TimeSpan.FromSeconds(5)), Is.True);
+            using ManualResetEventSlim lookupCompleted = new();
             Task<bool> concurrentLookup = RunOnDedicatedThread(() =>
-                blobPool.TryGetValue(cacheEvictor.Hash!.ValueHash256, out _));
+            {
+                try
+                {
+                    return blobPool.TryGetValue(cacheEvictor.Hash!.ValueHash256, out _);
+                }
+                finally
+                {
+                    lookupCompleted.Set();
+                }
+            });
+            bool lookupCompletedBeforeRelease;
             try
             {
-                Assert.That(await concurrentLookup.WaitAsync(TimeSpan.FromSeconds(5)), Is.True);
+                lookupCompletedBeforeRelease = lookupCompleted.Wait(TimeSpan.FromSeconds(5));
             }
             finally
             {
                 storage.ReleaseBlockedRead();
             }
 
-            Assert.That(await merge, Is.EqualTo(BlobCellMergeResult.Accepted));
+            await Task.WhenAll(merge, concurrentLookup);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(lookupCompletedBeforeRelease, Is.True);
+                Assert.That(await concurrentLookup, Is.True);
+                Assert.That(await merge, Is.EqualTo(BlobCellMergeResult.Accepted));
+            }
         }
 
         [TestCase(false)]

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -347,6 +347,7 @@ namespace Nethermind.TxPool.Test
             }
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
 
@@ -354,6 +355,33 @@ namespace Nethermind.TxPool.Test
             await RaiseBlockAddedToMainAndWaitForNewHead(head);
 
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+        }
+
+        [Test]
+        public async Task should_revalidate_when_head_spec_changes_during_construction()
+        {
+            BlobTxStorage storage = new();
+            _txPool = CreatePool(specProvider: new TestSpecProvider(Prague.Instance), txStorage: storage);
+            Assert.That(
+                () => ((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(),
+                Is.Not.Null.After(Timeout, 10));
+            await _txPool.DisposeAsync();
+
+            IChainHeadSpecProvider changingSpecProvider = Substitute.For<IChainHeadSpecProvider>();
+            // Both pools are empty, so UpdateBucketsWithoutRevalidation consumes no head-spec read:
+            // ObserveHeadSpec and InitializeValidatedSpec see Prague; the final startup check sees Osaka.
+            changingSpecProvider.GetCurrentHeadSpec().Returns(Prague.Instance, Prague.Instance, Osaka.Instance);
+            changingSpecProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(Osaka.Instance);
+            ChainHeadInfoProvider headInfo = new(changingSpecProvider, _blockTree, _stateProvider);
+
+            _txPool = CreatePool(
+                specProvider: new TestSpecProvider(Prague.Instance),
+                chainHeadInfoProvider: headInfo,
+                txStorage: storage);
+
+            Assert.That(
+                () => _txPool.IsRevalidatedFor(Build.A.BlockHeader.TestObject),
+                Is.True.After(Timeout, 10));
         }
 
         [Test]
@@ -378,6 +406,7 @@ namespace Nethermind.TxPool.Test
 
             EnsureSenderBalance(TestItem.AddressA, UInt256.Zero);
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             int pendingTransactionsCount = _txPool.GetPendingTransactionsCount();
             AcceptTxResult resubmissionResult = _txPool.SubmitTx(transaction, TxHandlingOptions.None);
@@ -413,6 +442,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
         }
@@ -445,11 +475,11 @@ namespace Nethermind.TxPool.Test
 
             _blockTree.BestSuggestedHeader = preForkHead.Header;
             await RaiseBlockAddedToMainAndWaitForNewHead(preForkHead, forkHead);
+            Assert.That(() => _txPool.IsRevalidatedFor(preForkHead.Header), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
-                Assert.That(_txPool.IsRevalidatedFor(preForkHead.Header), Is.True);
             }
         }
 
@@ -478,6 +508,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -511,6 +542,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -552,6 +584,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -571,8 +604,12 @@ namespace Nethermind.TxPool.Test
                 NextForkSpec = Osaka.Instance,
                 ForkOnBlockNumber = head.Number + 2
             };
-            ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
+            ISpecChangeTxValidator specChangeTxValidator = Substitute.For<ISpecChangeTxValidator>();
             specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(ValidationResult.Success);
+            specChangeTxValidator.IsWellFormedAfterFullValidation(
+                    Arg.Any<Transaction>(),
+                    Arg.Any<IReleaseSpec>())
+                .Returns(ValidationResult.Success);
 
             _txPool = CreatePool(specProvider: provider, specChangeTxValidator: specChangeTxValidator);
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
@@ -582,7 +619,9 @@ namespace Nethermind.TxPool.Test
                 .TestObject;
 
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
-            specChangeTxValidator.Received(1).IsWellFormed(transaction, Prague.Instance);
+            specChangeTxValidator.Received(1).IsWellFormedAfterFullValidation(
+                transaction,
+                Prague.Instance);
             specChangeTxValidator.ClearReceivedCalls();
             Assert.That(_txPool.IsRevalidatedFor(Build.A.BlockHeader.WithNumber(head.Number + 1).TestObject), Is.True);
 
@@ -594,6 +633,7 @@ namespace Nethermind.TxPool.Test
             _blockTree.BestSuggestedHeader = nextBlock.Header;
             Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.False);
             await RaiseBlockAddedToMainAndWaitForNewHead(nextBlock);
+            Assert.That(() => _txPool.IsRevalidatedFor(nextBlock.Header), Is.True.After(Timeout, 10));
 
             specChangeTxValidator.Received(1).IsWellFormed(transaction, Osaka.Instance);
             Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.True);
@@ -614,7 +654,7 @@ namespace Nethermind.TxPool.Test
 
             await AddEmptyBlock();
 
-            Assert.That(_txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True);
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
         }
 
         [Test]
@@ -637,7 +677,7 @@ namespace Nethermind.TxPool.Test
 
             await AddEmptyBlock();
             BlockHeader forkHeader = _blockTree.BestSuggestedHeader;
-            Assert.That(_txPool.IsRevalidatedFor(forkHeader), Is.True);
+            Assert.That(() => _txPool.IsRevalidatedFor(forkHeader), Is.True.After(Timeout, 10));
 
             // A reorg back below the fork makes the pool accept transactions under the previous rules again,
             // which stops the mark left by the walk for the fork spec from covering the pool.
@@ -661,7 +701,7 @@ namespace Nethermind.TxPool.Test
                 ForkOnBlockNumber = head.Number + 1
             };
             ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
-            TaskCompletionSource revalidationFailed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource revalidationFailureTriggered = new(TaskCreationOptions.RunContinuationsAsynchronously);
             using ManualResetEventSlim allowRevalidation = new(false);
             int validationAttempts = 0;
             specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(callInfo =>
@@ -674,7 +714,7 @@ namespace Nethermind.TxPool.Test
                 Interlocked.Increment(ref validationAttempts);
                 if (!allowRevalidation.IsSet)
                 {
-                    revalidationFailed.TrySetResult();
+                    revalidationFailureTriggered.TrySetResult();
                     throw new InvalidOperationException();
                 }
 
@@ -704,13 +744,13 @@ namespace Nethermind.TxPool.Test
                 handler => _txPool.TxPoolHeadChanged -= handler,
                 block => block.Hash == forkBlock.Hash);
             _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
-            await revalidationFailed.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            await revalidationFailureTriggered.Task.WaitAsync(TimeSpan.FromSeconds(10));
             await forkHeadProcessed.WaitAsync(TimeSpan.FromSeconds(10));
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(_txPool.IsRevalidatedFor(forkBlock.Header), Is.False);
-                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+                Assert.That(() => _txPool.GetPendingTransactionsCount(), Is.EqualTo(1).After(Timeout, 10));
                 Assert.That(_txPool.ContainsTx(transaction.Hash!, transaction.Type), Is.True);
             }
 
@@ -719,11 +759,248 @@ namespace Nethermind.TxPool.Test
             Block nextBlock = Build.A.Block.WithNumber(forkBlock.Number + 1).TestObject;
             _blockTree.BestSuggestedHeader = nextBlock.Header;
             await RaiseBlockAddedToMainAndWaitForNewHead(nextBlock);
+            Assert.That(() => _txPool.IsRevalidatedFor(nextBlock.Header), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.True);
                 Assert.That(validationAttempts, Is.GreaterThanOrEqualTo(2));
+            }
+        }
+
+        [Test]
+        public async Task should_reconcile_buckets_when_spec_change_revalidation_is_abandoned()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider provider = new(Prague.Instance)
+            {
+                NextForkSpec = Osaka.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            Transaction retainedTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            Transaction unaffordableTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyB)
+                .TestObject;
+            TaskCompletionSource firstPassStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource secondPassStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> firstPassReleased = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> secondPassReleased = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseFirstPass = new(false);
+            using ManualResetEventSlim releaseSecondPass = new(false);
+            int retainedTransactionValidations = 0;
+            ISpecChangeTxValidator specChangeTxValidator = Substitute.For<ISpecChangeTxValidator>();
+            specChangeTxValidator.IsWellFormedAfterFullValidation(
+                    Arg.Any<Transaction>(),
+                    Arg.Any<IReleaseSpec>())
+                .Returns(ValidationResult.Success);
+            specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(callInfo =>
+            {
+                if (ReferenceEquals(callInfo.Arg<Transaction>(), retainedTransaction))
+                {
+                    int validation = Interlocked.Increment(ref retainedTransactionValidations);
+                    if (validation == 1)
+                    {
+                        firstPassStarted.TrySetResult();
+                        firstPassReleased.TrySetResult(releaseFirstPass.Wait(TimeSpan.FromSeconds(10)));
+                    }
+                    else if (validation == 2)
+                    {
+                        secondPassStarted.TrySetResult();
+                        secondPassReleased.TrySetResult(releaseSecondPass.Wait(TimeSpan.FromSeconds(10)));
+                    }
+                }
+
+                return ValidationResult.Success;
+            });
+
+            _txPool = CreatePool(specProvider: provider, specChangeTxValidator: specChangeTxValidator);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+            Assert.That(_txPool.SubmitTx(retainedTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(unaffordableTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            EnsureSenderBalance(TestItem.AddressB, UInt256.Zero);
+
+            Block forkBlock = Build.A.Block.WithNumber(head.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = forkBlock.Header;
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
+            await firstPassStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Block rollbackBlock = Build.A.Block.WithNumber(head.Number).TestObject;
+            _blockTree.BestSuggestedHeader = rollbackBlock.Header;
+            Task rollbackProcessed = Wait.ForEventCondition<Block>(
+                CancellationToken.None,
+                handler => _txPool.TxPoolHeadChanged += handler,
+                handler => _txPool.TxPoolHeadChanged -= handler,
+                block => block.Hash == rollbackBlock.Hash);
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(rollbackBlock));
+
+            try
+            {
+                await rollbackProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+                releaseFirstPass.Set();
+                await secondPassStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+                Assert.That(await firstPassReleased.Task.WaitAsync(TimeSpan.FromSeconds(10)), Is.True);
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(_txPool.ContainsTx(retainedTransaction.Hash!, retainedTransaction.Type), Is.True);
+                    Assert.That(_txPool.ContainsTx(unaffordableTransaction.Hash!, unaffordableTransaction.Type), Is.False);
+                    Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+                }
+            }
+            finally
+            {
+                releaseFirstPass.Set();
+                releaseSecondPass.Set();
+            }
+
+            Assert.That(await secondPassReleased.Task.WaitAsync(TimeSpan.FromSeconds(10)), Is.True);
+            Assert.That(() => _txPool.IsRevalidatedFor(rollbackBlock.Header), Is.True.After(Timeout, 10));
+        }
+
+        [Test]
+        public async Task should_apply_revalidation_evictions_when_head_advances_during_pass()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider provider = new(Prague.Instance)
+            {
+                NextForkSpec = Osaka.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            TaskCompletionSource revalidationStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRevalidation = new(false);
+            int validationAttempts = 0;
+            Transaction invalidTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            Transaction validTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyB)
+                .TestObject;
+            ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
+            specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(callInfo =>
+            {
+                if (!ReferenceEquals(callInfo.Arg<IReleaseSpec>(), Osaka.Instance))
+                {
+                    return ValidationResult.Success;
+                }
+
+                Interlocked.Increment(ref validationAttempts);
+                revalidationStarted.TrySetResult();
+                Assert.That(
+                    releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "Timed out waiting to release fork revalidation.");
+                return ReferenceEquals(callInfo.Arg<Transaction>(), invalidTransaction)
+                    ? new ValidationResult("fork rejection")
+                    : ValidationResult.Success;
+            });
+
+            _txPool = CreatePool(specProvider: provider, specChangeTxValidator: specChangeTxValidator);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+            Assert.That(_txPool.SubmitTx(invalidTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(validTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Block forkBlock = Build.A.Block.WithNumber(head.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = forkBlock.Header;
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
+            await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Block nextBlock = Build.A.Block.WithNumber(forkBlock.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = nextBlock.Header;
+            Task nextHeadProcessed = Wait.ForEventCondition<Block>(
+                CancellationToken.None,
+                handler => _txPool.TxPoolHeadChanged += handler,
+                handler => _txPool.TxPoolHeadChanged -= handler,
+                block => block.Hash == nextBlock.Hash);
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(nextBlock));
+            releaseRevalidation.Set();
+
+            await nextHeadProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.That(() => _txPool.IsRevalidatedFor(nextBlock.Header), Is.True.After(Timeout, 10));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(validationAttempts, Is.EqualTo(2));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+                Assert.That(_txPool.ContainsTx(invalidTransaction.Hash!, invalidTransaction.Type), Is.False);
+                Assert.That(_txPool.ContainsTx(validTransaction.Hash!, validTransaction.Type), Is.True);
+                Assert.That(_txPool.IsRevalidatedFor(nextBlock.Header), Is.True);
+            }
+        }
+
+        [Test]
+        public async Task should_restart_revalidation_after_head_spec_changes_and_returns_during_pass()
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+            TestSpecProvider provider = new(Prague.Instance)
+            {
+                NextForkSpec = Osaka.Instance,
+                ForkOnBlockNumber = head.Number + 1
+            };
+            TaskCompletionSource revalidationStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            using ManualResetEventSlim releaseRevalidation = new(false);
+            Transaction existingTransaction = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA)
+                .TestObject;
+            Transaction invalidUnderOsaka = Build.A.Transaction
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyB)
+                .TestObject;
+            ITxValidator specChangeTxValidator = Substitute.For<ITxValidator>();
+            specChangeTxValidator.IsWellFormed(Arg.Any<Transaction>(), Arg.Any<IReleaseSpec>()).Returns(callInfo =>
+            {
+                if (!ReferenceEquals(callInfo.Arg<IReleaseSpec>(), Osaka.Instance))
+                {
+                    return ValidationResult.Success;
+                }
+
+                revalidationStarted.TrySetResult();
+                Assert.That(
+                    releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "Timed out waiting to release fork revalidation.");
+                return ReferenceEquals(callInfo.Arg<Transaction>(), invalidUnderOsaka)
+                    ? new ValidationResult("fork rejection")
+                    : ValidationResult.Success;
+            });
+
+            _txPool = CreatePool(specProvider: provider, specChangeTxValidator: specChangeTxValidator);
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+            Assert.That(_txPool.SubmitTx(existingTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Block forkBlock = Build.A.Block.WithNumber(head.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = forkBlock.Header;
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
+            await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+            Block rollbackBlock = Build.A.Block.WithNumber(head.Number).TestObject;
+            _blockTree.BestSuggestedHeader = rollbackBlock.Header;
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(rollbackBlock));
+            Assert.That(_txPool.SubmitTx(invalidUnderOsaka, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Block finalBlock = Build.A.Block.WithNumber(forkBlock.Number + 1).TestObject;
+            _blockTree.BestSuggestedHeader = finalBlock.Header;
+            Task finalHeadProcessed = Wait.ForEventCondition<Block>(
+                CancellationToken.None,
+                handler => _txPool.TxPoolHeadChanged += handler,
+                handler => _txPool.TxPoolHeadChanged -= handler,
+                block => block.Hash == finalBlock.Hash);
+            _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(finalBlock));
+            releaseRevalidation.Set();
+
+            await finalHeadProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.That(() => _txPool.IsRevalidatedFor(finalBlock.Header), Is.True.After(Timeout, 10));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(_txPool.ContainsTx(invalidUnderOsaka.Hash!, invalidUnderOsaka.Type), Is.False);
+                Assert.That(_txPool.IsRevalidatedFor(finalBlock.Header), Is.True);
             }
         }
 
@@ -785,6 +1062,7 @@ namespace Nethermind.TxPool.Test
             }
 
             await finalHeadProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.That(() => _txPool.IsRevalidatedFor(head.Header), Is.True.After(Timeout, 10));
 
             using (Assert.EnterMultipleScope())
             {
@@ -795,7 +1073,8 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
-        public async Task should_keep_submission_and_production_view_responsive_during_revalidation()
+        [NonParallelizable]
+        public async Task should_keep_submission_production_and_head_processing_responsive_during_revalidation()
         {
             Block head = _blockTree.Head;
             _blockTree.BestSuggestedHeader = head.Header;
@@ -819,7 +1098,10 @@ namespace Nethermind.TxPool.Test
                     && ReferenceEquals(callInfo.Arg<IReleaseSpec>(), Osaka.Instance))
                 {
                     revalidationStarted.TrySetResult();
-                    releaseRevalidation.Wait();
+                    Assert.That(
+                        releaseRevalidation.Wait(TimeSpan.FromSeconds(10)),
+                        Is.True,
+                        "Timed out waiting to release fork revalidation.");
                 }
 
                 return ValidationResult.Success;
@@ -838,30 +1120,49 @@ namespace Nethermind.TxPool.Test
                 handler => _txPool.TxPoolHeadChanged -= handler,
                 block => block.Hash == forkBlock.Hash);
             _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(forkBlock));
-            await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
-
-            Task<(PendingTransactionsView View, AcceptTxResult Result)> concurrentAccess = RunOnDedicatedThread(() =>
-            {
-                PendingTransactionsView view = _txPool.GetPendingForProduction(forkBlock.Header, filterToReadyTx: false, UInt256.Zero);
-                AcceptTxResult result = _txPool.SubmitTx(concurrentTransaction, TxHandlingOptions.None);
-                return (view, result);
-            });
 
             try
             {
+                await headProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+                await revalidationStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+                Task<(PendingTransactionsView View, AcceptTxResult Result)> concurrentAccess = RunOnDedicatedThread(() =>
+                {
+                    PendingTransactionsView view = _txPool.GetPendingForProduction(forkBlock.Header, filterToReadyTx: false, UInt256.Zero);
+                    AcceptTxResult result = _txPool.SubmitTx(concurrentTransaction, TxHandlingOptions.None);
+                    return (view, result);
+                });
+
                 (PendingTransactionsView view, AcceptTxResult result) = await concurrentAccess.WaitAsync(TimeSpan.FromSeconds(5));
                 using (Assert.EnterMultipleScope())
                 {
                     Assert.That(view.IsRevalidated, Is.False);
                     Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
                 }
+
+                Block nextBlock = Build.A.Block
+                    .WithNumber(forkBlock.Number + 1)
+                    .WithTransactions(concurrentTransaction)
+                    .TestObject;
+                _blockTree.BestSuggestedHeader = nextBlock.Header;
+                Task nextHeadProcessed = Wait.ForEventCondition<Block>(
+                    CancellationToken.None,
+                    handler => _txPool.TxPoolHeadChanged += handler,
+                    handler => _txPool.TxPoolHeadChanged -= handler,
+                    block => block.Hash == nextBlock.Hash);
+                _blockTree.RaiseBlockAddedToMain(new BlockReplacementEventArgs(nextBlock));
+
+                await nextHeadProcessed.WaitAsync(TimeSpan.FromSeconds(5));
+                Assert.That(_txPool.ContainsTx(concurrentTransaction.Hash!, concurrentTransaction.Type), Is.False);
             }
             finally
             {
                 releaseRevalidation.Set();
             }
 
-            await headProcessed.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.That(
+                () => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader),
+                Is.True.After(Timeout, 10));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/BlobTxStorage.cs
@@ -21,10 +21,12 @@ namespace Nethermind.TxPool;
 public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage, IBlobTxMetadataStorage, ISpecChangeValidationStorage, IBatchDeleteTxStorage
 {
     private const int MaxPooledKeys = 128;
+    private const int ObsoleteSweepBatchSize = 16;
     private const int TransactionLockCount = 64;
 
     // Sidecar-free records live in the full-txs column under a key shape (prefix + hash) that
     // cannot collide with the 64-byte timestamp-prefixed full-tx keys.
+    private const int FullTxKeyLength = 64;
     private const int ElidedTxKeyLength = 33;
     private const byte ElidedTxKeyPrefix = 0x01;
     private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
@@ -41,7 +43,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
 
     public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, [NotNullWhen(true)] out Transaction? transaction)
     {
-        Span<byte> txHashPrefixed = stackalloc byte[64];
+        Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
         GetHashPrefixedByTimestamp(timestamp, hash, txHashPrefixed);
 
         byte[]? txBytes = _fullBlobTxsDb.Get(txHashPrefixed);
@@ -71,7 +73,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         if (count == 0) return 0;
 
         // Outer array must be exact-size for the IDb indexer (uses keys.Length).
-        // Inner byte[64] keys are pooled via ConcurrentQueue to avoid per-call allocations.
+        // Inner full-transaction keys are pooled via ConcurrentQueue to avoid per-call allocations.
         byte[][] dbKeys = new byte[count][];
         int rentedKeyCount = 0;
         try
@@ -123,7 +125,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         ValueHash256 hash = transaction.Hash.ValueHash256;
         lock (GetTransactionLock(hash))
         {
-            Span<byte> txHashPrefixed = stackalloc byte[64];
+            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
             GetHashPrefixedByTimestamp(transaction.Timestamp, hash, txHashPrefixed);
 
             EncodeAndSaveTx(transaction, _fullBlobTxsDb, txHashPrefixed);
@@ -143,7 +145,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         ValueHash256 hash = transaction.Hash.ValueHash256;
         lock (GetTransactionLock(hash))
         {
-            Span<byte> txHashPrefixed = stackalloc byte[64];
+            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
             GetHashPrefixedByTimestamp(transaction.Timestamp, hash, txHashPrefixed);
             if (!_fullBlobTxsDb.KeyExists(txHashPrefixed))
             {
@@ -176,7 +178,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
     {
         lock (GetTransactionLock(hash))
         {
-            Span<byte> txHashPrefixed = stackalloc byte[64];
+            Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
             GetHashPrefixedByTimestamp(timestamp, hash, txHashPrefixed);
 
             Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
@@ -190,7 +192,52 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
         }
     }
 
-    void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys)
+    void IBatchDeleteTxStorage.DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys) =>
+        DeleteMany(keys, deleteSharedEntries: true);
+
+    void IBatchDeleteTxStorage.DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys) =>
+        DeleteMany(keys, deleteSharedEntries: false);
+
+    void IBatchDeleteTxStorage.DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken)
+    {
+        using ArrayPoolList<TxLookupKey> candidates = new(ObsoleteSweepBatchSize);
+        foreach (byte[] key in _fullBlobTxsDb.GetAllKeys())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Elided and marker keys share this column; only timestamp-prefixed full bodies are 64 bytes.
+            if (key.Length != FullTxKeyLength)
+            {
+                continue;
+            }
+
+            TxLookupKey candidate = new(
+                new ValueHash256(key.AsSpan(32)),
+                Address.Zero,
+                new UInt256(key.AsSpan(0, 32), isBigEndian: true));
+            if (IsCurrentFullBlobTransaction(candidate))
+            {
+                continue;
+            }
+
+            candidates.Add(candidate);
+
+            if (candidates.Count == ObsoleteSweepBatchSize)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                DeleteMany(candidates.AsSpan(), deleteSharedEntries: false, deleteOnlyIfObsolete: true);
+                candidates.Clear();
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        DeleteMany(candidates.AsSpan(), deleteSharedEntries: false, deleteOnlyIfObsolete: true);
+    }
+
+    private void DeleteMany(
+        scoped ReadOnlySpan<TxLookupKey> keys,
+        bool deleteSharedEntries,
+        bool deleteOnlyIfObsolete = false)
     {
         if (keys.IsEmpty)
         {
@@ -216,19 +263,23 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
                 }
             }
 
-            using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
-            IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
-            IWriteBatch lightBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs);
-            Span<byte> txHashPrefixed = stackalloc byte[64];
-            Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
-            for (int i = 0; i < keys.Length; i++)
+            if (deleteOnlyIfObsolete)
             {
-                ref readonly TxLookupKey key = ref keys[i];
-                GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
-                GetElidedTxKey(key.Hash, elidedKey);
-                fullBlobTxsBatch.Remove(txHashPrefixed);
-                fullBlobTxsBatch.Remove(elidedKey);
-                lightBlobTxsBatch.Remove(key.Hash.BytesAsSpan);
+                using ArrayPoolList<TxLookupKey> obsoleteKeys = new(keys.Length);
+                for (int i = 0; i < keys.Length; i++)
+                {
+                    ref readonly TxLookupKey key = ref keys[i];
+                    if (!IsCurrentFullBlobTransaction(key))
+                    {
+                        obsoleteKeys.Add(key);
+                    }
+                }
+
+                DeleteManyFromStorage(obsoleteKeys.AsSpan(), deleteSharedEntries);
+            }
+            else
+            {
+                DeleteManyFromStorage(keys, deleteSharedEntries);
             }
         }
         finally
@@ -239,6 +290,39 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             }
         }
     }
+
+    private void DeleteManyFromStorage(scoped ReadOnlySpan<TxLookupKey> keys, bool deleteSharedEntries)
+    {
+        if (keys.IsEmpty)
+        {
+            return;
+        }
+
+        using IColumnsWriteBatch<BlobTxsColumns> batch = _database.StartWriteBatch();
+        IWriteBatch fullBlobTxsBatch = batch.GetColumnBatch(BlobTxsColumns.FullBlobTxs);
+        IWriteBatch? lightBlobTxsBatch = deleteSharedEntries
+            ? batch.GetColumnBatch(BlobTxsColumns.LightBlobTxs)
+            : null;
+        Span<byte> txHashPrefixed = stackalloc byte[FullTxKeyLength];
+        Span<byte> elidedKey = stackalloc byte[ElidedTxKeyLength];
+        for (int i = 0; i < keys.Length; i++)
+        {
+            ref readonly TxLookupKey key = ref keys[i];
+            GetHashPrefixedByTimestamp(key.Timestamp, key.Hash, txHashPrefixed);
+            fullBlobTxsBatch.Remove(txHashPrefixed);
+            if (deleteSharedEntries)
+            {
+                GetElidedTxKey(key.Hash, elidedKey);
+                fullBlobTxsBatch.Remove(elidedKey);
+                lightBlobTxsBatch!.Remove(key.Hash.BytesAsSpan);
+            }
+        }
+    }
+
+    private bool IsCurrentFullBlobTransaction(in TxLookupKey key) =>
+        TryDecodeLightTx(_lightBlobTxsDb.Get(key.Hash.BytesAsSpan), out LightTransaction? currentTransaction)
+        && currentTransaction is not null
+        && currentTransaction.Timestamp == key.Timestamp;
 
     string? ISpecChangeValidationStorage.GetSpecChangeValidationMarker()
     {
@@ -324,7 +408,7 @@ public class BlobTxStorage(IColumnsDb<BlobTxsColumns> database) : IBlobTxStorage
             return key;
         }
 
-        return new byte[64];
+        return new byte[FullTxKeyLength];
     }
 
     private void ReturnKey(byte[] key)

--- a/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/BlobTxDistinctSortedPool.cs
@@ -26,6 +26,8 @@ public class BlobTxDistinctSortedPool(int capacity, IComparer<Transaction> compa
 
     internal readonly Dictionary<byte[], List<Hash256>> BlobIndex = new(Bytes.EqualityComparer);
 
+    internal virtual void FlushPendingRevalidationDeletes() { }
+
     protected override IComparer<Transaction> GetReplacementComparer(IComparer<Transaction> comparer)
         => comparer.GetBlobReplacementComparer();
 

--- a/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/PersistentBlobTxDistinctSortedPool.cs
@@ -765,26 +765,62 @@ public class PersistentBlobTxDistinctSortedPool : BlobTxDistinctSortedPool, IDis
         finally
         {
             _batchStorageDeletes = false;
-            try
+        }
+
+        FlushPendingRevalidationDeletesNonLocked();
+    }
+
+    internal override void FlushPendingRevalidationDeletes()
+    {
+        using McsLock.Disposable lockRelease = Lock.Acquire();
+        FlushPendingRevalidationDeletesNonLocked();
+    }
+
+    private void FlushPendingRevalidationDeletesNonLocked()
+    {
+        if (_batchedDeletes.Count == 0)
+        {
+            return;
+        }
+
+        using ArrayPoolList<TxLookupKey> deletes = new(_batchedDeletes.Count);
+        using ArrayPoolList<TxLookupKey> obsoleteFullTransactions = new(_batchedDeletes.Count);
+        for (int i = 0; i < _batchedDeletes.Count; i++)
+        {
+            TxLookupKey key = _batchedDeletes[i];
+            if (!base.TryGetValueNonLocked(key.Hash, out Transaction? liveTransaction))
             {
-                if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
-                {
-                    batchStorage.DeleteMany(CollectionsMarshal.AsSpan(_batchedDeletes));
-                }
-                else
-                {
-                    for (int i = 0; i < _batchedDeletes.Count; i++)
-                    {
-                        TxLookupKey key = _batchedDeletes[i];
-                        _blobTxStorage.Delete(key.Hash, key.Timestamp);
-                    }
-                }
+                deletes.Add(key);
             }
-            finally
+            else if (liveTransaction.Timestamp != key.Timestamp)
             {
-                _batchedDeletes.Clear();
+                obsoleteFullTransactions.Add(key);
             }
         }
+
+        if (_blobTxStorage is IBatchDeleteTxStorage batchStorage)
+        {
+            if (deletes.Count > 0)
+            {
+                batchStorage.DeleteMany(deletes.AsSpan());
+            }
+
+            if (obsoleteFullTransactions.Count > 0)
+            {
+                batchStorage.DeleteFullBlobTransactions(obsoleteFullTransactions.AsSpan());
+            }
+        }
+        else
+        {
+            // No timestamp-only fallback exists; Delete also removes hash-keyed records owned by a reinserted transaction.
+            for (int i = 0; i < deletes.Count; i++)
+            {
+                TxLookupKey key = deletes[i];
+                _blobTxStorage.Delete(key.Hash, key.Timestamp);
+            }
+        }
+
+        _batchedDeletes.Clear();
     }
 
     protected override void OnBlobTransactionUpdatedNonLocked(Transaction blobTx)

--- a/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/MalformedTxFilter.cs
@@ -19,6 +19,10 @@ namespace Nethermind.TxPool.Filters
         ILogger logger)
         : IIncomingTxFilter
     {
+        // Plugins may supply only ITxValidator, in which case they require the full validation pass.
+        private readonly ISpecChangeTxValidator? _incrementalSpecChangeTxValidator =
+            specChangeTxValidator as ISpecChangeTxValidator;
+
         public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
         {
             IReleaseSpec spec = state.HeadSpec;
@@ -63,7 +67,9 @@ namespace Nethermind.TxPool.Filters
                     blockGasLimit: 0,
                     TxValidationOptions.SkipBlobProofs);
                 return validationResult
-                    ? specChangeTxValidator.IsWellFormed(transaction, releaseSpec)
+                    ? _incrementalSpecChangeTxValidator is null
+                        ? specChangeTxValidator.IsWellFormed(transaction, releaseSpec)
+                        : _incrementalSpecChangeTxValidator.IsWellFormedAfterFullValidation(transaction, releaseSpec)
                     : validationResult;
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxStorage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -23,7 +24,32 @@ public interface ITxStorage
 
 internal interface IBatchDeleteTxStorage
 {
+    /// <summary>
+    /// Removes the timestamped full-body record and the hash-keyed light and elided records for each key.
+    /// </summary>
     void DeleteMany(scoped ReadOnlySpan<TxLookupKey> keys);
+
+    /// <summary>
+    /// Removes only the timestamped full-body record for each key, leaving the hash-keyed light and elided
+    /// records intact.
+    /// </summary>
+    /// <remarks>
+    /// Used to drop an obsolete body when the same hash is live under a different <see cref="TxLookupKey.Timestamp"/>;
+    /// use <see cref="DeleteMany"/> when no current transaction owns the hash-keyed records.
+    /// </remarks>
+    void DeleteFullBlobTransactions(scoped ReadOnlySpan<TxLookupKey> keys);
+
+    /// <summary>
+    /// Removes timestamped full-body records that are not referenced by their hash-keyed light record.
+    /// </summary>
+    /// <remarks>
+    /// This can scan the entire persisted full-transaction collection and should run outside latency-sensitive paths.
+    /// </remarks>
+    /// <param name="cancellationToken">
+    /// Aborts the scan. Implementations must throw rather than return early so an interrupted sweep is not treated as complete.
+    /// </param>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was cancelled.</exception>
+    void DeleteObsoleteFullBlobTransactions(CancellationToken cancellationToken);
 }
 
 internal interface ISpecChangeValidationStorage

--- a/src/Nethermind/Nethermind.TxPool/ITxValidator.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxValidator.cs
@@ -36,6 +36,12 @@ namespace Nethermind.TxPool
         /// A process-independent fingerprint that changes whenever the validator's behavior or configuration changes.
         /// </summary>
         string PersistenceFingerprint { get; }
+
+        /// <summary>
+        /// Validates rules not already covered by a successful full transaction-validation pass.
+        /// </summary>
+        ValidationResult IsWellFormedAfterFullValidation(Transaction transaction, IReleaseSpec releaseSpec) =>
+            IsWellFormed(transaction, releaseSpec);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.TxPool/PendingTransactionsView.cs
+++ b/src/Nethermind/Nethermind.TxPool/PendingTransactionsView.cs
@@ -20,17 +20,21 @@ public readonly struct PendingTransactionsView(
     IDictionary<AddressAsKey, Transaction[]> blobTransactions,
     bool isRevalidated)
 {
-    private static readonly IDictionary<AddressAsKey, Transaction[]> _empty =
+    private static readonly IReadOnlyDictionary<AddressAsKey, Transaction[]> _empty =
         new ReadOnlyDictionary<AddressAsKey, Transaction[]>(new Dictionary<AddressAsKey, Transaction[]>());
 
-    private readonly IDictionary<AddressAsKey, Transaction[]>? _transactions = transactions;
-    private readonly IDictionary<AddressAsKey, Transaction[]>? _blobTransactions = blobTransactions;
+    private readonly IReadOnlyDictionary<AddressAsKey, Transaction[]>? _transactions =
+        transactions as IReadOnlyDictionary<AddressAsKey, Transaction[]>
+        ?? new ReadOnlyDictionary<AddressAsKey, Transaction[]>(transactions);
+    private readonly IReadOnlyDictionary<AddressAsKey, Transaction[]>? _blobTransactions =
+        blobTransactions as IReadOnlyDictionary<AddressAsKey, Transaction[]>
+        ?? new ReadOnlyDictionary<AddressAsKey, Transaction[]>(blobTransactions);
 
     /// <summary>Non-blob transactions grouped by sender address, sorted by nonce and later tx pool sorting.</summary>
-    public IDictionary<AddressAsKey, Transaction[]> Transactions => _transactions ?? _empty;
+    public IReadOnlyDictionary<AddressAsKey, Transaction[]> Transactions => _transactions ?? _empty;
 
     /// <summary>Blob transaction light equivalences grouped by sender address, sorted the same way.</summary>
-    public IDictionary<AddressAsKey, Transaction[]> BlobTransactions => _blobTransactions ?? _empty;
+    public IReadOnlyDictionary<AddressAsKey, Transaction[]> BlobTransactions => _blobTransactions ?? _empty;
 
     /// <summary>
     /// Whether every transaction in this view has already been validated against the target block's release

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -36,6 +36,7 @@ namespace Nethermind.TxPool
     /// </summary>
     public class TxPool : ITxPool, IAsyncDisposable
     {
+        private const int MaxObsoleteBlobRecoveryAttempts = 2;
         private const int RevalidationAbandonmentWarningThreshold = 3;
 
         private readonly RetryCache<PooledTransactionRequestMessage, ValueHash256> _retryCache;
@@ -60,6 +61,9 @@ namespace Nethermind.TxPool
         private readonly string? _specChangeValidationFingerprint;
         private readonly ISpecChangeValidationStorage? _specChangeValidationStorage;
         private readonly bool _blobReorgsSupportEnabled;
+        private bool _specChangeMarkerUnpublished;
+        private bool _obsoleteBlobRecoveryCompleted;
+        private int _obsoleteBlobRecoveryFailures;
         private readonly DelegationCache _pendingDelegations = new();
         private readonly HashSet<Hash256> _forkInvalidatedHashes = [];
         private IReleaseSpec? _forkInvalidatedSpec;
@@ -67,8 +71,16 @@ namespace Nethermind.TxPool
         private readonly ILogger _logger;
 
         private readonly Channel<HeadChange> _headBlocksChannel = Channel.CreateUnbounded<HeadChange>(new UnboundedChannelOptions() { SingleReader = true, SingleWriter = true });
+        private readonly Channel<long> _revalidationChannel = Channel.CreateBounded<long>(new BoundedChannelOptions(1)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropOldest
+        });
         private readonly ReaderWriterLockSlim _newHeadLock = new(LockRecursionPolicy.SupportsRecursion);
         private readonly Lock _forkStateLock = new();
+        // Publish the spec and its epoch through one reference so readers cannot combine different observations.
+        private HeadSpecObservation? _headSpecObservation;
         private long _headGeneration;
         private long _forkStateVersion;
         private int _consecutiveRevalidationAbandonments;
@@ -76,6 +88,7 @@ namespace Nethermind.TxPool
         private readonly UpdateGroupDelegate _updateBucket;
         private readonly UpdateGroupDelegate _updateBucketAdded;
         private readonly Task _headProcessing;
+        private readonly Task _revalidationProcessing;
         private readonly CancellationTokenSource _cts;
 
         public event EventHandler<Block>? TxPoolHeadChanged;
@@ -147,6 +160,7 @@ namespace Nethermind.TxPool
             _blobReorgsSupportEnabled = txPoolConfig.BlobsSupport.SupportsReorgs();
             _accounts = _accountCache = new AccountCache(_headInfo.ReadOnlyStateProvider);
             _specProvider = _headInfo.SpecProvider;
+            ObserveHeadSpec(_specProvider.GetCurrentHeadSpec());
             SupportsBlobs = _txPoolConfig.BlobsSupport != BlobsSupportMode.Disabled;
             _cts = new();
             _retryCache = new RetryCache<PooledTransactionRequestMessage, ValueHash256>(
@@ -221,6 +235,12 @@ namespace Nethermind.TxPool
                 _timer.Start();
             }
 
+            _revalidationProcessing = ProcessRevalidations();
+            bool specValidatedForHead = ReferenceEquals(Volatile.Read(ref _validatedSpec), _specProvider.GetCurrentHeadSpec());
+            if (RequiresRevalidation(specValidatedForHead))
+            {
+                RequestRevalidation(Volatile.Read(ref _headGeneration));
+            }
             _headProcessing = ProcessNewHeads();
         }
 
@@ -332,6 +352,28 @@ namespace Nethermind.TxPool
             }
         }
 
+        private long ObserveHeadSpec(IReleaseSpec spec)
+        {
+            HeadSpecObservation? observation = Volatile.Read(ref _headSpecObservation);
+            while (!ReferenceEquals(observation?.Spec, spec))
+            {
+                HeadSpecObservation updated = new(spec, (observation?.Generation ?? 0) + 1);
+                HeadSpecObservation? published = Interlocked.CompareExchange(
+                    ref _headSpecObservation,
+                    updated,
+                    observation);
+
+                if (ReferenceEquals(published, observation))
+                {
+                    return updated.Generation;
+                }
+
+                observation = published;
+            }
+
+            return observation.Generation;
+        }
+
         private async Task ProcessNewHeads()
         {
             try
@@ -347,8 +389,6 @@ namespace Nethermind.TxPool
 
         private async Task ProcessNewHeadLoop()
         {
-            TryRevalidateCurrentSpec(Volatile.Read(ref _headGeneration));
-
             while (await _headBlocksChannel.Reader.WaitToReadAsync(_cts.Token))
             {
                 while (_headBlocksChannel.Reader.TryRead(out HeadChange headChange))
@@ -357,6 +397,7 @@ namespace Nethermind.TxPool
                     try
                     {
                         bool bucketsUpdated;
+                        bool revalidationRequired;
                         _newHeadLock.EnterWriteLock();
                         try
                         {
@@ -386,6 +427,7 @@ namespace Nethermind.TxPool
                             }
 
                             bucketsUpdated = ReferenceEquals(Volatile.Read(ref _validatedSpec), _specProvider.GetCurrentHeadSpec());
+                            revalidationRequired = RequiresRevalidation(bucketsUpdated);
                             if (bucketsUpdated)
                             {
                                 UpdateBucketsWithoutRevalidation();
@@ -396,19 +438,12 @@ namespace Nethermind.TxPool
                             _newHeadLock.ExitWriteLock();
                         }
 
-                        if (!TryRevalidateCurrentSpec(headChange.Generation) && !bucketsUpdated)
+                        if (revalidationRequired)
                         {
-                            _newHeadLock.EnterWriteLock();
-                            try
-                            {
-                                UpdateBucketsWithoutRevalidation();
-                            }
-                            finally
-                            {
-                                _newHeadLock.ExitWriteLock();
-                            }
+                            RequestRevalidation(headChange.Generation);
                         }
 
+                        // Subscribers can re-enter the pool, so invoke them after releasing _newHeadLock.
                         TxPoolHeadChanged?.Invoke(this, args.Block);
                         Metrics.TransactionCount = _transactions.Count;
                         Metrics.BlobTransactionCount = _blobTransactions.Count;
@@ -421,6 +456,62 @@ namespace Nethermind.TxPool
             }
 
             bool CanUseCache(Block block, [NotNullWhen(true)] ArrayPoolList<AddressAsKey>? accountChanges) => accountChanges is not null && block.ParentHash == _lastBlockHash && _lastBlockNumber + 1 == block.Number;
+        }
+
+        private void RequestRevalidation(long generation) => _revalidationChannel.Writer.TryWrite(generation);
+
+        private bool RequiresRevalidation(bool specValidatedForHead) =>
+            !specValidatedForHead
+            || Volatile.Read(ref _specChangeMarkerUnpublished)
+            || RequiresObsoleteBlobRecovery();
+
+        private async Task ProcessRevalidations()
+        {
+            try
+            {
+                await Task.Run(ProcessRevalidationLoop);
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                if (_logger.IsError) _logger.Error("Transaction pool revalidation failed.", ex);
+            }
+        }
+
+        private async Task ProcessRevalidationLoop()
+        {
+            while (await _revalidationChannel.Reader.WaitToReadAsync(_cts.Token))
+            {
+                long generation = 0;
+                while (_revalidationChannel.Reader.TryRead(out long requestedGeneration))
+                {
+                    generation = requestedGeneration;
+                }
+
+                try
+                {
+                    if (!TryRevalidateCurrentSpec(generation))
+                    {
+                        _newHeadLock.EnterWriteLock();
+                        try
+                        {
+                            if (!_cts.IsCancellationRequested)
+                            {
+                                // Bucket reconciliation uses live account state and remains valid after the requested generation becomes stale.
+                                UpdateBucketsWithoutRevalidation();
+                            }
+                        }
+                        finally
+                        {
+                            _newHeadLock.ExitWriteLock();
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (_logger.IsWarn) _logger.Warn($"Transaction pool failed to update after an unsuccessful revalidation with exception {ex}");
+                }
+            }
         }
 
         private void ReAddReorganisedTransactions(Block? previousBlock)
@@ -673,7 +764,10 @@ namespace Nethermind.TxPool
             _newHeadLock.EnterReadLock();
             try
             {
-                TxFilteringState state = new(tx, _accounts, _specProvider.GetCurrentHeadSpec());
+                IReleaseSpec headSpec = _specProvider.GetCurrentHeadSpec();
+                // Observation and insertion share the head lock so an A -> B -> A transition cannot cross a validation publish unseen.
+                ObserveHeadSpec(headSpec);
+                TxFilteringState state = new(tx, _accounts, headSpec);
                 accepted = FilterTransactions(tx, handlingOptions, ref state);
                 if (accepted)
                 {
@@ -984,13 +1078,24 @@ namespace Nethermind.TxPool
             bool isEmpty = _transactions.Count == 0 && _blobTransactions.Count == 0;
             bool markerMatches = _specChangeValidationStorage?.GetSpecChangeValidationMarker() == expectedMarker;
 
-            if (isEmpty || markerMatches)
+            if (markerMatches)
             {
-                PublishValidatedSpec(headSpec);
+                // A marker can also record a sweep abandoned after bounded failures; it suppresses recovery retries in either case.
+                Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
+                PublishValidatedSpec(headSpec, expectedMarker);
             }
             else
             {
-                _specChangeValidationStorage?.SetSpecChangeValidationMarker(null);
+                if (_specChangeValidationStorage is not null)
+                {
+                    Volatile.Write(ref _specChangeMarkerUnpublished, true);
+                    _specChangeValidationStorage.SetSpecChangeValidationMarker(null);
+                }
+
+                if (isEmpty)
+                {
+                    PublishValidatedSpec(headSpec, expectedMarker, persistMarker: false);
+                }
             }
         }
 
@@ -999,6 +1104,10 @@ namespace Nethermind.TxPool
             try
             {
                 return TryRevalidateCurrentSpecCore(generation);
+            }
+            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+            {
+                return false;
             }
             catch (Exception exception)
             {
@@ -1010,6 +1119,11 @@ namespace Nethermind.TxPool
         private bool TryRevalidateCurrentSpecCore(long generation)
         {
             IReleaseSpec spec;
+            long headSpecGeneration;
+            bool isEmpty;
+            bool isValidated;
+            string marker;
+            bool requiresObsoleteBlobRecovery;
 
             _newHeadLock.EnterWriteLock();
             try
@@ -1020,27 +1134,38 @@ namespace Nethermind.TxPool
                 }
 
                 spec = _specProvider.GetCurrentHeadSpec();
-                if (ReferenceEquals(Volatile.Read(ref _validatedSpec), spec))
+                headSpecGeneration = ObserveHeadSpec(spec);
+                marker = GetSpecChangeValidationMarker(spec);
+                bool isSpecChangeMarkerUnpublished = Volatile.Read(ref _specChangeMarkerUnpublished);
+                requiresObsoleteBlobRecovery = RequiresObsoleteBlobRecovery();
+                isValidated = ReferenceEquals(Volatile.Read(ref _validatedSpec), spec);
+                if (isValidated && !isSpecChangeMarkerUnpublished && !requiresObsoleteBlobRecovery)
                 {
                     return true;
                 }
 
-                ReleaseForkInvalidatedHashesFor(spec);
-                InvalidateValidatedSpec();
-
-                if (_transactions.Count == 0 && _blobTransactions.Count == 0)
+                if (!isValidated)
                 {
-                    PublishValidatedSpec(spec);
-                    return true;
+                    ReleaseForkInvalidatedHashesFor(spec);
+                    InvalidateValidatedSpec();
                 }
+
+                isEmpty = _transactions.Count == 0 && _blobTransactions.Count == 0;
             }
             finally
             {
                 _newHeadLock.ExitWriteLock();
             }
 
-            ForkRevalidation revalidation = new(this, spec, generation);
-            if (!revalidation.IsComplete)
+            if (requiresObsoleteBlobRecovery && !_cts.IsCancellationRequested)
+            {
+                RecoverObsoleteFullBlobTransactions();
+            }
+
+            ForkRevalidation? revalidation = isEmpty || isValidated
+                ? null
+                : new ForkRevalidation(this, spec, generation, headSpecGeneration);
+            if (revalidation is { IsComplete: false })
             {
                 return false;
             }
@@ -1048,29 +1173,33 @@ namespace Nethermind.TxPool
             _newHeadLock.EnterWriteLock();
             try
             {
-                if (!CanApplyRevalidation(spec, generation))
+                if (!CanApplyRevalidationResults(spec, headSpecGeneration))
                 {
                     RecordAbandonedRevalidation(spec, generation);
                     return false;
                 }
 
-                _transactions.UpdatePool(_accounts, revalidation.UpdateBucket);
-                _blobTransactions.UpdatePoolForRevalidation(_accounts, revalidation.UpdateBlobBucket);
+                if (revalidation is not null)
+                {
+                    UpdateGroupDelegate updateBucket = revalidation.UpdateBucket;
+                    _transactions.UpdatePool(_accounts, updateBucket);
+                    _blobTransactions.UpdatePoolForRevalidation(_accounts, updateBucket);
 
-                if (!CanApplyRevalidation(spec, generation))
+                    if (revalidation.RemovedCount != 0)
+                    {
+                        Metrics.PendingTransactionsEvicted += revalidation.RemovedCount;
+                        if (_logger.IsInfo) _logger.Info($"Removed {revalidation.RemovedCount:N0} transactions invalid under {spec.Name} after the protocol change.");
+                    }
+                }
+
+                if (!CanApplyRevalidationResults(spec, headSpecGeneration))
                 {
                     InvalidateValidatedSpec();
                     RecordAbandonedRevalidation(spec, generation);
                     return true;
                 }
 
-                PublishValidatedSpec(spec);
-
-                if (revalidation.RemovedCount != 0)
-                {
-                    Metrics.PendingTransactionsEvicted += revalidation.RemovedCount;
-                    if (_logger.IsInfo) _logger.Info($"Removed {revalidation.RemovedCount:N0} transactions invalid under {spec.Name} after the protocol change.");
-                }
+                PublishValidatedSpec(spec, marker);
 
                 return true;
             }
@@ -1080,15 +1209,52 @@ namespace Nethermind.TxPool
             }
         }
 
+        private void RecoverObsoleteFullBlobTransactions()
+        {
+            try
+            {
+                ((IBatchDeleteTxStorage)_blobTxStorage).DeleteObsoleteFullBlobTransactions(_cts.Token);
+            }
+            catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                int failures = Interlocked.Increment(ref _obsoleteBlobRecoveryFailures);
+                if (failures < MaxObsoleteBlobRecoveryAttempts)
+                {
+                    throw;
+                }
+
+                if (_logger.IsError) _logger.Error($"Skipping obsolete full blob transaction recovery after {failures} failed attempts.", exception);
+            }
+
+            // Retained revalidation deletes retry independently. Abandoning this sweep after bounded failures
+            // deliberately trades orphan reclamation for progress; the marker written by this pass suppresses later retries.
+            Volatile.Write(ref _obsoleteBlobRecoveryCompleted, true);
+        }
+
         private bool IsRevalidationGenerationCurrent(long generation) =>
             !_cts.IsCancellationRequested && generation == Volatile.Read(ref _headGeneration);
 
-        private bool CanApplyRevalidation(IReleaseSpec spec, long generation) =>
-            IsRevalidationGenerationCurrent(generation) && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());
-
-        private bool CanContinueRevalidation(IReleaseSpec spec, long generation)
+        private bool CanApplyRevalidationResults(IReleaseSpec spec, long headSpecGeneration)
         {
-            if (IsRevalidationGenerationCurrent(generation))
+            HeadSpecObservation? observation = Volatile.Read(ref _headSpecObservation);
+            return !_cts.IsCancellationRequested
+                && observation is not null
+                && observation.Generation == headSpecGeneration
+                && ReferenceEquals(observation.Spec, spec)
+                && ReferenceEquals(spec, _specProvider.GetCurrentHeadSpec());
+        }
+
+        private bool CanContinueRevalidation(IReleaseSpec spec, long generation, long headSpecGeneration)
+        {
+            HeadSpecObservation? observation = Volatile.Read(ref _headSpecObservation);
+            if (!_cts.IsCancellationRequested
+                && observation is not null
+                && observation.Generation == headSpecGeneration
+                && ReferenceEquals(observation.Spec, spec))
             {
                 return true;
             }
@@ -1101,11 +1267,18 @@ namespace Nethermind.TxPool
         {
             bool isCancellationRequested = _cts.IsCancellationRequested;
             long currentGeneration = Volatile.Read(ref _headGeneration);
-            string reason = isCancellationRequested
-                ? "shutdown was requested"
-                : generation != currentGeneration
-                    ? $"head generation advanced from {generation} to {currentGeneration}"
-                    : $"the head specification changed from {spec.Name} to {_specProvider.GetCurrentHeadSpec().Name}";
+            string reason;
+            if (isCancellationRequested)
+            {
+                reason = "shutdown was requested";
+            }
+            else
+            {
+                IReleaseSpec currentSpec = _specProvider.GetCurrentHeadSpec();
+                reason = !ReferenceEquals(spec, currentSpec)
+                    ? $"the head specification changed from {spec.Name} to {currentSpec.Name}"
+                    : $"the head changed during the pass (generation {generation}, now {currentGeneration})";
+            }
 
             if (_logger.IsDebug) _logger.Debug($"Abandoned transaction pool revalidation for {spec.Name} because {reason}.");
 
@@ -1141,14 +1314,26 @@ namespace Nethermind.TxPool
             _forkInvalidatedHashes.Add(hash);
         }
 
-        private void PublishValidatedSpec(IReleaseSpec spec)
+        private bool RequiresObsoleteBlobRecovery() =>
+            !Volatile.Read(ref _obsoleteBlobRecoveryCompleted)
+            && _txPoolConfig.BlobsSupport.IsPersistentStorage()
+            && _blobTxStorage is IBatchDeleteTxStorage;
+
+        private void PublishValidatedSpec(IReleaseSpec spec, string marker, bool persistMarker = true)
         {
+            _blobTransactions.FlushPendingRevalidationDeletes();
+
             lock (_forkStateLock)
             {
                 Interlocked.Increment(ref _forkStateVersion);
                 try
                 {
-                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(GetSpecChangeValidationMarker(spec));
+                    if (persistMarker)
+                    {
+                        _specChangeValidationStorage?.SetSpecChangeValidationMarker(marker);
+                        Volatile.Write(ref _specChangeMarkerUnpublished, false);
+                    }
+
                     Volatile.Write(ref _validatedSpec, spec);
                     Interlocked.Exchange(ref _consecutiveRevalidationAbandonments, 0);
                 }
@@ -1172,7 +1357,11 @@ namespace Nethermind.TxPool
                 try
                 {
                     Volatile.Write(ref _validatedSpec, null);
-                    _specChangeValidationStorage?.SetSpecChangeValidationMarker(null);
+                    if (_specChangeValidationStorage is not null)
+                    {
+                        Volatile.Write(ref _specChangeMarkerUnpublished, true);
+                        _specChangeValidationStorage.SetSpecChangeValidationMarker(null);
+                    }
                 }
                 finally
                 {
@@ -1210,11 +1399,11 @@ namespace Nethermind.TxPool
             private readonly IReleaseSpec _spec;
             private readonly Dictionary<Hash256, ForkValidationResult> _invalidTransactions = [];
 
-            public ForkRevalidation(TxPool pool, IReleaseSpec spec, long generation)
+            public ForkRevalidation(TxPool pool, IReleaseSpec spec, long generation, long headSpecGeneration)
             {
                 _pool = pool;
                 _spec = spec;
-                IsComplete = FindInvalidTransactions(generation);
+                IsComplete = FindInvalidTransactions(generation, headSpecGeneration);
             }
 
             public bool IsComplete { get; }
@@ -1223,9 +1412,6 @@ namespace Nethermind.TxPool
             public int RemovedCount { get; private set; }
 
             public void UpdateBucket(in AccountStruct account, EnhancedSortedSet<Transaction> transactions, ref Transaction? lastElement, UpdateTransactionDelegate updateTx) =>
-                RemovedCount += _pool.UpdateBucketCore(account, transactions, ref lastElement, updateTx, this);
-
-            public void UpdateBlobBucket(in AccountStruct account, EnhancedSortedSet<Transaction> transactions, ref Transaction? lastElement, UpdateTransactionDelegate updateTx) =>
                 RemovedCount += _pool.UpdateBucketCore(account, transactions, ref lastElement, updateTx, this);
 
             public ForkValidationResult Validate(Transaction transaction) =>
@@ -1246,12 +1432,12 @@ namespace Nethermind.TxPool
                 return false;
             }
 
-            private bool FindInvalidTransactions(long generation)
+            private bool FindInvalidTransactions(long generation, long headSpecGeneration)
             {
                 Transaction[] transactions = _pool._transactions.GetSnapshot();
                 for (int i = 0; i < transactions.Length; i++)
                 {
-                    if (!_pool.CanContinueRevalidation(_spec, generation))
+                    if (!_pool.CanContinueRevalidation(_spec, generation, headSpecGeneration))
                     {
                         return false;
                     }
@@ -1267,7 +1453,7 @@ namespace Nethermind.TxPool
 
                 for (int i = 0; i < blobTransactions.Length; i++)
                 {
-                    if (!_pool.CanContinueRevalidation(_spec, generation))
+                    if (!_pool.CanContinueRevalidation(_spec, generation, headSpecGeneration))
                     {
                         return false;
                     }
@@ -1296,7 +1482,7 @@ namespace Nethermind.TxPool
 
                     if (batchCount == BlobReadBatchSize)
                     {
-                        if (!ProcessBlobBatch(batchCount, generation, keys, hashes, fullTransactions))
+                        if (!ProcessBlobBatch(batchCount, generation, headSpecGeneration, keys, hashes, fullTransactions))
                         {
                             return false;
                         }
@@ -1305,12 +1491,13 @@ namespace Nethermind.TxPool
                     }
                 }
 
-                return batchCount == 0 || ProcessBlobBatch(batchCount, generation, keys, hashes, fullTransactions);
+                return batchCount == 0 || ProcessBlobBatch(batchCount, generation, headSpecGeneration, keys, hashes, fullTransactions);
             }
 
             private bool ProcessBlobBatch(
                 int count,
                 long generation,
+                long headSpecGeneration,
                 TxLookupKey[] keys,
                 Hash256[] hashes,
                 Transaction?[] fullTransactions)
@@ -1320,7 +1507,7 @@ namespace Nethermind.TxPool
 
                 for (int i = 0; i < count; i++)
                 {
-                    if (!_pool.CanContinueRevalidation(_spec, generation))
+                    if (!_pool.CanContinueRevalidation(_spec, generation, headSpecGeneration))
                     {
                         return false;
                     }
@@ -1595,15 +1782,17 @@ namespace Nethermind.TxPool
             _timer?.Dispose();
             await _cts.CancelAsync();
             TxPoolHeadChanged -= _broadcaster.OnNewHead;
-            _broadcaster.Dispose();
             _headInfo.HeadChanged -= OnHeadChange;
             _headBlocksChannel.Writer.Complete();
+            _revalidationChannel.Writer.Complete();
             _transactions.Inserted -= OnInsertedTx;
             _transactions.Removed -= OnRemovedTx;
-            (_blobTransactions as IDisposable)?.Dispose();
 
             await _retryCache.DisposeAsync();
             await _headProcessing;
+            await _revalidationProcessing;
+            _broadcaster.Dispose();
+            (_blobTransactions as IDisposable)?.Dispose();
         }
 
         private void TimerOnElapsed(object? sender, EventArgs e)
@@ -1622,6 +1811,7 @@ namespace Nethermind.TxPool
 
         private readonly record struct HeadChange(BlockReplacementEventArgs Args, long Generation);
 
+        private sealed record HeadSpecObservation(IReleaseSpec Spec, long Generation);
 
         private sealed class AccountCache : IAccountStateProvider
         {


### PR DESCRIPTION
## Changes

Updates `release/2.0.0-rc` with three PRs already merged to master

- **#13036: Log index backfill through sliced receipt islands** 
- **#13038: fix(txpool): harden fork-boundary revalidation** 
- **#13046: fix: don't log expected shutdown cancellation/teardown as error/warning** 

