### PR TITLE
fix(engine): apply custody columns on forkchoiceUpdatedV5

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/Data/EngineRpcParameterConvertersTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/Data/EngineRpcParameterConvertersTests.cs
@@ -72,6 +72,28 @@ public class EngineRpcParameterConvertersTests
         Assert.That(mask, Has.Length.EqualTo(BlobCellMask.CellCount));
     }
 
+    // Pins the wire bit convention shared by every packing site: bit i is bit i % 8 of byte i / 8.
+    [Test]
+    public void Blob_cell_mask_converter_round_trips_the_wire_bit_order()
+    {
+        JsonSerializerOptions options = CreateOptions(new BlobCellBitArrayConverter());
+        int[] indices = [0, 60, 62, 100, 114, BlobCellMask.CellCount - 1];
+        BitArray bits = new(BlobCellMask.CellCount);
+        foreach (int index in indices)
+        {
+            bits.Set(index, true);
+        }
+
+        string json = JsonSerializer.Serialize(bits, options);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(json, Is.EqualTo("\"0x01000000000000500000000010000480\""));
+            Assert.That(BlobCellBits.ToMask(bits), Is.EqualTo(BlobCellMask.FromIndices(indices)));
+            Assert.That(JsonSerializer.Deserialize<BitArray>(json, options), Is.EqualTo(bits));
+        }
+    }
+
     private static JsonSerializerOptions CreateOptions(System.Text.Json.Serialization.JsonConverter converter)
     {
         JsonSerializerOptions options = new();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -936,14 +936,27 @@ public partial class EngineModuleTests
         yield return EngineApiVersions.Fcu.V5;
     }
 
-    private static IReleaseSpec CustodyColumnFcuSpec(int version) =>
-        version == EngineApiVersions.Fcu.V4 ? Amsterdam.Instance : Bogota.Instance;
+    private static IReleaseSpec CustodyColumnFcuSpec(int version) => version switch
+    {
+        EngineApiVersions.Fcu.V4 => Amsterdam.Instance,
+        EngineApiVersions.Fcu.V5 => Bogota.Instance,
+        _ => throw new ArgumentOutOfRangeException(nameof(version), version, "Unhandled forkchoice version")
+    };
+
+    private static string CustodyColumnFcuMethodName(int version) => version switch
+    {
+        EngineApiVersions.Fcu.V4 => nameof(IEngineRpcModule.engine_forkchoiceUpdatedV4),
+        EngineApiVersions.Fcu.V5 => nameof(IEngineRpcModule.engine_forkchoiceUpdatedV5),
+        _ => throw new ArgumentOutOfRangeException(nameof(version), version, "Unhandled forkchoice version")
+    };
 
     private static async Task<IResultWrapper> ForkchoiceUpdatedWithCustodyColumns(
-        IEngineRpcModule rpcModule, int version, ForkchoiceStateV1 forkchoiceState, BitArray custodyColumns) =>
-        version == EngineApiVersions.Fcu.V4
-            ? await rpcModule.engine_forkchoiceUpdatedV4(forkchoiceState, payloadAttributes: null, custodyColumns)
-            : await rpcModule.engine_forkchoiceUpdatedV5(forkchoiceState, payloadAttributes: null, custodyColumns);
+        IEngineRpcModule rpcModule, int version, ForkchoiceStateV1 forkchoiceState, BitArray custodyColumns) => version switch
+        {
+            EngineApiVersions.Fcu.V4 => await rpcModule.engine_forkchoiceUpdatedV4(forkchoiceState, payloadAttributes: null, custodyColumns),
+            EngineApiVersions.Fcu.V5 => await rpcModule.engine_forkchoiceUpdatedV5(forkchoiceState, payloadAttributes: null, custodyColumns),
+            _ => throw new ArgumentOutOfRangeException(nameof(version), version, "Unhandled forkchoice version")
+        };
 
     [TestCaseSource(nameof(CustodyColumnFcuVersions))]
     public async Task ForkchoiceUpdated_should_update_blob_custody_tracker(int version)
@@ -1000,10 +1013,10 @@ public partial class EngineModuleTests
         }
     }
 
-    [Test]
-    public async Task ForkchoiceUpdatedV4_should_accept_hex_custody_columns_bitarray_over_json_rpc()
+    [TestCaseSource(nameof(CustodyColumnFcuVersions))]
+    public async Task ForkchoiceUpdated_should_accept_hex_custody_columns_bitarray_over_json_rpc(int version)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Amsterdam.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: CustodyColumnFcuSpec(version));
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
         IBlobCustodyTracker blobCustodyTracker = chain.Container.Resolve<IBlobCustodyTracker>();
 
@@ -1016,7 +1029,7 @@ public partial class EngineModuleTests
 
         string response = await RpcTest.TestSerializedRequest(
             rpcModule,
-            "engine_forkchoiceUpdatedV4",
+            CustodyColumnFcuMethodName(version),
             chain.JsonSerializer.Serialize(forkchoiceState),
             null,
             "0x00000000000000500000000010000400");
@@ -1032,11 +1045,24 @@ public partial class EngineModuleTests
         }
     }
 
-    [Test]
-    public async Task ForkchoiceUpdatedV4_should_reject_invalid_hex_custody_columns_over_json_rpc()
+    // The prefix-less case only rejects if the version declares the strict BlobCellBitArrayConverter:
+    // the lenient fallback converter decodes it into a well-formed 128-bit mask, which then passes the
+    // length check behind it. So this is what holds the two versions' parameter binding together.
+    private static IEnumerable<TestCaseData> MalformedCustodyColumnsOverJsonRpc()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Amsterdam.Instance);
+        foreach (int version in CustodyColumnFcuVersions())
+        {
+            yield return new TestCaseData(version, "0x");
+            yield return new TestCaseData(version, "00000000000000500000000010000400");
+        }
+    }
+
+    [TestCaseSource(nameof(MalformedCustodyColumnsOverJsonRpc))]
+    public async Task ForkchoiceUpdated_should_reject_invalid_hex_custody_columns_over_json_rpc(int version, string custodyColumns)
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: CustodyColumnFcuSpec(version));
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
+        IBlobCustodyTracker blobCustodyTracker = chain.Container.Resolve<IBlobCustodyTracker>();
         var forkchoiceState = new
         {
             headBlockHash = chain.BlockTree.HeadHash.ToString(true),
@@ -1046,12 +1072,16 @@ public partial class EngineModuleTests
 
         string response = await RpcTest.TestSerializedRequest(
             rpcModule,
-            "engine_forkchoiceUpdatedV4",
+            CustodyColumnFcuMethodName(version),
             chain.JsonSerializer.Serialize(forkchoiceState),
             null,
-            "0x");
+            custodyColumns);
 
-        Assert.That(JsonNode.Parse(response)?["error"]?["code"]?.GetValue<int>(), Is.EqualTo(ErrorCodes.InvalidParams));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(JsonNode.Parse(response)?["error"]?["code"]?.GetValue<int>(), Is.EqualTo(ErrorCodes.InvalidParams));
+            Assert.That(blobCustodyTracker.CurrentMask, Is.EqualTo(BlobCellMask.Empty));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -929,16 +929,32 @@ public partial class EngineModuleTests
         }
     }
 
-    [Test]
-    public async Task ForkchoiceUpdatedV4_should_update_blob_custody_tracker()
+    // Every forkchoice version that accepts custody columns must handle them identically (execution-apis#793).
+    private static IEnumerable<int> CustodyColumnFcuVersions()
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Amsterdam.Instance);
+        yield return EngineApiVersions.Fcu.V4;
+        yield return EngineApiVersions.Fcu.V5;
+    }
+
+    private static IReleaseSpec CustodyColumnFcuSpec(int version) =>
+        version == EngineApiVersions.Fcu.V4 ? Amsterdam.Instance : Bogota.Instance;
+
+    private static async Task<IResultWrapper> ForkchoiceUpdatedWithCustodyColumns(
+        IEngineRpcModule rpcModule, int version, ForkchoiceStateV1 forkchoiceState, BitArray custodyColumns) =>
+        version == EngineApiVersions.Fcu.V4
+            ? await rpcModule.engine_forkchoiceUpdatedV4(forkchoiceState, payloadAttributes: null, custodyColumns)
+            : await rpcModule.engine_forkchoiceUpdatedV5(forkchoiceState, payloadAttributes: null, custodyColumns);
+
+    [TestCaseSource(nameof(CustodyColumnFcuVersions))]
+    public async Task ForkchoiceUpdated_should_update_blob_custody_tracker(int version)
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: CustodyColumnFcuSpec(version));
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
         IBlobCustodyTracker blobCustodyTracker = chain.Container.Resolve<IBlobCustodyTracker>();
 
         BlobCellMask custodyMask = BlobCellMask.FromIndices([1, 4, 9]);
         ForkchoiceStateV1 forkchoiceState = new(chain.BlockTree.HeadHash, chain.BlockTree.HeadHash, chain.BlockTree.HeadHash);
-        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpcModule.engine_forkchoiceUpdatedV4(forkchoiceState, payloadAttributes: null, custodyColumns: ToBitArray(custodyMask));
+        IResultWrapper result = await ForkchoiceUpdatedWithCustodyColumns(rpcModule, version, forkchoiceState, ToBitArray(custodyMask));
 
         using (Assert.EnterMultipleScope())
         {
@@ -947,16 +963,16 @@ public partial class EngineModuleTests
         }
     }
 
-    [Test]
-    public async Task ForkchoiceUpdatedV4_should_update_blob_custody_tracker_even_when_forkchoice_fails()
+    [TestCaseSource(nameof(CustodyColumnFcuVersions))]
+    public async Task ForkchoiceUpdated_should_update_blob_custody_tracker_even_when_forkchoice_fails(int version)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Amsterdam.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: CustodyColumnFcuSpec(version));
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
         IBlobCustodyTracker blobCustodyTracker = chain.Container.Resolve<IBlobCustodyTracker>();
 
         BlobCellMask custodyMask = BlobCellMask.FromIndices([2, 7]);
         ForkchoiceStateV1 forkchoiceState = new(chain.BlockTree.HeadHash, TestItem.KeccakF, chain.BlockTree.HeadHash);
-        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpcModule.engine_forkchoiceUpdatedV4(forkchoiceState, payloadAttributes: null, custodyColumns: ToBitArray(custodyMask));
+        IResultWrapper result = await ForkchoiceUpdatedWithCustodyColumns(rpcModule, version, forkchoiceState, ToBitArray(custodyMask));
 
         using (Assert.EnterMultipleScope())
         {
@@ -966,15 +982,15 @@ public partial class EngineModuleTests
         }
     }
 
-    [Test]
-    public async Task ForkchoiceUpdatedV4_should_reject_invalid_custody_columns_bitarray()
+    [TestCaseSource(nameof(CustodyColumnFcuVersions))]
+    public async Task ForkchoiceUpdated_should_reject_invalid_custody_columns_bitarray(int version)
     {
-        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: Amsterdam.Instance);
+        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: CustodyColumnFcuSpec(version));
         IEngineRpcModule rpcModule = chain.EngineRpcModule;
         IBlobCustodyTracker blobCustodyTracker = chain.Container.Resolve<IBlobCustodyTracker>();
 
         ForkchoiceStateV1 forkchoiceState = new(chain.BlockTree.HeadHash, chain.BlockTree.HeadHash, chain.BlockTree.HeadHash);
-        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpcModule.engine_forkchoiceUpdatedV4(forkchoiceState, payloadAttributes: null, custodyColumns: new BitArray(0));
+        IResultWrapper result = await ForkchoiceUpdatedWithCustodyColumns(rpcModule, version, forkchoiceState, new BitArray(0));
 
         using (Assert.EnterMultipleScope())
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -304,16 +304,35 @@ public class SszMiddlewareTests
         _engineModule.engine_forkchoiceUpdatedV4(Arg.Any<ForkchoiceStateV1>(), Arg.Any<PayloadAttributes?>(), Arg.Any<BitArray?>())
             .Returns(ResultWrapper<ForkchoiceUpdatedV1Result>.Success(fcuResult));
 
-        BitArray custodyColumns = new(128);
-        custodyColumns.Set(0, true);
-        custodyColumns.Set(3, true);
-        custodyColumns.Set(127, true);
+        BitArray custodyColumns = CustodyColumnsFixture();
         DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", BuildForkchoiceV4Request(custodyColumns), fork: "amsterdam");
 
         await _middleware.InvokeAsync(ctx);
 
         Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
         await _engineModule.Received(1).engine_forkchoiceUpdatedV4(
+            Arg.Any<ForkchoiceStateV1>(),
+            Arg.Any<PayloadAttributes?>(),
+            Arg.Is<BitArray>(actual => BitsEqual(actual, custodyColumns)));
+    }
+
+    [Test]
+    public async Task Forkchoice_v5_passes_custody_columns()
+    {
+        ForkchoiceUpdatedV2Result fcuResult = new()
+        {
+            PayloadStatus = new PayloadStatusV2 { Status = PayloadStatus.Valid, LatestValidHash = TestItem.KeccakA }
+        };
+        _engineModule.engine_forkchoiceUpdatedV5(Arg.Any<ForkchoiceStateV1>(), Arg.Any<PayloadAttributes?>(), Arg.Any<BitArray?>())
+            .Returns(ResultWrapper<ForkchoiceUpdatedV2Result>.Success(fcuResult));
+
+        BitArray custodyColumns = CustodyColumnsFixture();
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", BuildForkchoiceV5Request(custodyColumns), fork: "bogota");
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+        await _engineModule.Received(1).engine_forkchoiceUpdatedV5(
             Arg.Any<ForkchoiceStateV1>(),
             Arg.Any<PayloadAttributes?>(),
             Arg.Is<BitArray>(actual => BitsEqual(actual, custodyColumns)));
@@ -766,6 +785,28 @@ public class SszMiddlewareTests
             PayloadAttributes = [],
             CustodyColumns = custodyColumns is null ? [] : [new SszCustodyColumns { Bits = custodyColumns }],
         });
+
+    private static byte[] BuildForkchoiceV5Request(BitArray? custodyColumns = null) =>
+        ForkchoiceUpdatedV5RequestWire.Encode(new ForkchoiceUpdatedV5RequestWire
+        {
+            ForkchoiceState = new ForkchoiceStateWire
+            {
+                HeadBlockHash = TestItem.KeccakA,
+                SafeBlockHash = TestItem.KeccakB,
+                FinalizedBlockHash = Keccak.Zero,
+            },
+            PayloadAttributes = [],
+            CustodyColumns = custodyColumns is null ? [] : [new SszCustodyColumns { Bits = custodyColumns }],
+        });
+
+    private static BitArray CustodyColumnsFixture()
+    {
+        BitArray custodyColumns = new(128);
+        custodyColumns.Set(0, true);
+        custodyColumns.Set(3, true);
+        custodyColumns.Set(127, true);
+        return custodyColumns;
+    }
 
     private static bool BitsEqual(BitArray actual, BitArray expected)
     {
@@ -1348,18 +1389,7 @@ public class SszMiddlewareTests
         _engineModule.engine_forkchoiceUpdatedV5(Arg.Any<ForkchoiceStateV1>(), Arg.Any<PayloadAttributes?>(), Arg.Any<BitArray?>())
             .Returns(ResultWrapper<ForkchoiceUpdatedV2Result>.Success(fcuResult));
 
-        byte[] body = ForkchoiceUpdatedV5RequestWire.Encode(new ForkchoiceUpdatedV5RequestWire
-        {
-            ForkchoiceState = new ForkchoiceStateWire
-            {
-                HeadBlockHash = TestItem.KeccakA,
-                SafeBlockHash = TestItem.KeccakB,
-                FinalizedBlockHash = Keccak.Zero
-            },
-            PayloadAttributes = [],
-            CustodyColumns = []
-        });
-        DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", body, fork: "bogota");
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/forkchoice", BuildForkchoiceV5Request(), fork: "bogota");
 
         await _middleware.InvokeAsync(ctx);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/BlobCellBits.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/BlobCellBits.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections;
+using Nethermind.Core;
+
+namespace Nethermind.Merge.Plugin.Data;
+
+/// <summary>The single place the Engine API cell-bitfield bit convention lives.</summary>
+internal static class BlobCellBits
+{
+    /// <summary>Packs a bitfield of exactly <see cref="BlobCellMask.CellCount"/> bits into its mask.</summary>
+    /// <remarks><see cref="BitArray.CopyTo(System.Array, int)"/> already emits the wire layout: bit <c>i</c>
+    /// is bit <c>i % 8</c> of byte <c>i / 8</c>.</remarks>
+    /// <param name="bits">The bitfield, which callers must have length-checked.</param>
+    internal static BlobCellMask ToMask(BitArray bits)
+    {
+        byte[] bytes = new byte[BlobCellMask.FixedByteLength];
+        bits.CopyTo(bytes, 0);
+        return BlobCellMask.FromBytes(bytes);
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/EngineRpcParameterConverters.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/EngineRpcParameterConverters.cs
@@ -125,15 +125,7 @@ internal sealed class BlobCellBitArrayConverter : JsonConverter<BitArray>
         }
 
         Span<byte> bytes = stackalloc byte[BlobCellMask.FixedByteLength];
-        bytes.Clear();
-        for (int i = 0; i < value.Length; i++)
-        {
-            if (value.Get(i))
-            {
-                bytes[i >> 3] |= (byte)(1 << (i & 7));
-            }
-        }
-
+        BlobCellBits.ToMask(value).WriteTo(bytes);
         ByteArrayConverter.Convert(writer, bytes, skipLeadingZeros: false);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Amsterdam.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Amsterdam.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -51,38 +50,4 @@ public partial class EngineRpcModule : IEngineRpcModule
 
     public Task<ResultWrapper<IReadOnlyList<BlobCellsAndProofs?>?>> engine_getBlobsV4(byte[][] blobVersionedHashes, BitArray indicesBitarray)
         => _getBlobsHandlerV4.HandleAsync(new(blobVersionedHashes, indicesBitarray));
-
-    /// <summary>Validates a custody-column update carried by a forkchoice call, and applies it
-    /// (execution-apis#793).</summary>
-    /// <remarks>Shared by every forkchoice version that accepts the field, so the validation and the
-    /// tracker update cannot drift apart between them. Applying is best-effort per execution-apis#793 —
-    /// a failure is logged and swallowed; only a malformed bitfield is reported back to the caller.</remarks>
-    /// <returns><c>null</c> when there is nothing to reject, otherwise the <c>InvalidParams</c> message.</returns>
-    private string? ValidateAndApplyCustodyColumns(BitArray? custodyColumns)
-    {
-        if (custodyColumns is null) return null;
-        if (custodyColumns.Length != BlobCellMask.CellCount)
-            return $"Custody columns must be exactly {BlobCellMask.FixedByteLength} bytes.";
-
-        try
-        {
-            Span<byte> bytes = stackalloc byte[BlobCellMask.FixedByteLength];
-            bytes.Clear();
-            for (int i = 0; i < BlobCellMask.CellCount; i++)
-            {
-                if (custodyColumns.Get(i))
-                {
-                    bytes[i >> 3] |= (byte)(1 << (i & 7));
-                }
-            }
-
-            _blobCustodyTracker.Update(BlobCellMask.FromBytes(bytes));
-        }
-        catch (Exception ex)
-        {
-            if (_logger.IsWarn) _logger.Warn($"Failed to update blob custody columns: {ex.Message}");
-        }
-
-        return null;
-    }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Amsterdam.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Amsterdam.cs
@@ -38,7 +38,7 @@ public partial class EngineRpcModule : IEngineRpcModule
             new ExecutionPayloadParams<ExecutionPayloadV4>(executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequests));
 
     public Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV4(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null, BitArray? custodyColumns = null)
-        => TryUpdateCustodyColumns(custodyColumns) is { } error
+        => ValidateAndApplyCustodyColumns(custodyColumns) is { } error
             ? Task.FromResult(ResultWrapper<ForkchoiceUpdatedV1Result>.Fail(error, ErrorCodes.InvalidParams))
             : ForkchoiceUpdated(forkchoiceState, payloadAttributes, EngineApiVersions.Fcu.V4);
 
@@ -52,12 +52,13 @@ public partial class EngineRpcModule : IEngineRpcModule
     public Task<ResultWrapper<IReadOnlyList<BlobCellsAndProofs?>?>> engine_getBlobsV4(byte[][] blobVersionedHashes, BitArray indicesBitarray)
         => _getBlobsHandlerV4.HandleAsync(new(blobVersionedHashes, indicesBitarray));
 
-    /// <summary>Applies a custody-column update carried by a forkchoice call (execution-apis#793).</summary>
+    /// <summary>Validates a custody-column update carried by a forkchoice call, and applies it
+    /// (execution-apis#793).</summary>
     /// <remarks>Shared by every forkchoice version that accepts the field, so the validation and the
     /// tracker update cannot drift apart between them. Applying is best-effort per execution-apis#793 —
     /// a failure is logged and swallowed; only a malformed bitfield is reported back to the caller.</remarks>
     /// <returns><c>null</c> when there is nothing to reject, otherwise the <c>InvalidParams</c> message.</returns>
-    private string? TryUpdateCustodyColumns(BitArray? custodyColumns)
+    private string? ValidateAndApplyCustodyColumns(BitArray? custodyColumns)
     {
         if (custodyColumns is null) return null;
         if (custodyColumns.Length != BlobCellMask.CellCount)

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Amsterdam.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Amsterdam.cs
@@ -38,21 +38,9 @@ public partial class EngineRpcModule : IEngineRpcModule
             new ExecutionPayloadParams<ExecutionPayloadV4>(executionPayload, blobVersionedHashes, parentBeaconBlockRoot, executionRequests));
 
     public Task<ResultWrapper<ForkchoiceUpdatedV1Result>> engine_forkchoiceUpdatedV4(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null, BitArray? custodyColumns = null)
-    {
-        if (custodyColumns is { Length: not BlobCellMask.CellCount })
-        {
-            return Task.FromResult(ResultWrapper<ForkchoiceUpdatedV1Result>.Fail(
-                $"Custody columns must be exactly {BlobCellMask.FixedByteLength} bytes.",
-                ErrorCodes.InvalidParams));
-        }
-
-        if (custodyColumns is not null)
-        {
-            TryUpdateCustodyColumns(custodyColumns);
-        }
-
-        return ForkchoiceUpdated(forkchoiceState, payloadAttributes, EngineApiVersions.Fcu.V4);
-    }
+        => TryUpdateCustodyColumns(custodyColumns) is { } error
+            ? Task.FromResult(ResultWrapper<ForkchoiceUpdatedV1Result>.Fail(error, ErrorCodes.InvalidParams))
+            : ForkchoiceUpdated(forkchoiceState, payloadAttributes, EngineApiVersions.Fcu.V4);
 
     public Task<ResultWrapper<IReadOnlyList<ExecutionPayloadBodyV2Result?>>> engine_getPayloadBodiesByHashV2(
         IReadOnlyList<Hash256> blockHashes)
@@ -64,8 +52,17 @@ public partial class EngineRpcModule : IEngineRpcModule
     public Task<ResultWrapper<IReadOnlyList<BlobCellsAndProofs?>?>> engine_getBlobsV4(byte[][] blobVersionedHashes, BitArray indicesBitarray)
         => _getBlobsHandlerV4.HandleAsync(new(blobVersionedHashes, indicesBitarray));
 
-    private void TryUpdateCustodyColumns(BitArray custodyColumns)
+    /// <summary>Applies a custody-column update carried by a forkchoice call (execution-apis#793).</summary>
+    /// <remarks>Shared by every forkchoice version that accepts the field, so the validation and the
+    /// tracker update cannot drift apart between them. Applying is best-effort per execution-apis#793 —
+    /// a failure is logged and swallowed; only a malformed bitfield is reported back to the caller.</remarks>
+    /// <returns><c>null</c> when there is nothing to reject, otherwise the <c>InvalidParams</c> message.</returns>
+    private string? TryUpdateCustodyColumns(BitArray? custodyColumns)
     {
+        if (custodyColumns is null) return null;
+        if (custodyColumns.Length != BlobCellMask.CellCount)
+            return $"Custody columns must be exactly {BlobCellMask.FixedByteLength} bytes.";
+
         try
         {
             Span<byte> bytes = stackalloc byte[BlobCellMask.FixedByteLength];
@@ -84,5 +81,7 @@ public partial class EngineRpcModule : IEngineRpcModule
         {
             if (_logger.IsWarn) _logger.Warn($"Failed to update blob custody columns: {ex.Message}");
         }
+
+        return null;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Bogota.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Bogota.cs
@@ -74,7 +74,9 @@ public partial class EngineRpcModule : IEngineRpcModule
         ForkchoiceStateV1 forkchoiceState,
         PayloadAttributes? payloadAttributes = null,
         BitArray? custodyColumns = null)
-        => ForkchoiceUpdatedWithInclusionList(forkchoiceState, payloadAttributes, EngineApiVersions.Fcu.V5);
+        => TryUpdateCustodyColumns(custodyColumns) is { } error
+            ? Task.FromResult(ResultWrapper<ForkchoiceUpdatedV2Result>.Fail(error, ErrorCodes.InvalidParams))
+            : ForkchoiceUpdatedWithInclusionList(forkchoiceState, payloadAttributes, EngineApiVersions.Fcu.V5);
 
     /// <summary>Registers any inclusion list for the build, then runs <see cref="ForkchoiceUpdated"/> and maps
     /// its result onto the Bogota <see cref="ForkchoiceUpdatedV2Result"/> shape.</summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Bogota.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.Bogota.cs
@@ -74,7 +74,7 @@ public partial class EngineRpcModule : IEngineRpcModule
         ForkchoiceStateV1 forkchoiceState,
         PayloadAttributes? payloadAttributes = null,
         BitArray? custodyColumns = null)
-        => TryUpdateCustodyColumns(custodyColumns) is { } error
+        => ValidateAndApplyCustodyColumns(custodyColumns) is { } error
             ? Task.FromResult(ResultWrapper<ForkchoiceUpdatedV2Result>.Fail(error, ErrorCodes.InvalidParams))
             : ForkchoiceUpdatedWithInclusionList(forkchoiceState, payloadAttributes, EngineApiVersions.Fcu.V5);
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
@@ -132,17 +132,7 @@ public partial class EngineRpcModule(
 
         try
         {
-            Span<byte> bytes = stackalloc byte[BlobCellMask.FixedByteLength];
-            bytes.Clear();
-            for (int i = 0; i < BlobCellMask.CellCount; i++)
-            {
-                if (custodyColumns.Get(i))
-                {
-                    bytes[i >> 3] |= (byte)(1 << (i & 7));
-                }
-            }
-
-            _blobCustodyTracker.Update(BlobCellMask.FromBytes(bytes));
+            _blobCustodyTracker.Update(BlobCellBits.ToMask(custodyColumns));
         }
         catch (Exception ex)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/EngineRpcModule.cs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Nethermind.Api;
 using Nethermind.Consensus.Transactions;
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.JsonRpc;
@@ -115,4 +117,38 @@ public partial class EngineRpcModule(
 
     public ResultWrapper<ClientVersionV1[]> engine_getClientVersionV1(ClientVersionV1 clientVersionV1) =>
         ResultWrapper<ClientVersionV1[]>.Success(string.IsNullOrEmpty(clientVersionV1.Code) ? [new()] : [new(), clientVersionV1]);
+
+    /// <summary>Validates a custody-column update carried by a forkchoice call, and applies it
+    /// (execution-apis#793).</summary>
+    /// <remarks>Shared by every forkchoice version that accepts the field, so the validation and the
+    /// tracker update cannot drift apart between them. Applying is best-effort per execution-apis#793 —
+    /// a failure is logged and swallowed; only a malformed bitfield is reported back to the caller.</remarks>
+    /// <returns><c>null</c> when there is nothing to reject, otherwise the <c>InvalidParams</c> message.</returns>
+    private string? ValidateAndApplyCustodyColumns(BitArray? custodyColumns)
+    {
+        if (custodyColumns is null) return null;
+        if (custodyColumns.Length != BlobCellMask.CellCount)
+            return $"Custody columns must be exactly {BlobCellMask.FixedByteLength} bytes.";
+
+        try
+        {
+            Span<byte> bytes = stackalloc byte[BlobCellMask.FixedByteLength];
+            bytes.Clear();
+            for (int i = 0; i < BlobCellMask.CellCount; i++)
+            {
+                if (custodyColumns.Get(i))
+                {
+                    bytes[i >> 3] |= (byte)(1 << (i & 7));
+                }
+            }
+
+            _blobCustodyTracker.Update(BlobCellMask.FromBytes(bytes));
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsWarn) _logger.Warn($"Failed to update blob custody columns: {ex.Message}");
+        }
+
+        return null;
+    }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandlerV4.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetBlobsHandlerV4.cs
@@ -162,17 +162,7 @@ public class GetBlobsHandlerV4(ITxPool txPool, IEthSyncingInfo? ethSyncingInfo) 
             return false;
         }
 
-        Span<byte> bytes = stackalloc byte[BlobCellMask.FixedByteLength];
-        bytes.Clear();
-        for (int i = 0; i < BlobCellMask.CellCount; i++)
-        {
-            if (bitarray.Get(i))
-            {
-                bytes[i >> 3] |= (byte)(1 << (i & 7));
-            }
-        }
-
-        cellMask = BlobCellMask.FromBytes(bytes);
+        cellMask = BlobCellBits.ToMask(bitarray);
         error = null;
         return true;
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Bogota.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IEngineRpcModule.Bogota.cs
@@ -36,5 +36,8 @@ public partial interface IEngineRpcModule : IRpcModule
         Description = "Applies fork choice and starts building a new block if payload attributes are present.",
         IsSharable = true,
         IsImplemented = true)]
-    Task<ResultWrapper<ForkchoiceUpdatedV2Result>> engine_forkchoiceUpdatedV5(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes = null, BitArray? custodyColumns = null);
+    Task<ResultWrapper<ForkchoiceUpdatedV2Result>> engine_forkchoiceUpdatedV5(
+        ForkchoiceStateV1 forkchoiceState,
+        PayloadAttributes? payloadAttributes = null,
+        [JsonRpcParameter(ConverterType = typeof(BlobCellBitArrayConverter))] BitArray? custodyColumns = null);
 }


### PR DESCRIPTION
## Changes

`engine_forkchoiceUpdatedV5` accepted a `BitArray? custodyColumns` parameter and dropped it entirely — no length validation, no tracker update. Its Amsterdam sibling `engine_forkchoiceUpdatedV4` validated the bitfield against `BlobCellMask.CellCount` and applied it via `TryUpdateCustodyColumns`, so a CL that moved from V4 to V5 at Bogota silently lost custody updates it had previously been making successfully.

This affects both transports: the JSON-RPC method, and `ForkchoiceUpdatedV5SszHandler`, which decodes the field off the SSZ wire and forwards it to the same method.

- Folded the length check into `TryUpdateCustodyColumns`, which now returns the `InvalidParams` message (or `null`) instead of taking a pre-validated non-null bitfield.
- Both V4 and V5 call that one method, so the validation and the tracker update cannot drift apart between versions again.
- Parameterized the three existing custody-column forkchoice tests over both V4 and V5, each pinned to its own fork.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`ForkchoiceUpdated_should_update_blob_custody_tracker`, `..._even_when_forkchoice_fails` and `..._should_reject_invalid_custody_columns_bitarray` now run for both V4 and V5. Positive control: with the `EngineRpcModule.Bogota.cs` change reverted, exactly the three V5 cases fail and every V4 case still passes. With the fix, the full `Nethermind.Merge.Plugin.Test` suite is green (1830 passed, 2 skipped).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No