### PR TITLE
ci: fall back to the base EVM benchmark harness when the PR harness will not compile

### DIFF
--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -133,6 +133,17 @@ jobs:
             cp "${GITHUB_WORKSPACE}/${source}" "${BASE_WORKTREE}/${source}"
           done
 
+          # A PR that changes an EVM API the harness calls (e.g. the opcode delegate signature) leaves
+          # the PR harness uncompilable against base. Fall back to base's own harness so the comparison
+          # still runs; the compare step flags that the two sides measured with different sources.
+          pushd "${BASE_WORKTREE}/src/Nethermind" >/dev/null
+          dotnet restore Benchmarks.slnx --locked-mode
+          if ! dotnet build Nethermind.Evm.Benchmark/Nethermind.Evm.Benchmark.csproj -c Release --no-restore; then
+            git -C "${BASE_WORKTREE}" checkout -- "${benchmark_sources[@]}"
+            echo "BASE_HARNESS_FALLBACK=true" >> "${GITHUB_ENV}"
+          fi
+          popd >/dev/null
+
       - name: Run base benchmark
         shell: bash
         run: |
@@ -293,6 +304,11 @@ jobs:
           summary_lines.append("## EVM Opcode Benchmark Diff")
           summary_lines.append("")
           summary_lines.append(f"Aggregated runs: base={len(base_logs)}, pr={len(pr_logs)}")
+          if os.environ.get("BASE_HARNESS_FALLBACK") == "true":
+              summary_lines.append(
+                  "⚠️ The PR benchmark harness does not compile against the base commit, so the base "
+                  "side ran its own harness sources. Treat the comparison as indicative if the harness itself changed."
+              )
           if os.path.exists("evm-rerun-opcodes.txt"):
               with open("evm-rerun-opcodes.txt", "r", encoding="utf-8") as f:
                   rerun_ops = [line.strip() for line in f if line.strip()]

--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -120,7 +120,7 @@ jobs:
           git worktree add --detach -f "${base_dir}" "${base_sha}"
           echo "BASE_WORKTREE=${base_dir}" >> "${GITHUB_ENV}"
 
-      - name: Use PR opcode benchmark harness for base
+      - name: Use PR opcode benchmark harness for base (probe, fall back to base harness)
         shell: bash
         run: |
           set -euo pipefail
@@ -136,11 +136,28 @@ jobs:
           # A PR that changes an EVM API the harness calls (e.g. the opcode delegate signature) leaves
           # the PR harness uncompilable against base. Fall back to base's own harness so the comparison
           # still runs; the compare step flags that the two sides measured with different sources.
+          # Probing the runner rather than the harness alone matches what the benchmark steps build.
+          probe_project="Nethermind.Benchmark.Runner/Nethermind.Benchmark.Runner.csproj"
           pushd "${BASE_WORKTREE}/src/Nethermind" >/dev/null
           dotnet restore Benchmarks.slnx --locked-mode
-          if ! dotnet build Nethermind.Evm.Benchmark/Nethermind.Evm.Benchmark.csproj -c Release --no-restore; then
-            git -C "${BASE_WORKTREE}" checkout -- "${benchmark_sources[@]}"
-            echo "BASE_HARNESS_FALLBACK=true" >> "${GITHUB_ENV}"
+          if ! dotnet build "${probe_project}" -c Release --no-restore 2>&1 | tee "${GITHUB_WORKSPACE}/evm-base-harness-probe.log"; then
+            # Restore only the sources base tracks; a harness file the PR adds has no base version.
+            mapfile -t tracked < <(git -C "${BASE_WORKTREE}" ls-files -- "${benchmark_sources[@]}")
+            if [[ "${#tracked[@]}" -gt 0 ]]; then
+              git -C "${BASE_WORKTREE}" checkout -- "${tracked[@]}"
+            fi
+            for source in "${benchmark_sources[@]}"; do
+              git -C "${BASE_WORKTREE}" ls-files --error-unmatch -- "${source}" >/dev/null 2>&1 || rm -f "${BASE_WORKTREE}/${source}"
+            done
+            # A base that fails to build on its own sources was never a harness incompatibility; let it
+            # fail here rather than publish a comparison whose two sides ran different harnesses.
+            dotnet build "${probe_project}" -c Release --no-restore
+            harness_delta="$(git -C "${GITHUB_WORKSPACE}" diff --shortstat "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" -- "${benchmark_sources[@]}" | sed 's/^[[:space:]]*//')"
+            {
+              echo "BASE_HARNESS_FALLBACK=true"
+              echo "BASE_HARNESS_DELTA=${harness_delta:-not reported}"
+            } >> "${GITHUB_ENV}"
+            echo "::warning::PR opcode benchmark harness does not compile against base; the base side used its own harness sources (${harness_delta:-not reported})."
           fi
           popd >/dev/null
 
@@ -305,10 +322,15 @@ jobs:
           summary_lines.append("")
           summary_lines.append(f"Aggregated runs: base={len(base_logs)}, pr={len(pr_logs)}")
           if os.environ.get("BASE_HARNESS_FALLBACK") == "true":
+              harness_delta = os.environ.get("BASE_HARNESS_DELTA") or "not reported"
+              summary_lines.append("")
+              summary_lines.append("> [!WARNING]")
               summary_lines.append(
-                  "⚠️ The PR benchmark harness does not compile against the base commit, so the base "
-                  "side ran its own harness sources. Treat the comparison as indicative if the harness itself changed."
+                  "> The PR benchmark harness does not compile against the base commit, so the base side ran "
+                  "its own harness sources rather than the PR's."
               )
+              summary_lines.append(f"> Harness delta between base and PR: {harness_delta}.")
+              summary_lines.append("")
           if os.path.exists("evm-rerun-opcodes.txt"):
               with open("evm-rerun-opcodes.txt", "r", encoding="utf-8") as f:
                   rerun_ops = [line.strip() for line in f if line.strip()]
@@ -418,6 +440,7 @@ jobs:
             evm-opcodes-base-rerun-*.log
             evm-opcodes-pr-rerun-*.log
             evm-rerun-opcodes.txt
+            evm-base-harness-probe.log
           if-no-files-found: warn
 
       - name: Cleanup base worktree

--- a/.github/workflows/evm-opcode-benchmark-diff.yml
+++ b/.github/workflows/evm-opcode-benchmark-diff.yml
@@ -138,9 +138,17 @@ jobs:
           # still runs; the compare step flags that the two sides measured with different sources.
           # Probing the runner rather than the harness alone matches what the benchmark steps build.
           probe_project="Nethermind.Benchmark.Runner/Nethermind.Benchmark.Runner.csproj"
+          probe_log="${GITHUB_WORKSPACE}/evm-base-harness-probe.log"
+          # Taken before the probe so it can gate the fallback: an unchanged harness cannot be why base
+          # fails to build. `|| true` keeps a git failure from aborting a run the probe may yet pass.
+          harness_delta="$(git -C "${GITHUB_WORKSPACE}" diff --shortstat "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" -- "${benchmark_sources[@]}" | sed 's/^[[:space:]]*//')" || true
           pushd "${BASE_WORKTREE}/src/Nethermind" >/dev/null
           dotnet restore Benchmarks.slnx --locked-mode
-          if ! dotnet build "${probe_project}" -c Release --no-restore 2>&1 | tee "${GITHUB_WORKSPACE}/evm-base-harness-probe.log"; then
+          if ! dotnet build "${probe_project}" -c Release --no-restore 2>&1 | tee "${probe_log}"; then
+            if [[ -z "${harness_delta}" ]]; then
+              echo "::error::Base build failed with no benchmark harness delta against base (unchanged, or undeterminable); this is not a harness incompatibility."
+              exit 1
+            fi
             # Restore only the sources base tracks; a harness file the PR adds has no base version.
             mapfile -t tracked < <(git -C "${BASE_WORKTREE}" ls-files -- "${benchmark_sources[@]}")
             if [[ "${#tracked[@]}" -gt 0 ]]; then
@@ -150,14 +158,14 @@ jobs:
               git -C "${BASE_WORKTREE}" ls-files --error-unmatch -- "${source}" >/dev/null 2>&1 || rm -f "${BASE_WORKTREE}/${source}"
             done
             # A base that fails to build on its own sources was never a harness incompatibility; let it
-            # fail here rather than publish a comparison whose two sides ran different harnesses.
-            dotnet build "${probe_project}" -c Release --no-restore
-            harness_delta="$(git -C "${GITHUB_WORKSPACE}" diff --shortstat "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" -- "${benchmark_sources[@]}" | sed 's/^[[:space:]]*//')"
+            # fail here rather than publish a comparison whose two sides ran different harnesses. Its
+            # output appends to the probe log so a red check shows which of the two builds broke.
+            dotnet build "${probe_project}" -c Release --no-restore 2>&1 | tee -a "${probe_log}"
             {
               echo "BASE_HARNESS_FALLBACK=true"
-              echo "BASE_HARNESS_DELTA=${harness_delta:-not reported}"
+              echo "BASE_HARNESS_DELTA=${harness_delta}"
             } >> "${GITHUB_ENV}"
-            echo "::warning::PR opcode benchmark harness does not compile against base; the base side used its own harness sources (${harness_delta:-not reported})."
+            echo "::warning::PR opcode benchmark harness does not compile against base; the base side used its own harness sources (${harness_delta})."
           fi
           popd >/dev/null
 


### PR DESCRIPTION
## Changes

- Probe the base build after copying the PR's opcode benchmark harness into the base worktree
- If that build fails, restore base's own harness sources so the comparison still runs, and flag it in the comparison comment

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Reproduced both halves locally against a master worktree: copying #13079's `EvmOpcodesBenchmark.cs` onto master fails the probe build with the same `CS0029` and exit 1, and `git checkout --` followed by a rebuild then succeeds with a clean tree.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`Compare EVM opcode benchmarks (base vs PR)` fails outright on [#13079](https://github.com/NethermindEth/nethermind/pull/13079):

```
nethermind-base-.../Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs(222,20): error CS0029:
Cannot implicitly convert type 'delegate*<..., ref int, EvmExceptionType>[]'
                            to 'delegate*<..., ref nint, EvmExceptionType>[]'
The build failed. Fix the build errors and run again.
```

The base side deliberately builds the PR's harness sources so both sides measure with identical code, which requires those sources to compile against the base commit. A PR that changes an EVM API the harness calls — there, the opcode delegate's program counter type — breaks that build, no `COMMENT_BODY` is produced, and the check goes red with no numbers.

This cannot be solved in the harness source: it would have to compile against unmodified master as well, `ref` arguments need an exact type match, `var` cannot type a field, and hiding the pointer type behind an indirection would change what the benchmark measures. Falling back to base's own harness keeps the comparison meaningful whenever the harness itself is unchanged apart from the incompatibility — on #13079 the only differences are the four `int pc` → `nint pc` lines and the field type, so the measurement code is otherwise byte-for-byte identical. When the harness did change materially the comment now says so, rather than the check simply failing.

Cost is one incremental build of `Nethermind.Evm.Benchmark` against base, largely reused by the base benchmark run that follows.
