### PR TITLE
Return null from eth_getHeaderByNumber for the pending tag

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -1549,7 +1549,8 @@ public partial class EthRpcModuleTests
     [TestCase("eth_getHeaderByNumber", "0x9999999", TestName = "UnknownNumber")]
     [TestCase("eth_getHeaderByNumber", "finalized", TestName = "FinalizedAbsent")]
     [TestCase("eth_getHeaderByNumber", "safe", TestName = "SafeAbsent")]
-    public async Task EthGetHeaderByX_WhenBlockUnknown_ReturnsNull(string method, string blockParam)
+    [TestCase("eth_getHeaderByNumber", "pending", TestName = "Pending")]
+    public async Task EthGetHeaderByX_ReturnsNull(string method, string blockParam)
     {
         using Context ctx = await Context.Create();
         string serialized = await ctx.Test.TestEthRpc(method, blockParam);
@@ -1557,12 +1558,13 @@ public partial class EthRpcModuleTests
     }
 
     [Test]
-    public async Task EthGetHeaderByNumber_WhenPending_NilsTransientFields([Values("hash", "nonce", "miner")] string field)
+    public async Task EthGetHeaderByHash_WhenPendingHash_ReturnsHeader()
     {
         using Context ctx = await Context.Create();
-        string serialized = await ctx.Test.TestEthRpc("eth_getHeaderByNumber", "pending");
-        JToken json = JToken.Parse(serialized);
-        Assert.That(json["result"]![field]!.Type, Is.EqualTo(JTokenType.Null));
+        // PendingHash resolves to the head hash, so a hash lookup of it must still return a full header.
+        string serialized = await ctx.Test.TestEthRpc("eth_getHeaderByHash", ctx.Test.BlockTree.Head!.Hash!.ToString());
+        JObject result = (JObject)JToken.Parse(serialized)["result"]!;
+        Assert.That(result["hash"]!.Value<string>(), Is.EqualTo(ctx.Test.BlockTree.Head!.Hash!.ToString()));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -664,6 +664,13 @@ public partial class EthRpcModule(
 
     private ResultWrapper<BlockHeaderForRpc?> GetHeader(BlockParameter blockParameter)
     {
+        // ethereum/execution-apis#877 makes the pending tag return null; the block methods keep
+        // their partially-nulled pending object, which that spec does not cover.
+        if (blockParameter.Type == BlockParameterType.Pending)
+        {
+            return ResultWrapper<BlockHeaderForRpc?>.Success(null);
+        }
+
         // SearchForHeader avoids loading the block body — header endpoints don't need transactions/uncles.
         SearchResult<BlockHeader> searchResult = _blockFinder.SearchForHeader(blockParameter);
         if (searchResult.IsError)
@@ -671,15 +678,7 @@ public partial class EthRpcModule(
             return ResultWrapper<BlockHeaderForRpc?>.Success(null);
         }
 
-        BlockHeaderForRpc result = _blockForRpcFactory.CreateHeader(searchResult.Object!, _specProvider);
-        if (blockParameter.Type == BlockParameterType.Pending)
-        {
-            result.Hash = null;
-            result.Nonce = null;
-            result.Miner = null;
-        }
-
-        return ResultWrapper<BlockHeaderForRpc?>.Success(result);
+        return ResultWrapper<BlockHeaderForRpc?>.Success(_blockForRpcFactory.CreateHeader(searchResult.Object!, _specProvider));
     }
 
     public virtual ResultWrapper<TransactionForRpc?> eth_getTransactionByHash(Hash256 transactionHash)


### PR DESCRIPTION
## Changes

- `eth_getHeaderByNumber` returns `null` for the `pending` tag. It previously returned the canonical head with `hash`, `nonce`, and `miner` set to `null`, because `PendingHash => Head?.Hash`.
- The early return also skips a `SearchForHeader` and a `CreateHeader` call.

[ethereum/execution-apis#877](https://github.com/ethereum/execution-apis/pull/877) specifies this. go-ethereum made the same change in [#35627](https://github.com/ethereum/go-ethereum/pull/35627), which is merged, so the two clients agree again.

`eth_getHeaderByHash` is unaffected. It passes a `BlockHash` parameter, so the `pending` branch never fires. A new test proves that a hash lookup of the head hash still returns a full header.

The block methods keep their partially-nulled `pending` object. #877 does not cover them.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`pending` is now a case on `EthGetHeaderByX_ReturnsNull`, next to the unknown-hash, unknown-number, `safe` and `finalized` cases. `EthGetHeaderByHash_WhenPendingHash_ReturnsHeader` covers the hash path.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

`eth_getHeaderByNumber("pending")` now returns `null`. It shipped in #11531 and previously returned a header object with `hash`, `nonce`, and `miner` set to `null`.
