### PR TITLE
Align Bootnode releases with Nethermind versions

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -36,9 +36,10 @@ jobs:
         run: |
           version="$TAG_NAME"
           json=$(curl -sL "$ASSETS_URL")
-          arm64_url=$(echo "$json" | jq -r '.[].browser_download_url | select(endswith("linux-arm64.zip"))')
+          asset_prefix="nethermind-$TAG_NAME-"
+          arm64_url=$(echo "$json" | jq -r --arg prefix "$asset_prefix" '.[] | select((.name | startswith($prefix)) and (.name | endswith("linux-arm64.zip"))) | .browser_download_url')
           arm64_hash=$(curl -sL $arm64_url | sha256sum | awk '{print $1}')
-          x64_url=$(echo "$json" | jq -r '.[].browser_download_url | select(endswith("linux-x64.zip"))')
+          x64_url=$(echo "$json" | jq -r --arg prefix "$asset_prefix" '.[] | select((.name | startswith($prefix)) and (.name | endswith("linux-x64.zip"))) | .browser_download_url')
           x64_hash=$(curl -sL $x64_url | sha256sum | awk '{print $1}')
           awk -i inplace -v n=1 '/url/ { if (++count == n) sub(/url.*/, "url='$arm64_url'"); } 1' debian/postinst
           awk -i inplace -v n=2 '/url/ { if (++count == n) sub(/url.*/, "url='$x64_url'"); } 1' debian/postinst
@@ -96,7 +97,8 @@ jobs:
           ASSETS_URL: ${{ github.event.release.assets_url }}
         run: |
           $releaseInfo = curl -sL $env:ASSETS_URL | ConvertFrom-Json
-          $releaseUrl = $releaseInfo | Where-Object -Property name -like '*windows-x64.zip' | Select-Object -ExpandProperty browser_download_url
+          $assetPattern = "nethermind-$env:TAG_NAME-*-windows-x64.zip"
+          $releaseUrl = $releaseInfo | Where-Object { $_.name -like $assetPattern } | Select-Object -First 1 -ExpandProperty browser_download_url
           curl -sL https://aka.ms/wingetcreate/latest -o wingetcreate.exe
           ./wingetcreate update Nethermind.Nethermind -s -v $env:TAG_NAME -u $releaseUrl
 
@@ -127,9 +129,10 @@ jobs:
           ASSETS_URL: ${{ github.event.release.assets_url }}
         run: |
           json=$(curl -sL "$ASSETS_URL")
-          arm64_url=$(echo "$json" | jq -r '.[].browser_download_url | select(endswith("macos-arm64.zip"))')
+          asset_prefix="nethermind-$TAG_NAME-"
+          arm64_url=$(echo "$json" | jq -r --arg prefix "$asset_prefix" '.[] | select((.name | startswith($prefix)) and (.name | endswith("macos-arm64.zip"))) | .browser_download_url')
           arm64_hash=$(curl -sL $arm64_url | shasum -a 256 | awk '{print $1}')
-          x64_url=$(echo "$json" | jq -r '.[].browser_download_url | select(endswith("macos-x64.zip"))')
+          x64_url=$(echo "$json" | jq -r --arg prefix "$asset_prefix" '.[] | select((.name | startswith($prefix)) and (.name | endswith("macos-x64.zip"))) | .browser_download_url')
           x64_hash=$(curl -sL $x64_url | shasum -a 256 | awk '{print $1}')
           sed -i "s/version .*/version \"$TAG_NAME\"/" $FORMULA
           awk -i inplace -v n=1 '/url/ { if (++count == n) sub(/url.*/, "url \"'$x64_url'\""); } 1' $FORMULA

--- a/.github/workflows/release-bootnode.yml
+++ b/.github/workflows/release-bootnode.yml
@@ -3,27 +3,14 @@ name: Release Bootnode
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: Bootnode release tag, for example bootnode-r1
-        required: true
-        default: bootnode-r1
-      release_name:
-        description: GitHub release title. Leave empty to derive it from the tag.
-        required: false
-        default: ""
-      prerelease:
-        description: Mark the GitHub release as a prerelease.
-        required: true
-        type: boolean
-        default: true
       publish_latest:
-        description: Also publish Docker latest and mark the GitHub release latest. Valid only when prerelease is false.
+        description: Also publish Docker latest. Valid only when the matching Nethermind release is stable.
         required: true
         type: boolean
         default: false
 
 concurrency:
-  group: bootnode-release-${{ inputs.tag }}
+  group: bootnode-release-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
@@ -41,45 +28,35 @@ jobs:
     name: Build Bootnode packages
     runs-on: ubuntu-latest
     outputs:
-      release-tag: ${{ steps.release.outputs.release-tag }}
-      release-name: ${{ steps.release.outputs.release-name }}
-      package-prefix: ${{ steps.release.outputs.package-prefix }}
-      prerelease: ${{ steps.release.outputs.prerelease }}
-      publish-latest: ${{ steps.release.outputs.publish-latest }}
+      release-tag: ${{ steps.version.outputs.version }}
+      package-prefix: ${{ steps.version.outputs.package-prefix }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+      publish-latest: ${{ steps.version.outputs.publish-latest }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Resolve release metadata
-        id: release
+      - name: Detect version
+        id: version
+        working-directory: src/Nethermind
         env:
-          INPUT_TAG: ${{ inputs.tag }}
-          INPUT_RELEASE_NAME: ${{ inputs.release_name }}
-          INPUT_PRERELEASE: ${{ inputs.prerelease }}
           INPUT_PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
-          tag="$INPUT_TAG"
-          if [[ ! "$tag" =~ ^bootnode-[0-9A-Za-z][0-9A-Za-z._-]*$ ]]; then
-            echo "Bootnode release tags must start with 'bootnode-' and contain only letters, digits, dots, underscores, or hyphens."
+          sudo apt-get update && sudo apt-get install xmlstarlet -y --no-install-recommends
+          version_prefix=$(xmlstarlet sel -t -v "//Project/PropertyGroup/VersionPrefix" Directory.Build.props)
+          version_suffix=$(xmlstarlet sel -t -v "//Project/PropertyGroup/VersionSuffix" -n Directory.Build.props)
+          version=$([[ -n "$version_suffix" ]] && echo "$version_prefix-$version_suffix" || echo "$version_prefix")
+          package_prefix=nethermind-bootnode-$version
+
+          if [[ -n "$version_suffix" && "$INPUT_PUBLISH_LATEST" == "true" ]]; then
+            echo "Docker latest cannot be published for a prerelease."
             exit 1
           fi
 
-          if [[ "$INPUT_PRERELEASE" == "true" && "$INPUT_PUBLISH_LATEST" == "true" ]]; then
-            echo "A prerelease cannot also be published as latest."
-            exit 1
-          fi
-
-          release_name="$INPUT_RELEASE_NAME"
-          if [[ -z "$release_name" ]]; then
-            release_name="Nethermind Bootnode ${tag#bootnode-}"
-          fi
-
-          package_prefix=nethermind-$tag
-
-          echo "release-tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "release-name=$release_name" >> "$GITHUB_OUTPUT"
+          echo "Detected version $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "package-prefix=$package_prefix" >> "$GITHUB_OUTPUT"
-          echo "prerelease=$INPUT_PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$([[ -n "$version_suffix" ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
           echo "publish-latest=$INPUT_PUBLISH_LATEST" >> "$GITHUB_OUTPUT"
           echo "PACKAGE_PREFIX=$package_prefix" >> "$GITHUB_ENV"
 
@@ -108,7 +85,7 @@ jobs:
         run: |
           printf '%s' "$GPG_SECRET_KEY" | base64 --decode | gpg --import --no-tty --batch --yes
 
-          for file_name in *.tar.gz *.zip SHA256SUMS; do
+          for file_name in *.tar.gz *.zip "$PACKAGE_PREFIX-SHA256SUMS"; do
             gpg --no-tty --batch --yes --pinentry-mode loopback \
               --passphrase-file <(printf '%s' "$GPG_PASSPHRASE") \
               -o "$file_name.asc" -ab "$file_name"
@@ -158,61 +135,31 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.gh-app.outputs.token }}
           RELEASE_TAG: ${{ needs.build.outputs.release-tag }}
-          RELEASE_NAME: ${{ needs.build.outputs.release-name }}
-          PRERELEASE: ${{ needs.build.outputs.prerelease }}
-          PUBLISH_LATEST: ${{ needs.build.outputs.publish-latest }}
         run: |
-          relnotes=$(cat <<EOF
-          # Release notes
-
-          Standalone Nethermind Bootnode release.
-
-          ## Docker image
-
-          \`\`\`bash
-          docker pull nethermind/nethermind-bootnode:$RELEASE_TAG
-          \`\`\`
-
-          ## Build signatures
-
-          The packages are signed with the following OpenPGP key: \`AD12 7976 5093 C675 9CD8 A400 24A7 7461 6F1E 617E\`.
-          EOF
-          )
-
-          prerelease_flag=()
-          latest_flag=()
-          if [[ "$PRERELEASE" == "true" ]]; then
-            prerelease_flag=(-p)
-          elif [[ "$PUBLISH_LATEST" == "true" ]]; then
-            latest_flag=(--latest)
+          if ! release=$(gh release view "$RELEASE_TAG" --json isDraft,targetCommitish); then
+            echo "::error::The matching Nethermind release $RELEASE_TAG must be created as a draft before its Bootnode assets can be uploaded."
+            exit 1
           fi
 
-          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "Drafting release $RELEASE_TAG"
-            gh release create "$RELEASE_TAG" \
-              --target "$GITHUB_SHA" \
-              -t "$RELEASE_NAME" \
-              -d \
-              "${prerelease_flag[@]}" \
-              -F <(printf '%s' "$relnotes")
+          release_draft=$(jq -r '.isDraft' <<< "$release")
+          release_target=$(jq -r '.targetCommitish' <<< "$release")
+          if [[ "$release_draft" != "true" ]]; then
+            echo "::error::The matching Nethermind release $RELEASE_TAG must remain a draft until its Bootnode assets are uploaded."
+            exit 1
+          fi
+
+          if [[ "$release_target" != "$GITHUB_SHA" ]]; then
+            echo "::error::The matching Nethermind release $RELEASE_TAG targets $release_target, but this Bootnode build targets $GITHUB_SHA."
+            exit 1
           fi
 
           echo "Uploading assets"
           gh release upload "$RELEASE_TAG" "$PACKAGE_DIR"/* --clobber
 
-          echo "Publishing release $RELEASE_TAG"
-          gh release edit "$RELEASE_TAG" \
-            --verify-tag \
-            --target "$GITHUB_SHA" \
-            -t "$RELEASE_NAME" \
-            --draft=false \
-            "${prerelease_flag[@]}" \
-            "${latest_flag[@]}"
-
   publish-docker:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
-    needs: [approval, build]
+    needs: [approval, build, publish-github]
     steps:
       - name: Check out Nethermind repository
         uses: actions/checkout@v6

--- a/scripts/build/archive-bootnode.sh
+++ b/scripts/build/archive-bootnode.sh
@@ -23,6 +23,6 @@ tar -czf "$package_path/$PACKAGE_PREFIX-macos-x64.tar.gz" -C osx-x64 .
 cd win-x64 && zip -r "$package_path/$PACKAGE_PREFIX-windows-x64.zip" . && cd ..
 
 cd "$package_path"
-sha256sum *.tar.gz *.zip > SHA256SUMS
+sha256sum *.tar.gz *.zip > "$PACKAGE_PREFIX-SHA256SUMS"
 
 echo "Archiving completed"

--- a/tools/Bootnode/README.md
+++ b/tools/Bootnode/README.md
@@ -39,10 +39,10 @@ The tool is a discovery-only bootnode. It advertises TCP port `0` in the enode a
 
 ## Release Assets
 
-Bootnode side releases use `bootnode-*` tags and the `Release Bootnode` GitHub workflow. The workflow builds signed standalone binaries for Linux x64/arm64, macOS x64/arm64, and Windows x64, then publishes a Docker image:
+Bootnode releases use the matching Nethermind version tag, for example `1.39.1`. The `Release Bootnode` workflow reads the same version source as the main release workflow; run it after the matching GitHub release draft has been created and before it is published. It builds signed standalone binaries for Linux x64/arm64, macOS x64/arm64, and Windows x64, then publishes a Docker image. For a stable version, select `publish_latest` to also refresh the Bootnode `latest` image tag:
 
 ```powershell
-docker pull nethermind/nethermind-bootnode:bootnode-r1
+docker pull nethermind/nethermind-bootnode:1.39.1
 ```
 
 The default container command stores state in `/nethermind-bootnode/data` and binds REST and Prometheus to all interfaces:
@@ -53,7 +53,7 @@ docker run --rm -it `
   -p 127.0.0.1:8546:8546 `
   -p 127.0.0.1:6060:6060 `
   -v bootnode-data:/nethermind-bootnode/data `
-  nethermind/nethermind-bootnode:bootnode-r1
+  nethermind/nethermind-bootnode:1.39.1
 ```
 
 Pass CLI options after the image name to override the defaults, for example:
@@ -64,7 +64,7 @@ docker run --rm -it `
   -p 127.0.0.1:8546:8546 `
   -p 127.0.0.1:6060:6060 `
   -v bootnode-data:/nethermind-bootnode/data `
-  nethermind/nethermind-bootnode:bootnode-r1 `
+  nethermind/nethermind-bootnode:1.39.1 `
   --local-ip :: `
   --external-ip-v4 203.0.113.10 `
   --external-ip-v6 2001:db8::10


### PR DESCRIPTION
## Changes

- Derive Bootnode release and Docker tags from the same version source as Nethermind releases.
- Upload namespaced Bootnode artifacts only to the matching main-release draft and prevent them from being selected by main package publishing.
- Document the shared version tag and release order.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

- Validated the workflows, package-asset selection, and Bootnode archive output; built and exercised the focused Bootnode coverage.

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

Updated `tools/Bootnode/README.md` with the version-tag and release-order guidance.

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No