### PR TITLE
Keep a frame transaction's paymaster across a restart

### DIFF
--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -375,8 +375,8 @@ public static class FrameTxValidation
     /// still keyed. Derived from the frame layout alone, never from state. The target is resolved as the processor
     /// resolves it, so omitting it is not a second, uncapped encoding of the same transaction, and a sender paying
     /// for itself — the self-relay prefix included — uses no paymaster and is bounded by its own balance instead.
-    /// A frameless pool record instead answers from <see cref="Transaction.PersistedPaymaster"/>, unset after a
-    /// reload — <c>null</c> then means unknown, not unsponsored.
+    /// A frameless pool record instead answers from <see cref="Transaction.PersistedPaymaster"/>, which the record
+    /// persists; one written before it carried that slot reads <c>null</c> though sponsored, under-counting the cap.
     /// </remarks>
     public static Address? GetPrefixPaymaster(Transaction transaction)
     {

--- a/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
@@ -327,8 +327,85 @@ public class LightTxDecoderTests
         }
     }
 
-    // The group is written only for a payer, so a keys-only record keeps the flat list every earlier build
-    // writes — and stays readable by one, which a nested form would not be.
+    // The pool holds a frameless record, so the sponsor the cap counts is recoverable only from the record
+    // itself. A paymaster with no resolved payer leaves slot 1 empty, which is the shape that has to survive —
+    // including behind a populated keys list, which a keyed transaction admitted without simulation produces.
+    [TestCase(false, false, TestName = "paymaster alone")]
+    [TestCase(true, false, TestName = "paymaster behind a payer")]
+    [TestCase(false, true, TestName = "paymaster behind keys, no payer")]
+    [TestCase(true, true, TestName = "paymaster behind keys and a payer")]
+    public void Round_trip_carries_the_paymaster(bool withPayer, bool withKeys)
+    {
+        // Two keys, each 20 bytes wide: the shape byte-identical to an address plus a scalar.
+        UInt256[] keys = withKeys ? [UInt256.One << 152, (UInt256.One << 152) + 1] : null;
+        Transaction tx = BlobCarryingTx(TxType.FrameTx, nonceKeys: keys, paymaster: TestItem.AddressC);
+        if (withPayer)
+        {
+            tx.PayerAddress = TestItem.AddressB;
+            tx.PayerExposure = 12_345;
+        }
+
+        LightTransaction decoded = LightTxDecoder.Decode(LightTxDecoder.Encode(tx));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.PersistedPaymaster, Is.EqualTo(TestItem.AddressC));
+            Assert.That(FrameTxValidation.GetPrefixPaymaster(decoded), Is.EqualTo(TestItem.AddressC));
+            Assert.That(decoded.PayerAddress, Is.EqualTo(withPayer ? TestItem.AddressB : null));
+            Assert.That(decoded.NonceKeys, Is.EqualTo(keys));
+        }
+    }
+
+    // Downgrade readability is why the trailing fields are one nested group: a build predating a later slot
+    // must still read the record, losing that field rather than the whole record.
+    [Test]
+    public void A_group_carrying_a_slot_this_build_does_not_know_still_decodes()
+    {
+        byte[] bare = LightTxDecoder.Encode(BlobCarryingTx(TxType.FrameTx));
+        // [keys: [], payer: absent, exposure: 0, paymaster: AddressC, one slot this build has no name for]
+        byte[] group = [0xD9, 0xC0, 0x80, 0x80, 0x94, .. TestItem.AddressC.Bytes, 0x01];
+
+        LightTransaction decoded = LightTxDecoder.Decode([.. bare, .. group]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.PersistedPaymaster, Is.EqualTo(TestItem.AddressC));
+            Assert.That(decoded.PayerAddress, Is.Null);
+        }
+    }
+
+    // Slot 3 tolerates the placeholder for the reason slot 1 does: behind a later slot an absent paymaster is
+    // written out rather than omitted, so the strict read would throw on a record a newer build wrote.
+    [Test]
+    public void A_group_whose_paymaster_slot_is_empty_decodes_as_unsponsored()
+    {
+        byte[] bare = LightTxDecoder.Encode(BlobCarryingTx(TxType.FrameTx));
+        // [keys: [], payer: absent, exposure: 0, paymaster: absent, one slot this build has no name for]
+        byte[] group = [0xC5, 0xC0, 0x80, 0x80, 0x80, 0x01];
+
+        LightTransaction decoded = LightTxDecoder.Decode([.. bare, .. group]);
+
+        Assert.That(decoded.PersistedPaymaster, Is.Null);
+    }
+
+    // A paymaster on its own opens the group, so it costs the header, the empty keys list, the empty payer
+    // slot, a zero reservation and the address. Measured off two frameless records that differ in nothing
+    // else: carrying the sponsor in a pay frame instead would also move the two persisted size fields.
+    [Test]
+    public void A_paymaster_alone_grows_the_record_by_the_group_and_the_address()
+    {
+        static LightTransaction Record(Address paymaster) => new(
+            timestamp: 42, TestItem.AddressA, nonce: 7, TestItem.KeccakA, value: 5, gasLimit: 1_000_000,
+            gasPrice: 1, maxFeePerGas: 2, maxFeePerBlobGas: 3, [new byte[32]], poolIndex: 11, size: 100,
+            ProofVersion.V1, BlobCellMask.Full, sparseBlobNetworkSize: 100, TxType.FrameTx, paymaster: paymaster);
+
+        int grownBy = LightTxDecoder.Encode(Record(TestItem.AddressC)).Length - LightTxDecoder.Encode(Record(null)).Length;
+
+        Assert.That(grownBy, Is.EqualTo(1 + 1 + 1 + 1 + 21));
+    }
+
+    // The group is written only for a payer or a paymaster, so a keys-only record keeps the flat list every
+    // earlier build writes — and stays readable by one, which a nested form would not be.
     [Test]
     public void A_keys_only_record_keeps_the_flat_list()
     {
@@ -362,7 +439,7 @@ public class LightTxDecoderTests
         Assert.That(grownBy, Is.EqualTo(1 + 1 + 21 + 1));
     }
 
-    private static Transaction BlobCarryingTx(TxType type, ulong? deadline = null, UInt256[] nonceKeys = null)
+    private static Transaction BlobCarryingTx(TxType type, ulong? deadline = null, UInt256[] nonceKeys = null, Address paymaster = null)
     {
         byte[][] versionedHashes = [new byte[32]];
         Transaction tx = new()
@@ -385,7 +462,9 @@ public class LightTxDecoderTests
 
         if (type == TxType.FrameTx)
         {
-            tx.Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default)];
+            tx.Frames = paymaster is null
+                ? [FrameTxTestFrames.SelfVerify(FrameTxTestFrames.PrefixFrameGas)]
+                : [FrameTxTestFrames.OnlyVerify(FrameTxTestFrames.PrefixFrameGas), FrameTxTestFrames.Pay(paymaster, FrameTxTestFrames.PrefixFrameGas)];
             tx.FrameSignatures = [];
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -4792,17 +4792,15 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        // EIP8141-GAP: this pins a known bypass, not correct behaviour. A reloaded record carries no paymaster,
-        // so it takes no slot; the key cannot be persisted until the light-record trailing-field layout is settled
-        // (two adjacent optional sequences are ambiguous), which is why the fix is not here. Asserted so that a
-        // half-fix encoding the key on write but not on read fails here rather than silently under-counting.
+        // EIP-8141: the cap is summed over the pending set, so a record that survived a restart has to keep
+        // holding its sponsor's slot, and to free it on removal.
         [Test]
-        public void Restored_blob_carrying_frame_tx_bypasses_the_sponsor_cap_until_its_key_is_persisted()
+        public async Task Restored_blob_carrying_frame_tx_keeps_its_sponsor_slot_across_a_restart()
         {
             TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.StorageWithReorgs, PersistentBlobStorageSize = 10, BlobCacheSize = 10 };
             BlobTxStorage blobTxStorage = new();
             _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: blobTxStorage);
-            foreach (PrivateKey sender in new[] { TestItem.PrivateKeyA, TestItem.PrivateKeyB, TestItem.PrivateKeyC, TestItem.PrivateKeyD })
+            foreach (PrivateKey sender in new[] { TestItem.PrivateKeyA, TestItem.PrivateKeyB, TestItem.PrivateKeyC })
             {
                 EnsureSenderBalance(sender.Address, UInt256.MaxValue);
             }
@@ -4818,17 +4816,20 @@ namespace Nethermind.TxPool.Test
             _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: blobTxStorage);
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1), "the reloaded record is what the rest reads against");
 
+            // The bookkeeping check runs only on a head change, and the restore is the one place a slot is taken
+            // that the accumulator never sees being taken, so the seeded ledger needs a head to be checked at all.
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).TestObject);
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1), "a new head must not disturb what the cap is read against");
+
             AcceptTxResult afterRestart = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyB), TxHandlingOptions.None);
-            AcceptTxResult beyondTheHole = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyC), TxHandlingOptions.None);
 
             _txPool.RemoveTransaction(restored.Hash);
-            AcceptTxResult afterRestoredRemoval = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyD), TxHandlingOptions.None);
+            AcceptTxResult afterRestoredRemoval = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyC), TxHandlingOptions.None);
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(afterRestart, Is.EqualTo(AcceptTxResult.Accepted), "the bypass: the reloaded record has no sponsor to count");
-                Assert.That(beyondTheHole, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached), "the bypass costs one slot per restart rather than being unbounded");
-                Assert.That(afterRestoredRemoval, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached), "a record that took no slot must at least not free one");
+                Assert.That(afterRestart, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached), "the reloaded record still holds its sponsor's slot");
+                Assert.That(afterRestoredRemoval, Is.EqualTo(AcceptTxResult.Accepted), "removing it frees the slot it kept");
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPaymasterFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPaymasterFilter.cs
@@ -25,13 +25,7 @@ internal sealed class FrameTxPaymasterFilter(
 {
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        if (!tx.SupportsFrames)
-        {
-            return AcceptTxResult.Accepted;
-        }
-
-        Address? paymaster = FrameTxValidation.GetPrefixPaymaster(tx);
-        if (paymaster is null)
+        if (PendingPaymasterCache.KeyFor(tx) is not Address paymaster)
         {
             return AcceptTxResult.Accepted;
         }
@@ -66,5 +60,5 @@ internal sealed class FrameTxPaymasterFilter(
     /// slot while still taking one here.</remarks>
     private bool ReplacesPendingTxOfSamePaymaster(Transaction tx, Address paymaster) =>
         PendingReplacement.Find(tx, standardPool, blobPool) is Transaction replaced
-        && paymaster == FrameTxValidation.GetPrefixPaymaster(replaced);
+        && paymaster == PendingPaymasterCache.KeyFor(replaced);
 }

--- a/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/NotSupportedTxFilter.cs
@@ -28,9 +28,8 @@ internal sealed class NotSupportedTxFilter(ITxPoolConfig txPoolConfig, IChainHea
         // EIP8141-GAP (devnet only): frame txs are admitted while the fork is unscheduled on public networks.
         // Still missing: canonical-paymaster recognition (the EIP pins no runtime code) and re-counting the
         // cap when a pay target gains code, a deadline-ordered eviction index (only the near-expiry shed pass
-        // exists), the payer and paymaster on blob-pool records restored from disk, which LightTxDecoder cannot
-        // tell from the expiry deadline as a second optional trailing scalar, and an approve-flagged prefix
-        // frame whose target declines, which moves the real payer past the frame the cap keys on.
+        // exists), and an approve-flagged prefix frame whose target declines, which moves the real payer past
+        // the frame the cap keys on.
         // Revalidation itself is account-keyed, so it does not see a helper contract an opaque prefix
         // reaches through CALL*, nor the block context the prefix reads, and it skips the frameless
         // blob-pool record entirely, whose prefix is no longer there to re-resolve. A record admitted while

--- a/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
@@ -43,7 +43,7 @@ public class LightTransaction : Transaction
         PersistedExpiryDeadline = FrameTxValidation.TryGetExpiryDeadline(fullTx, out ulong deadline) ? deadline : null;
         // Derived here or the cap never counts a blob-carrying frame tx: the pool holds this frameless
         // record, so the paymaster is no longer recoverable from the frame list once the full tx is gone.
-        PersistedPaymaster = FrameTxValidation.GetPrefixPaymaster(fullTx);
+        PersistedPaymaster = PendingPaymasterCache.KeyFor(fullTx);
         BlobCellMask = (fullTx.NetworkWrapper as ShardBlobNetworkWrapper)?.GetAvailableCellMask() ?? default;
         _consensusEncodingSize = fullTx.GetLength(shouldCountBlobs: false);
         _size = fullTx.GetLength();
@@ -90,7 +90,8 @@ public class LightTransaction : Transaction
         ulong? expiryDeadline = null,
         UInt256[]? nonceKeys = null,
         Address? payerAddress = null,
-        UInt256? payerExposure = null)
+        UInt256? payerExposure = null,
+        Address? paymaster = null)
     {
         Type = type;
         Hash = hash;
@@ -113,6 +114,8 @@ public class LightTransaction : Transaction
         // admission took rather than nothing.
         PayerAddress = payerAddress;
         PayerExposure = payerExposure;
+        // The slot this record already holds against its sponsor, so the cap keeps counting it after a reload.
+        PersistedPaymaster = paymaster;
         _size = size;
     }
 

--- a/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
@@ -14,7 +14,7 @@ public class LightTxDecoder : TxDecoder<Transaction>
 {
     private const byte ConsensusEncodingSizeFormatVersion = 1;
 
-    private static int GetLength(Transaction tx) => Rlp.LengthOf(tx.Timestamp)
+    private static int GetLength(Transaction tx, Address? paymaster) => Rlp.LengthOf(tx.Timestamp)
                + Rlp.LengthOf(tx.SenderAddress)
                + Rlp.LengthOf(tx.Nonce)
                + Rlp.LengthOf(tx.Hash)
@@ -32,7 +32,7 @@ public class LightTxDecoder : TxDecoder<Transaction>
                + Rlp.LengthOf(ConsensusEncodingSizeFormatVersion)
                + Rlp.LengthOf((byte)tx.Type)
                + (FrameTxValidation.TryGetExpiryDeadline(tx, out ulong expiryDeadline) ? Rlp.LengthOf(expiryDeadline) : 0)
-               + TrailingLength(tx);
+               + TrailingLength(tx, paymaster);
 
     /// <summary>
     /// Length of the single optional trailing group, or zero when the record needs none.
@@ -41,29 +41,34 @@ public class LightTxDecoder : TxDecoder<Transaction>
     /// One group rather than two adjacent optional sequences: RLP cannot tell a 20-byte integer from an
     /// address, so a two-key <c>nonce_keys</c> list is byte-identical to a payer pair.
     /// </remarks>
-    private static int TrailingLength(Transaction tx)
+    private static int TrailingLength(Transaction tx, Address? paymaster)
     {
-        int content = TrailingContentLength(tx);
+        int content = TrailingContentLength(tx, paymaster);
         return content == 0
             ? tx.NonceKeys is { } keysOnly ? FrameTxNonceCalldata.KeysLength(keysOnly) : 0
             : Rlp.LengthOfSequence(content);
     }
 
-    /// <summary>Content length of the grouped form, or zero for a record that needs no payer.</summary>
-    private static int TrailingContentLength(Transaction tx)
+    /// <summary>Content length of the grouped form, or zero for a record that needs neither payer nor paymaster.</summary>
+    /// <remarks>The paymaster is passed in rather than re-derived, so the length pass and the write pass cannot
+    /// disagree and over- or under-fill the buffer.</remarks>
+    private static int TrailingContentLength(Transaction tx, Address? paymaster)
     {
-        if (tx.PayerAddress is null) return 0;
+        if (tx.PayerAddress is null && paymaster is null) return 0;
 
         // Slot 0 is always the keys list, so its sequence header is what tells this form from the flat
-        // nonce_keys list a payerless record still writes, whose first element is a scalar.
+        // nonce_keys list a groupless record still writes, whose first element is a scalar.
         return (tx.NonceKeys is { } nonceKeys ? FrameTxNonceCalldata.KeysLength(nonceKeys) : Rlp.LengthOfSequence(0))
                + Rlp.LengthOf(tx.PayerAddress)
-               + Rlp.LengthOf(tx.PayerExposure ?? default);
+               + Rlp.LengthOf(tx.PayerExposure ?? default)
+               + (paymaster is null ? 0 : Rlp.LengthOf(paymaster));
     }
 
     public static byte[] Encode(Transaction tx)
     {
-        byte[] bytes = new byte[GetLength(tx)];
+        // Read once through the pool's own key, so the record and the cap's ledger cannot disagree on the sponsor.
+        Address? paymaster = PendingPaymasterCache.KeyFor(tx);
+        byte[] bytes = new byte[GetLength(tx, paymaster)];
         RlpWriter writer = new(bytes);
 
         writer.Encode(tx.Timestamp);
@@ -88,10 +93,10 @@ public class LightTxDecoder : TxDecoder<Transaction>
         if (FrameTxValidation.TryGetExpiryDeadline(tx, out ulong expiryDeadline)) writer.Encode(expiryDeadline);
         // One optional trailing group, a sequence so the decoder tells it from the expiry deadline that only
         // sometimes precedes it. Written whole, so the keys list is present even when empty.
-        int trailingContent = TrailingContentLength(tx);
+        int trailingContent = TrailingContentLength(tx, paymaster);
         if (trailingContent == 0)
         {
-            // No payer, so no group: a keys-only record keeps the exact bytes every earlier build writes.
+            // Nothing to group: a keys-only record keeps the exact bytes every earlier build writes.
             if (tx.NonceKeys is { } keysOnly) FrameTxNonceCalldata.EncodeKeys(keysOnly, ref writer);
         }
         else
@@ -100,10 +105,13 @@ public class LightTxDecoder : TxDecoder<Transaction>
             if (tx.NonceKeys is { } nonceKeys) FrameTxNonceCalldata.EncodeKeys(nonceKeys, ref writer);
             else writer.StartSequence(0);
 
+            // Null when only the paymaster needs the group: a record admitted without simulation names a
+            // sponsor the cap counts, but has no resolved payer to reserve against.
             writer.Encode(tx.PayerAddress);
             // A payer that never reached the exposure gate holds no reservation, which this record does not
             // distinguish from a zero one: reserving, releasing and restoring zero are all no-ops.
             writer.Encode(tx.PayerExposure ?? default);
+            if (paymaster is not null) writer.Encode(paymaster);
         }
 
         return bytes;
@@ -154,6 +162,7 @@ public class LightTxDecoder : TxDecoder<Transaction>
         UInt256[]? nonceKeys = null;
         Address? payerAddress = null;
         UInt256? payerExposure = null;
+        Address? paymaster = null;
         if (ctx.PeekNumberOfItemsRemaining(maxSearch: 1) == 1)
         {
             // Legacy records end in a flat nonce_keys list, whose first element is a scalar; the grouped form
@@ -166,8 +175,15 @@ public class LightTxDecoder : TxDecoder<Transaction>
             if (trailingLength > 0 && ctx.IsSequenceNext())
             {
                 nonceKeys = DecodeKeysOrNull(ref ctx);
-                if (ctx.Position < end) payerAddress = ctx.DecodeAddress();
+                // Nullable: a group written for the paymaster alone leaves this slot empty.
+                if (ctx.Position < end) payerAddress = ctx.DecodeAddressOrNull();
                 if (ctx.Position < end) payerExposure = ctx.DecodeUInt256();
+                // Nullable for the same reason as the payer: once a later slot exists, an absent paymaster
+                // is written as the placeholder rather than omitted.
+                if (ctx.Position < end) paymaster = ctx.DecodeAddressOrNull();
+                // Anything a later build appended is skipped, so a new slot costs this one that field
+                // rather than making every grouped record unreadable.
+                ctx.Position = end;
             }
             else
             {
@@ -199,7 +215,8 @@ public class LightTxDecoder : TxDecoder<Transaction>
             expiryDeadline,
             nonceKeys,
             payerAddress,
-            payerExposure);
+            payerExposure,
+            paymaster);
     }
 
     private static void EncodeAvailableCellMask(Transaction tx, ref RlpWriter writer)

--- a/src/Nethermind/Nethermind.TxPool/PendingPaymasterCache.cs
+++ b/src/Nethermind/Nethermind.TxPool/PendingPaymasterCache.cs
@@ -16,6 +16,15 @@ internal sealed class PendingPaymasterCache
 {
     private readonly ConcurrentDictionary<AddressAsKey, int> _pending = new();
 
+    /// <summary>
+    /// The paymaster a frame transaction pays through, keying the EIP-8141 non-canonical paymaster cap;
+    /// <c>null</c> when it uses none.
+    /// </summary>
+    /// <remarks>The single definition of the key: the reserve that takes a slot, the restore and release that
+    /// return it, and the persisted record all derive it here, so no two of them can disagree on the sponsor.</remarks>
+    public static Address? KeyFor(Transaction tx) =>
+        tx.SupportsFrames ? FrameTxValidation.GetPrefixPaymaster(tx) : null;
+
     /// <summary>Pending frame transactions currently paying through <paramref name="key"/>.</summary>
     public int GetPendingCount(AddressAsKey key) => _pending.TryGetValue(key, out int count) ? count : 0;
 

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -217,8 +217,8 @@ namespace Nethermind.TxPool
                     TimeProvider.System,
                     RequestCurrentSpecRevalidation)
                 : new BlobTxDistinctSortedPool(txPoolConfig.BlobsSupport == BlobsSupportMode.InMemory ? _txPoolConfig.InMemoryBlobPoolSize : 0, comparer, logManager);
-            // Records restored inside the pool's constructor predate the handlers below, so the count and the
-            // payer ledger are seeded before subscribing: UpdatePool evicts during startup, and a removal must
+            // Records restored inside the pool's constructor predate the handlers below, so the count and both
+            // ledgers are seeded before subscribing: UpdatePool evicts during startup, and a removal must
             // release against a ledger that already covers what it removes.
             if (_blobTransactions.Count > 0)
             {
@@ -232,6 +232,12 @@ namespace Nethermind.TxPool
                     if (TryGetPayerReservation(restored, out Address? payer, out UInt256 reserved))
                     {
                         _payerExposure.Restore(payer, reserved);
+                    }
+
+                    // Re-taken rather than re-gated for the same reason, and through the key the release reads.
+                    if (PendingPaymasterCache.KeyFor(restored) is Address paymaster)
+                    {
+                        _pendingPaymasters.Reserve(paymaster);
                     }
                 }
             }
@@ -473,14 +479,6 @@ namespace Nethermind.TxPool
 
         private static bool HasExpiryDeadline(Transaction tx) => tx.SupportsFrames && FrameTxValidation.TryGetExpiryDeadline(tx, out _);
 
-        /// <summary>
-        /// The paymaster a pending frame transaction pays through, keying the EIP-8141 non-canonical
-        /// paymaster cap; <c>null</c> when it uses none, or when a reloaded record no longer records one.
-        /// </summary>
-        /// <remarks>Admission and release derive the same key from the record the pool holds, so a slot is
-        /// always returned to the sponsor it was taken from.</remarks>
-        private static Address? GetPaymaster(Transaction tx) => tx.SupportsFrames ? FrameTxValidation.GetPrefixPaymaster(tx) : null;
-
         [Conditional("DEBUG")]
         private void TrackPoolMutation()
         {
@@ -553,8 +551,7 @@ namespace Nethermind.TxPool
         }
 
 #if DEBUG
-        // A restored record's payer is persisted, so it is inside this check's reach. Its paymaster is not:
-        // LightTxDecoder drops it, so GetPaymaster prices null here and at release alike.
+        // A restored record's payer and paymaster are both persisted, so it is inside this check's reach.
         private static void AccumulateFrameTxBookkeeping(
             Transaction[] snapshot, Dictionary<AddressAsKey, UInt256> exposure, Dictionary<AddressAsKey, int> paymasters, ref int expiring)
         {
@@ -562,7 +559,7 @@ namespace Nethermind.TxPool
             {
                 if (HasExpiryDeadline(tx)) expiring++;
 
-                if (GetPaymaster(tx) is Address paymaster)
+                if (PendingPaymasterCache.KeyFor(tx) is Address paymaster)
                 {
                     paymasters[paymaster] = paymasters.TryGetValue(paymaster, out int pending) ? pending + 1 : 1;
                 }
@@ -1328,7 +1325,7 @@ namespace Nethermind.TxPool
                 // The cap counts ahead of the filters that follow it, so anything leaving the transaction
                 // unpooled — a later rejection or a throw — hands the slot back; AddCore clears the flag
                 // once the pool owns it or has released it itself.
-                if (state.PaymasterReserved && GetPaymaster(tx) is Address paymaster)
+                if (state.PaymasterReserved && PendingPaymasterCache.KeyFor(tx) is Address paymaster)
                 {
                     _pendingPaymasters.Decrement(paymaster);
                 }
@@ -1544,7 +1541,7 @@ namespace Nethermind.TxPool
                 _payerExposure.Subtract(payer, maxCost);
             }
 
-            if (GetPaymaster(tx) is Address paymaster)
+            if (PendingPaymasterCache.KeyFor(tx) is Address paymaster)
             {
                 _pendingPaymasters.Decrement(paymaster);
             }


### PR DESCRIPTION
## Changes

Closes the `EIP8141-GAP` marker in `TxPoolTests.Blobs` that pinned a known bypass: a blob-carrying frame transaction reloaded from disk carried no paymaster, so it took no slot against the non-canonical paymaster cap. The cap under-counted by one per restart, and the test asserted the bypass rather than correct behaviour.

- `LightTxDecoder` — carry the paymaster as a fourth slot of the trailing group. The payer slot becomes nullable, so a record that names a sponsor but has no resolved payer still opens the group.
- `LightTransaction` — restore `PersistedPaymaster` from the decoded record.
- `TxPool` — re-take the sponsor's slot for restored records in the constructor, before the insert/removal handlers are subscribed, mirroring how the payer's exposure is restored. Admission, restore and release all key off `GetPaymaster`, so a slot is always returned to the sponsor it was taken from.
- Rewrite the bypass test as `Restored_blob_carrying_frame_tx_keeps_its_sponsor_slot_across_a_restart`.

### Why this is possible now

The marker said the key could not be persisted until the light-record trailing-field layout was settled, because two adjacent optional sequences are ambiguous. The base branch replaced that layout with a single nested group carrying a structural discriminator, whose slots are read positionally against the group end. A fourth slot is therefore unambiguous, and the ambiguity the marker cited no longer applies.

The group landed in the base branch with #12897, so this builds directly on it.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `Round_trip_carries_the_paymaster` covers a paymaster alone (the empty payer slot) and a paymaster behind a payer.
- `A_paymaster_alone_grows_the_record_by_the_group_and_the_address` pins the encoded size, so a layout change has to be deliberate.
- `Restored_blob_carrying_frame_tx_keeps_its_sponsor_slot_across_a_restart` asserts the reloaded record still holds its sponsor's slot, and frees it on removal.

Negative control: reverting the three production files and keeping the tests fails 4 of the 5, including both round-trip cases and the restart case.

`Nethermind.TxPool.Test` is green in both configurations — 967 tests, 0 failures in release and in debug, the latter covering the `#if DEBUG` ledger symmetry assert that a one-sided restore would trip. Full release build of `Nethermind.slnx` is clean, as is the lint gate in CI's form (positive-controlled).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
