### PR TITLE
fix(rpc): keep the module rented until a streamed result has been written

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -8,7 +8,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Find;
-using Nethermind.Blockchain.Tracing.ParityStyle;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -5,8 +5,10 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Tracing.ParityStyle;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -24,6 +26,7 @@ using Nethermind.JsonRpc.Modules;
 using Nethermind.JsonRpc.Modules.Admin;
 using Nethermind.JsonRpc.Modules.Eth;
 using Nethermind.JsonRpc.Modules.Net;
+using Nethermind.JsonRpc.Modules.Trace;
 using Nethermind.JsonRpc.Modules.Web3;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
@@ -396,6 +399,29 @@ public class JsonRpcServiceTests
 
         response.Dispose();
         pool.Received().ReturnModule(rpcModule);
+    }
+
+    // A streamed trace executes while the response is written, on the module's own overridable env; the module must
+    // therefore stay rented until the response is disposed, or the next rental races it on that env.
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Returns_module_to_pool_only_after_a_streamed_result_is_disposed(bool streamed)
+    {
+        IRpcModulePool<ITraceRpcModule> pool = Substitute.For<IRpcModulePool<ITraceRpcModule>>();
+        ITraceRpcModule rpcModule = Substitute.For<ITraceRpcModule>();
+        pool.GetModule(false).Returns(rpcModule);
+        using CancellationTokenSource timeoutCts = new();
+        IEnumerable<ParityTxTraceFromReplay> traces = streamed
+            ? new ParityTxTraceStreamingResult<ParityTxTraceFromReplay>(static (_, _, _) => { }, timeoutCts, LimboLogs.Instance.GetClassLogger<JsonRpcServiceTests>())
+            : [];
+        rpcModule.trace_replayBlockTransactions(Arg.Any<BlockParameter>(), Arg.Any<string[]>())
+            .Returns(ResultWrapper<IEnumerable<ParityTxTraceFromReplay>>.Success(traces));
+
+        JsonRpcResponse response = TestRequestWithPool(pool, "trace_replayBlockTransactions", "latest", new[] { "trace" });
+
+        pool.Received(streamed ? 0 : 1).ReturnModule(rpcModule);
+        response.Dispose();
+        pool.Received(1).ReturnModule(rpcModule);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -112,8 +112,9 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         {
             contextAwareModule.Context = context;
         }
+        void ReturnRental() => _rpcModuleProvider.Return(method, rpcModule);
         bool returnImmediately = methodName != GetLogsMethodName;
-        Action? returnAction = returnImmediately ? null : () => _rpcModuleProvider.Return(method, rpcModule);
+        Action? returnAction = returnImmediately ? null : ReturnRental;
         IResultWrapper? resultWrapper = null;
         try
         {
@@ -141,10 +142,10 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             // A streamed result executes while the response is written, after this method has returned, on state the
             // module owns (its overridable world state env). Returning the module now would let the next rental run on
             // that same env concurrently, so the rental has to last until the response is disposed.
-            if (returnImmediately && resultWrapper is JsonRpcResponse streamed && streamed.TryGetStreamableResult(out _))
+            if (returnImmediately && resultWrapper is JsonRpcResponse invocationResponse && invocationResponse.TryGetStreamableResult(out _))
             {
                 returnImmediately = false;
-                returnAction = () => _rpcModuleProvider.Return(method, rpcModule);
+                returnAction = ReturnRental;
             }
         }
         catch (Exception ex)
@@ -155,7 +156,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         {
             if (returnImmediately)
             {
-                _rpcModuleProvider.Return(method, rpcModule);
+                ReturnRental();
             }
         }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -137,6 +137,15 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
                 default:
                     break;
             }
+
+            // A streamed result executes while the response is written, after this method has returned, on state the
+            // module owns (its overridable world state env). Returning the module now would let the next rental run on
+            // that same env concurrently, so the rental has to last until the response is disposed.
+            if (returnImmediately && resultWrapper is JsonRpcResponse streamed && streamed.TryGetStreamableResult(out _))
+            {
+                returnImmediately = false;
+                returnAction = () => _rpcModuleProvider.Return(method, rpcModule);
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Changes

- `JsonRpcService.ExecuteAsync`: when the invocation result is streamable (`TryGetStreamableResult`), defer returning the module to the pool until the response is disposed — the same deferral `eth_getLogs` already uses — instead of returning it right after the invocation.
- Regression test `JsonRpcServiceTests.Returns_module_to_pool_only_after_a_streamed_result_is_disposed` (streamed and non-streamed cases); the streamed case fails without the fix.

### Why

Parity-style trace methods (`trace_call`, `trace_replayBlockTransactions`, `trace_block`) return a `ParityTxTraceStreamingResult` whose execution runs **while the response is written**, on the module's own overridable world state env (`BuildAndOverride` is called from inside the stream). The module was returned to its pool as soon as the method returned, so the next request could rent the same instance and re-arm that env while the previous stream was still executing on it:

```
System.InvalidOperationException: Previous overridable world scope was not closed
   at OverridableEnvFactory.OverridableEnv.BuildAndOverride(...)  (OverridableEnvFactory.cs:41)
   at TraceRpcModule.<TraceTx>b__0 / TraceRpcModule.ExecuteBlockStreaming(...)
   at StreamingResultBase.WriteJsonToAsync(...)
   at HttpJsonRpcResponseSink.WriteAfterWriteAsync(...)
```

It surfaces as "An unhandled exception was thrown by the application" in Kestrel and a truncated response body; the HTTP status is already sent, so `http_req_failed`-style monitoring never sees it. Geth-style `debug_trace*` is unaffected.

Measured on `master-b26e059` with the RPC benchmark workflow (mixed workload, 20% tracing, flat snapshot at 25,490,000, amd64 box):

| load | broken parity-trace responses |
|---|---|
| 100 rps mixed | 1.5% |
| 300 rps mixed | 12% |
| 100 rps of block-level traces only | 57% |

Runs: [33518822147](https://github.com/NethermindEth/nethermind/actions/runs/33518822147), [33531594826](https://github.com/NethermindEth/nethermind/actions/runs/33531594826), [33533783344](https://github.com/NethermindEth/nethermind/actions/runs/33533783344) (the last also shows the collision disappearing when instances stop being shared, via #12988's `PreloadRpcModules`, which is how the mechanism was pinned down).

With the rental spanning the stream, the module pool bounds concurrent *streams* — what it was always meant to bound. Under saturation the trace pool (2 instances on master) now queues and times out rentals instead of corrupting in-flight responses.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Returns_module_to_pool_only_after_a_streamed_result_is_disposed(true)` fails on master (module returned before the response is disposed) and passes with the fix; the `false` case guards the non-streamed path (returned immediately, exactly once). A benchmark re-run of the mixed workload on this branch's image is being dispatched and will be linked in a comment.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Fixes concurrent `trace_call` / `trace_replayBlockTransactions` / `trace_block` requests intermittently failing with `Previous overridable world scope was not closed` and a truncated response.

Because the module now stays rented until its response has been fully written, the trace module pool (2 instances by default) bounds concurrent trace *streams*. Under sustained heavy-trace overload the rental queue grows until `RequestQueueLimit` (500 waiters, process-wide) trips, after which further queued-path requests — including `debug_*`, whose own pool may still have capacity — are rejected with `-32005 LimitExceeded`; waits are bounded by `JsonRpc.Timeout`. At moderate heavy-trace load (40 block traces/s on the benchmark box) p50 rises ~24% because streams no longer overlap on one instance. Making the trace pool size configurable (`TraceModuleConcurrentInstances`) is part of #12988.

## Remarks

Found while running full-path benchmarks for #12988; that PR's lazy module pool amplifies this race (~10x at 100 rps) because trace rentals became near-instant, so #12988 should rebase on or include this fix.


