### PR TITLE
Drop the gap marker from the frame receipt derivation note

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -94,7 +94,7 @@ namespace Nethermind.Serialization.Rlp
         }
 
         // EIP-8141 ReceiptPayload: [cumulative_gas_used, payer, [[status, gas_used, logs], ...]], gas_used = [execution, state].
-        // EIP8141-GAP: the spec receipt has no top-level status or bloom; both are derived from the frame receipts.
+        // The payload carries no top-level status or bloom; both are derived from the frame receipts.
         private void DecodeFrameTxReceipt(TxReceipt txReceipt, ref RlpReader ctx, RlpBehaviors rlpBehaviors)
         {
             int sequenceLength = ctx.ReadSequenceLength();


### PR DESCRIPTION
## Changes

- Drop the `EIP8141-GAP` marker from the frame-receipt derivation note in `ReceiptMessageDecoder`, keeping the sentence itself.

The marker read as a known limitation, but there is nothing unimplemented behind it. The receipt payload deliberately carries no top-level status or bloom, and both are fully derived today:

- status — `DecodeFrameTxReceipt` sets `StatusCode` from `TxFrameReceipt.AggregateStatus(frameReceipts)`, and the producing side (`BlockReceiptsTracer`) sets it from the same helper, so the two ends cannot drift.
- bloom — `TxReceipt.Bloom` falls back to `CalculateBloom()` over `Logs`, which `DecodeFrameTxReceipt` builds from the frame receipts' logs in frame order.

Neither omission is a gap to be closed upstream, so the marker is misleading where a plain note is not. The explanatory sentence stays, since it is what tells a reader why the decoder does not read status or bloom off the wire.

## Types of changes

#### What types of changes does your code introduce?

- [x] Documentation update

## Testing

#### Requires testing

- [x] No

#### Notes on testing

Comment-only. Full release build of `Nethermind.slnx` is clean (0 warnings, 0 errors), as is the lint gate in CI's form.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
