### PR TITLE
test: deflake the peer session-conflict agreement test

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -394,7 +394,7 @@ namespace Nethermind.Network.Test
 
         [TestCase(true, ConnectionDirection.In)]
         [TestCase(false, ConnectionDirection.In)]
-        // [TestCase(true, ConnectionDirection.Out)] // cannot create an active peer waiting for the test
+        [TestCase(true, ConnectionDirection.Out)]
         [TestCase(false, ConnectionDirection.Out)]
         [NonParallelizable]
         public async Task Will_agree_on_which_session_to_disconnect_when_connecting_at_once(bool shouldLose,
@@ -436,11 +436,13 @@ namespace Nethermind.Network.Test
             }
             else
             {
+                // Dialing rlpx directly would leave the session unowned: the peer manager only keeps an
+                // outgoing session for a peer it already made active. Adding the node to the pool makes it
+                // dial, which activates the peer and attaches the OUT session before the IN one arrives.
                 ctx.RlpxPeer.SessionCreated += HandshakeOnCreate;
-                if (!await ctx.RlpxPeer.ConnectAsync(session1.Node))
-                {
-                    throw new NetworkingException($"Failed to connect to {session1.Node:s}", NetworkExceptionType.TargetUnreachable);
-                }
+                ctx.PeerPool.GetOrAdd(session1.Node);
+                Assert.That(() => ctx.PeerManager.ActivePeers.SingleOrDefault()?.OutSession,
+                    Is.Not.Null.After(_delayLonger, 20), "peer manager did not establish the OUT session");
                 ctx.RlpxPeer.SessionCreated -= HandshakeOnCreate;
                 ctx.RlpxPeer.CreateIncoming(session1);
             }


### PR DESCRIPTION
## Changes

- Make the `Out` direction of `Will_agree_on_which_session_to_disconnect_when_connecting_at_once` establish its outgoing session through the peer manager and wait for it, instead of dialling rlpx directly
- Re-enable the `[TestCase(true, ConnectionDirection.Out)]` case that was commented out for the same reason

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

The change is itself a test fix. `PeerManagerTests` runs 45 passed / 1 skipped locally; the four cases of this test pass across repeated runs.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Seen failing on an unrelated PR ([#13079](https://github.com/NethermindEth/nethermind/pull/13079), `Nethermind.Network.Test [no-intrinsics]`):

```
failed Will_agree_on_which_session_to_disconnect_when_connecting_at_once(False,Out) (3s 030ms)
  Assert.That(..., Is.True.After(_delayLonger, 20))
  After 3000 milliseconds delay   Expected: True   But was: False
```

It is not a timing flake, so a longer poll would not have helped. In the `Out` direction the test dialled rlpx directly:

```csharp
ctx.RlpxPeer.SessionCreated += HandshakeOnCreate;
await ctx.RlpxPeer.ConnectAsync(session1.Node);
```

`ProcessOutgoingConnection` only keeps an outgoing session for a peer already in `ActivePeers`, and the pool is empty at that point, so it immediately does `MarkDisconnected(DuplicatedConnection, "peer removed")`. The session the assertion actually observed came from a *second*, incidental dial by the peer manager — instrumenting the test shows `connects=2` for `(False, Out)` although the test calls `ConnectAsync` once.

That second dial is triggered by `SignalPeerUpdateNeeded()` when `ProcessIncomingConnection` adds the node to the pool, and it only yields a session if the update loop snapshots candidates *before* `AddActivePeer` runs. Once the peer is active, `SelectAndRankCandidates` skips it permanently, so a lost race leaves `OutSession` null for the entire poll window. A loaded runner loses that race.

Adding the node to the pool and waiting for the peer manager to attach the OUT session removes the race and makes the "out first, then in" ordering real rather than accidental. That also fixes the reason `(true, Out)` was disabled — its expectation that the IN session ends up closing is only reachable through `ResolveOppositeDirectionSessionConflict`, so the re-enabled case covers the conflict path directly.
