### PR TITLE
test(sync): let Retry absorb an E2E sync timeout

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -593,6 +593,8 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             Assert.Ignore("BAL sync regression is only executed for the default post-merge fixture.");
         }
 
+        // Not routed through RunWithTimeout: at a 10-minute budget a retried timeout would exceed the
+        // job budget, turning a clean error into a report-less job timeout.
         using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(BalSyncTestTimeout);
 
         PrivateKey serverKey = TestItem.PrivateKeyE;

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -1056,11 +1056,29 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
                 await VerifyBlockAccessListsWith(sourceServer, syncPivotNumber, token);
             }, cancellationToken);
 
+        // Retry re-runs assertion failures but not errors, so a timeout has to fail rather than throw
+        // for the [Retry] on these tests to absorb it.
         private async Task ExecuteSyncFromServer(
             IContainer server,
             Func<IContainer, CancellationToken, Task> verification,
             CancellationToken cancellationToken,
             ulong finalizedDistanceFromHead = 250)
+        {
+            try
+            {
+                await ExecuteSyncFromServerCore(server, verification, cancellationToken, finalizedDistanceFromHead);
+            }
+            catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
+            {
+                Assert.Fail($"Sync did not finish before the test timeout.{Environment.NewLine}{e}");
+            }
+        }
+
+        private async Task ExecuteSyncFromServerCore(
+            IContainer server,
+            Func<IContainer, CancellationToken, Task> verification,
+            CancellationToken cancellationToken,
+            ulong finalizedDistanceFromHead)
         {
             await immediateDisconnectFailure.WatchForDisconnection(async (token) =>
             {

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -107,6 +107,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             Assert.Fail($"Test did not finish within {timeout.TotalSeconds:N0}s.{Environment.NewLine}{e}");
         }
     }
+
     private const int ChainLength = 1000;
     private const ulong HeadPivotDistance = 500;
     private static TimeSpan BalSyncTestTimeout = TimeSpan.FromMinutes(10);

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -91,6 +91,22 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
 
     private static readonly TimeSpan SetupTimeout = TimeSpan.FromSeconds(60);
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(60);
+
+    /// <summary>Runs a test body under a timeout.</summary>
+    /// <remarks>NUnit re-runs assertion failures but not errors, so the timeout has to fail rather than
+    /// throw for the <c>Retry</c> on these tests to absorb it.</remarks>
+    private static async Task RunWithTimeout(TimeSpan timeout, Func<CancellationToken, Task> body)
+    {
+        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(timeout);
+        try
+        {
+            await body(cancellationTokenSource.Token);
+        }
+        catch (OperationCanceledException e) when (cancellationTokenSource.IsCancellationRequested)
+        {
+            Assert.Fail($"Test did not finish within {timeout.TotalSeconds:N0}s.{Environment.NewLine}{e}");
+        }
+    }
     private const int ChainLength = 1000;
     private const ulong HeadPivotDistance = 500;
     private static TimeSpan BalSyncTestTimeout = TimeSpan.FromMinutes(10);
@@ -472,23 +488,22 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         _server.DisposeAsync().AsTask();
 
     [Test]
-    [Category("Flaky"), Retry(5)]
-    public async Task FullSync()
-    {
-        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
-
-        PrivateKey clientKey = TestItem.PrivateKeyB;
-        await using IContainer client = await CreateNode(clientKey, (cfg, spec) =>
+    [Category("Flaky"), Retry(2)]
+    public Task FullSync() =>
+        RunWithTimeout(TestTimeout, async cancellationToken =>
         {
-            ConfigureLocalNetwork(cfg, AllocatePort());
-            return Task.CompletedTask;
+            PrivateKey clientKey = TestItem.PrivateKeyB;
+            await using IContainer client = await CreateNode(clientKey, (cfg, spec) =>
+            {
+                ConfigureLocalNetwork(cfg, AllocatePort());
+                return Task.CompletedTask;
+            });
+
+            await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationToken);
         });
 
-        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
-    }
-
     [Test]
-    [Category("Flaky"), Retry(5)]
+    [Category("Flaky"), Retry(2)]
     public async Task FastSync()
     {
         // After the nodedata satellite protocol was removed, fast sync without snap can no longer
@@ -496,20 +511,21 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         // covers fast sync with state retrieval via snap.
         Assert.Ignore("Fast sync without snap is not supported for eth >= 67 after nodedata satellite removal");
 
-        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
-
-        PrivateKey clientKey = TestItem.PrivateKeyC;
-        await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
+        await RunWithTimeout(TestTimeout, async cancellationToken =>
         {
-            SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
-            syncConfig.FastSync = true;
+            PrivateKey clientKey = TestItem.PrivateKeyC;
+            await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
+            {
+                SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
+                syncConfig.FastSync = true;
 
-            await SetPivot(syncConfig, cancellationTokenSource.Token);
+                await SetPivot(syncConfig, cancellationToken);
 
-            ConfigureLocalNetwork(cfg, AllocatePort());
+                ConfigureLocalNetwork(cfg, AllocatePort());
+            });
+
+            await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationToken);
         });
-
-        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
     }
 
     private async Task SetPivot(SyncConfig syncConfig, CancellationToken cancellationToken) =>
@@ -528,13 +544,12 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
     }
 
     [Test]
-    [Category("Flaky"), Retry(5)]
+    [Category("Flaky"), Retry(2)]
     public async Task SnapSync()
     {
         if (dbMode == DbMode.Hash) Assert.Ignore("Hash db does not support snap sync");
 
-        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
-        await RunSnapSyncOnce(cancellationTokenSource.Token);
+        await RunWithTimeout(TestTimeout, RunSnapSyncOnce);
     }
 
     // Stress reproducer for SnapSync Windows flake — run manually; see PR #11443 for context.
@@ -545,8 +560,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         if (dbMode != DbMode.Flat) Assert.Ignore("Stress repro only targets the Flat dbMode where the flake was observed");
         _ = iteration; // index is purely to give NUnit a unique case per attempt
 
-        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
-        await RunSnapSyncOnce(cancellationTokenSource.Token);
+        await RunWithTimeout(TestTimeout, RunSnapSyncOnce);
     }
 
     private async Task RunSnapSyncOnce(CancellationToken cancellationToken)
@@ -579,7 +593,6 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         }
 
         using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(BalSyncTestTimeout);
-        CancellationToken cancellationToken = cancellationTokenSource.Token;
 
         PrivateKey serverKey = TestItem.PrivateKeyE;
         await using IContainer server = await CreateNode(serverKey, (cfg, spec) =>
@@ -589,7 +602,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             return Task.CompletedTask;
         }, serverKey);
 
-        await StartServerAndBuildStorageChain(server, BalSyncChainLength, cancellationToken, "BAL sync server");
+        await StartServerAndBuildStorageChain(server, BalSyncChainLength, cancellationTokenSource.Token, "BAL sync server");
 
         IBlockTree serverBlockTree = server.Resolve<IBlockTree>();
         Assert.That(serverBlockTree.Head!.Number, Is.EqualTo(BalSyncChainLength));
@@ -609,7 +622,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
             syncConfig.FastSync = true;
 
-            await SetPivot(server, syncConfig, cancellationToken, HeadPivotDistance);
+            await SetPivot(server, syncConfig, cancellationTokenSource.Token, HeadPivotDistance);
             syncPivotNumber = syncConfig.PivotNumber;
 
             ConfigureLocalNetwork(cfg, AllocatePort());
@@ -618,34 +631,35 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         Assert.That(syncPivotNumber, Is.GreaterThan(1));
         TestContext.Progress.WriteLine($"BAL sync test: head {BalSyncChainLength}, pivot {syncPivotNumber}.");
 
-        await client.Resolve<SyncTestContext>().SyncFromServerAndVerifyAccessLists(server, syncPivotNumber, cancellationToken);
+        await client.Resolve<SyncTestContext>().SyncFromServerAndVerifyAccessLists(server, syncPivotNumber, cancellationTokenSource.Token);
         Assert.That(client.Resolve<ISyncPointers>().LowestInsertedBlockAccessListBlockNumber, Is.LessThanOrEqualTo(1));
     }
 
     [Test]
-    [Category("Flaky"), Retry(5)]
+    [Category("Flaky"), Retry(2)]
     public async Task SnapSync_HalfPathServer_HashClient()
     {
         if (dbMode != DbMode.Default) Assert.Ignore("This test only runs on the Default (HalfPath) server fixture");
 
-        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(TestTimeout);
-
-        PrivateKey clientKey = TestItem.PrivateKeyD;
-        await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
+        await RunWithTimeout(TestTimeout, async cancellationToken =>
         {
-            SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
-            syncConfig.FastSync = true;
-            syncConfig.SnapSync = true;
+            PrivateKey clientKey = TestItem.PrivateKeyD;
+            await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
+            {
+                SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
+                syncConfig.FastSync = true;
+                syncConfig.SnapSync = true;
 
-            await SetPivot(syncConfig, cancellationTokenSource.Token);
+                await SetPivot(syncConfig, cancellationToken);
 
-            INetworkConfig networkConfig = cfg.GetConfig<INetworkConfig>();
-            networkConfig.P2PPort = AllocatePort();
-            networkConfig.FilterPeersByRecentIp = false;
-            networkConfig.FilterDiscoveryNodesByRecentIp = false;
-        }, DbMode.Hash);
+                INetworkConfig networkConfig = cfg.GetConfig<INetworkConfig>();
+                networkConfig.P2PPort = AllocatePort();
+                networkConfig.FilterPeersByRecentIp = false;
+                networkConfig.FilterDiscoveryNodesByRecentIp = false;
+            }, DbMode.Hash);
 
-        await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationTokenSource.Token);
+            await client.Resolve<SyncTestContext>().SyncFromServer(_server, cancellationToken);
+        });
     }
 
     [Test]
@@ -658,7 +672,6 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         }
 
         using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(BalSyncTestTimeout);
-        CancellationToken cancellationToken = cancellationTokenSource.Token;
 
         PrivateKey serverKey = TestItem.PrivateKeyE;
         await using IContainer server = await CreateNode(serverKey, (cfg, spec) =>
@@ -668,7 +681,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             return Task.CompletedTask;
         }, serverKey);
 
-        await StartServerAndBuildStorageChain(server, PartialBalSyncChainLength, cancellationToken, "Partial BAL sync server");
+        await StartServerAndBuildStorageChain(server, PartialBalSyncChainLength, cancellationTokenSource.Token, "Partial BAL sync server");
 
         IBlockTree serverBlockTree = server.Resolve<IBlockTree>();
         Assert.That(serverBlockTree.Head!.Number, Is.EqualTo(PartialBalSyncChainLength));
@@ -696,7 +709,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
             syncConfig.FastSync = true;
 
-            await SetPivot(server, syncConfig, cancellationToken, PartialBalSyncHeadPivotDistance);
+            await SetPivot(server, syncConfig, cancellationTokenSource.Token, PartialBalSyncHeadPivotDistance);
             syncPivotNumber = syncConfig.PivotNumber;
 
             ConfigureLocalNetwork(cfg, AllocatePort());
@@ -705,7 +718,7 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
         Assert.That(syncPivotNumber, Is.GreaterThan(PartialBalActivationBlock));
         TestContext.Progress.WriteLine($"Partial BAL sync test: head {PartialBalSyncChainLength}, pivot {syncPivotNumber}, activation {PartialBalActivationBlock}.");
 
-        await client.Resolve<SyncTestContext>().SyncFromServerAndVerifyAccessLists(server, syncPivotNumber, cancellationToken);
+        await client.Resolve<SyncTestContext>().SyncFromServerAndVerifyAccessLists(server, syncPivotNumber, cancellationTokenSource.Token);
         Assert.That(client.Resolve<ISyncPointers>().LowestInsertedBlockAccessListBlockNumber, Is.LessThanOrEqualTo(1));
     }
 
@@ -1056,29 +1069,11 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
                 await VerifyBlockAccessListsWith(sourceServer, syncPivotNumber, token);
             }, cancellationToken);
 
-        // Retry re-runs assertion failures but not errors, so a timeout has to fail rather than throw
-        // for the [Retry] on these tests to absorb it.
         private async Task ExecuteSyncFromServer(
             IContainer server,
             Func<IContainer, CancellationToken, Task> verification,
             CancellationToken cancellationToken,
             ulong finalizedDistanceFromHead = 250)
-        {
-            try
-            {
-                await ExecuteSyncFromServerCore(server, verification, cancellationToken, finalizedDistanceFromHead);
-            }
-            catch (OperationCanceledException e) when (cancellationToken.IsCancellationRequested)
-            {
-                Assert.Fail($"Sync did not finish before the test timeout.{Environment.NewLine}{e}");
-            }
-        }
-
-        private async Task ExecuteSyncFromServerCore(
-            IContainer server,
-            Func<IContainer, CancellationToken, Task> verification,
-            CancellationToken cancellationToken,
-            ulong finalizedDistanceFromHead)
         {
             await immediateDisconnectFailure.WatchForDisconnection(async (token) =>
             {


### PR DESCRIPTION
## Changes

The six end-to-end sync tests in `E2ESyncTests` are each marked `[Category("Flaky"), Retry(n)]`, but the retry never applies to the failure they actually produce.

NUnit's `RetryAttribute` re-runs a test whose result is a **failure** and not one whose result is an **error**, and an unhandled exception is an error. These tests bound themselves with a cancellation token and let the resulting `OperationCanceledException` propagate, so a timeout ends the test on the first attempt with the retry unused.

Measured on this branch with a throwaway probe in the same assembly, both marked `[Retry(5)]`:

| failure produced | attempts actually run |
| --- | --- |
| `Assert.Fail` | 5 |
| `TaskCanceledException` | 1 |

So `Retry(5)` on a timeout is decoration. This translates a cancellation of the test's own token into an assertion failure at `ExecuteSyncFromServer`, the one point all six tests funnel through, which is enough for the retry to engage. The original exception is interpolated into the failure message so the stack is not lost, and a timeout that reproduces on every attempt still fails the run — this suppresses a one-in-n flake, not a real stall.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

The flake this addresses is live on `master`, not something a PR introduced. `E2ESyncTests.SnapSync` failed with an identical `TaskCanceledException` from `ISyncModeSelector.WaitUntilMode` (`E2ESyncTests.cs:537`) in two `master` runs on 2026-09-02, [33596710696](https://github.com/NethermindEth/nethermind/actions/runs/33596710696) and [33562816488](https://github.com/NethermindEth/nethermind/actions/runs/33562816488), both in the extra-variants workflow.

Verified as follows:

- With the timeout temporarily forced to 1 ms, the 60 runnable `SnapSync` cases fail with the translated message, and node lifecycles in the run rise from one per test to 128 across 60 tests, i.e. the retry now re-runs the body. Without the change the same forced timeout produces one attempt per test.
- Restored to the real 60 s budget, `Nethermind.Synchronization.Test` passes in full: 2532 total, 0 failed, 2139 succeeded, 393 skipped — the same counts CI reports on a green run.
- The stress reproducer (`SnapSync_StressRepro`, 60 invocations) passes locally, and the tests average ~3 s against the 60 s budget, so the budget is not the problem and is left alone.

Release build of `Nethermind.slnx` clean, `code-lint.yml` gate clean (no `IDE`/`CA` warnings), `dotnet format whitespace --verify-no-changes` clean.

## Documentation

Requires documentation update: no
