### PR TITLE
Dispose sync peer allocations with using

### DIFF
--- a/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptFixMigration.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptFixMigration.cs
@@ -113,7 +113,7 @@ namespace Nethermind.Init.Steps.Migrations
                 }
 
                 FastBlocksAllocationStrategy strategy = new(TransferSpeedType.Receipts, block.Number, true);
-                SyncPeerAllocation peer = await syncPeerPool.Allocate(strategy, AllocationContexts.Receipts);
+                using SyncPeerAllocation peer = await syncPeerPool.Allocate(strategy, AllocationContexts.Receipts);
                 ISyncPeer? currentSyncPeer = peer.Current?.SyncPeer;
                 if (currentSyncPeer is not null)
                 {
@@ -135,10 +135,6 @@ namespace Nethermind.Init.Steps.Migrations
                     catch (Exception e)
                     {
                         if (_logger.IsInfo) _logger.Error($"Fail to download missing receipts for block {block.ToString(Block.Format.FullHashAndNumber)}.", e);
-                    }
-                    finally
-                    {
-                        syncPeerPool.Free(peer);
                     }
                 }
                 else

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -835,12 +835,17 @@ public partial class EngineModuleTests
         ExecutionPayloadV3 payloadResultB3 = await AddNewBlockV3(rpcModuleB, chainB, 1);
 
         SyncPeerMock chainAPeer = new(chainA.BlockTree);
-        SyncPeerAllocation alloc = new(new PeerInfo(chainAPeer), AllocationContexts.All);
+        PeerInfo chainAPeerInfo = new(chainAPeer);
         chainC.SyncPeerPool!.Allocate(
             Arg.Any<IPeerAllocationStrategy>(),
             Arg.Any<AllocationContexts>(),
             Arg.Any<int>(),
-            Arg.Any<CancellationToken>())!.Returns(Task.FromResult(alloc));
+            Arg.Any<CancellationToken>())!.Returns(ci =>
+            {
+                SyncPeerAllocation allocation = new(ci.ArgAt<AllocationContexts>(1));
+                allocation.AllocatePeer(chainAPeerInfo);
+                return Task.FromResult(allocation);
+            });
 
 
         await rpcModuleC.engine_forkchoiceUpdatedV3(new(payloadResultA1.BlockHash, chainC.BlockTree.GenesisHash, chainC.BlockTree.GenesisHash), null);

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -981,20 +981,16 @@ public partial class BlockDownloaderTests
         public void ConfigureBestPeer(PeerInfo peerInfo)
         {
             SemaphoreSlim peerSemaphore = new(1, 1);
-            SyncPeerAllocation peerAllocation = new(peerInfo, AllocationContexts.Blocks, null);
-
             PeerPool
                 .Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(async ci =>
                 {
                     CancellationToken token = ci.ArgAt<CancellationToken>(3);
                     await peerSemaphore.WaitAsync(token);
+                    SyncPeerAllocation peerAllocation = new(ci.ArgAt<AllocationContexts>(1), null, () => peerSemaphore.Release());
+                    peerAllocation.AllocatePeer(peerInfo);
                     return peerAllocation;
                 });
-
-            PeerPool
-                .When((p) => p.Free(peerAllocation))
-                .Do((c) => peerSemaphore.Release());
         }
 
         public async Task SyncUntilNoRequest(SyncFeedComponent<BlocksRequest> component, PeerInfo peerInfo)

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTester.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTester.cs
@@ -21,15 +21,13 @@ namespace Nethermind.Synchronization.Test.FastSync.SnapProtocolTests
         public async Task ExecuteDispatch(StateSyncBatch batch, int times)
         {
             StateSyncAllocationStrategyFactory strategyFactory = new();
-            SyncPeerAllocation allocation = await syncPeerPool.Allocate(
+            using SyncPeerAllocation allocation = await syncPeerPool.Allocate(
                 strategyFactory.Create(batch), AllocationContexts.State, _syncConfig.SyncDispatcherAllocateTimeoutMs);
 
             for (int i = 0; i < times; i++)
             {
                 await downloader.Dispatch(allocation.Current!, batch, CancellationToken.None);
             }
-
-            syncPeerPool.Free(allocation);
         }
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
@@ -544,14 +544,15 @@ public partial class ForwardHeaderProviderTests
         public void ConfigureBestPeer(ISyncPeer syncPeer) =>
             ConfigureBestPeer(new PeerInfo(syncPeer));
 
-        public void ConfigureBestPeer(PeerInfo peerInfo)
-        {
-            SyncPeerAllocation peerAllocation = new(peerInfo, AllocationContexts.Blocks, null);
-
+        public void ConfigureBestPeer(PeerInfo peerInfo) =>
             PeerPool
                 .Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(peerAllocation));
-        }
+                .Returns(ci =>
+                {
+                    SyncPeerAllocation peerAllocation = new(ci.ArgAt<AllocationContexts>(1), null);
+                    peerAllocation.AllocatePeer(peerInfo);
+                    return Task.FromResult(peerAllocation);
+                });
     }
 
     private class SyncPeerMock : ISyncPeer

--- a/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
@@ -278,7 +278,7 @@ public partial class ForwardHeaderProviderTests
         int allocationTimeout = -1;
         ctx.PeerPool
             .Allocate(Arg.Do<IPeerAllocationStrategy>(s => strategy = s), Arg.Any<AllocationContexts>(), Arg.Do<int>(t => allocationTimeout = t), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(SyncPeerAllocation.FailedAllocation));
+            .Returns(Task.FromResult(new SyncPeerAllocation(AllocationContexts.None)));
 
         using IOwnedReadOnlyList<BlockHeader?>? headers = await ctx.ForwardHeaderProvider.GetBlockHeaders(0, 128, CancellationToken.None);
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -35,7 +35,7 @@ public class SyncDispatcherTests
             CancellationToken cancellationToken = default)
         {
             // Mirrors SyncPeerPool.Allocate: a cancelled token reports a failed allocation, it does not throw.
-            if (cancellationToken.IsCancellationRequested) return SyncPeerAllocation.FailedAllocation;
+            if (cancellationToken.IsCancellationRequested) return new SyncPeerAllocation(contexts);
 
             await Task.Yield();
             await _peerSemaphore.WaitAsync(cancellationToken);

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -40,7 +40,8 @@ public class SyncDispatcherTests
             await Task.Yield();
             await _peerSemaphore.WaitAsync(cancellationToken);
             ISyncPeer syncPeer = new MockSyncPeer("Nethermind", UInt256.One);
-            SyncPeerAllocation allocation = new(new PeerInfo(syncPeer), contexts, _lock);
+            SyncPeerAllocation allocation = new(contexts, _lock, () => _peerSemaphore.Release());
+            allocation.AllocatePeer(new PeerInfo(syncPeer));
             return allocation;
         }
 
@@ -51,9 +52,6 @@ public class SyncDispatcherTests
         }
 
         public int AvailablePeers => _peerSemaphore.CurrentCount;
-
-        public void Free(SyncPeerAllocation syncPeerAllocation) =>
-            _peerSemaphore.Release();
 
         public void ReportNoSyncProgress(PeerInfo peerInfo, AllocationContexts contexts)
         {
@@ -320,11 +318,11 @@ public class SyncDispatcherTests
     }
 
     [Test, CancelAfter(30_000)]
-    public async Task Cancelled_in_flight_dispatch_skips_its_response_and_frees_its_allocation(CancellationToken cancellationToken)
+    public async Task Cancelled_in_flight_dispatch_skips_its_response_and_disposes_its_allocation(CancellationToken cancellationToken)
     {
         // The dispatch loop cancels its token on every exit, including the routine feed-finish exit
         // on a live node. The cancelled dispatch must not handle its response into a finishing feed,
-        // and it must still free its allocation - a leaked slot retires the peer for the lifetime
+        // and it must still dispose its allocation - a leaked slot retires the peer for the lifetime
         // of the connection.
         TestSyncPeerPool pool = new(peerCount: 2);
         TestSyncFeed syncFeed = new(max: 16);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -450,7 +450,7 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 1);
 
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
 
         Assert.That(allocation.Current?.SyncPeer, Is.SameAs(peers[0]));
     }
@@ -461,13 +461,19 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 1);
 
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        ctx.Pool.Free(allocation);
-        allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        ctx.Pool.Free(allocation);
-        allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using (SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true)))
+        {
+            Assert.That(allocation.Current?.SyncPeer, Is.SameAs(peers[0]));
+        }
 
-        Assert.That(allocation.Current?.SyncPeer, Is.SameAs(peers[0]));
+        using (SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true)))
+        {
+            allocation.Dispose();
+            allocation.Dispose();
+        }
+
+        using SyncPeerAllocation reallocated = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        Assert.That(reallocated.Current?.SyncPeer, Is.SameAs(peers[0]));
     }
 
     [Test]
@@ -476,19 +482,16 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         await SetupPeers(ctx, 2);
 
-        SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        Assert.That(allocation2.Current, Is.Not.SameAs(allocation1.Current), "first");
-        Assert.That(allocation1.Current, Is.Not.Null, "first A");
-        Assert.That(allocation2.Current, Is.Not.Null, "first B");
+        using (SyncPeerAllocation firstAllocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true)))
+        using (SyncPeerAllocation secondAllocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true)))
+        {
+            Assert.That(secondAllocation.Current, Is.Not.SameAs(firstAllocation.Current), "first");
+            Assert.That(firstAllocation.Current, Is.Not.Null, "first A");
+            Assert.That(secondAllocation.Current, Is.Not.Null, "first B");
+        }
 
-        ctx.Pool.Free(allocation1);
-        ctx.Pool.Free(allocation2);
-        Assert.That(allocation1.Current, Is.Null, "null A");
-        Assert.That(allocation2.Current, Is.Null, "null B");
-
-        allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
         Assert.That(allocation2.Current, Is.Not.SameAs(allocation1.Current));
         Assert.That(allocation1.Current, Is.Not.Null, "second A");
         Assert.That(allocation2.Current, Is.Not.Null, "second B");
@@ -504,9 +507,9 @@ public class SyncPeerPoolTests
             ctx.Pool.ReportNoSyncProgress(ctx.Pool.InitializedPeers.First(), AllocationContexts.All);
         }
 
-        SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation3 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation3 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
 
         Assert.That(allocation1.HasPeer, Is.True);
         Assert.That(allocation2.HasPeer, Is.True);
@@ -523,9 +526,9 @@ public class SyncPeerPoolTests
 
         ctx.Pool.WakeUpAll();
 
-        SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation3 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation3 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
 
         Assert.That(allocation1.HasPeer, Is.True);
         Assert.That(allocation2.HasPeer, Is.True);
@@ -557,8 +560,8 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 1);
 
-        SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
 
         Assert.That(allocation1.Current?.SyncPeer, Is.SameAs(peers[0]));
         Assert.That(allocation2.Current, Is.Null);
@@ -589,7 +592,7 @@ public class SyncPeerPoolTests
         bool refreshAttempted = await Wait.ForCondition(() => peer.DisconnectRequested, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(50));
         Assert.That(refreshAttempted, Is.True, "refresh loop did not attempt the failing peer in time");
 
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
         ctx.Pool.RemovePeer(peer);
 
         Assert.That(allocation.Current, Is.EqualTo(null));
@@ -602,8 +605,7 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         await SetupPeers(ctx, 1);
 
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        ctx.Pool.Free(allocation);
+        using SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
     }
 
     [Test]
@@ -612,8 +614,8 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         await SetupPeers(ctx, 1);
 
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        allocation.Cancel();
+        using SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        allocation.Dispose();
 
         ctx.BlockTree.NewHeadBlock += Raise.EventWith(new object(), new BlockEventArgs(Build.A.Block.WithTotalDifficulty(1L).TestObject));
     }
@@ -640,8 +642,7 @@ public class SyncPeerPoolTests
 
         foreach (SyncPeerAllocation allocation in successfulAllocations)
         {
-            // free allocated peers
-            ctx.Pool.Free(allocation);
+            allocation.Dispose();
         }
 
         foreach (SyncPeerAllocation allocation in allocations)
@@ -688,16 +689,16 @@ public class SyncPeerPoolTests
         await SetupPeers(ctx, 1);
 
         // Allocate the only peer
-        SyncPeerAllocation first = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
+        using SyncPeerAllocation first = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
         Assert.That(first.HasPeer, Is.True);
 
         // Start a second allocation that must wait (only 1 peer, already allocated)
         Task<SyncPeerAllocation> secondTask = ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 2000);
 
-        // Free the first — this signals peers changed and wakes the waiter
-        ctx.Pool.Free(first);
+        // Dispose the first — this signals peers changed and wakes the waiter
+        first.Dispose();
 
-        SyncPeerAllocation second = await secondTask;
+        using SyncPeerAllocation second = await secondTask;
         Assert.That(second.HasPeer, Is.True);
     }
 
@@ -711,7 +712,7 @@ public class SyncPeerPoolTests
         using CancellationTokenSource cts = new();
         cts.CancelAfter(100);
 
-        SyncPeerAllocation result = await ctx.Pool.Allocate(
+        using SyncPeerAllocation result = await ctx.Pool.Allocate(
             new BySpeedStrategy(TransferSpeedType.Headers, true),
             AllocationContexts.All,
             5000,
@@ -736,7 +737,7 @@ public class SyncPeerPoolTests
         await ctx.DisposeAsync();
 
         // Must complete (not hang) and return failed
-        SyncPeerAllocation result = await allocTask.WaitAsync(TimeSpan.FromSeconds(2));
+        using SyncPeerAllocation result = await allocTask.WaitAsync(TimeSpan.FromSeconds(2));
         Assert.That(result.HasPeer, Is.False);
     }
 
@@ -765,6 +766,11 @@ public class SyncPeerPoolTests
         }
 
         Assert.That(successful, Is.EqualTo(3));
+
+        foreach (Task<SyncPeerAllocation> task in tasks)
+        {
+            task.Result.Dispose();
+        }
     }
 
     [Test]
@@ -774,8 +780,8 @@ public class SyncPeerPoolTests
         await SetupPeers(ctx, 2);
 
         // Allocate both peers — pool exhausted
-        SyncPeerAllocation a1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
-        SyncPeerAllocation a2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
+        using SyncPeerAllocation a1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
+        using SyncPeerAllocation a2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
         Assert.That(a1.HasPeer, Is.True);
         Assert.That(a2.HasPeer, Is.True);
 
@@ -783,12 +789,12 @@ public class SyncPeerPoolTests
         Task<SyncPeerAllocation> w1 = ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 3000);
         Task<SyncPeerAllocation> w2 = ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 3000);
 
-        // Free both peers — both waiters must wake
-        ctx.Pool.Free(a1);
-        ctx.Pool.Free(a2);
+        // Dispose both peers — both waiters must wake
+        a1.Dispose();
+        a2.Dispose();
 
-        SyncPeerAllocation r1 = await w1;
-        SyncPeerAllocation r2 = await w2;
+        using SyncPeerAllocation r1 = await w1;
+        using SyncPeerAllocation r2 = await w2;
         Assert.That(r1.HasPeer, Is.True);
         Assert.That(r2.HasPeer, Is.True);
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -600,15 +600,6 @@ public class SyncPeerPoolTests
     }
 
     [Test]
-    public async Task Can_return()
-    {
-        await using Context ctx = new();
-        await SetupPeers(ctx, 1);
-
-        using SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-    }
-
-    [Test]
     public async Task Does_not_fail_when_receiving_a_new_block_and_allocation_has_no_peer()
     {
         await using Context ctx = new();
@@ -757,19 +748,19 @@ public class SyncPeerPoolTests
                 100);
         }
 
-        await Task.WhenAll(tasks);
+        SyncPeerAllocation[] allocations = await Task.WhenAll(tasks);
 
         int successful = 0;
-        for (int i = 0; i < tasks.Length; i++)
+        foreach (SyncPeerAllocation allocation in allocations)
         {
-            if (tasks[i].Result.HasPeer) successful++;
+            if (allocation.HasPeer) successful++;
         }
 
         Assert.That(successful, Is.EqualTo(3));
 
-        foreach (Task<SyncPeerAllocation> task in tasks)
+        foreach (SyncPeerAllocation allocation in allocations)
         {
-            task.Result.Dispose();
+            allocation.Dispose();
         }
     }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
@@ -177,8 +177,9 @@ public class RecoveryTests
         _syncPeerPool.Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(c =>
         {
             AllocationContexts allocationContexts = (AllocationContexts)c[1];
-            SyncPeerAllocation alloc = new(peers[0], allocationContexts);
-            return alloc;
+            SyncPeerAllocation allocation = new(allocationContexts);
+            allocation.AllocatePeer(peers[0]);
+            return allocation;
         });
         return recovery.Recover(_rootHash, _storageHash, _path, _hash, _fullPath);
     }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
@@ -62,56 +62,48 @@ public class PowForwardHeaderProvider(
     {
         // PrepareRequest must return to the dispatcher when no better peer exists so a feed-state
         // transition is observed; an unbounded allocation would remain parked inside this method.
-        SyncPeerAllocation allocation = await syncPeerPool.Allocate(
+        using SyncPeerAllocation allocation = await syncPeerPool.Allocate(
             _bestPeerAllocationStrategy,
             AllocationContexts.ForwardHeader,
             timeoutMilliseconds: 0,
             cancellationToken: cancellation);
 
-        // Skip Free for a failed allocation: it holds no peer and would signal peers-changed each poll.
         PeerInfo? peerInfo = allocation.Current;
         if (peerInfo is null) return null;
 
-        try
+        if (peerInfo != _currentBestPeer)
         {
-            if (peerInfo != _currentBestPeer)
-            {
-                OnNewBestPeer(peerInfo);
-            }
+            OnNewBestPeer(peerInfo);
+        }
 
-            syncReport.FullSyncBlocksDownloaded.TargetValue = peerInfo.HeadNumber;
+        syncReport.FullSyncBlocksDownloaded.TargetValue = peerInfo.HeadNumber;
 
-            if (_logger.IsTrace) _logger.Trace($"Allocated {peerInfo} for PoW header info. currentNumber: {_currentNumber} skipLastN: {skipLastN}, maxHeaders: {maxHeaders}");
+        if (_logger.IsTrace) _logger.Trace($"Allocated {peerInfo} for PoW header info. currentNumber: {_currentNumber} skipLastN: {skipLastN}, maxHeaders: {maxHeaders}");
 
-            // Provide a way so that it does not redownload if part of the. I guess it does not care about skiplastn and maxheaders.
-            // TODO: Unit test this mechanism.
-            IOwnedReadOnlyList<BlockHeader?>? headers = AssembleResponseFromLastResponseBatch();
-            if (headers is not null)
-            {
-                ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
-                if (_logger.IsTrace) _logger.Trace($"PoW header info from last response from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
-                return headers;
-            }
-
-            headers = await GetBlockHeaders(peerInfo, skipLastN, maxHeaders, cancellation);
-            if (headers is not null)
-            {
-                ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
-                if (_logger.IsTrace) _logger.Trace($"Assembled batch from {peerInfo} of {headersSpan.Length} header from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
-            }
-            else
-            {
-                if (_logger.IsTrace) _logger.Trace($"No header received");
-                _currentBestPeer = null;
-            }
-
-            if (headers is not null && headers.Count > MinCachedHeaderBatchSize) LastResponseBatch = headers.AsSpan().ToPooledList();
+        // Provide a way so that it does not redownload if part of the. I guess it does not care about skiplastn and maxheaders.
+        // TODO: Unit test this mechanism.
+        IOwnedReadOnlyList<BlockHeader?>? headers = AssembleResponseFromLastResponseBatch();
+        if (headers is not null)
+        {
+            ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
+            if (_logger.IsTrace) _logger.Trace($"PoW header info from last response from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
             return headers;
         }
-        finally
+
+        headers = await GetBlockHeaders(peerInfo, skipLastN, maxHeaders, cancellation);
+        if (headers is not null)
         {
-            syncPeerPool.Free(allocation);
+            ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
+            if (_logger.IsTrace) _logger.Trace($"Assembled batch from {peerInfo} of {headersSpan.Length} header from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
         }
+        else
+        {
+            if (_logger.IsTrace) _logger.Trace($"No header received");
+            _currentBestPeer = null;
+        }
+
+        if (headers is not null && headers.Count > MinCachedHeaderBatchSize) LastResponseBatch = headers.AsSpan().ToPooledList();
+        return headers;
     }
 
     private IOwnedReadOnlyList<BlockHeader>? AssembleResponseFromLastResponseBatch()

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
@@ -57,26 +57,44 @@ public class SimpleDispatcher<T>(
 
             if (peer is null)
             {
+                allocation.Dispose();
                 HandleResponse(request, null);
                 continue;
             }
 
-            await semaphore.WaitAsync(token);
-            _ = Task.Run(async () =>
+            try
             {
-                try
+                await semaphore.WaitAsync(token);
+            }
+            catch
+            {
+                allocation.Dispose();
+                throw;
+            }
+
+            try
+            {
+                _ = Task.Run(async () =>
                 {
-                    await DoDispatch(request, peer, allocation, token);
-                }
-                finally
-                {
-                    semaphore.Release();
-                }
-            });
+                    try
+                    {
+                        await DoDispatch(request, peer, allocation, token);
+                    }
+                    finally
+                    {
+                        semaphore.Release();
+                    }
+                });
+            }
+            catch
+            {
+                allocation.Dispose();
+                semaphore.Release();
+                throw;
+            }
         }
 
-        // Wait for in-flight tasks to complete. Drain with CancellationToken.None so that
-        // peer allocations are always freed in DoDispatch even when the caller cancels.
+        // Drain with CancellationToken.None so cancellation does not abandon in-flight tasks.
         for (int i = 0; i < maxThreads; i++)
             await semaphore.WaitAsync(CancellationToken.None);
     }
@@ -88,30 +106,31 @@ public class SimpleDispatcher<T>(
         CancellationToken token)
     {
         long dispatchTime = Stopwatch.GetTimestamp();
-        try
         {
-            await downloader.Dispatch(peer, request, token);
+            using SyncPeerAllocation ownedAllocation = allocation;
+            try
+            {
+                await downloader.Dispatch(peer, request, token);
+            }
+            catch (ConcurrencyLimitReachedException)
+            {
+                if (_logger.IsDebug) _logger.Debug($"{request} - concurrency limit reached. Peer: {peer}");
+            }
+            catch (TimeoutException)
+            {
+                if (_logger.IsDebug) _logger.Debug($"{request} - timed out. Peer: {peer}");
+            }
+            catch (OperationCanceledException)
+            {
+                if (_logger.IsTrace) _logger.Trace($"{request} - cancelled");
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Failure when executing request {e}");
+            }
+            Metrics.SyncDispatcherDispatchTimeMicros.Observe(
+                Stopwatch.GetElapsedTime(dispatchTime).TotalMicroseconds, new StringLabel(_feedName));
         }
-        catch (ConcurrencyLimitReachedException)
-        {
-            if (_logger.IsDebug) _logger.Debug($"{request} - concurrency limit reached. Peer: {peer}");
-        }
-        catch (TimeoutException)
-        {
-            if (_logger.IsDebug) _logger.Debug($"{request} - timed out. Peer: {peer}");
-        }
-        catch (OperationCanceledException)
-        {
-            if (_logger.IsTrace) _logger.Trace($"{request} - cancelled");
-        }
-        catch (Exception e)
-        {
-            if (_logger.IsWarn) _logger.Warn($"Failure when executing request {e}");
-        }
-        Metrics.SyncDispatcherDispatchTimeMicros.Observe(
-            Stopwatch.GetElapsedTime(dispatchTime).TotalMicroseconds, new StringLabel(_feedName));
-
-        peerPool.Free(allocation);
 
         if (token.IsCancellationRequested) return;
 

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
@@ -72,26 +72,17 @@ public class SimpleDispatcher<T>(
                 throw;
             }
 
-            try
+            _ = Task.Run(async () =>
             {
-                _ = Task.Run(async () =>
+                try
                 {
-                    try
-                    {
-                        await DoDispatch(request, peer, allocation, token);
-                    }
-                    finally
-                    {
-                        semaphore.Release();
-                    }
-                });
-            }
-            catch
-            {
-                allocation.Dispose();
-                semaphore.Release();
-                throw;
-            }
+                    await DoDispatch(request, peer, allocation, token);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            });
         }
 
         // Drain with CancellationToken.None so cancellation does not abandon in-flight tasks.
@@ -106,8 +97,8 @@ public class SimpleDispatcher<T>(
         CancellationToken token)
     {
         long dispatchTime = Stopwatch.GetTimestamp();
+        using (allocation)
         {
-            using SyncPeerAllocation ownedAllocation = allocation;
             try
             {
                 await downloader.Dispatch(peer, request, token);

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -168,33 +168,23 @@ namespace Nethermind.Synchronization.ParallelSync
                                 break;
                             }
 
-                            Task task;
-                            try
-                            {
-                                // The lambda must be async so the finally runs after DoDispatch's Task fully completes;
-                                // a non-async `() => DoDispatch(...)` would call SignalActiveTask the moment DoDispatch
-                                // yields (e.g. on the IsMultiFeed semaphore await), dropping the _activeTasks count
-                                // while the dispatch was still in flight. That race is what the flaky
-                                // When_ConcurrentHandleResponseIsRunning_Then_BlockDispose test was catching.
-                                task = Task.Run(
-                                    async () =>
+                            // The lambda must be async so the finally runs after DoDispatch's Task fully completes;
+                            // a non-async `() => DoDispatch(...)` would call SignalActiveTask the moment DoDispatch
+                            // yields (e.g. on the IsMultiFeed semaphore await), dropping the _activeTasks count
+                            // while the dispatch was still in flight. That race is what the flaky
+                            // When_ConcurrentHandleResponseIsRunning_Then_BlockDispose test was catching.
+                            Task task = Task.Run(
+                                async () =>
+                                {
+                                    try
                                     {
-                                        try
-                                        {
-                                            await DoDispatch(cancellationToken, allocatedPeer, request, allocation);
-                                        }
-                                        finally
-                                        {
-                                            SignalActiveTask();
-                                        }
-                                    });
-                            }
-                            catch
-                            {
-                                allocation.Dispose();
-                                SignalActiveTask();
-                                throw;
-                            }
+                                        await DoDispatch(cancellationToken, allocatedPeer, request, allocation);
+                                    }
+                                    finally
+                                    {
+                                        SignalActiveTask();
+                                    }
+                                });
 
                             if (!Feed.IsMultiFeed)
                             {
@@ -229,8 +219,8 @@ namespace Nethermind.Synchronization.ParallelSync
             SyncPeerAllocation allocation)
         {
             long dispatchTimeStart = Stopwatch.GetTimestamp();
+            using (allocation)
             {
-                using SyncPeerAllocation ownedAllocation = allocation;
                 try
                 {
                     await Downloader.Dispatch(allocatedPeer, request, cancellationToken);
@@ -257,6 +247,7 @@ namespace Nethermind.Synchronization.ParallelSync
                 {
                     if (Feed.IsMultiFeed)
                     {
+                        // Holding the allocation across this wait provides backpressure while responses queue for processing.
                         await _concurrentProcessingSemaphore.WaitAsync(cancellationToken);
                     }
                 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -157,30 +157,44 @@ namespace Nethermind.Synchronization.ParallelSync
                             try
                             {
                                 if (!_activeTasks.TryAddCount())
+                                {
+                                    allocation.Dispose();
                                     break;
+                                }
                             }
                             catch (ObjectDisposedException)
                             {
+                                allocation.Dispose();
                                 break;
                             }
 
-                            // The lambda must be async so the finally runs after DoDispatch's Task fully completes;
-                            // a non-async `() => DoDispatch(...)` would call SignalActiveTask the moment DoDispatch
-                            // yields (e.g. on the IsMultiFeed semaphore await), dropping the _activeTasks count
-                            // while the dispatch was still in flight. That race is what the flaky
-                            // When_ConcurrentHandleResponseIsRunning_Then_BlockDispose test was catching.
-                            Task task = Task.Run(
-                                async () =>
-                                {
-                                    try
+                            Task task;
+                            try
+                            {
+                                // The lambda must be async so the finally runs after DoDispatch's Task fully completes;
+                                // a non-async `() => DoDispatch(...)` would call SignalActiveTask the moment DoDispatch
+                                // yields (e.g. on the IsMultiFeed semaphore await), dropping the _activeTasks count
+                                // while the dispatch was still in flight. That race is what the flaky
+                                // When_ConcurrentHandleResponseIsRunning_Then_BlockDispose test was catching.
+                                task = Task.Run(
+                                    async () =>
                                     {
-                                        await DoDispatch(cancellationToken, allocatedPeer, request, allocation);
-                                    }
-                                    finally
-                                    {
-                                        SignalActiveTask();
-                                    }
-                                });
+                                        try
+                                        {
+                                            await DoDispatch(cancellationToken, allocatedPeer, request, allocation);
+                                        }
+                                        finally
+                                        {
+                                            SignalActiveTask();
+                                        }
+                                    });
+                            }
+                            catch
+                            {
+                                allocation.Dispose();
+                                SignalActiveTask();
+                                throw;
+                            }
 
                             if (!Feed.IsMultiFeed)
                             {
@@ -191,6 +205,7 @@ namespace Nethermind.Synchronization.ParallelSync
                         }
                         else
                         {
+                            allocation.Dispose();
                             Logger.Debug($"DISPATCHER - {GetType().NameWithGenerics()}: peer NOT allocated");
                             DoHandleResponse(request);
                         }
@@ -214,52 +229,47 @@ namespace Nethermind.Synchronization.ParallelSync
             SyncPeerAllocation allocation)
         {
             long dispatchTimeStart = Stopwatch.GetTimestamp();
-            try
             {
-                await Downloader.Dispatch(allocatedPeer, request, cancellationToken);
-            }
-            catch (ConcurrencyLimitReachedException)
-            {
-                if (Logger.IsDebug) Logger.Debug($"{request} - concurrency limit reached. Peer: {allocatedPeer}");
-            }
-            catch (TimeoutException)
-            {
-                if (Logger.IsDebug) Logger.Debug($"{request} - timed out. Peer: {allocatedPeer}");
-            }
-            catch (OperationCanceledException)
-            {
-                if (Logger.IsTrace) Logger.Debug($"{request} - Operation was canceled");
-            }
-            catch (Exception e)
-            {
-                if (Logger.IsWarn) Logger.Warn($"Failure when executing request {e}");
-            }
-            Metrics.SyncDispatcherDispatchTimeMicros.Observe(Stopwatch.GetElapsedTime(dispatchTimeStart).TotalMicroseconds, new StringLabel(_feedName));
-
-            try
-            {
-                if (Feed.IsMultiFeed)
+                using SyncPeerAllocation ownedAllocation = allocation;
+                try
                 {
-                    // Limit multithreaded feed concurrency. Note, this also blocks freeing the allocation, which is deliberate.
-                    // otherwise, we will keep spawning requests without processing it fast enough, which consume memory.
-                    await _concurrentProcessingSemaphore.WaitAsync(cancellationToken);
+                    await Downloader.Dispatch(allocatedPeer, request, cancellationToken);
                 }
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (ObjectDisposedException)
-            {
-                // Teardown raced this dispatch; stop rather than fault the un-awaited task.
-                if (Logger.IsDebug) Logger.Debug($"{_feedName} dispatch abandoned during shutdown.");
-                return;
-            }
-            finally
-            {
-                // The allocation must return to the pool on every exit: a cancelled wait would
-                // otherwise retire the peer's slot for the lifetime of the connection.
-                Free(allocation);
+                catch (ConcurrencyLimitReachedException)
+                {
+                    if (Logger.IsDebug) Logger.Debug($"{request} - concurrency limit reached. Peer: {allocatedPeer}");
+                }
+                catch (TimeoutException)
+                {
+                    if (Logger.IsDebug) Logger.Debug($"{request} - timed out. Peer: {allocatedPeer}");
+                }
+                catch (OperationCanceledException)
+                {
+                    if (Logger.IsTrace) Logger.Debug($"{request} - Operation was canceled");
+                }
+                catch (Exception e)
+                {
+                    if (Logger.IsWarn) Logger.Warn($"Failure when executing request {e}");
+                }
+                Metrics.SyncDispatcherDispatchTimeMicros.Observe(Stopwatch.GetElapsedTime(dispatchTimeStart).TotalMicroseconds, new StringLabel(_feedName));
+
+                try
+                {
+                    if (Feed.IsMultiFeed)
+                    {
+                        await _concurrentProcessingSemaphore.WaitAsync(cancellationToken);
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Teardown raced this dispatch; stop rather than fault the un-awaited task.
+                    if (Logger.IsDebug) Logger.Debug($"{_feedName} dispatch abandoned during shutdown.");
+                    return;
+                }
             }
 
             dispatchTimeStart = Stopwatch.GetTimestamp();
@@ -301,8 +311,6 @@ namespace Nethermind.Synchronization.ParallelSync
                 if (Logger.IsError) Logger.Error("Error when handling response", e);
             }
         }
-
-        private void Free(SyncPeerAllocation allocation) => SyncPeerPool.Free(allocation);
 
         protected async Task<SyncPeerAllocation> Allocate(T request, CancellationToken cancellationToken) =>
             await SyncPeerPool.Allocate(PeerAllocationStrategyFactory.Create(request), Feed.Contexts, _allocateTimeoutMs, cancellationToken);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -125,12 +125,12 @@ namespace Nethermind.Synchronization.Peers
             AllocationContexts allocationContexts,
             CancellationToken cancellationToken)
         {
-            using SyncPeerAllocation allocation = await syncPeerPool.Allocate(
+            using SyncPeerAllocation? allocation = await syncPeerPool.Allocate(
                 peerAllocationStrategy,
                 allocationContexts,
                 timeoutMilliseconds: int.MaxValue,
                 cancellationToken: cancellationToken);
-            if (allocation.Current is null) return default;
+            if (allocation?.Current is null) return default;
             return await func(allocation.Current);
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -23,8 +23,6 @@ namespace Nethermind.Synchronization.Peers
             int timeoutMilliseconds = 0,
             CancellationToken cancellationToken = default);
 
-        void Free(SyncPeerAllocation syncPeerAllocation);
-
         void ReportNoSyncProgress(PeerInfo peerInfo, AllocationContexts allocationContexts);
 
         void ReportBreachOfProtocol(PeerInfo peerInfo, DisconnectReason disconnectReason, string details);
@@ -127,20 +125,13 @@ namespace Nethermind.Synchronization.Peers
             AllocationContexts allocationContexts,
             CancellationToken cancellationToken)
         {
-            SyncPeerAllocation? allocation = await syncPeerPool.Allocate(
+            using SyncPeerAllocation allocation = await syncPeerPool.Allocate(
                 peerAllocationStrategy,
                 allocationContexts,
                 timeoutMilliseconds: int.MaxValue,
                 cancellationToken: cancellationToken);
-            try
-            {
-                if (allocation?.Current is null) return default;
-                return await func(allocation.Current);
-            }
-            finally
-            {
-                syncPeerPool.Free(allocation);
-            }
+            if (allocation.Current is null) return default;
+            return await func(allocation.Current);
         }
 
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
@@ -9,8 +9,6 @@ namespace Nethermind.Synchronization.Peers
 {
     public class SyncPeerAllocation(AllocationContexts contexts, Lock? allocationLock = null) : IDisposable
     {
-        public static readonly SyncPeerAllocation FailedAllocation = new(AllocationContexts.None, null);
-
         /// <summary>
         /// this should be used whenever we change IsAllocated property on PeerInfo-
         /// </summary>
@@ -27,10 +25,6 @@ namespace Nethermind.Synchronization.Peers
         public PeerInfo? Current { get; private set; }
 
         public bool HasPeer => Current is not null;
-
-        public SyncPeerAllocation(PeerInfo peerInfo, AllocationContexts contexts, Lock? allocationLock = null)
-
-            : this(contexts, allocationLock) => Current = peerInfo;
 
         public void AllocatePeer(PeerInfo? selected)
         {
@@ -50,6 +44,9 @@ namespace Nethermind.Synchronization.Peers
             }
         }
 
+        /// <summary>
+        /// Returns the allocated peer slot. Repeated calls have no effect.
+        /// </summary>
         public void Dispose()
         {
             bool released = false;
@@ -70,6 +67,7 @@ namespace Nethermind.Synchronization.Peers
                 }
             }
 
+            // A peer-less disposal must not wake every allocator on zero-timeout polling paths.
             if (released)
             {
                 _onDisposed?.Invoke();

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
@@ -1,19 +1,25 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Nethermind.Synchronization.Peers
 {
-    public class SyncPeerAllocation(AllocationContexts contexts, Lock? allocationLock = null)
+    public class SyncPeerAllocation(AllocationContexts contexts, Lock? allocationLock = null) : IDisposable
     {
-        public static SyncPeerAllocation FailedAllocation = new(AllocationContexts.None, null);
+        public static readonly SyncPeerAllocation FailedAllocation = new(AllocationContexts.None, null);
 
         /// <summary>
         /// this should be used whenever we change IsAllocated property on PeerInfo-
         /// </summary>
         private readonly Lock? _allocationLock = allocationLock ?? new Lock();
+        private readonly Action? _onDisposed;
+        private bool _disposed;
+
+        internal SyncPeerAllocation(AllocationContexts contexts, Lock? allocationLock, Action onDisposed)
+            : this(contexts, allocationLock) => _onDisposed = onDisposed;
 
         private AllocationContexts Contexts { get; } = contexts;
 
@@ -28,34 +34,45 @@ namespace Nethermind.Synchronization.Peers
 
         public void AllocatePeer(PeerInfo? selected)
         {
-            PeerInfo? current = Current;
-            if (selected == current)
-            {
-                return;
-            }
-
             lock (_allocationLock)
             {
+                if (_disposed || selected == Current)
+                {
+                    return;
+                }
+
                 if (selected is not null && selected.TryAllocate(Contexts))
                 {
+                    PeerInfo? current = Current;
                     Current = selected;
                     current?.Free(Contexts);
                 }
             }
         }
 
-        public void Cancel()
+        public void Dispose()
         {
-            PeerInfo? current = Current;
-            if (current is null)
-            {
-                return;
-            }
-
+            bool released = false;
             lock (_allocationLock)
             {
-                current.Free(Contexts);
-                Current = null;
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                PeerInfo? current = Current;
+                if (current is not null)
+                {
+                    current.Free(Contexts);
+                    Current = null;
+                    released = true;
+                }
+            }
+
+            if (released)
+            {
+                _onDisposed?.Invoke();
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -137,13 +137,11 @@ namespace Nethermind.Synchronization.Peers
 
         public async Task<int?> EstimateRequestLimit(RequestType requestType, IPeerAllocationStrategy allocationStrategy, AllocationContexts context, CancellationToken token)
         {
-            // So, to know which peer is next, we just try to allocate it, and then free it back.
-            SyncPeerAllocation syncPeerAllocation = await Allocate(allocationStrategy, context, 1000, token);
+            // So, to know which peer is next, we just try to allocate it, and then dispose it.
+            using SyncPeerAllocation syncPeerAllocation = await Allocate(allocationStrategy, context, 1000, token);
             if (!syncPeerAllocation.HasPeer) return null;
 
-            int requestSize = _stats.GetOrAdd(syncPeerAllocation.Current!.SyncPeer.Node).GetCurrentRequestLimit(requestType);
-            Free(syncPeerAllocation);
-            return requestSize;
+            return _stats.GetOrAdd(syncPeerAllocation.Current!.SyncPeer.Node).GetCurrentRequestLimit(requestType);
         }
 
         public void Start()
@@ -373,7 +371,7 @@ namespace Nethermind.Synchronization.Peers
 
             using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _refreshLoopCancellation.Token);
 
-            SyncPeerAllocation allocation = new(allocationContexts, _isAllocatedChecks);
+            SyncPeerAllocation allocation = new(allocationContexts, _isAllocatedChecks, SignalPeersChanged);
             while (true)
             {
                 // Snapshot the signal task before attempting allocation so that any
@@ -417,19 +415,6 @@ namespace Nethermind.Synchronization.Peers
                 allocation.AllocatePeer(selected);
                 return allocation.HasPeer;
             }
-        }
-
-        /// <summary>
-        ///     Frees the allocation space borrowed earlier for some sync consumer.
-        /// </summary>
-        /// <param name="syncPeerAllocation">Allocation to free</param>
-        public void Free(SyncPeerAllocation syncPeerAllocation)
-        {
-            if (_logger.IsTrace) _logger.Trace($"Returning {syncPeerAllocation}");
-
-            syncPeerAllocation.Cancel();
-
-            SignalPeersChanged();
         }
 
         private async Task RunRefreshPeerLoop()

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -361,9 +361,10 @@ namespace Nethermind.Synchronization.Peers
             int timeoutMilliseconds = 0,
             CancellationToken cancellationToken = default)
         {
+            SyncPeerAllocation allocation = new(allocationContexts, _isAllocatedChecks, SignalPeersChanged);
             if (cancellationToken.IsCancellationRequested)
             {
-                return SyncPeerAllocation.FailedAllocation;
+                return allocation;
             }
 
             int tryCount = 1;
@@ -371,7 +372,6 @@ namespace Nethermind.Synchronization.Peers
 
             using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _refreshLoopCancellation.Token);
 
-            SyncPeerAllocation allocation = new(allocationContexts, _isAllocatedChecks, SignalPeersChanged);
             while (true)
             {
                 // Snapshot the signal task before attempting allocation so that any
@@ -387,7 +387,7 @@ namespace Nethermind.Synchronization.Peers
                 bool timeoutReached = timeoutMilliseconds == 0
                                       || elapsedMilliseconds < 0
                                       || elapsedMilliseconds > timeoutMilliseconds;
-                if (timeoutReached) return SyncPeerAllocation.FailedAllocation;
+                if (timeoutReached) return allocation;
 
                 int waitTime = GetAllocationWaitTime(tryCount++);
                 waitTime = Math.Min(waitTime, timeoutMilliseconds - (int)elapsedMilliseconds);
@@ -397,7 +397,7 @@ namespace Nethermind.Synchronization.Peers
                     await Task.WhenAny(signal, Task.Delay(waitTime, cts.Token));
                     if (cts.IsCancellationRequested)
                     {
-                        return SyncPeerAllocation.FailedAllocation;
+                        return allocation;
                     }
                 }
             }


### PR DESCRIPTION
## Changes

- make `SyncPeerAllocation` implement idempotent `IDisposable` ownership
- remove `ISyncPeerPool.Free` and migrate production consumers to concise `using` declarations
- preserve allocation lifetimes across asynchronous dispatcher task handoffs
- update test pools and add disposal/reallocation coverage

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [x] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Release build of `Nethermind.Synchronization.Test` succeeded with 0 warnings and 0 errors.
- Focused synchronization tests passed: 187/187.
- Focused Merge Plugin tests passed: 2/2.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
