### PR TITLE
fix: release the history pruning hold at the feed's live floor

### DIFF
--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -305,7 +305,8 @@ public class HistoryPrunerTests
     }
 
     [TestCase(null, false, TestName = "SetDeletePointerToOldestBlock_never_searches_while_no_body_was_inserted")]
-    [TestCase(7000UL, false, TestName = "SetDeletePointerToOldestBlock_holds_above_the_static_barrier")]
+    [TestCase(7000UL, false, TestName = "SetDeletePointerToOldestBlock_holds_above_the_rolling_cutoff")]
+    [TestCase(6800UL, true, TestName = "SetDeletePointerToOldestBlock_releases_at_the_rolling_cutoff")]
     [TestCase(1UL, true, TestName = "SetDeletePointerToOldestBlock_releases_at_the_static_barrier")]
     public void SetDeletePointerToOldestBlock_holds_while_the_ancient_bodies_feed_is_descending(ulong? bodyPointer, bool searches)
     {
@@ -336,23 +337,6 @@ public class HistoryPrunerTests
         TestMemDb metadataDb = new();
         metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(7000UL).Bytes);
         metadataDb.Set(MetadataDbKeys.AncientBodiesDownloadComplete, [1]);
-        IDbProvider dbProvider = Substitute.For<IDbProvider>();
-        dbProvider.MetadataDb.Returns(metadataDb);
-        dbProvider.BlocksDb.Returns(new TestMemDb());
-        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
-
-        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels);
-
-        pruner.SetDeletePointerToOldestBlock();
-        chainLevels.Received().LoadLevel(Arg.Any<ulong>());
-    }
-
-    [Test]
-    public void SetDeletePointerToOldestBlock_releases_a_pointer_parked_at_the_barrier_the_feed_last_started_with()
-    {
-        TestMemDb metadataDb = new();
-        metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(5000UL).Bytes);
-        metadataDb.Set(MetadataDbKeys.BodiesBarrierWhenStarted, ((long)5000).ToBigEndianByteArrayWithoutLeadingZeros());
         IDbProvider dbProvider = Substitute.For<IDbProvider>();
         dbProvider.MetadataDb.Returns(metadataDb);
         dbProvider.BlocksDb.Returns(new TestMemDb());
@@ -411,24 +395,6 @@ public class HistoryPrunerTests
 
         Assert.That(pruner.OldestUnreclaimedBlockNumber, Is.EqualTo(9_000UL),
             "with no persisted state the barrier is the whole answer, matching a never-pruned node");
-    }
-
-    [Test]
-    public void SetDeletePointerToOldestBlock_holds_when_the_barrier_dropped_below_the_one_the_feed_last_started_with()
-    {
-        TestMemDb metadataDb = new();
-        metadataDb.Set(MetadataDbKeys.LowestInsertedBodyNumber, Rlp.Encode(7000UL).Bytes);
-        metadataDb.Set(MetadataDbKeys.BodiesBarrierWhenStarted, ((long)7000).ToBigEndianByteArrayWithoutLeadingZeros());
-        IDbProvider dbProvider = Substitute.For<IDbProvider>();
-        dbProvider.MetadataDb.Returns(metadataDb);
-        dbProvider.BlocksDb.Returns(new TestMemDb());
-        IChainLevelInfoRepository chainLevels = Substitute.For<IChainLevelInfoRepository>();
-
-        HistoryPruner pruner = CreateDetachedPruner(dbProvider, chainLevels);
-
-        Assert.That(pruner.SetDeletePointerToOldestBlock(), Is.False,
-            "a recorded barrier above the current one describes a finished descent the config since reopened");
-        chainLevels.DidNotReceive().LoadLevel(Arg.Any<ulong>());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.History/HistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/HistoryPruner.cs
@@ -411,16 +411,13 @@ public class HistoryPruner : IHistoryPruner
             return false;
         }
 
-        // The feed persists a completion marker when it reaches its own latched barrier, so the release
-        // never has to reconstruct a barrier that drifts with the pruning cutoff. The static barrier is a
-        // term of the feed's ComputeBarrier and so always releasable, and a pointer parked at the barrier
-        // the feed recorded when it last started is a finished descent even if the marker predates this
-        // build - only for a descent whose barrier never moved, since a rolling cutoff climbs during a
-        // long descent and parks the pointer above the recorded value; a legacy database self-heals
-        // regardless, because the feed activates once and writes the marker. A written pointer above
-        // those with no marker is a descent in progress - the persisted pointer only moves every flush
-        // interval, so its quietness proves nothing and the hold stays; an absent pointer is a feed that
-        // has not run yet, which a synchronizing process eventually runs.
+        // The feed persists a completion marker when it reaches its own latched barrier. For a database
+        // from a build that predates the marker, the release mirrors the feed's own stop condition
+        // instead: the feed never fetches below max(static barrier, pruning cutoff), so a pointer at or
+        // below that is a parked descent no matter where its barrier was latched when it ran. A pointer
+        // above it with no marker is a descent in progress - the persisted pointer only moves every
+        // flush interval, so its quietness proves nothing and the hold stays; an absent pointer is a
+        // feed that has not run yet, which a synchronizing process eventually runs.
         if (_metadataDb.KeyExists(MetadataDbKeys.AncientBodiesDownloadComplete))
         {
             return false;
@@ -429,21 +426,9 @@ public class HistoryPruner : IHistoryPruner
         byte[]? pointerBytes = _metadataDb.Get(MetadataDbKeys.LowestInsertedBodyNumber) ?? _blocksDb.Get(LegacyLowestInsertedBodyNumberKey);
         ulong? pointer = pointerBytes is null ? null : new RlpReader(pointerBytes).DecodeULong();
         ulong barrier = ulong.Max(1UL, ulong.Min(pivot, _syncConfig.AncientBodiesBarrier));
-        if (pointer <= barrier)
+        if (pointer <= ulong.Max(barrier, CutoffBlockNumber ?? 0))
         {
             return false;
-        }
-
-        byte[]? barrierWhenStartedBytes = _metadataDb.Get(MetadataDbKeys.BodiesBarrierWhenStarted);
-        if (pointer is not null && barrierWhenStartedBytes is not null)
-        {
-            ulong barrierWhenStarted = barrierWhenStartedBytes.AsSpan().ToULongFromBigEndianByteArrayWithoutLeadingZeros();
-            // Only while the feed still targets at least that barrier: a config edit that lowered it reopens
-            // the descent, and the recorded value then describes the descent that finished, not the current one.
-            if (barrierWhenStarted <= ulong.Max(barrier, CutoffBlockNumber ?? 0) && pointer <= barrierWhenStarted)
-            {
-                return false;
-            }
         }
 
         bool firstHoldLog = _ancientHoldLastLogged == 0;


### PR DESCRIPTION
Fixes a permanent history-pruning stall on databases from builds that predate the `AncientBodiesDownloadComplete` marker (#13036), surfaced by review on the release cherry-pick (#13081, https://github.com/NethermindEth/nethermind/pull/13081#discussion_r3906604499).

## Problem

Without the marker, `AncientBodiesStillDownloading` released only for a pointer at the static ancient barrier or at `BodiesBarrierWhenStarted`. On a node with rolling pruning the bodies feed stops at its live barrier `max(static barrier, cutoff)`, and the cutoff climbs during a long descent - so the pointer parks above both release points, the hold latches forever, `TryLoadDeletePointers` never succeeds, and pruning never starts. The feed does not reactivate on a finished descent, so the marker is never written and the database cannot self-heal.

## Fix

The legacy release now mirrors the feed's own stop condition: a pointer at or below `max(static barrier, CutoffBlockNumber)` is a parked descent, wherever its barrier was latched. This strictly subsumes the `BodiesBarrierWhenStarted` door (`pointer <= barrierWhenStarted <= max(barrier, cutoff)` implies the new check), so that path is removed.

## Tests

- `SetDeletePointerToOldestBlock_releases_at_the_rolling_cutoff` - fails on master (the latched hold), passes with the fix.
- Holds above the live floor and releases at the static barrier keep their existing coverage; the two barrier-door tests are removed with the door they tested.
- History suite 88/88.

Candidate for the `release/2.0.0-rc` cherry-pick alongside #13036.
