### PR TITLE
Reduce routine debug logging noise

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -166,9 +166,9 @@ public class BlockCachePreWarmerTests
 
     [TestCase(false, "validation")]
     [TestCase(true, "preparation")]
-    public async Task PreWarmCaches_TraceLogsPurposeAndTransactionCount(bool speculative, string purpose)
+    public async Task PreWarmCaches_LogsPurposeAndTransactionCount(bool speculative, string purpose)
     {
-        TestLogger logger = new() { IsDebug = false };
+        TestLogger logger = new();
         using BlockCachePreWarmer preWarmer = CreatePreWarmerFromConfig(
             parallelExecution: false,
             parallelExecutionBatchRead: false,

--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -21,6 +21,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Eip2930;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Blockchain;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
@@ -161,6 +162,32 @@ public class BlockCachePreWarmerTests
         }
 
         Assert.That(created, Is.Empty, "tiny blocks must not rent reactive warming environments");
+    }
+
+    [TestCase(false, "validation")]
+    [TestCase(true, "preparation")]
+    public async Task PreWarmCaches_LogsPurposeAndTransactionCount(bool speculative, string purpose)
+    {
+        TestLogger logger = new();
+        using BlockCachePreWarmer preWarmer = CreatePreWarmerFromConfig(
+            parallelExecution: false,
+            parallelExecutionBatchRead: false,
+            new OneLoggerLogManager(new(logger)));
+        Block block = BuildReactiveWarmBlock();
+
+        if (speculative)
+        {
+            RunSpeculativePreWarm(preWarmer, BuildParentHeader(), Osaka.Instance, block);
+        }
+        else
+        {
+            await RunPreWarmCaches(preWarmer, block, BuildParentHeader(), Osaka.Instance);
+        }
+
+        Assert.That(logger.LogList, Has.Some.EqualTo(
+            $"Started pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} transactions."));
+        Assert.That(logger.LogList, Has.Some.EqualTo(
+            $"Finished pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} transactions."));
     }
 
     /// <summary>
@@ -1332,7 +1359,10 @@ public class BlockCachePreWarmerTests
             delta ?? BuildTwoSenderBlock(),
             () => preWarmer.SpeculativeMarkerPublished);
 
-    private BlockCachePreWarmer CreatePreWarmerFromConfig(bool parallelExecution, bool parallelExecutionBatchRead)
+    private BlockCachePreWarmer CreatePreWarmerFromConfig(
+        bool parallelExecution,
+        bool parallelExecutionBatchRead,
+        ILogManager? logManager = null)
     {
         PrewarmerEnvFactory envFactory = _processingScope.Resolve<PrewarmerEnvFactory>();
         PreBlockCaches preBlockCaches = _processingScope.Resolve<PreBlockCaches>();
@@ -1346,7 +1376,7 @@ public class BlockCachePreWarmerTests
             ParallelExecutionBatchRead = parallelExecutionBatchRead
         };
 
-        return new BlockCachePreWarmer(envFactory, config, nodeStorageCache, preBlockCaches, LimboLogs.Instance);
+        return new BlockCachePreWarmer(envFactory, config, nodeStorageCache, preBlockCaches, logManager ?? LimboLogs.Instance);
     }
 
     private (BlockCachePreWarmer, ConcurrentBag<IReadOnlyTxProcessorSource> created, ConcurrentBag<IReadOnlyTxProcessorSource> disposed) CreatePreWarmer(int minPoolSize, bool parallelExecutionBatchRead = true)

--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -164,9 +164,9 @@ public class BlockCachePreWarmerTests
         Assert.That(created, Is.Empty, "tiny blocks must not rent reactive warming environments");
     }
 
-    [TestCase(false, "validation")]
-    [TestCase(true, "preparation")]
-    public async Task PreWarmCaches_LogsPurposeAndTransactionCount(bool speculative, string purpose)
+    [TestCase(false, "validation", "transactions")]
+    [TestCase(true, "preparation", "new transactions")]
+    public async Task PreWarmCaches_LogsPurposeAndTransactionCount(bool speculative, string purpose, string transactionDescription)
     {
         TestLogger logger = new();
         using BlockCachePreWarmer preWarmer = CreatePreWarmerFromConfig(
@@ -187,9 +187,9 @@ public class BlockCachePreWarmerTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(logger.LogList, Has.Some.EqualTo(
-                $"Started pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} transactions."));
+                $"Started pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} {transactionDescription}."));
             Assert.That(logger.LogList, Has.Some.EqualTo(
-                $"Finished pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} transactions."));
+                $"Finished pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} {transactionDescription}."));
         }
     }
 

--- a/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/BlockCachePreWarmerTests.cs
@@ -166,9 +166,9 @@ public class BlockCachePreWarmerTests
 
     [TestCase(false, "validation")]
     [TestCase(true, "preparation")]
-    public async Task PreWarmCaches_LogsPurposeAndTransactionCount(bool speculative, string purpose)
+    public async Task PreWarmCaches_TraceLogsPurposeAndTransactionCount(bool speculative, string purpose)
     {
-        TestLogger logger = new();
+        TestLogger logger = new() { IsDebug = false };
         using BlockCachePreWarmer preWarmer = CreatePreWarmerFromConfig(
             parallelExecution: false,
             parallelExecutionBatchRead: false,
@@ -184,10 +184,13 @@ public class BlockCachePreWarmerTests
             await RunPreWarmCaches(preWarmer, block, BuildParentHeader(), Osaka.Instance);
         }
 
-        Assert.That(logger.LogList, Has.Some.EqualTo(
-            $"Started pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} transactions."));
-        Assert.That(logger.LogList, Has.Some.EqualTo(
-            $"Finished pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} transactions."));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(logger.LogList, Has.Some.EqualTo(
+                $"Started pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} transactions."));
+            Assert.That(logger.LogList, Has.Some.EqualTo(
+                $"Finished pre-warming caches for {purpose} of block {block.Number} with {block.Transactions.Length} transactions."));
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -635,7 +635,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         {
             if (cancellationToken.IsCancellationRequested) return;
 
-            if (_logger.IsDebug) DebugPreWarming("Started", suggestedBlock.Number, isPreparation, transactionCount);
+            if (_logger.IsTrace) TracePreWarming("Started", suggestedBlock.Number, isPreparation, transactionCount);
 
             if (!addressWarmer.HasBal)
             {
@@ -643,7 +643,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                 WarmupWithdrawals(parallelOptions, spec, suggestedBlock, parent);
             }
 
-            if (_logger.IsDebug) DebugPreWarming("Finished", suggestedBlock.Number, isPreparation, transactionCount);
+            if (_logger.IsTrace) TracePreWarming("Finished", suggestedBlock.Number, isPreparation, transactionCount);
         }
         catch (Exception ex)
         {
@@ -657,8 +657,8 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        void DebugPreWarming(string state, ulong blockNumber, bool isPreparation, int transactionCount) =>
-            _logger.Debug(
+        void TracePreWarming(string state, ulong blockNumber, bool isPreparation, int transactionCount) =>
+            _logger.Trace(
                 $"{state} pre-warming caches for {(isPreparation ? "preparation" : "validation")} of block {blockNumber} with {transactionCount} transactions.");
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -605,7 +605,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         {
             if (cancellationToken.IsCancellationRequested) return;
 
-            if (_logger.IsDebug) _logger.Debug($"Started pre-warming caches for block {suggestedBlock.Number}.");
+            if (_logger.IsDebug) DebugPreWarming("Started", suggestedBlock.Number);
 
             if (!addressWarmer.HasBal)
             {
@@ -613,7 +613,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                 WarmupWithdrawals(parallelOptions, spec, suggestedBlock, parent);
             }
 
-            if (_logger.IsDebug) _logger.Debug($"Finished pre-warming caches for block {suggestedBlock.Number}.");
+            if (_logger.IsDebug) DebugPreWarming("Finished", suggestedBlock.Number);
         }
         catch (Exception ex)
         {
@@ -625,6 +625,10 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
             addressWarmer.Wait();
             addressWarmer.Dispose();
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void DebugPreWarming(string state, ulong blockNumber) =>
+            _logger.Debug($"{state} pre-warming caches for block {blockNumber}.");
     }
 
     private void WarmupWithdrawals(ParallelOptions parallelOptions, IReleaseSpec spec, Block block, BlockHeader? parent)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -635,7 +635,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         {
             if (cancellationToken.IsCancellationRequested) return;
 
-            if (_logger.IsTrace) TracePreWarming("Started", suggestedBlock.Number, isPreparation, transactionCount);
+            if (_logger.IsDebug) DebugPreWarming("Started", suggestedBlock.Number, isPreparation, transactionCount);
 
             if (!addressWarmer.HasBal)
             {
@@ -643,7 +643,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                 WarmupWithdrawals(parallelOptions, spec, suggestedBlock, parent);
             }
 
-            if (_logger.IsTrace) TracePreWarming("Finished", suggestedBlock.Number, isPreparation, transactionCount);
+            if (_logger.IsDebug) DebugPreWarming("Finished", suggestedBlock.Number, isPreparation, transactionCount);
         }
         catch (Exception ex)
         {
@@ -657,8 +657,8 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        void TracePreWarming(string state, ulong blockNumber, bool isPreparation, int transactionCount) =>
-            _logger.Trace(
+        void DebugPreWarming(string state, ulong blockNumber, bool isPreparation, int transactionCount) =>
+            _logger.Debug(
                 $"{state} pre-warming caches for {(isPreparation ? "preparation" : "validation")} of block {blockNumber} with {transactionCount} transactions.");
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -13,6 +13,7 @@ using Collections.Pooled;
 using Microsoft.Extensions.ObjectPool;
 using Nethermind.Blockchain;
 using Nethermind.Config;
+using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -152,7 +153,18 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         // Run address warmer ahead of transactions warmer, but queue to ThreadPool so it doesn't block the txs
         ThreadPool.UnsafeQueueUserWorkItem(addressWarmer, preferLocal: false);
         // Do not pass the cancellation token to the task, we don't want exceptions to be thrown in the main processing thread
-        Task normalWarmTask = Task.Run(() => PreWarmCachesParallel(blockState, suggestedBlock, parent, spec, parallelOptions, addressWarmer, cancellationToken));
+        bool isPreparation = suggestedBlock is BlockToProduce;
+        int transactionCount = suggestedBlock.Transactions.Length;
+        Task normalWarmTask = Task.Run(() => PreWarmCachesParallel(
+            blockState,
+            suggestedBlock,
+            parent,
+            spec,
+            parallelOptions,
+            addressWarmer,
+            isPreparation,
+            transactionCount,
+            cancellationToken));
 
         if (discoveryCandidates is null) return normalWarmTask;
 
@@ -438,7 +450,16 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
     {
         (BlockState blockState, ParallelOptions parallelOptions, AddressWarmer addressWarmer) = PrepareWarm(delta, head, spec, speculativelyWarmed: null, _speculativeConcurrencyLevel, token, systemAccessLists: default);
         ThreadPool.UnsafeQueueUserWorkItem(addressWarmer, preferLocal: false);
-        PreWarmCachesParallel(blockState, delta, head, spec, parallelOptions, addressWarmer, token);
+        PreWarmCachesParallel(
+            blockState,
+            delta,
+            head,
+            spec,
+            parallelOptions,
+            addressWarmer,
+            isPreparation: true,
+            transactionCount: delta.Transactions.Length,
+            cancellationToken: token);
     }
 
     private (BlockState BlockState, ParallelOptions ParallelOptions, AddressWarmer AddressWarmer) PrepareWarm(Block block, BlockHeader parent, IReleaseSpec spec, ISet<Hash256>? speculativelyWarmed, int maxDegreeOfParallelism, CancellationToken token, ReadOnlySpan<IHasAccessList> systemAccessLists)
@@ -599,13 +620,22 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         (_envPool as IDisposable)?.Dispose();
     }
 
-    private void PreWarmCachesParallel(BlockState blockState, Block suggestedBlock, BlockHeader parent, IReleaseSpec spec, ParallelOptions parallelOptions, AddressWarmer addressWarmer, CancellationToken cancellationToken)
+    private void PreWarmCachesParallel(
+        BlockState blockState,
+        Block suggestedBlock,
+        BlockHeader parent,
+        IReleaseSpec spec,
+        ParallelOptions parallelOptions,
+        AddressWarmer addressWarmer,
+        bool isPreparation,
+        int transactionCount,
+        CancellationToken cancellationToken)
     {
         try
         {
             if (cancellationToken.IsCancellationRequested) return;
 
-            if (_logger.IsDebug) DebugPreWarming("Started", suggestedBlock.Number);
+            if (_logger.IsDebug) DebugPreWarming("Started", suggestedBlock.Number, isPreparation, transactionCount);
 
             if (!addressWarmer.HasBal)
             {
@@ -613,7 +643,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
                 WarmupWithdrawals(parallelOptions, spec, suggestedBlock, parent);
             }
 
-            if (_logger.IsDebug) DebugPreWarming("Finished", suggestedBlock.Number);
+            if (_logger.IsDebug) DebugPreWarming("Finished", suggestedBlock.Number, isPreparation, transactionCount);
         }
         catch (Exception ex)
         {
@@ -627,8 +657,9 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        void DebugPreWarming(string state, ulong blockNumber) =>
-            _logger.Debug($"{state} pre-warming caches for block {blockNumber}.");
+        void DebugPreWarming(string state, ulong blockNumber, bool isPreparation, int transactionCount) =>
+            _logger.Debug(
+                $"{state} pre-warming caches for {(isPreparation ? "preparation" : "validation")} of block {blockNumber} with {transactionCount} transactions.");
     }
 
     private void WarmupWithdrawals(ParallelOptions parallelOptions, IReleaseSpec spec, Block block, BlockHeader? parent)

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -659,7 +659,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         [MethodImpl(MethodImplOptions.NoInlining)]
         void DebugPreWarming(string state, ulong blockNumber, bool isPreparation, int transactionCount) =>
             _logger.Debug(
-                $"{state} pre-warming caches for {(isPreparation ? "preparation" : "validation")} of block {blockNumber} with {transactionCount} transactions.");
+                $"{state} pre-warming caches for {(isPreparation ? "preparation" : "validation")} of block {blockNumber} with {transactionCount} {(isPreparation ? "new transactions" : "transactions")}.");
     }
 
     private void WarmupWithdrawals(ParallelOptions parallelOptions, IReleaseSpec spec, Block block, BlockHeader? parent)

--- a/src/Nethermind/Nethermind.Consensus/Transactions/TxFilterPipeline.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/TxFilterPipeline.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Logging;
@@ -27,11 +28,14 @@ public class TxFilterPipeline(ILogManager logManager) : ITxFilterPipeline
             bool isAllowed = filter.IsAllowed(tx, parentHeader, currentSpec);
             if (!isAllowed)
             {
-                if (_logger.IsDebug) _logger.Debug($"Rejected tx ({isAllowed}) {tx.ToShortString()}");
+                if (_logger.IsTrace) TraceRejection(tx, isAllowed);
                 return isAllowed;
             }
         }
 
         return true;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceRejection(Transaction tx, bool isAllowed) => _logger.Trace($"Rejected tx ({isAllowed}) {tx.ToShortString()}");
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -585,7 +585,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
             {
                 case JsonValueKind.Object:
                     JsonRpcRequest request = CreateRequest(rootElement);
-                    if (_logger.IsDebug) _logger.Debug($"JSON RPC request {request.Method}");
+                    if (_logger.IsDebug) DebugRequest(request);
 
                     JsonRpcResult.Entry singleResponse = await HandleSingleRequest(request, context);
                     await WriteSingleEntryAsync(singleResponse, sink, cancellationToken);
@@ -614,7 +614,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
     {
         try
         {
-            if (_logger.IsDebug) _logger.Debug($"JSON RPC request {request.Method}");
+            if (_logger.IsDebug) DebugRequest(request);
 
             JsonRpcResult.Entry response = await HandleSingleRequest(request, context);
             await WriteSingleEntryAsync(response, sink, cancellationToken);
@@ -624,6 +624,10 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
             request.DisposeParsedParamsDocument();
         }
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void DebugRequest(JsonRpcRequest request) =>
+        _logger.Debug($"JSON RPC request {request.Method}");
 
     private async ValueTask ProcessBatchDocumentToSink(
         JsonElement rootElement,

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/DiscoveryMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/DiscoveryMessageSerializerTests.cs
@@ -78,6 +78,21 @@ public class DiscoveryMessageSerializerTests
     }
 
     [Test]
+    public void PingMessage_rejects_invalid_packet_hash()
+    {
+        PingMsg message =
+            new(_privateKey.PublicKey, 60 + _timestamper.UnixTime.MillisecondsLong, _farAddress, _nearAddress,
+                new byte[32])
+            { FarAddress = _farAddress };
+
+        using DisposableByteBuffer data = _messageSerializationService.ZeroSerialize(message).AsDisposable();
+        data.SetByte(data.ReaderIndex, data.GetByte(data.ReaderIndex) ^ 1);
+
+        Assert.That(() => _messageSerializationService.Deserialize<PingMsg>(data),
+            Throws.TypeOf<NetworkingException>().And.Message.EqualTo("Invalid packet hash"));
+    }
+
+    [Test]
     public void PingMessage_Serializes_Endpoint_Ports_In_Discv4_Order()
     {
         IPEndPoint source = new(IPAddress.Parse("10.0.0.5"), 30304);

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/NettyDiscoveryHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/NettyDiscoveryHandlerTests.cs
@@ -248,6 +248,22 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             _ = _kademliaAdaptersMocks[1].DidNotReceive().OnIncomingMsg(Arg.Any<DiscoveryMsg>());
         }
 
+        [TestCase(-60, "has expired")]
+        [TestCase(7200, "expires too far in the future")]
+        public async Task InvalidExpirationIsLoggedAtTrace(long expirationOffsetSeconds, string expectedMessage)
+        {
+            TestLogger logger = new() { IsDebug = false };
+            (IKademliaAdapter adapter, NettyDiscoveryHandler handler, IChannelHandlerContext ctx, IMessageSerializationService service) =
+                CreateHandler(logManager: new OneLoggerLogManager(new ILogger(logger)));
+            byte[] data = SerializePing(service, expirationOffsetSeconds);
+
+            handler.ChannelRead(ctx, new DatagramPacket(Unpooled.WrappedBuffer(data), _address2, _address));
+            await SleepWhileWaiting();
+
+            Assert.That(logger.LogList, Has.Some.Contains(expectedMessage));
+            _ = adapter.DidNotReceive().OnIncomingMsg(Arg.Any<DiscoveryMsg>());
+        }
+
         [Test]
         public async Task EnrResponseWithoutExpirationIsAccepted()
         {
@@ -402,9 +418,9 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             Assert.That(() => Interlocked.CompareExchange(ref received, 0, 0), Is.EqualTo(2).After(5000, 10));
         }
 
-        private byte[] SerializePing(IMessageSerializationService service)
+        private byte[] SerializePing(IMessageSerializationService service, long expirationOffsetSeconds = 1200)
         {
-            PingMsg msg = new(_privateKey2.PublicKey, Timestamper.Default.UnixTime.SecondsLong + 1200, _address2, _address, new byte[32])
+            PingMsg msg = new(_privateKey2.PublicKey, Timestamper.Default.UnixTime.SecondsLong + expirationOffsetSeconds, _address2, _address, new byte[32])
             {
                 FarAddress = _address
             };

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/NettyDiscoveryHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Discv4/NettyDiscoveryHandlerTests.cs
@@ -14,6 +14,7 @@ using DotNetty.Transport.Bootstrapping;
 using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Sockets;
 using Nethermind.Core;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Modules;
 using Nethermind.Crypto;
@@ -168,7 +169,8 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             int? globalInboundMessageBurst = null,
             int? inboundMessageQueueCapacity = null,
             int? inboundMessageWorkerCount = null,
-            IMessageSerializationService? messageSerializationService = null)
+            IMessageSerializationService? messageSerializationService = null,
+            ILogManager? logManager = null)
         {
             IKademliaAdapter adapter = Substitute.For<IKademliaAdapter>();
             adapter.OnIncomingMsg(Arg.Any<DiscoveryMsg>()).Returns(Task.CompletedTask);
@@ -179,7 +181,7 @@ namespace Nethermind.Network.Discovery.Test.Discv4
                 channel,
                 service,
                 Timestamper.Default,
-                LimboLogs.Instance,
+                logManager ?? LimboLogs.Instance,
                 nodeFilter,
                 globalInboundMessageBurst,
                 inboundMessageQueueCapacity,
@@ -215,6 +217,21 @@ namespace Nethermind.Network.Discovery.Test.Discv4
             ctx.FireChannelRead(Arg.Is<DatagramPacket>(
                 p => p.Content.ReadAllBytesAsArray().SequenceEqual(data)
             ));
+        }
+
+        [Test]
+        public void ForwardsDiscv5MinimumSizePacketWithoutDebugLogging()
+        {
+            TestLogger logger = new() { IsTrace = false };
+            (IKademliaAdapter _, NettyDiscoveryHandler handler, IChannelHandlerContext ctx, IMessageSerializationService _) =
+                CreateHandler(logManager: new OneLoggerLogManager(new ILogger(logger)));
+            byte[] data = new byte[63];
+            DatagramPacket packet = new(Unpooled.WrappedBuffer(data), _address2, _address);
+
+            handler.ChannelRead(ctx, packet);
+
+            ctx.Received().FireChannelRead(Arg.Any<DatagramPacket>());
+            Assert.That(logger.LogList, Is.Empty);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryV5HandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/NettyDiscoveryV5HandlerTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Buffers;
@@ -13,6 +14,7 @@ using DotNetty.Transport.Channels;
 using DotNetty.Transport.Channels.Embedded;
 using DotNetty.Transport.Channels.Sockets;
 using Nethermind.Core;
+using Nethermind.Core.Test;
 using Nethermind.Logging;
 using Nethermind.Network.Discovery.Discv4;
 using Nethermind.Network.Discovery.Discv5;
@@ -81,6 +83,26 @@ namespace Nethermind.Network.Discovery.Test
             {
                 ReferenceCountUtil.Release(packet);
             }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void AddressNotAvailableSendFailureIsTraceOnly(bool traceEnabled)
+        {
+            TestLogger logger = new() { IsDebug = true, IsTrace = traceEnabled };
+            IChannel channel = Substitute.For<IChannel>();
+            channel.WriteAndFlushAsync(Arg.Any<object>())
+                .Returns(Task.FromException(new SocketException((int)SocketError.AddressNotAvailable)));
+            NettyDiscoveryV5Handler handler = new(new OneLoggerLogManager(new ILogger(logger)), channel);
+            IPEndPoint destination = new(IPAddress.Parse("2001:db8::1"), 30303);
+
+            Assert.ThrowsAsync<SocketException>(
+                async () => await handler.SendAsync([1, 2, 3], destination, CancellationToken.None));
+
+            if (traceEnabled)
+                Assert.That(logger.LogList, Has.Some.EqualTo($"TRACE/ERROR: Failed to send discv5 UDP packet to {destination}"));
+            else
+                Assert.That(logger.LogList, Is.Empty);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Kademlia/KademliaAdapter.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Nethermind.Config;
 using Nethermind.Core;
@@ -298,13 +299,13 @@ public class KademliaAdapter(
 
         if (!session.HasEndpointBond(endpoint))
         {
-            if (Logger.IsDebug) Logger.Debug($"Rejecting enr request from unbonded endpoint {endpoint} for peer {node.Id}");
+            if (Logger.IsTrace) TraceUnbondedEnrRequest(endpoint, node);
             return false;
         }
 
         if (msg.Hash is not { } requestHash)
         {
-            if (Logger.IsDebug) Logger.Debug($"Rejecting enr request without packet hash from {node}");
+            if (Logger.IsTrace) TraceEnrRequestWithoutHash(node);
             return false;
         }
 
@@ -319,7 +320,7 @@ public class KademliaAdapter(
 
         if (!session.HasEndpointBond(endpoint))
         {
-            if (Logger.IsDebug) Logger.Debug($"Rejecting findNode request from unbonded endpoint {endpoint} for peer {node.Id}");
+            if (Logger.IsTrace) TraceUnbondedFindNodeRequest(endpoint, node);
             return false;
         }
 
@@ -353,7 +354,7 @@ public class KademliaAdapter(
         if (Logger.IsTrace) Logger.Trace($"Receive ping from {node}");
         if (ping.Mdc is not { } pingMdc)
         {
-            if (Logger.IsDebug) Logger.Debug($"Rejecting ping without packet hash from {node}");
+            if (Logger.IsTrace) TracePingWithoutHash(node);
             return;
         }
 
@@ -375,6 +376,22 @@ public class KademliaAdapter(
         await RefreshRemoteRecordIfNewer(node, advertisedSequence, token);
         PublishNode(node, session, ping, advertisedSequence);
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceUnbondedEnrRequest(IPEndPoint endpoint, Node node) =>
+        Logger.Trace($"Rejecting enr request from unbonded endpoint {endpoint} for peer {node.Id}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceEnrRequestWithoutHash(Node node) =>
+        Logger.Trace($"Rejecting enr request without packet hash from {node}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceUnbondedFindNodeRequest(IPEndPoint endpoint, Node node) =>
+        Logger.Trace($"Rejecting findNode request from unbonded endpoint {endpoint} for peer {node.Id}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TracePingWithoutHash(Node node) =>
+        Logger.Trace($"Rejecting ping without packet hash from {node}");
 
     private void PublishNode(Node node, NodeSession session, PingMsg? signedPing, ulong? advertisedEnrSequence)
     {

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
@@ -134,7 +134,7 @@ public class NettyDiscoveryHandler(
 
         if (size < 98)
         {
-            if (_logger.IsDebug) _logger.Debug($"Incorrect discovery message, length: {size}, sender: {address}");
+            if (_logger.IsTrace) TraceNonDiscv4Message(size, address);
             return false;
         }
 
@@ -163,6 +163,10 @@ public class NettyDiscoveryHandler(
         }
 
         return true;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceNonDiscv4Message(int messageSize, EndPoint sender) =>
+            _logger.Trace($"Forwarding non-discv4 discovery message, length: {messageSize}, sender: {sender}");
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         void TraceUnsupportedMessageType(byte messageType, EndPoint sender) =>

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
@@ -229,14 +229,14 @@ public class NettyDiscoveryHandler(
             if (timeToExpire < 0)
             {
                 if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(msg.FarAddress, "disc v4", $"{msg.MsgType} expired", size);
-                if (_logger.IsDebug) _logger.Debug($"Received a discovery message that has expired {-timeToExpire} seconds ago, type: {type}, sender: {address}, message: {msg}");
+                if (_logger.IsTrace) TraceExpiredMessage(-timeToExpire, type, address, msg);
                 return false;
             }
 
             if (timeToExpire > MaxFutureExpirationOffset.TotalSeconds)
             {
                 if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(msg.FarAddress, "disc v4", $"{msg.MsgType} far future", size);
-                if (_logger.IsDebug) _logger.Debug($"Received a discovery message that expires too far in the future ({timeToExpire} seconds), type: {type}, sender: {address}, message: {msg}");
+                if (_logger.IsTrace) TraceFarFutureMessage(timeToExpire, type, address, msg);
                 return false;
             }
         }
@@ -244,25 +244,45 @@ public class NettyDiscoveryHandler(
         if (msg.FarAddress is null)
         {
             if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(msg.FarAddress, "disc v4", $"{msg.MsgType} has null far address", size);
-            if (_logger.IsDebug) _logger.Debug($"Discovery message without a valid far address {msg.FarAddress}, type: {type}, sender: {address}, message: {msg}");
+            if (_logger.IsTrace) TraceMissingFarAddress(type, address, msg);
             return false;
         }
 
         if (!msg.FarAddress.Equals(address))
         {
             if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(msg.FarAddress, "disc v4", $"{msg.MsgType} has incorrect far address", size);
-            if (_logger.IsDebug) _logger.Debug($"Discovery fake IP detected - pretended {msg.FarAddress}, type: {type}, sender: {address}, message: {msg}");
+            if (_logger.IsTrace) TraceFakeIp(type, address, msg);
             return false;
         }
 
         if (msg.FarPublicKey is null)
         {
             if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportIncomingMessage(msg.FarAddress, "disc v4", $"{msg.MsgType} has null far public key", size);
-            if (_logger.IsDebug) _logger.Debug($"Discovery message without a valid signature {msg.FarAddress}, type: {type}, sender: {address}, message: {msg}");
+            if (_logger.IsTrace) TraceMissingPublicKey(type, address, msg);
             return false;
         }
 
         return true;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceExpiredMessage(long secondsAgo, MsgType messageType, EndPoint sender, DiscoveryMsg message) =>
+            _logger.Trace($"Received a discovery message that has expired {secondsAgo} seconds ago, type: {messageType}, sender: {sender}, message: {message}");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceFarFutureMessage(long seconds, MsgType messageType, EndPoint sender, DiscoveryMsg message) =>
+            _logger.Trace($"Received a discovery message that expires too far in the future ({seconds} seconds), type: {messageType}, sender: {sender}, message: {message}");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceMissingFarAddress(MsgType messageType, EndPoint sender, DiscoveryMsg message) =>
+            _logger.Trace($"Discovery message without a valid far address {message.FarAddress}, type: {messageType}, sender: {sender}, message: {message}");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceFakeIp(MsgType messageType, EndPoint sender, DiscoveryMsg message) =>
+            _logger.Trace($"Discovery fake IP detected - pretended {message.FarAddress}, type: {messageType}, sender: {sender}, message: {message}");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceMissingPublicKey(MsgType messageType, EndPoint sender, DiscoveryMsg message) =>
+            _logger.Trace($"Discovery message without a valid signature {message.FarAddress}, type: {messageType}, sender: {sender}, message: {message}");
     }
 
     private static void ReportMsgByType(DiscoveryMsg msg, int size)

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using DotNetty.Buffers;
 using DotNetty.Common.Utilities;
@@ -141,7 +142,7 @@ public class NettyDiscoveryHandler(
         byte msgTypeByte = content.GetByte(readerIndex + 97);
         if (FromMsgTypeByte(msgTypeByte) is not { } resolvedType)
         {
-            if (_logger.IsDebug) _logger.Debug($"Unsupported message type: {msgTypeByte}, sender: {address}");
+            if (_logger.IsTrace) TraceUnsupportedMessageType(msgTypeByte, address);
             return false;
         }
 
@@ -162,6 +163,10 @@ public class NettyDiscoveryHandler(
         }
 
         return true;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceUnsupportedMessageType(byte messageType, EndPoint sender) =>
+            _logger.Trace($"Unsupported message type: {messageType}, sender: {sender}");
     }
 
     protected override void ChannelRead0(IChannelHandlerContext ctx, DatagramPacket packet)

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/NettyDiscoveryHandler.cs
@@ -379,9 +379,13 @@ public class NettyDiscoveryHandler(
         }
         catch (Exception e)
         {
-            if (_logger.IsDebug) _logger.Debug($"Error during deserialization of the message, type: {packet.Type}, sender: {packet.Address}, msg: {msgBytes.AsSpan(0, packet.Size).ToHexString()}, {e.Message}");
+            if (_logger.IsTrace) TraceDeserializationFailure(packet, msgBytes, e);
             return false;
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceDeserializationFailure(InboundDiscoveryPacket failedPacket, byte[] messageBytes, Exception exception) =>
+            _logger.Trace($"Error during deserialization of the message, type: {failedPacket.Type}, sender: {failedPacket.Address}, msg: {messageBytes.AsSpan(0, failedPacket.Size).ToHexString()}, {exception.Message}");
     }
 
     private static void ForwardPacket(InboundDiscoveryPacket packet)

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv4/Serializers/DiscoveryMsgSerializerBase.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv4/Serializers/DiscoveryMsgSerializerBase.cs
@@ -104,7 +104,7 @@ public abstract class DiscoveryMsgSerializerBase(IEcdsa ecdsa,
 
         if (!Bytes.AreEqual(mdc.Bytes, computedMdc))
         {
-            throw new NetworkingException("Invalid MDC", NetworkExceptionType.Validation);
+            throw new NetworkingException("Invalid packet hash", NetworkExceptionType.Validation);
         }
 
         PublicKey nodeId = _nodeIdResolver.GetNodeId(sigAndData[..64], sigAndData[64], sigAndData[65..]);

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/NodeSource.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/Kademlia/NodeSource.cs
@@ -114,7 +114,7 @@ public sealed class NodeSource(
 
             if (channel.Writer.TryWrite(peerCandidate))
             {
-                if (_logger.IsDebug) _logger.Debug($"Discv5 node source queued discovered node {peerCandidate:s}.");
+                if (_logger.IsTrace) TraceQueuedDiscoveredNode(peerCandidate);
                 return;
             }
 
@@ -123,6 +123,10 @@ public sealed class NodeSource(
             {
                 _logger.Trace($"Discv5 node source queue is full, dropping discovered node {node:s}.");
             }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void TraceQueuedDiscoveredNode(Node candidate) =>
+                _logger.Trace($"Discv5 node source queued discovered node {candidate:s}.");
         }
 
         bool TryReservePeerCandidate(Node node, [NotNullWhen(true)] out Node? peerCandidate)

--- a/src/Nethermind/Nethermind.Network.Discovery/Discv5/NettyDiscoveryV5Handler.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery/Discv5/NettyDiscoveryV5Handler.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Channels;
 using DotNetty.Buffers;
@@ -60,11 +61,20 @@ public sealed class NettyDiscoveryV5Handler(ILogManager loggerManager, IChannel?
             await Channel.WriteAndFlushAsync(packet).WaitAsync(token);
             Interlocked.Add(ref Metrics.DiscoveryBytesSent, data.Length);
         }
+        catch (SocketException exception) when (exception.SocketErrorCode == SocketError.AddressNotAvailable)
+        {
+            if (_logger.IsTrace) TraceAddressNotAvailable(destination, exception);
+            throw;
+        }
         catch (SocketException exception)
         {
             _logger.DebugError("Error sending data", exception);
             throw;
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceAddressNotAvailable(IPEndPoint failedDestination, SocketException exception) =>
+            _logger.TraceError($"Failed to send discv5 UDP packet to {failedDestination}", exception);
     }
 
     internal async IAsyncEnumerable<PooledUdpReceiveResult> ReadMessagesAsync([System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken token = default)

--- a/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/NetworkNodeDecoderTests.cs
@@ -42,6 +42,24 @@ namespace Nethermind.Network.Test
             }
         }
 
+        [Test]
+        public void Can_read_unbracketed_ipv4_mapped_ipv6_enode_regression()
+        {
+            NetworkNodeDecoder networkNodeDecoder = new();
+            Rlp encoded = new(Bytes.FromHexString("f8b2b8af656e6f64653a2f2f3661353034306166366634643434383035643830373936623237383466656630393136366430623565643862396565643437376639373030346664313138636330623564303734643535613933393763396466653239373137653934356139336336376134623030336634353363306664313237326439663466326531376130403a3a666666663a3134342e37362e3134392e3131393a303f64697363706f72743d333033303380"));
+            RlpReader context = new(encoded.Bytes);
+
+            NetworkNode decoded = networkNodeDecoder.Decode(ref context);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(decoded.Host, Is.EqualTo("144.76.149.119"));
+                Assert.That(decoded.Port, Is.Zero);
+                Assert.That(decoded.DiscoveryPort, Is.EqualTo(30303));
+                Assert.That(decoded.Reputation, Is.Zero);
+            }
+        }
+
         private static void AssertRoundtripPreservesFields(NetworkNode node)
         {
             NetworkNodeDecoder networkNodeDecoder = new();

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -147,7 +147,7 @@ namespace Nethermind.Network.Test.P2P
 
             p2PProtocolHandler.HandleMessage(CreateP2PPacket(message));
 
-            Assert.That(logger.LogList, Has.Some.Contains("received disconnect [BreachOfProtocol]"));
+            Assert.That(logger.LogList, Has.Some.Contains("P2P received disconnect [BreachOfProtocol]"));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -9,6 +9,7 @@ using Nethermind.Config;
 using Nethermind.Consensus.Scheduler;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Timers;
 using Nethermind.Logging;
@@ -37,7 +38,8 @@ namespace Nethermind.Network.Test.P2P
             _serializer = new MessageSerializationService(
                 SerializerInfo.Create(new HelloMessageSerializer()),
                 SerializerInfo.Create(new PingMessageSerializer()),
-                SerializerInfo.Create(new AddCapabilityMessageSerializer())
+                SerializerInfo.Create(new AddCapabilityMessageSerializer()),
+                SerializerInfo.Create(new DisconnectMessageSerializer())
             );
         }
 
@@ -57,7 +59,7 @@ namespace Nethermind.Network.Test.P2P
 
         private const int ListenPort = 8003;
 
-        private P2PProtocolHandler CreateSession()
+        private P2PProtocolHandler CreateSession(ILogManager? logManager = null)
         {
             _session.LocalPort.Returns(ListenPort);
             _session.Node.Returns(node);
@@ -70,7 +72,7 @@ namespace Nethermind.Network.Test.P2P
                 _nodeStatsManager,
                 _serializer,
                 Substitute.For<IBackgroundTaskScheduler>(),
-                LimboLogs.Instance);
+                logManager ?? LimboLogs.Instance);
         }
 
         [Test]
@@ -134,6 +136,18 @@ namespace Nethermind.Network.Test.P2P
             P2PProtocolHandler p2PProtocolHandler = CreateSession();
             p2PProtocolHandler.HandleMessage(CreatePacket(PingMessage.Instance));
             _session.Received(1).DeliverMessage(Arg.Any<PongMessage>());
+        }
+
+        [Test]
+        public void Received_disconnect_is_logged_at_trace()
+        {
+            TestLogger logger = new() { IsDebug = false };
+            P2PProtocolHandler p2PProtocolHandler = CreateSession(new OneLoggerLogManager(new(logger)));
+            using DisconnectMessage message = new(EthDisconnectReason.BreachOfProtocol);
+
+            p2PProtocolHandler.HandleMessage(CreateP2PPacket(message));
+
+            Assert.That(logger.LogList, Has.Some.Contains("received disconnect [BreachOfProtocol]"));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/ProtocolHandlers/ProtocolHandlerBaseTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/ProtocolHandlers/ProtocolHandlerBaseTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Consensus.Scheduler;
+using Nethermind.Core.Test;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.EventArg;
@@ -12,6 +13,7 @@ using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.Rlpx;
 using Nethermind.Network.Rlpx.Handshake;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using NSubstitute;
@@ -28,8 +30,13 @@ public class ProtocolHandlerBaseTests
     private static readonly Func<TestRequestMessage, CancellationToken, ValueTask<TestResponseMessage>> SyncServeValueTaskHandler =
         static (_, _) => ValueTask.FromResult(new TestResponseMessage());
 
-    private class TestProtocolHandler(ISession session, TimeSpan initTimeout, IBackgroundTaskScheduler? backgroundTaskScheduler = null)
-        : ProtocolHandlerBase(session, Substitute.For<INodeStatsManager>(), Substitute.For<IMessageSerializationService>(), backgroundTaskScheduler ?? Substitute.For<IBackgroundTaskScheduler>(), LimboLogs.Instance)
+    private class TestProtocolHandler(
+        ISession session,
+        TimeSpan initTimeout,
+        IBackgroundTaskScheduler? backgroundTaskScheduler = null,
+        IMessageSerializationService? serializationService = null,
+        ILogManager? logManager = null)
+        : ProtocolHandlerBase(session, Substitute.For<INodeStatsManager>(), serializationService ?? Substitute.For<IMessageSerializationService>(), backgroundTaskScheduler ?? Substitute.For<IBackgroundTaskScheduler>(), logManager ?? LimboLogs.Instance)
     {
         public override string Name => "test";
         protected override TimeSpan InitTimeout => initTimeout;
@@ -46,6 +53,7 @@ public class ProtocolHandlerBaseTests
             BackgroundTaskScheduler.TryScheduleSyncServe(request, syncServe);
         public void ScheduleSyncServeValueTask(TestRequestMessage request, Func<TestRequestMessage, CancellationToken, ValueTask<TestResponseMessage>> syncServe) =>
             BackgroundTaskScheduler.TryScheduleSyncServe(request, syncServe);
+        public TestRequestMessage Deserialize(byte[] data) => Deserialize<TestRequestMessage>(data);
         public override void Init() { }
         public override void Dispose() { }
         public override void DisconnectProtocol(DisconnectReason disconnectReason, string details) { }
@@ -149,5 +157,23 @@ public class ProtocolHandlerBaseTests
 
         long allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
         Assert.That(allocated, Is.Zero);
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Rlp_deserialization_exceptions_are_not_logged_at_debug(bool limitExceeded)
+    {
+        Exception exception = limitExceeded ? new RlpLimitException("limit") : new RlpException("invalid");
+        IMessageSerializationService serializationService = Substitute.For<IMessageSerializationService>();
+        serializationService.Deserialize<TestRequestMessage>(Arg.Any<ArraySegment<byte>>()).Returns(_ => throw exception);
+        TestLogger logger = new() { IsTrace = false };
+        TestProtocolHandler handler = new(
+            Substitute.For<ISession>(),
+            TimeSpan.FromMilliseconds(50),
+            serializationService: serializationService,
+            logManager: new OneLoggerLogManager(new ILogger(logger)));
+
+        Assert.That(() => handler.Deserialize([]), Throws.TypeOf(exception.GetType()));
+        Assert.That(logger.LogList, Is.Empty);
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/SessionTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DotNetty.Transport.Channels;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
@@ -578,6 +579,26 @@ public class SessionTests
         session.DeliverMessage(message);
         _packetSender.DidNotReceive().Enqueue(Arg.Any<TestMessage>());
         Assert.That(message.WasDisposed, Is.True);
+    }
+
+    [Test]
+    public void Initiated_disconnect_is_not_logged_at_debug()
+    {
+        TestLogger logger = new() { IsTrace = false };
+        Session session = new(
+            30312,
+            new Node(TestItem.PublicKeyA, "127.0.0.1", 8545),
+            _channel,
+            NullDisconnectsAnalyzer.Instance,
+            new OneLoggerLogManager(new ILogger(logger)));
+        session.Disconnected += static (_, _) => { };
+        session.Handshake(TestItem.PublicKeyA);
+        session.Init(5, _channelHandlerContext, _packetSender);
+        logger.LogList.Clear();
+
+        session.InitiateDisconnect(DisconnectReason.BreachOfProtocol);
+
+        Assert.That(logger.LogList, Has.None.Contains("initiating disconnect"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
@@ -386,13 +386,48 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         [Test]
         public void Will_disconnect_on_invalid_tx()
         {
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 1000; i++)
             {
                 _controller.Report(AcceptTxResult.Invalid);
             }
 
-            _session.Received(1)
+            using (Assert.EnterMultipleScope())
+            {
+                _session.Received(1)
+                    .InitiateDisconnect(DisconnectReason.InvalidTxReceived, "invalid tx");
+                Assert.That(_controller.IsDowngraded, Is.False);
+            }
+        }
+
+        [Test]
+        public void Invalid_tx_disconnect_can_be_requested_again_after_window_reset()
+        {
+            _controller.Report(AcceptTxResult.Invalid);
+            AdvanceWindow();
+
+            _controller.Report(AcceptTxResult.Invalid);
+
+            _session.Received(2)
                 .InitiateDisconnect(DisconnectReason.InvalidTxReceived, "invalid tx");
+        }
+
+        [Test]
+        public void Pending_disconnect_does_not_suppress_next_invalid_tx_disconnect()
+        {
+            ReportPooledRequestWindow(32_768, 0);
+            ReportPooledRequestWindow(32_768, 0);
+            AdvanceWindow();
+
+            _controller.Report(AcceptTxResult.Invalid);
+            _controller.Report(AcceptTxResult.Invalid);
+
+            using (Assert.EnterMultipleScope())
+            {
+                _session.Received(1)
+                    .InitiateDisconnect(DisconnectReason.TxFlooding, Arg.Any<string>());
+                _session.Received(1)
+                    .InitiateDisconnect(DisconnectReason.InvalidTxReceived, "invalid tx");
+            }
         }
 
         [TestCase(false)]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
@@ -380,7 +380,10 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         [Test]
         public void Will_disconnect_on_invalid_tx()
         {
-            _controller.Report(AcceptTxResult.Invalid);
+            for (int i = 0; i < 100; i++)
+            {
+                _controller.Report(AcceptTxResult.Invalid);
+            }
 
             _session.Received(1)
                 .InitiateDisconnect(DisconnectReason.InvalidTxReceived, "invalid tx");

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
@@ -24,6 +24,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         private TxFloodController _controller;
         private Eth62ProtocolHandler _handler;
         private ISession _session;
+        private TestLogger _testLogger;
         private ITimestamper _timestamper;
         private DateTime _now;
 
@@ -46,7 +47,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _timestamper = Substitute.For<ITimestamper>();
             _now = DateTime.UtcNow;
             _timestamper.UtcNow.Returns(_ => _now);
-            _controller = new TxFloodController(_handler, _timestamper, LimboNoErrorLogger.Instance, new Random(0));
+            _testLogger = new TestLogger { IsDebug = false };
+            _controller = new TxFloodController(_handler, _timestamper, new ILogger(_testLogger), new Random(0));
         }
 
         [TearDown]
@@ -120,7 +122,11 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
                 _controller.Report(Flooding);
             }
 
-            Assert.That(_controller.IsDowngraded, Is.True);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(_controller.IsDowngraded, Is.True);
+                Assert.That(_testLogger.LogList, Has.Some.EndsWith("due to tx flooding"));
+            }
         }
 
         [Test]
@@ -398,7 +404,11 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
                 _controller.Report(AcceptTxResult.InvalidBlobProofs);
             }
 
-            Assert.That(_controller.IsDowngraded, Is.True);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(_controller.IsDowngraded, Is.True);
+                Assert.That(_testLogger.LogList, Has.Some.EndsWith("due to invalid blob proofs"));
+            }
             _session.DidNotReceive().InitiateDisconnect(Arg.Any<DisconnectReason>(), Arg.Any<string>());
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
@@ -395,6 +395,22 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
                 .InitiateDisconnect(DisconnectReason.InvalidTxReceived, "invalid tx");
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Disconnect_message_is_trace_only(bool traceEnabled)
+        {
+            _testLogger.IsDebug = true;
+            _testLogger.IsTrace = traceEnabled;
+            _controller = new TxFloodController(_handler, _timestamper, new ILogger(_testLogger), new Random(0));
+
+            _controller.Report(AcceptTxResult.Invalid);
+
+            if (traceEnabled)
+                Assert.That(_testLogger.LogList, Has.One.EndsWith("due to invalid tx received"));
+            else
+                Assert.That(_testLogger.LogList, Is.Empty);
+        }
+
         [TestCase(1)]
         [TestCase(101)]
         public void Will_downgrade_without_disconnect_on_invalid_blob_proofs(int reports)

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
@@ -391,12 +391,9 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
                 _controller.Report(AcceptTxResult.Invalid);
             }
 
-            using (Assert.EnterMultipleScope())
-            {
-                _session.Received(1)
-                    .InitiateDisconnect(DisconnectReason.InvalidTxReceived, "invalid tx");
-                Assert.That(_controller.IsDowngraded, Is.False);
-            }
+            Assert.That(_controller.IsDowngraded, Is.False);
+            _session.Received(1)
+                .InitiateDisconnect(DisconnectReason.InvalidTxReceived, "invalid tx");
         }
 
         [Test]
@@ -421,13 +418,10 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             _controller.Report(AcceptTxResult.Invalid);
             _controller.Report(AcceptTxResult.Invalid);
 
-            using (Assert.EnterMultipleScope())
-            {
-                _session.Received(1)
-                    .InitiateDisconnect(DisconnectReason.TxFlooding, Arg.Any<string>());
-                _session.Received(1)
-                    .InitiateDisconnect(DisconnectReason.InvalidTxReceived, "invalid tx");
-            }
+            _session.Received(1)
+                .InitiateDisconnect(DisconnectReason.TxFlooding, Arg.Any<string>());
+            _session.Received(1)
+                .InitiateDisconnect(DisconnectReason.InvalidTxReceived, "invalid tx");
         }
 
         [TestCase(false)]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/TxFloodControllerTests.cs
@@ -103,8 +103,12 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
 
             // for easier debugging
             _controller.Report(Flooding);
+            for (int i = 0; i < 100; i++)
+            {
+                _controller.Report(Flooding);
+            }
 
-            _session.Received()
+            _session.Received(1)
                 .InitiateDisconnect(DisconnectReason.TxFlooding, Arg.Any<string>());
         }
 

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -368,6 +368,17 @@ public class Eth72ProtocolHandlerTests
     }
 
     [Test]
+    public void should_log_blob_cell_request_at_trace()
+    {
+        TestLogger logger = new() { IsDebug = false };
+        RecreateHandler(logManager: new OneLoggerLogManager(new ILogger(logger)));
+        HandleIncomingStatusMessage();
+
+        Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(HashFromInt(1), BlobCellMask.FromIndices([1])), Is.True);
+        Assert.That(logger.LogList, Has.Some.Contains("requesting blob cells"));
+    }
+
+    [Test]
     public void should_preserve_pending_mask_expanded_while_request_is_sent()
     {
         RecreateHandler();
@@ -4902,7 +4913,8 @@ public class Eth72ProtocolHandlerTests
         int providerProbabilityPercent = 15,
         IBackgroundTaskScheduler? backgroundTaskScheduler = null,
         ISparseBlobPoolPeerRegistry? sparseBlobPoolPeerRegistry = null,
-        IMessageSerializationService? serializer = null)
+        IMessageSerializationService? serializer = null,
+        ILogManager? logManager = null)
     {
         _handler.Dispose();
         _txPoolConfig.SparseBlobProviderProbabilityPercent.Returns(providerProbabilityPercent);
@@ -4915,7 +4927,7 @@ public class Eth72ProtocolHandlerTests
             _transactionPool,
             _gossipPolicy,
             new ForkInfo(_specProvider, _syncManager),
-            LimboLogs.Instance,
+            logManager ?? LimboLogs.Instance,
             _txPoolConfig,
             _specProvider,
             _blobCustodyTracker,

--- a/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
@@ -35,7 +35,7 @@ public class PeerPoolTests
 
         TestNodeSource nodeSource = new();
         TestLogger logger = new();
-        ImmediateTimeProvider timeProvider = new();
+        FirstTwoDelaysImmediateTimeProvider timeProvider = new();
         PeerPool pool = new(
             nodeSource,
             Substitute.For<INodeStatsManager>(),
@@ -363,7 +363,7 @@ public class PeerPoolTests
         "nrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPK" +
         "Y0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
 
-    private sealed class ImmediateTimeProvider : TimeProvider
+    private sealed class FirstTwoDelaysImmediateTimeProvider : TimeProvider
     {
         private readonly TaskCompletionSource _secondDelayRequested = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _delayCount;
@@ -372,8 +372,31 @@ public class PeerPoolTests
 
         public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
         {
-            if (Interlocked.Increment(ref _delayCount) == 2) _secondDelayRequested.TrySetResult();
-            return System.CreateTimer(callback, state, TimeSpan.Zero, period);
+            int delayCount = Interlocked.Increment(ref _delayCount);
+            if (delayCount == 2) _secondDelayRequested.TrySetResult();
+            return delayCount <= 2
+                ? new ImmediateTimer(callback, state, dueTime, period)
+                : TimeProvider.System.CreateTimer(callback, state, dueTime, period);
+        }
+
+        private sealed class ImmediateTimer(
+            TimerCallback callback,
+            object? state,
+            TimeSpan dueTime,
+            TimeSpan period) : ITimer
+        {
+            private readonly ITimer _timer =
+                TimeProvider.System.CreateTimer(callback, state, GetDueTime(dueTime), period);
+
+            public bool Change(TimeSpan dueTime, TimeSpan period) =>
+                _timer.Change(GetDueTime(dueTime), period);
+
+            public void Dispose() => _timer.Dispose();
+
+            public ValueTask DisposeAsync() => _timer.DisposeAsync();
+
+            private static TimeSpan GetDueTime(TimeSpan dueTime) =>
+                dueTime == Timeout.InfiniteTimeSpan ? dueTime : TimeSpan.Zero;
         }
     }
 

--- a/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
@@ -35,6 +35,7 @@ public class PeerPoolTests
 
         TestNodeSource nodeSource = new();
         TestLogger logger = new();
+        ImmediateTimeProvider timeProvider = new();
         PeerPool pool = new(
             nodeSource,
             Substitute.For<INodeStatsManager>(),
@@ -45,7 +46,8 @@ public class PeerPoolTests
                 MaxCandidatePeerCount = 10
             },
             new OneLoggerLogManager(new ILogger(logger)),
-            trustedNodesManager);
+            trustedNodesManager,
+            timeProvider);
 
         Random rand = new(0);
         PrivateKeyGenerator keyGen = new(new TestRandom((m) => rand.Next(m), (s) =>
@@ -75,7 +77,7 @@ public class PeerPoolTests
         try
         {
             Assert.That(() => nodeSource.BufferedNodeCount, Is.EqualTo(10).After(100, 10));
-            await Task.Delay(1200);
+            await timeProvider.SecondDelayRequested.WaitAsync(TimeSpan.FromSeconds(5));
             Assert.That(logger.LogList, Has.Exactly(1).EqualTo("Peer cleanup threshold reached. Throttling discovery."));
         }
         finally
@@ -360,6 +362,20 @@ public class PeerPoolTests
         "enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOo" +
         "nrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPK" +
         "Y0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8";
+
+    private sealed class ImmediateTimeProvider : TimeProvider
+    {
+        private readonly TaskCompletionSource _secondDelayRequested = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _delayCount;
+
+        public Task SecondDelayRequested => _secondDelayRequested.Task;
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            if (Interlocked.Increment(ref _delayCount) == 2) _secondDelayRequested.TrySetResult();
+            return System.CreateTimer(callback, state, TimeSpan.Zero, period);
+        }
+    }
 
     private static PeerPool CreatePeerPool(TestNodeSource nodeSource, ITrustedNodesManager trustedNodesManager, int maxActivePeers, int maxCandidatePeerCount) => new(
             nodeSource,

--- a/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerPoolTests.cs
@@ -34,6 +34,7 @@ public class PeerPoolTests
         ITrustedNodesManager trustedNodesManager = Substitute.For<ITrustedNodesManager>();
 
         TestNodeSource nodeSource = new();
+        TestLogger logger = new();
         PeerPool pool = new(
             nodeSource,
             Substitute.For<INodeStatsManager>(),
@@ -43,7 +44,7 @@ public class PeerPoolTests
                 MaxActivePeers = 5,
                 MaxCandidatePeerCount = 10
             },
-            LimboLogs.Instance,
+            new OneLoggerLogManager(new ILogger(logger)),
             trustedNodesManager);
 
         Random rand = new(0);
@@ -71,9 +72,16 @@ public class PeerPoolTests
             nodeSource.AddNode(node);
         }
 
-        Assert.That(() => nodeSource.BufferedNodeCount, Is.EqualTo(10).After(100, 10));
-
-        await pool.StopAsync();
+        try
+        {
+            Assert.That(() => nodeSource.BufferedNodeCount, Is.EqualTo(10).After(100, 10));
+            await Task.Delay(1200);
+            Assert.That(logger.LogList, Has.Exactly(1).EqualTo("Peer cleanup threshold reached. Throttling discovery."));
+        }
+        finally
+        {
+            await pool.StopAsync();
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/ProtocolsManagerTests.cs
@@ -88,6 +88,44 @@ public class ProtocolsManagerTests
         Assert.That(session.RemovedDisconnectedHandler, Is.Null);
     }
 
+    [TestCase(DisconnectReason.TooManyPeers, DisconnectType.Remote)]
+    [TestCase(DisconnectReason.ConnectionClosed, DisconnectType.Remote)]
+    [TestCase(DisconnectReason.ConnectionReset, DisconnectType.Local)]
+    [TestCase(DisconnectReason.OutgoingConnectionFailed, DisconnectType.Local)]
+    [TestCase(DisconnectReason.Exception, DisconnectType.Local)]
+    [TestCase(DisconnectReason.ClientQuitting, DisconnectType.Remote)]
+    [TestCase(DisconnectReason.Other, DisconnectType.Remote)]
+    [TestCase(DisconnectReason.BreachOfProtocol, DisconnectType.Remote)]
+    public void Initialized_session_disconnects_are_not_logged_at_debug(
+        DisconnectReason reason,
+        DisconnectType type)
+    {
+        TestLogger logger = new() { IsTrace = false };
+        IRlpxHost rlpxHost = Substitute.For<IRlpxHost>();
+        ISession session = Substitute.For<ISession>();
+        session.BestStateReached.Returns(SessionState.Initialized);
+        session.Node.Returns(new Node(TestItem.PublicKeyA, IPAddress.Loopback.ToString(), 30303));
+        _ = new ProtocolsManager(
+            Substitute.For<ISyncPeerPool>(),
+            Substitute.For<ITxPool>(),
+            Substitute.For<IDiscoveryApp>(),
+            rlpxHost,
+            Substitute.For<INodeStatsManager>(),
+            Substitute.For<IProtocolValidator>(),
+            Substitute.For<IPeerManager>(),
+            Substitute.For<INetworkStorage>(),
+            [],
+            [],
+            new OneLoggerLogManager(new ILogger(logger)));
+
+        rlpxHost.SessionDisconnected += Raise.Event<SessionDisconnectedEventHandler>(
+            new object(),
+            session,
+            new DisconnectEventArgs(reason, type, "test"));
+
+        Assert.That(logger.LogList, Is.Empty);
+    }
+
     [Test]
     public void Advertised_capabilities_apply_resolver_additions_and_removals()
     {

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
@@ -9,11 +9,13 @@ using DotNetty.Buffers;
 using DotNetty.Codecs;
 using DotNetty.Transport.Channels;
 using Nethermind.Core.Exceptions;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.Rlpx;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats.Model;
 using NSubstitute;
 using NUnit.Framework;
@@ -40,6 +42,18 @@ public class ZeroNettyP2PHandlerTests
     {
         yield return new TestCaseData(new Exception(), DisconnectReason.Exception).SetName("Generic_exception_uses_generic_reason");
         yield return new TestCaseData(new CorruptedFrameException("malformed frame"), DisconnectReason.Exception).SetName("Corrupted_frame_uses_generic_reason");
+    }
+
+    [Test]
+    public void Rlp_exception_is_not_logged_at_debug_by_netty_handler()
+    {
+        TestLogger logger = new() { IsTrace = false };
+        ISession session = Substitute.For<ISession>();
+        ZeroNettyP2PHandler handler = new(session, new OneLoggerLogManager(new ILogger(logger)));
+
+        handler.ExceptionCaught(Substitute.For<IChannelHandlerContext>(), new RlpException("malformed message"));
+
+        Assert.That(logger.LogList, Is.Empty);
     }
 
     [TestCase(true)]

--- a/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/Rlpx/ZeroNettyP2PHandlerTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using DotNetty.Buffers;
 using DotNetty.Codecs;
+using DotNetty.Handlers.Timeout;
 using DotNetty.Transport.Channels;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Test;
@@ -44,16 +45,22 @@ public class ZeroNettyP2PHandlerTests
         yield return new TestCaseData(new CorruptedFrameException("malformed frame"), DisconnectReason.Exception).SetName("Corrupted_frame_uses_generic_reason");
     }
 
-    [Test]
-    public void Rlp_exception_is_not_logged_at_debug_by_netty_handler()
+    [TestCaseSource(nameof(ExpectedCommunicationExceptions))]
+    public void Expected_communication_exception_is_logged_at_trace(Exception exception)
     {
-        TestLogger logger = new() { IsTrace = false };
+        TestLogger logger = new() { IsDebug = false };
         ISession session = Substitute.For<ISession>();
         ZeroNettyP2PHandler handler = new(session, new OneLoggerLogManager(new ILogger(logger)));
 
-        handler.ExceptionCaught(Substitute.For<IChannelHandlerContext>(), new RlpException("malformed message"));
+        handler.ExceptionCaught(Substitute.For<IChannelHandlerContext>(), exception);
 
-        Assert.That(logger.LogList, Is.Empty);
+        Assert.That(logger.LogList, Has.Some.Contains(exception.GetType().Name));
+    }
+
+    private static IEnumerable<TestCaseData> ExpectedCommunicationExceptions()
+    {
+        yield return new TestCaseData(new RlpException("malformed message")).SetName("RLP_exception_is_logged_at_trace");
+        yield return new TestCaseData(ReadTimeoutException.Instance).SetName("Read_timeout_is_logged_at_trace");
     }
 
     [TestCase(true)]

--- a/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/SessionMonitorTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Transport.Channels;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
@@ -79,7 +80,8 @@ namespace Nethermind.Network.Test
 
             NetworkConfig networkConfig = new();
             networkConfig.P2PPingInterval = 200;
-            SessionMonitor sessionMonitor = new(networkConfig, LimboLogs.Instance);
+            TestLogger logger = new() { IsDebug = false };
+            SessionMonitor sessionMonitor = new(networkConfig, new OneLoggerLogManager(new(logger)));
             sessionMonitor.AddSession(responsive);
             sessionMonitor.AddSession(unresponsive);
             responsive.LastPongUtc = DateTime.UtcNow;
@@ -100,6 +102,8 @@ namespace Nethermind.Network.Test
             {
                 sessionMonitor.Stop();
             }
+
+            Assert.That(logger.LogList, Has.Some.Contains("No pong received in response"));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network/NetworkNodeDecoder.cs
+++ b/src/Nethermind/Nethermind.Network/NetworkNodeDecoder.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
@@ -30,10 +32,45 @@ namespace Nethermind.Network
             string nodeString = Encoding.UTF8.GetString(firstItem);
             long reputation = decoderContext.DecodeLong();
             decoderContext.Check(contentEnd);
-            return new NetworkNode(nodeString)
+            NetworkNode node = new(NormalizeLegacyUnbracketedIpv6Enode(nodeString));
+            node.Reputation = reputation;
+            return node;
+        }
+
+        private static string NormalizeLegacyUnbracketedIpv6Enode(string nodeString)
+        {
+            if (!nodeString.StartsWith("enode://", StringComparison.OrdinalIgnoreCase))
             {
-                Reputation = reputation
-            };
+                return nodeString;
+            }
+
+            int hostSeparator = nodeString.IndexOf('@');
+            if (hostSeparator < 0)
+            {
+                return nodeString;
+            }
+
+            int hostStart = hostSeparator + 1;
+            int queryStart = nodeString.IndexOf('?', hostStart);
+            int endpointEnd = queryStart < 0 ? nodeString.Length : queryStart;
+            int portSeparator = nodeString.LastIndexOf(':', endpointEnd - 1);
+            if (portSeparator <= hostStart)
+            {
+                return nodeString;
+            }
+
+            ReadOnlySpan<char> hostText = nodeString.AsSpan(hostStart, portSeparator - hostStart);
+            if (hostText[0] == '['
+                || !IPAddress.TryParse(hostText, out IPAddress? host)
+                || host.AddressFamily != AddressFamily.InterNetworkV6)
+            {
+                return nodeString;
+            }
+
+            return string.Concat(
+                nodeString.AsSpan(0, hostStart),
+                Enode.FormatEnodeHost(host),
+                nodeString.AsSpan(portSeparator));
         }
 
         private static NetworkNode DecodeLegacyFormat(ref RlpReader decoderContext, ReadOnlySpan<byte> publicKeyBytes)

--- a/src/Nethermind/Nethermind.Network/NetworkNodeDecoder.cs
+++ b/src/Nethermind/Nethermind.Network/NetworkNodeDecoder.cs
@@ -53,6 +53,7 @@ namespace Nethermind.Network
             int hostStart = hostSeparator + 1;
             int queryStart = nodeString.IndexOf('?', hostStart);
             int endpointEnd = queryStart < 0 ? nodeString.Length : queryStart;
+            // The persisted legacy format always ends its endpoint with :port, including unbracketed IPv6 hosts.
             int portSeparator = nodeString.LastIndexOf(':', endpointEnd - 1);
             if (portSeparator <= hostStart)
             {

--- a/src/Nethermind/Nethermind.Network/NetworkStorage.cs
+++ b/src/Nethermind/Nethermind.Network/NetworkStorage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -87,9 +88,13 @@ namespace Nethermind.Network
                 }
                 catch (Exception e)
                 {
-                    if (_logger.IsDebug) _logger.Debug($"Failed to add one of the persisted nodes (with RLP {nodeRlp.ToHexString()}), {e.Message}");
+                    if (_logger.IsTrace) TracePersistedNodeFailure(nodeRlp, e);
                 }
             }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void TracePersistedNodeFailure(byte[] nodeRlp, Exception exception) =>
+                _logger.Trace($"Failed to add one of the persisted nodes (with RLP {nodeRlp.ToHexString()}), {exception.Message}");
         }
 
         public void UpdateNode(NetworkNode node)

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -464,27 +464,14 @@ public class P2PProtocolHandler(
     private void Close(EthDisconnectReason ethDisconnectReason)
     {
         Dispose();
-        if (ethDisconnectReason != EthDisconnectReason.TooManyPeers &&
-            ethDisconnectReason != EthDisconnectReason.Other &&
-            ethDisconnectReason != EthDisconnectReason.DisconnectRequested)
-        {
-            if (Logger.IsDebug) DebugReceivedDisconnect(ethDisconnectReason);
-        }
-        else
-        {
-            if (Logger.IsTrace) TraceReceivedDisconnect(ethDisconnectReason);
-        }
+        if (Logger.IsTrace) TraceReceivedDisconnect(ethDisconnectReason);
 
         // Received disconnect message, triggering direct TCP disconnection
         Session.MarkDisconnected(ethDisconnectReason.ToDisconnectReason(), DisconnectType.Remote, "message");
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        void DebugReceivedDisconnect(EthDisconnectReason reason)
-            => Logger.Debug($"{Session} received disconnect [{reason}]");
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
         void TraceReceivedDisconnect(EthDisconnectReason reason)
-            => Logger.Trace($"{Session} P2P received disconnect [{reason}]");
+            => Logger.Trace($"{Session} received disconnect [{reason}]");
     }
 
     public override string Name => Protocol.P2P;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -471,7 +471,7 @@ public class P2PProtocolHandler(
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         void TraceReceivedDisconnect(EthDisconnectReason reason)
-            => Logger.Trace($"{Session} received disconnect [{reason}]");
+            => Logger.Trace($"{Session} P2P received disconnect [{reason}]");
     }
 
     public override string Name => Protocol.P2P;

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Buffers;
@@ -73,16 +74,24 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         private void HandleRlpException<T>(int dataLength, RlpException e) where T : P2PMessage
         {
-            if (Logger.IsDebug) Logger.Debug($"Failed to deserialize message {typeof(T).Name} on session {Session}, with exception {e}");
+            if (Logger.IsTrace) TraceRlpException(typeof(T).Name, e);
             ReportIn($"{typeof(T).Name} - Deserialization exception", dataLength);
         }
 
         private void HandleRlpLimitException<T>(int dataLength, RlpLimitException e) where T : P2PMessage
         {
             Session.InitiateDisconnect(DisconnectReason.MessageLimitsBreached, e.Message);
-            if (Logger.IsDebug) Logger.Debug($"Failed to deserialize message {typeof(T).Name} on session {Session} due to rlp limits, with exception {e}");
+            if (Logger.IsTrace) TraceRlpLimitException(typeof(T).Name, e);
             ReportIn($"{typeof(T).Name} - Deserialization limit exception", dataLength);
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceRlpException(string messageType, RlpException exception) =>
+            Logger.Trace($"Failed to deserialize message {messageType} on session {Session}, with exception {exception}");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceRlpLimitException(string messageType, RlpLimitException exception) =>
+            Logger.Trace($"Failed to deserialize message {messageType} on session {Session} due to rlp limits, with exception {exception}");
 
         protected T Deserialize<T>(IByteBuffer data) where T : P2PMessage
         {

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using DotNetty.Buffers;
 using DotNetty.Codecs;
 using DotNetty.Common.Utilities;
@@ -12,6 +13,7 @@ using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
 using Nethermind.Logging;
 using Nethermind.Network.Rlpx;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats.Model;
 using Snappier;
 
@@ -117,10 +119,9 @@ public class ZeroNettyP2PHandler(ISession session, ILogManager logManager) : Sim
 
     public override void ExceptionCaught(IChannelHandlerContext context, Exception exception)
     {
-        //In case of SocketException we log it as debug to avoid noise
-        if (exception is SocketException)
+        if (exception is SocketException or RlpException)
         {
-            if (_logger.IsTrace) _logger.Trace($"Error in communication with {GetClientId(_session)} (SocketException): {exception}");
+            if (_logger.IsTrace) TraceCommunicationError(exception);
         }
         else
         {
@@ -143,6 +144,10 @@ public class ZeroNettyP2PHandler(ISession session, ILogManager logManager) : Sim
         {
             base.ExceptionCaught(context, exception);
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceCommunicationError(Exception communicationException) =>
+            _logger.Trace($"Error in communication with {GetClientId(_session)} ({communicationException.GetType().Name}): {communicationException}");
     }
 
     private static string GetClientId(ISession? session) =>

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroNettyP2PHandler.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using DotNetty.Buffers;
 using DotNetty.Codecs;
 using DotNetty.Common.Utilities;
+using DotNetty.Handlers.Timeout;
 using DotNetty.Transport.Channels;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
@@ -119,7 +120,7 @@ public class ZeroNettyP2PHandler(ISession session, ILogManager logManager) : Sim
 
     public override void ExceptionCaught(IChannelHandlerContext context, Exception exception)
     {
-        if (exception is SocketException or RlpException)
+        if (exception is SocketException or RlpException or ReadTimeoutException)
         {
             if (_logger.IsTrace) TraceCommunicationError(exception);
         }

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ZeroProtocolHandlerBase.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Common.Utilities;
@@ -125,10 +126,14 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
                 StatsManager.ReportTransferSpeedEvent(Session.Node, speedType, 0L);
 
-                if (Logger.IsDebug) Logger.Debug($"{Session} Request timeout in {describeRequestFunc(request.Message)}");
+                if (Logger.IsTrace) TraceRequestTimeout(describeRequestFunc(request.Message));
             }
 
             return task;
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceRequestTimeout(string requestDescription) =>
+            Logger.Trace($"{Session} Request timeout in {requestDescription}");
     }
 }

--- a/src/Nethermind/Nethermind.Network/P2P/Session.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Session.cs
@@ -410,7 +410,7 @@ namespace Nethermind.Network.P2P
                 State = SessionState.DisconnectingProtocols;
             }
 
-            if (_logger.IsDebug) DebugInitiatingDisconnect(disconnectReason, details);
+            if (_logger.IsTrace) TraceInitiatingDisconnect(disconnectReason, details);
 
             //Trigger disconnect on each protocol handler (if p2p is initialized it will send disconnect message to the peer)
             if (!_protocols.IsEmpty)
@@ -437,17 +437,8 @@ namespace Nethermind.Network.P2P
                 => _logger.Trace($"{this} not disconnecting for static/trusted peer on {reason} ({det})");
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            void DebugInitiatingDisconnect(DisconnectReason reason, string? det)
-            {
-                if (reason is DisconnectReason.InvalidNetworkId)
-                {
-                    if (_logger.IsTrace) _logger.Trace($"{this} initiating disconnect because {reason}, details: {det}");
-                }
-                else
-                {
-                    _logger.Debug($"{this} initiating disconnect because {reason}, details: {det}");
-                }
-            }
+            void TraceInitiatingDisconnect(DisconnectReason reason, string? det) =>
+                _logger.Trace($"{this} initiating disconnect because {reason}, details: {det}");
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             void TraceDisconnectingProtocol(IProtocolHandler handler, DisconnectReason reason, string? det)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
@@ -10,6 +10,7 @@ using Nethermind.TxPool;
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Threading;
 
@@ -94,7 +95,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                     }
                     else if (accepted == AcceptTxResult.InvalidBlobProofs)
                     {
-                        if (_logger.IsDebug) _logger.Debug($"Downgrading {_protocolHandler} due to invalid blob proofs");
+                        if (_logger.IsTrace) TraceDowngrading("invalid blob proofs");
                         _isLegacyDowngraded = true;
                     }
                     else
@@ -102,7 +103,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                         _notAcceptedSinceLastCheck++;
                         if (!_isLegacyDowngraded && _notAcceptedSinceLastCheck / _checkInterval.TotalSeconds > 10)
                         {
-                            if (_logger.IsDebug) _logger.Debug($"Downgrading {_protocolHandler} due to tx flooding");
+                            if (_logger.IsTrace) TraceDowngrading("tx flooding");
                             _isLegacyDowngraded = true;
                         }
                         else if (!_isLegacyDisconnectRequested
@@ -119,6 +120,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
             }
 
             DisconnectIfRequested(disconnectRequest);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void TraceDowngrading(string reason) =>
+                _logger.Trace($"Downgrading {_protocolHandler} due to {reason}");
         }
 
         public void ReportPooledTransactionRequest(ReadOnlySpan<Hash256> hashes)

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
@@ -39,6 +39,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         private int _unproductivePooledTransactionWindows;
         private bool _isLegacyDowngraded;
         private bool _isLegacyDisconnectRequested;
+        private bool _isInvalidTransactionDisconnectRequested;
         private bool _isPooledTransactionDowngraded;
 
         public TxFloodController(Eth62ProtocolHandler protocolHandler, ITimestamper timestamper, ILogger logger, Random? random = null)
@@ -83,8 +84,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
 
                 if (!accepted)
                 {
-                    if (accepted == AcceptTxResult.Invalid)
+                    if (accepted == AcceptTxResult.Invalid && !_isInvalidTransactionDisconnectRequested)
                     {
+                        _isInvalidTransactionDisconnectRequested = true;
                         disconnectRequest ??= new(
                             DisconnectReason.InvalidTxReceived,
                             "invalid tx",

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
@@ -272,14 +272,17 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 return;
             }
 
-            if (_logger.IsDebug) _logger.Debug(disconnect.DebugMessage);
+            if (_logger.IsTrace) TraceDisconnect(disconnect.TraceMessage);
             _protocolHandler.Disconnect(disconnect.Reason, disconnect.Details);
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void TraceDisconnect(string message) => _logger.Trace(message);
         }
 
         private readonly record struct DisconnectRequest(
             DisconnectReason Reason,
             string Details,
-            string DebugMessage);
+            string TraceMessage);
 
         private sealed class PooledTransactionSample(int capacity)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
@@ -38,6 +38,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         private long _notAcceptedSinceLastCheck;
         private int _unproductivePooledTransactionWindows;
         private bool _isLegacyDowngraded;
+        private bool _isLegacyDisconnectRequested;
         private bool _isPooledTransactionDowngraded;
 
         public TxFloodController(Eth62ProtocolHandler protocolHandler, ITimestamper timestamper, ILogger logger, Random? random = null)
@@ -102,8 +103,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                             if (_logger.IsDebug) _logger.Debug($"Downgrading {_protocolHandler} due to tx flooding");
                             _isLegacyDowngraded = true;
                         }
-                        else if (_notAcceptedSinceLastCheck / _checkInterval.TotalSeconds > 100)
+                        else if (!_isLegacyDisconnectRequested
+                            && _notAcceptedSinceLastCheck / _checkInterval.TotalSeconds > 100)
                         {
+                            _isLegacyDisconnectRequested = true;
                             disconnectRequest ??= new(
                                 DisconnectReason.TxFlooding,
                                 $"tx flooding {_notAcceptedSinceLastCheck}/{_checkInterval.TotalSeconds}",
@@ -207,6 +210,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 _checkpoint = now;
                 _notAcceptedSinceLastCheck = 0;
                 _isLegacyDowngraded = false;
+                _isLegacyDisconnectRequested = false;
                 _previousPooledTransactionSample.Clear();
                 (_currentPooledTransactionSample, _previousPooledTransactionSample) =
                     (_previousPooledTransactionSample, _currentPooledTransactionSample);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/TxFloodController.cs
@@ -85,13 +85,16 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
 
                 if (!accepted)
                 {
-                    if (accepted == AcceptTxResult.Invalid && !_isInvalidTransactionDisconnectRequested)
+                    if (accepted == AcceptTxResult.Invalid)
                     {
-                        _isInvalidTransactionDisconnectRequested = true;
-                        disconnectRequest ??= new(
-                            DisconnectReason.InvalidTxReceived,
-                            "invalid tx",
-                            $"Disconnecting {_protocolHandler} due to invalid tx received");
+                        if (!_isInvalidTransactionDisconnectRequested && disconnectRequest is null)
+                        {
+                            _isInvalidTransactionDisconnectRequested = true;
+                            disconnectRequest = new(
+                                DisconnectReason.InvalidTxReceived,
+                                "invalid tx",
+                                "invalid tx received");
+                        }
                     }
                     else if (accepted == AcceptTxResult.InvalidBlobProofs)
                     {
@@ -113,7 +116,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                             disconnectRequest ??= new(
                                 DisconnectReason.TxFlooding,
                                 $"tx flooding {_notAcceptedSinceLastCheck}/{_checkInterval.TotalSeconds}",
-                                $"Disconnecting {_protocolHandler} due to tx flooding");
+                                "tx flooding");
                         }
                     }
                 }
@@ -218,6 +221,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 _notAcceptedSinceLastCheck = 0;
                 _isLegacyDowngraded = false;
                 _isLegacyDisconnectRequested = false;
+                _isInvalidTransactionDisconnectRequested = false;
                 _previousPooledTransactionSample.Clear();
                 (_currentPooledTransactionSample, _previousPooledTransactionSample) =
                     (_previousPooledTransactionSample, _currentPooledTransactionSample);
@@ -237,7 +241,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                         return new(
                             DisconnectReason.TxFlooding,
                             $"pooled transaction flooding: returned requested transactions in {useful} of {sampled} sampled request messages",
-                            $"Disconnecting {_protocolHandler} due to unproductive pooled transaction announcements");
+                            "unproductive pooled transaction announcements");
                     }
                 }
                 else
@@ -272,17 +276,18 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                 return;
             }
 
-            if (_logger.IsTrace) TraceDisconnect(disconnect.TraceMessage);
+            if (_logger.IsTrace) TraceDisconnect(disconnect.TraceReason);
             _protocolHandler.Disconnect(disconnect.Reason, disconnect.Details);
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            void TraceDisconnect(string message) => _logger.Trace(message);
+            void TraceDisconnect(string reason) =>
+                _logger.Trace($"Disconnecting {_protocolHandler} due to {reason}");
         }
 
         private readonly record struct DisconnectRequest(
             DisconnectReason Reason,
             string Details,
-            string TraceMessage);
+            string TraceReason);
 
         private sealed class PooledTransactionSample(int capacity)
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -1055,16 +1055,17 @@ public class Eth72ProtocolHandler(
 
     private void SendGetCells(Hash256 hash, BlobCellMask requestMask)
     {
-        if (Logger.IsDebug)
-        {
-            Logger.Debug($"{Node:c} requesting blob cells for {hash} with mask {requestMask}.");
-        }
+        if (Logger.IsTrace) TraceRequestingBlobCells(hash, requestMask);
 
         ValueHash256 key = hash.ValueHash256;
         BlobCellMask sentMask = GetSentCellRequestMask(key, requestMask);
         GetCellsMessage72 message = new([hash], sentMask.ToBytes());
         AddSentCellRequest(key, sentMask, message.RequestId);
         Send(message);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void TraceRequestingBlobCells(Hash256 transactionHash, BlobCellMask cellMask) =>
+            Logger.Trace($"{Node:c} requesting blob cells for {transactionHash} with mask {cellMask}.");
     }
 
     bool ISparseBlobPoolPeer.IsClosing => Session.IsClosing;

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -33,6 +33,7 @@ namespace Nethermind.Network
         private readonly INetworkConfig _networkConfig;
         private readonly ILogger _logger;
         private readonly ITrustedNodesManager _trustedNodesManager;
+        private readonly TimeProvider _timeProvider;
 
         public ConcurrentDictionary<PublicKeyAsKey, Peer> ActivePeers { get; } = new();
         public ConcurrentDictionary<PublicKeyAsKey, Peer> Peers { get; } = new();
@@ -52,7 +53,18 @@ namespace Nethermind.Network
             INetworkConfig networkConfig,
             ILogManager logManager,
             ITrustedNodesManager trustedNodesManager)
+            : this(nodeSource, nodeStatsManager, peerStorage, networkConfig, logManager, trustedNodesManager, TimeProvider.System)
+        {
+        }
 
+        internal PeerPool(
+            INodeSource nodeSource,
+            INodeStatsManager nodeStatsManager,
+            INetworkStorage peerStorage,
+            INetworkConfig networkConfig,
+            ILogManager logManager,
+            ITrustedNodesManager trustedNodesManager,
+            TimeProvider timeProvider)
         {
             _nodeSource = nodeSource ?? throw new ArgumentNullException(nameof(nodeSource));
             _stats = nodeStatsManager ?? throw new ArgumentNullException(nameof(nodeStatsManager));
@@ -61,6 +73,7 @@ namespace Nethermind.Network
             _peerStorage.StartBatch();
             _logger = logManager?.GetClassLogger<PeerPool>() ?? throw new ArgumentNullException(nameof(logManager));
             _trustedNodesManager = trustedNodesManager ?? throw new ArgumentNullException(nameof(trustedNodesManager));
+            _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
 
             _nodeSource.NodeRemoved += NodeSourceOnNodeRemoved;
         }
@@ -338,7 +351,7 @@ namespace Nethermind.Network
                         if (_logger.IsDebug) _logger.Debug("Peer cleanup threshold reached. Throttling discovery.");
                         throttlingLogged = true;
                     }
-                    await Task.Delay(1000, token);
+                    await Task.Delay(TimeSpan.FromSeconds(1), _timeProvider, token);
                 }
 
                 GetOrAdd(node);

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -103,7 +103,7 @@ namespace Nethermind.Network
             Peer peer = Peers.GetOrAdd(node.Id, created);
             if (ReferenceEquals(peer, created))
             {
-                if ((node.IsBootnode || node.IsStatic) && _logger.IsDebug) DebugAddingCandidatePeer(node);
+                if ((node.IsBootnode || node.IsStatic) && _logger.IsTrace) TraceAddingCandidatePeer(node);
                 PeerAdded?.Invoke(this, new PeerEventArgs(peer));
             }
             else
@@ -114,8 +114,8 @@ namespace Nethermind.Network
             return peer;
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            void DebugAddingCandidatePeer(Node n)
-                => _logger.Debug($"Adding a {(n.IsBootnode ? "bootnode" : "stored")} candidate peer {n:s}");
+            void TraceAddingCandidatePeer(Node n)
+                => _logger.Trace($"Adding a {(n.IsBootnode ? "bootnode" : "stored")} candidate peer {n:s}");
         }
 
         // A node id can reach the pool through several sources (the persisted peers db, discovery, the

--- a/src/Nethermind/Nethermind.Network/PeerPool.cs
+++ b/src/Nethermind/Nethermind.Network/PeerPool.cs
@@ -330,9 +330,14 @@ namespace Nethermind.Network
             {
                 // Static and trusted nodes bypass throttling so they are always registered (static to stay
                 // dialable, trusted so inbound connections are recognized and counted even at capacity).
+                bool throttlingLogged = false;
                 while (!node.IsStatic && !node.IsTrusted && (PeerCount >= _networkConfig.MaxCandidatePeerCount || ActivePeerCount >= _networkConfig.MaxActivePeers))
                 {
-                    if (_logger.IsDebug) _logger.Debug("Peer cleanup threshold reached. Throttling discovery.");
+                    if (!throttlingLogged)
+                    {
+                        if (_logger.IsDebug) _logger.Debug("Peer cleanup threshold reached. Throttling discovery.");
+                        throttlingLogged = true;
+                    }
                     await Task.Delay(1000, token);
                 }
 

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -93,9 +93,9 @@ namespace Nethermind.Network
             session.Initialized -= _onSessionInitialized;
             _sessions.TryRemove(session.SessionId, out _);
 
-            if (session.BestStateReached == SessionState.Initialized)
+            if (_logger.IsTrace && session.BestStateReached == SessionState.Initialized)
             {
-                if (_logger.IsTrace) TraceSessionDisconnected(session, e);
+                TraceSessionDisconnected(session, e);
             }
 
             if (session.Node is not null

--- a/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
+++ b/src/Nethermind/Nethermind.Network/ProtocolsManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Autofac.Features.AttributeFilters;
 using Nethermind.Config;
@@ -92,9 +93,9 @@ namespace Nethermind.Network
             session.Initialized -= _onSessionInitialized;
             _sessions.TryRemove(session.SessionId, out _);
 
-            if (_logger.IsDebug && session.BestStateReached == SessionState.Initialized)
+            if (session.BestStateReached == SessionState.Initialized)
             {
-                _logger.Debug($"{session.Direction} {session.Node:s} disconnected {e.DisconnectType} {e.DisconnectReason} {e.Details}");
+                if (_logger.IsTrace) TraceSessionDisconnected(session, e);
             }
 
             if (session.Node is not null
@@ -121,6 +122,10 @@ namespace Nethermind.Network
                 _txPool.RemovePeer(session.Node.Id);
             }
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceSessionDisconnected(ISession session, DisconnectEventArgs e) =>
+            _logger.Trace($"{session.Direction} {session.Node:s} disconnected {e.DisconnectType} {e.DisconnectReason} {e.Details}");
 
         private void SessionInitialized(object sender, EventArgs e)
         {

--- a/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
+++ b/src/Nethermind/Nethermind.Network/Rlpx/RlpxHost.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DotNetty.Common.Concurrency;
@@ -213,7 +214,7 @@ namespace Nethermind.Network.Rlpx
             Task firstTask = await Task.WhenAny(connectTask, Task.Delay(_connectTimeout.Add(TimeSpan.FromSeconds(2)), delayCancellation.Token));
             if (firstTask != connectTask)
             {
-                if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {node:s} OUT connection timed out");
+                if (_logger.IsTrace) TraceConnectionTimedOut(node);
 
                 _ = connectTask.ContinueWith(
                     _disconnectConnectedChannel,
@@ -222,25 +223,27 @@ namespace Nethermind.Network.Rlpx
                     TaskContinuationOptions.ExecuteSynchronously,
                     TaskScheduler.Default);
 
-                if (_logger.IsDebug) _logger.Debug($"Failed to connect to {node:s} (timeout)");
                 return false;
             }
 
             delayCancellation.Cancel();
             if (connectTask.IsFaulted)
             {
-                if (_logger.IsTrace)
-                {
-                    _logger.Trace($"|NetworkTrace| {node:s} error when OUT connecting {connectTask.Exception}");
-                }
-
-                if (_logger.IsDebug) _logger.Debug($"Failed to connect to {node:s}: {connectTask.Exception.Message}");
+                if (_logger.IsTrace) TraceConnectionFailure(node, connectTask.Exception!);
                 return false;
             }
 
             if (_logger.IsTrace) _logger.Trace($"|NetworkTrace| {node:s} OUT connected");
             return true;
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceConnectionTimedOut(Node node) =>
+            _logger.Trace($"|NetworkTrace| {node:s} OUT connection timed out");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceConnectionFailure(Node node, Exception exception) =>
+            _logger.Trace($"|NetworkTrace| {node:s} error when OUT connecting {exception}");
 
         public event EventHandler<SessionEventArgs> SessionCreated;
         public event SessionDisconnectedEventHandler SessionDisconnected;

--- a/src/Nethermind/Nethermind.Network/SessionMonitor.cs
+++ b/src/Nethermind/Nethermind.Network/SessionMonitor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -132,7 +133,7 @@ namespace Nethermind.Network
                 {
                     if (!session.IsClosing)
                     {
-                        if (_logger.IsDebug) _logger.Debug($"No pong received in response to the {pingTime:T} ping at {session?.Node:c} | last pong time {session.LastPongUtc:T}");
+                        if (_logger.IsTrace) TraceNoPongReceived(pingTime, session);
                         if (pingTime - session.LastPongUtc > MissedPongIntervalsBeforeDisconnect * _pingInterval)
                         {
                             session.InitiateDisconnect(DisconnectReason.ReceiveMessageTimeout, "no pong received");
@@ -149,6 +150,10 @@ namespace Nethermind.Network
             }
 
             return true;
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            void TraceNoPongReceived(DateTime pingSentAt, ISession monitoredSession) =>
+                _logger.Trace($"No pong received in response to the {pingSentAt:T} ping at {monitoredSession.Node:c} | last pong time {monitoredSession.LastPongUtc:T}");
         }
 
         private void StartPingTimer()

--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/SnapFlatStateServerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/Snap/SnapFlatStateServerTests.cs
@@ -118,6 +118,22 @@ public class SnapFlatStateServerTests
         Assert.That(result, Is.Null);
     }
 
+    [Test]
+    public void GetStorageRanges_ReturnsEmpty_WhenIndexedStateIsConcurrentlyRemoved()
+    {
+        _flatDbManager.GatherReadOnlySnapshotBundle(_stateId)
+            .Returns(_ => throw new StateUnavailableException($"State {_stateId} no longer exists; concurrently removed."));
+
+        (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> slots, IByteArrayList? proofs) =
+            _server.GetStorageRanges(_rootHash, [], null, null, 1, CancellationToken.None);
+        using (slots)
+        using (proofs)
+        {
+            Assert.That(slots, Is.Empty);
+            Assert.That(proofs, Is.Empty);
+        }
+    }
+
     private static byte[] BuildRootRlp(out Hash256 rootHash)
     {
         using MemDb trieDb = new();

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/SnapFlatStateServer.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/SnapFlatStateServer.cs
@@ -34,8 +34,16 @@ public class SnapFlatStateServer(
             return false;
         }
 
-        bundle = flatDbManager.GatherReadOnlySnapshotBundle(stateId);
-        return true;
+        try
+        {
+            bundle = flatDbManager.GatherReadOnlySnapshotBundle(stateId);
+            return true;
+        }
+        catch (StateUnavailableException)
+        {
+            bundle = null!;
+            return false;
+        }
     }
 
     public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken) =>

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -39,17 +39,18 @@ public class StateProviderTests(bool useFlat)
         public IWorldState WorldState { get; }
         private readonly IContainer? _container;
 
-        public Context(bool useFlat)
+        public Context(bool useFlat, ILogManager? logManager = null)
         {
+            logManager ??= Logger;
             if (useFlat)
             {
                 (IWorldStateScopeProvider scopeProvider, IContainer container) = TestWorldStateFactory.CreateFlatScopeProvider();
                 _container = container;
-                WorldState = new WorldState(scopeProvider, Logger);
+                WorldState = new WorldState(scopeProvider, logManager);
             }
             else
             {
-                WorldState = TestWorldStateFactory.CreateForTest();
+                WorldState = TestWorldStateFactory.CreateForTest(logManager: logManager);
             }
         }
 
@@ -95,6 +96,21 @@ public class StateProviderTests(bool useFlat)
         provider.Commit(releaseSpec);
 
         Assert.That(provider.AccountExists(systemUser), Is.True);
+    }
+
+    [Test]
+    public void Updating_code_hash_is_not_logged_at_debug()
+    {
+        TestLogger logger = new() { IsTrace = false };
+        using Context ctx = new(useFlat, new OneLoggerLogManager(new ILogger(logger)));
+        IWorldState provider = ctx.WorldState;
+        using IDisposable _ = provider.BeginScope(IWorldState.PreGenesis);
+        provider.CreateAccount(_address1, 0);
+        logger.LogList.Clear();
+
+        provider.InsertCode(_address1, new byte[] { 1 }, Frontier.Instance);
+
+        Assert.That(logger.LogList, Has.None.Contains($"Update {_address1} C"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -165,7 +165,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         if (account.CodeHash.ValueHash256 != codeHash)
         {
             _needsStateRootUpdate = true;
-            if (_logger.IsDebug) Debug(address, codeHash, account);
+            if (_logger.IsTrace) TraceUpdate(address, codeHash, account);
             Account changedAccount = account.WithChangedCodeHash((Hash256)codeHash);
 
             PushUpdate(address, changedAccount);
@@ -182,8 +182,8 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         return inserted;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        void Debug(Address address, in ValueHash256 codeHash, Account account)
-            => _logger.Debug($"Update {address} C {account.CodeHash} -> {codeHash}");
+        void TraceUpdate(Address address, in ValueHash256 codeHash, Account account)
+            => _logger.Trace($"Update {address} C {account.CodeHash} -> {codeHash}");
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         void Trace(Address address) => _logger.Trace($"Touch {address} (code hash)");

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -242,7 +242,7 @@ namespace Nethermind.Synchronization.Peers
 
         public void AddPeer(ISyncPeer syncPeer)
         {
-            if (_logger.IsDebug) _logger.Debug($"Adding sync peer {syncPeer.Node:c}");
+            if (_logger.IsTrace) TraceAddingPeer(syncPeer);
             if (!_isStarted)
             {
                 if (_logger.IsDebug) _logger.Debug($"Sync peer pool not started yet - adding peer is blocked: {syncPeer.Node:s}");
@@ -268,7 +268,7 @@ namespace Nethermind.Synchronization.Peers
                 Interlocked.Increment(ref PriorityPeerCount);
                 Metrics.PriorityPeers = PriorityPeerCount;
             }
-            if (_logger.IsDebug) _logger.Debug($"PeerCount: {PeerCount}, PriorityPeerCount: {PriorityPeerCount}");
+            if (_logger.IsTrace) TracePeerCount();
 
             BlockHeader? header = _blockTree.FindHeader(syncPeer.HeadHash, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             if (header is not null)
@@ -286,7 +286,7 @@ namespace Nethermind.Synchronization.Peers
 
         public void RemovePeer(ISyncPeer syncPeer)
         {
-            if (_logger.IsDebug) _logger.Debug($"Removing sync peer {syncPeer.Node:c}");
+            if (_logger.IsTrace) TraceRemovingPeer(syncPeer);
 
             if (!_isStarted)
             {
@@ -314,7 +314,7 @@ namespace Nethermind.Synchronization.Peers
                 Interlocked.Decrement(ref PriorityPeerCount);
                 Metrics.PriorityPeers = PriorityPeerCount;
             }
-            if (_logger.IsDebug) _logger.Debug($"PeerCount: {PeerCount}, PriorityPeerCount: {PriorityPeerCount}");
+            if (_logger.IsTrace) TracePeerCount();
 
             if (_refreshCancelTokens.TryGetValue(id, out CancellationTokenSource? initCancelTokenSource))
             {
@@ -528,8 +528,24 @@ namespace Nethermind.Synchronization.Peers
                 peersDropped += DropWorstPeer();
             }
 
-            if (_logger.IsDebug) _logger.Debug($"Dropped {peersDropped} useless peers");
+            if (peersDropped > 0 && _logger.IsTrace) TraceDroppedUselessPeers(peersDropped);
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceAddingPeer(ISyncPeer syncPeer) =>
+            _logger.Trace($"Adding sync peer {syncPeer.Node:c}");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceRemovingPeer(ISyncPeer syncPeer) =>
+            _logger.Trace($"Removing sync peer {syncPeer.Node:c}");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TracePeerCount() =>
+            _logger.Trace($"PeerCount: {PeerCount}, PriorityPeerCount: {PriorityPeerCount}");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceDroppedUselessPeers(int peersDropped) =>
+            _logger.Trace($"Dropped {peersDropped} useless peers");
 
         private int DropWorstPeer()
         {

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -278,7 +278,7 @@ namespace Nethermind.Synchronization.Peers
             }
             else
             {
-                if (_logger.IsDebug) _logger.Debug($"Adding {syncPeer.Node:c} to refresh queue");
+                if (_logger.IsTrace) TraceAddingToRefreshQueue(syncPeer);
                 if (NetworkDiagTracer.IsEnabled) NetworkDiagTracer.ReportInterestingEvent(syncPeer.Node.Address, "adding node to refresh queue");
                 _peerRefreshQueue.Writer.TryWrite(new RefreshTotalDiffTask(syncPeer));
             }
@@ -477,7 +477,7 @@ namespace Nethermind.Synchronization.Peers
                         }
                     }
 
-                    if (_logger.IsDebug) _logger.Debug($"Refreshed peer info for {syncPeer}.");
+                    if (_logger.IsTrace) TraceRefreshedPeerInfo(syncPeer);
 
                     initCancelSource.Dispose();
                     linkedSource.Dispose();
@@ -542,6 +542,14 @@ namespace Nethermind.Synchronization.Peers
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void TracePeerCount() =>
             _logger.Trace($"PeerCount: {PeerCount}, PriorityPeerCount: {PriorityPeerCount}");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceAddingToRefreshQueue(ISyncPeer syncPeer) =>
+            _logger.Trace($"Adding {syncPeer.Node:c} to refresh queue");
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void TraceRefreshedPeerInfo(ISyncPeer syncPeer) =>
+            _logger.Trace($"Refreshed peer info for {syncPeer}.");
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void TraceDroppedUselessPeers(int peersDropped) =>


### PR DESCRIPTION
## Changes

- Deduplicate transaction-flood and invalid-transaction disconnect requests.
- Move expected high-volume peer, discovery, synchronization, and request lifecycle diagnostics from Debug to Trace.
- Improve cache prewarming messages by distinguishing preparation batches of new transactions from full-block validation.
- Decode legacy persisted enodes without exception-driven flow, including IPv6 endpoints, while rejecting unusable port-zero peers.
- Treat concurrently pruned Flat State snapshots as unavailable responses instead of peer communication failures.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Logging and observability

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Focused tests passed for BlockCachePreWarmer, discovery v4/v5 handling, peer/session logging, transaction flooding, persisted node decoding, and Flat State snap serving.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No