### PR TITLE
test: stop the deadlock guard from ending the blocked blob update

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -728,6 +728,7 @@ namespace Nethermind.TxPool.Test
                 Assert.That(
                     () => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader),
                     Is.True.After(Timeout, 10));
+                Assert.That(storage.ReleaseTimedOut, Is.False, "the deadlock guard released the update, so it was no longer in flight");
                 Assert.That(((ISpecChangeValidationStorage)storage).GetSpecChangeValidationMarker(), Is.Null);
             }
             finally
@@ -4472,6 +4473,11 @@ namespace Nethermind.TxPool.Test
             ISpecChangeValidationStorage,
             IDisposable
         {
+            // Breaks a deadlock when a test never releases the blocked update. It has to outlast the
+            // polling assertions tests make while holding one, or the update resumes mid-test and the
+            // pool stops seeing an in-flight write.
+            private static readonly TimeSpan BlockedUpdateReleaseTimeout = TimeSpan.FromMilliseconds(Timeout * 3);
+
             private readonly BlobTxStorage _inner = new();
             private readonly ManualResetEventSlim _firstUpdateEntered = new();
             private readonly ManualResetEventSlim _releaseFirstUpdate = new();
@@ -4481,10 +4487,13 @@ namespace Nethermind.TxPool.Test
             private int _remainingDeleteFailures = failedDeleteCount;
             private int _successfulDeleteCount;
             private int _addCount;
+            private int _releaseTimedOut;
 
             public ConcurrentQueue<int> DeleteBatchSizes { get; } = [];
 
             public ConcurrentQueue<int> ReplaceDeleteBatchSizes { get; } = [];
+
+            public bool ReleaseTimedOut => Volatile.Read(ref _releaseTimedOut) != 0;
 
             public bool WaitForFirstUpdate(TimeSpan timeout) => _firstUpdateEntered.Wait(timeout);
 
@@ -4536,8 +4545,9 @@ namespace Nethermind.TxPool.Test
                 if (addCount == 2)
                 {
                     _firstUpdateEntered.Set();
-                    if (!_releaseFirstUpdate.Wait(TimeSpan.FromSeconds(10)))
+                    if (!_releaseFirstUpdate.Wait(BlockedUpdateReleaseTimeout))
                     {
+                        Volatile.Write(ref _releaseTimedOut, 1);
                         throw new TimeoutException("Timed out waiting to release the first sparse blob update.");
                     }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -40,6 +40,8 @@ namespace Nethermind.TxPool.Test
     [TestFixture]
     public partial class TxPoolTests
     {
+        private static readonly TimeSpan BlockedStorageReleaseTimeout = TimeSpan.FromMilliseconds(Timeout * 3);
+
         [Test]
         public void should_reject_blob_tx_if_blobs_not_supported([Values(true, false)] bool isBlobSupportEnabled)
         {
@@ -4473,11 +4475,6 @@ namespace Nethermind.TxPool.Test
             ISpecChangeValidationStorage,
             IDisposable
         {
-            // Breaks a deadlock when a test never releases the blocked update. It has to outlast the
-            // polling assertions tests make while holding one, or the update resumes mid-test and the
-            // pool stops seeing an in-flight write.
-            private static readonly TimeSpan BlockedUpdateReleaseTimeout = TimeSpan.FromMilliseconds(Timeout * 3);
-
             private readonly BlobTxStorage _inner = new();
             private readonly ManualResetEventSlim _firstUpdateEntered = new();
             private readonly ManualResetEventSlim _releaseFirstUpdate = new();
@@ -4545,7 +4542,7 @@ namespace Nethermind.TxPool.Test
                 if (addCount == 2)
                 {
                     _firstUpdateEntered.Set();
-                    if (!_releaseFirstUpdate.Wait(BlockedUpdateReleaseTimeout))
+                    if (!_releaseFirstUpdate.Wait(BlockedStorageReleaseTimeout))
                     {
                         Volatile.Write(ref _releaseTimedOut, 1);
                         throw new TimeoutException("Timed out waiting to release the first sparse blob update.");
@@ -4613,7 +4610,6 @@ namespace Nethermind.TxPool.Test
 
             public void Dispose()
             {
-                // Unpark a writer left blocked by a test that failed before releasing it.
                 _releaseFirstUpdate.Set();
                 _firstUpdateEntered.Dispose();
                 _releaseFirstUpdate.Dispose();
@@ -4662,7 +4658,7 @@ namespace Nethermind.TxPool.Test
 
                 bool found = _inner.TryGet(hash, sender, timestamp, out Transaction snapshot);
                 _readEntered.Set();
-                if (!_releaseRead.Wait(TimeSpan.FromSeconds(10)))
+                if (!_releaseRead.Wait(BlockedStorageReleaseTimeout))
                 {
                     throw new TimeoutException("Timed out waiting to release the stale blob transaction read.");
                 }
@@ -4682,7 +4678,7 @@ namespace Nethermind.TxPool.Test
                 if (Interlocked.Exchange(ref _blockNextElidedRead, 0) != 0)
                 {
                     _readEntered.Set();
-                    if (!_releaseRead.Wait(TimeSpan.FromSeconds(10)))
+                    if (!_releaseRead.Wait(BlockedStorageReleaseTimeout))
                     {
                         throw new TimeoutException("Timed out waiting to release the sidecar-free transaction read.");
                     }
@@ -4703,7 +4699,7 @@ namespace Nethermind.TxPool.Test
 
                 int found = _inner.TryGetMany(keys, count, results);
                 _readEntered.Set();
-                if (!_releaseRead.Wait(TimeSpan.FromSeconds(10)))
+                if (!_releaseRead.Wait(BlockedStorageReleaseTimeout))
                 {
                     throw new TimeoutException("Timed out waiting to release the stale blob transaction batch read.");
                 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -4613,6 +4613,8 @@ namespace Nethermind.TxPool.Test
 
             public void Dispose()
             {
+                // Unpark a writer left blocked by a test that failed before releasing it.
+                _releaseFirstUpdate.Set();
                 _firstUpdateEntered.Dispose();
                 _releaseFirstUpdate.Dispose();
                 _deleteEntered.Dispose();


### PR DESCRIPTION
## Changes

- `should_publish_marker_after_in_flight_blob_update_completes_without_another_head` parks a blob update inside `BlockingBlobTxStorage.Persist` so the pool sees an in-flight write, then adds a fork block and asserts the spec-change validation marker stays deferred. The storage's deadlock guard waited exactly 10s — the same budget as the `Is.True.After(Timeout, 10)` poll for `IsRevalidatedFor` that the test runs *inside* the blocked window. On a slow runner the guard fired first: the write threw, the pool's retry rewrote it successfully, `CompleteRetainedDeletes` cleared the retained delete and re-requested revalidation, and the marker got published — so the test failed with a non-null marker ([failing job](https://github.com/NethermindEth/nethermind/actions/runs/33565838189/job/100052113998)).
- Give the guard a budget (`Timeout * 3`) that outlasts every assertion window a test holds a blocked write across. It still breaks a genuine deadlock, but no longer ends the scenario under test.
- Record a guard release as `ReleaseTimedOut` and assert on it before the marker check, so a future trip fails as a lost precondition instead of a misleading marker mismatch.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Test-only fix for a flaky test

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

The failure mode was reproduced by shrinking the guard to 1ms, which fails at the same line with the same message as CI (`Expected: null / But was: "1|…|Amsterdam|…"`). With the fix in place that same experiment now fails on the new `ReleaseTimedOut` assertion instead. Full `Nethermind.TxPool.Test` suite: 760 passed, 1 skipped, 0 failed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
