### PR TITLE
perf(zkevm): cut guest hot paths — keccak wrapper, trie buffers, branch RLP

### DIFF
--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -90,13 +90,6 @@ public sealed partial class KeccakHash
         if ((uint)(output.Length - 1) >= STATE_SIZE)
             ThrowInvalidOutputSize(output.Length);
 
-#if ZK_EVM
-        if (output.Length == HASH_SIZE)
-        {
-            ComputeHash256(input, output);
-            return;
-        }
-#endif
         int inputLength = input.Length;
         // One-block fast path for the dominant EVM input sizes: address (20), word or hash (32), two words (64).
         if (Avx512F.VL.IsSupported && output.Length == HASH_SIZE &&
@@ -296,16 +289,6 @@ public sealed partial class KeccakHash
         if (_hash is not null)
             ThrowHashingComplete();
 
-#if ZK_EVM
-        if (_state.Length == 0 && _roundSize == HASH_DATA_AREA && output.Length == HASH_SIZE)
-        {
-            ComputeHash256(_remainderBuffer.AsSpan(0, _remainderLength), output);
-            Pool.ReturnRemainder(ref _remainderBuffer);
-
-            _remainderLength = 0;
-            return;
-        }
-#endif
         ulong[] state = _state;
 
         if (state.Length == 0)

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.zkevm.cs
@@ -10,9 +10,5 @@ namespace Nethermind.Core.Crypto;
 public sealed partial class KeccakHash
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ComputeHash256(ReadOnlySpan<byte> input, Span<byte> output)
-        => Accelerators.Keccak256(input, output);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static partial void KeccakF(Span<ulong> st) => Accelerators.KeccakF(st);
 }

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -941,9 +941,25 @@ namespace Nethermind.Core.Extensions
                 data = data[i..];
             }
 
-            for (int i = 0; i < data.Length; i++)
+            // Word-at-a-time tail. This is the whole loop on targets without vector acceleration
+            // (e.g. the zkVM guest), where a byte-at-a-time scan of transaction calldata dominates
+            // intrinsic gas calculation.
+            ref byte tail = ref MemoryMarshal.GetReference(data);
+            int offset = 0;
+            for (; offset <= data.Length - sizeof(ulong); offset += sizeof(ulong))
             {
-                if (data[i] == 0)
+                ulong word = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref tail, offset));
+                // Sets 0x80 in every zero byte. The shorter `(w - 0x01..) & ~w & 0x80..` form is not
+                // usable here: it only reports whether *some* byte is zero, because a borrow out of
+                // one byte corrupts its neighbour's flag. This form carries within each byte only.
+                ulong zeroFlags = ~((((word & 0x7F7F7F7F7F7F7F7FUL) + 0x7F7F7F7F7F7F7F7FUL) | word) | 0x7F7F7F7F7F7F7F7FUL);
+                // Sum the flags without PopCount, which lacks a hardware instruction on some targets.
+                totalZeros += (int)((zeroFlags >> 7) * 0x0101010101010101UL >> 56);
+            }
+
+            for (; offset < data.Length; offset++)
+            {
+                if (Unsafe.Add(ref tail, offset) == 0)
                 {
                     totalZeros++;
                 }

--- a/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.std.cs
+++ b/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.std.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Trie;
 /// <summary>
 /// Track every rented CappedArray<byte> and return them all at once
 /// </summary>
-public sealed partial class TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>? arrayPool = null, bool canBeParallel = true) : ICappedArrayPool, IDisposable
+public sealed class TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>? arrayPool = null, bool canBeParallel = true) : ICappedArrayPool, IDisposable
 {
     private readonly ConcurrentQueue<byte[]>? _rentedQueue = canBeParallel ? new() : null;
     private readonly List<byte[]>? _rentedList = canBeParallel ? null : new(initialCapacity);

--- a/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.std.cs
+++ b/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.std.cs
@@ -16,7 +16,7 @@ namespace Nethermind.Trie;
 /// <summary>
 /// Track every rented CappedArray<byte> and return them all at once
 /// </summary>
-public sealed class TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>? arrayPool = null, bool canBeParallel = true) : ICappedArrayPool, IDisposable
+public sealed partial class TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>? arrayPool = null, bool canBeParallel = true) : ICappedArrayPool, IDisposable
 {
     private readonly ConcurrentQueue<byte[]>? _rentedQueue = canBeParallel ? new() : null;
     private readonly List<byte[]>? _rentedList = canBeParallel ? null : new(initialCapacity);

--- a/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.std.cs
+++ b/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.std.cs
@@ -13,6 +13,7 @@ using Nethermind.Core.Collections;
 
 namespace Nethermind.Trie;
 
+#pragma warning disable NETH003 // Build variant: only one of TrackingCappedArrayPool.std.cs / TrackingCappedArrayPool.zkevm.cs is compiled per build
 /// <summary>
 /// Track every rented CappedArray<byte> and return them all at once
 /// </summary>

--- a/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.zkevm.cs
+++ b/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.zkevm.cs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers;
+using Nethermind.Core.Buffers;
+
+namespace Nethermind.Trie;
+
+/// <summary>
+/// Allocating buffer source for the zkVM guest &mdash; see the std counterpart for the tracking pool.
+/// </summary>
+/// <remarks>
+/// The guest never collects, so a fresh array costs a bump-pointer allocation plus a DMA clear,
+/// while the std pool's bookkeeping (a queue of rentals, a power-of-two bucket lookup and a
+/// software <c>Log2</c> per rent and return) is all main-loop instructions. Allocating outright is
+/// measurably cheaper here.
+/// </remarks>
+public sealed partial class TrackingCappedArrayPool : ICappedArrayPool, IDisposable
+{
+    // The std counterpart's parameters size and shape its rental tracking; the guest keeps none.
+    public TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>? arrayPool = null, bool canBeParallel = true) { }
+
+    public TrackingCappedArrayPool() { }
+
+    public CappedArray<byte> Rent(int size) => size == 0 ? CappedArray<byte>.Empty : new(new byte[size], size);
+
+    public void Return(in CappedArray<byte> buffer) { }
+
+    public void Dispose() { }
+}

--- a/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.zkevm.cs
+++ b/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.zkevm.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Buffers;
 
 namespace Nethermind.Trie;
 
+#pragma warning disable NETH003 // Build variant: only one of TrackingCappedArrayPool.std.cs / TrackingCappedArrayPool.zkevm.cs is compiled per build
 /// <summary>
 /// Allocating buffer source for the zkVM guest &mdash; see the std counterpart for the tracking pool.
 /// </summary>
@@ -16,7 +17,7 @@ namespace Nethermind.Trie;
 /// software <c>Log2</c> per rent and return) is all main-loop instructions. Allocating outright is
 /// measurably cheaper here.
 /// </remarks>
-public sealed partial class TrackingCappedArrayPool : ICappedArrayPool, IDisposable
+public sealed class TrackingCappedArrayPool : ICappedArrayPool, IDisposable
 {
     // The std counterpart's parameters size and shape its rental tracking; the guest keeps none.
     public TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>? arrayPool = null, bool canBeParallel = true) { }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -497,19 +497,31 @@ namespace Nethermind.Trie
                 RlpReader rlpReader = item.RlpReader;
                 item.SeekChild(ref rlpReader, 0);
                 int position = 0;
+                // Unchanged children are consecutive bytes of the old RLP, so a run of them is one
+                // copy rather than one per child. Most branches change a single child, so this turns
+                // sixteen short copies into two.
+                int runStart = -1;
+                int runLength = 0;
                 for (int i = 0; i < BranchesCount; i++)
                 {
                     object data = item._nodeData[i];
                     if (data is null)
                     {
                         int length = rlpReader.PeekNextRlpLength();
-                        ReadOnlySpan<byte> nextItem = rlpReader.Data.Slice(rlpReader.Position, length);
-                        nextItem.CopyTo(destination.Slice(position, nextItem.Length));
-                        position += nextItem.Length;
+                        if (runStart < 0) runStart = rlpReader.Position;
+                        runLength += length;
                         rlpReader.SkipBytes(length);
                     }
                     else
                     {
+                        if (runStart >= 0)
+                        {
+                            rlpReader.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
+                            position += runLength;
+                            runStart = -1;
+                            runLength = 0;
+                        }
+
                         if (ReferenceEquals(data, _nullNode) || data is null)
                         {
                             destination[position++] = 128;
@@ -541,6 +553,11 @@ namespace Nethermind.Trie
 
                         rlpReader.SkipItem();
                     }
+                }
+
+                if (runStart >= 0)
+                {
+                    rlpReader.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
                 }
             }
         }


### PR DESCRIPTION
Three independent zkVM guest optimizations, each measured on `ziskemu` over the CI input
`25532382.ssz` with byte-identical output.

## Changes

- **Keccak**: drop the `#if ZK_EVM` fast paths that route one-shot and streaming hashing to
  `Accelerators.Keccak256`. The guest now uses Nethermind's own C# sponge, whose `KeccakF` already
  maps to the ZisK syscall.
- **Trie buffers**: `TrackingCappedArrayPool` gets an allocating `.zkevm.cs` variant.
- **`Bytes.CountZeros`**: word-at-a-time tail, replacing a byte loop on targets without vector
  acceleration.
- **Branch RLP**: unchanged children of a branch node are copied as one run instead of one short
  copy each.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Covered by existing suites, all green: `Nethermind.Core.Test` 5980/0/107, `Nethermind.Trie.Test`
475/0/12, `Nethermind.Evm.Test/CodeInfoTests` 110/0, `Nethermind.Consensus.Test` 204/0.
`CodeInfoTests.JumpDestinationAnalyzer_are_equivalent` and the trie round-trip tests cover the two
behavioural surfaces here. `stateless-tests.yml` asserts the guest output hash for nine blocks.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

### Keccak: −5.59 % from a deletion

Building the witness node database was 53 M steps for 26,025 nodes. Rebuilding with the dictionary
insert removed split it: 37 M steps for the hashing alone, i.e. 1,422 steps to hash one ~500-byte
trie node — about four keccak permutations, so roughly 387 main steps of glue per permutation
against a precompile priced at ≈565 step-equivalents.

That glue was zisklib's Rust `keccak256`, which absorbs a byte at a time. The C# sponge absorbs 8
bytes at a time via `XorVectors`' `ulong` path (every vector path folds away on riscv64) and calls
the same `syscall_keccak_f` underneath, so the wrapper was pure overhead. An instruction trace
independently showed zisklib's `keccak256` as the second-largest source of single-byte accesses in
the guest.

| | steps |
|---|---|
| before | 678,276,600 |
| after | 640,338,808 |
| | **−5.59 %** |

Memory cost fell 8.30 B → 6.78 B over the same window.

### Trie buffers: −0.50 %

The guest never collects, so a fresh array is a bump-pointer allocation plus a DMA clear, while the
pool's bookkeeping — a rental queue, a power-of-two bucket lookup and a software `Log2` per rent and
return — is all main-loop instructions. An instruction window covering the receipts root was 52 %
pool bookkeeping (`ConcurrentQueueSegment.TryDequeue` 19.3 %, `SingleThreadedPow2Pool` 15.3 %,
`Log2SoftwareFallback` 10.0 %, `Stack.Push` 7.8 %).

This is the same effect from the other direction as two changes that were tried and **rejected** on
measurement: a trie node cache (+1.12 % cost) and giving the state/storage trees a returning buffer
pool (+0.44 % cost). On ZisK, trading allocation for bookkeeping pays in the expensive currency.

### `CountZeros`: −0.16 %

Every vector path is unavailable on riscv64, so counting calldata zero bytes for intrinsic gas was a
bounds-checked byte loop. Note the kernel deliberately does **not** use the common
`(v - 0x01..) & ~v & 0x80..` form: that only reports whether *some* byte is zero, because a borrow
out of one byte corrupts its neighbour's flag. A model check found 97,332 mismatches in 300,000
random words; the borrow-free form used here verified exhaustively at zero.

### Branch RLP: −1.69 %

Unchanged children of a branch are consecutive bytes of the old RLP, so a run of them is one copy
rather than one short `Memmove` each. Most branches change a single child, turning sixteen copies
into two.

### Cumulative

| | steps |
|---|---|
| master before this PR | 678,276,600 |
| this PR | **625,502,451** (−7.78 %) |

### One caveat on the numbers

The three deltas after the keccak change were measured with #13079 also applied, since that was the
working branch at the time. #13079 is step-neutral (its win is in the memory and opcode state
machines), and these changes touch unrelated code paths, so the standalone total should land at the
same place — but I have not been able to run the confirming measurement, because the emulator host
became unavailable. Worth one `ziskemu` run against this branch before merge; the keccak figure
above *is* a standalone measurement against master.
