### PR TITLE
test(merge): pin engine_getBlobsV4 SSZ middleware parity invariants

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/SszRest/SszMiddlewareTests.cs
@@ -396,6 +396,108 @@ public class SszMiddlewareTests
         await _engineModule.Received(1).engine_getBlobsV4(Arg.Any<byte[][]>(), Arg.Any<System.Collections.BitArray>());
     }
 
+    [Test]
+    public async Task GetBlobsV4_accepts_indices_with_fewer_set_bits_than_hashes()
+    {
+        Hash256[] requestHashes = [TestItem.KeccakA, TestItem.KeccakB, TestItem.KeccakC, TestItem.KeccakD, TestItem.KeccakE];
+        System.Collections.BitArray indices = new(BlobCellMask.CellCount);
+        indices.Set(0, true);
+        indices.Set(2, true);
+        indices.Set(4, true);
+
+        byte[][]? forwardedHashes = null;
+        System.Collections.BitArray? forwardedIndices = null;
+        _engineModule.engine_getBlobsV4(
+                Arg.Do<byte[][]>(h => forwardedHashes = h),
+                Arg.Do<System.Collections.BitArray>(i => forwardedIndices = i))
+            .Returns(ResultWrapper<IReadOnlyList<BlobCellsAndProofs?>?>.Success(new BlobCellsAndProofs?[requestHashes.Length]));
+
+        byte[] body = GetBlobsV4RequestWire.Encode(new GetBlobsV4RequestWire
+        {
+            BlobVersionedHashes = requestHashes,
+            IndicesBitarray = indices
+        });
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/blobs/v4", body);
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+        await _engineModule.Received(1).engine_getBlobsV4(Arg.Any<byte[][]>(), Arg.Any<System.Collections.BitArray>());
+        Assert.That(forwardedHashes, Is.Not.Null);
+        Assert.That(forwardedIndices, Is.Not.Null);
+        GetBlobsV4ResponseWire.Decode(new ReadOnlySequence<byte>(ResponseBytes(ctx)), out GetBlobsV4ResponseWire decoded);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(forwardedHashes!, Is.EqualTo(requestHashes.Select(h => h.Bytes.ToArray()).ToArray()),
+                "hashes must reach the engine verbatim");
+            Assert.That(BitsEqual(forwardedIndices!, indices), Is.True,
+                "indices must reach the engine verbatim");
+            Assert.That(decoded.Entries, Has.Length.EqualTo(requestHashes.Length),
+                "the encoder must emit exactly one entry per engine-result element");
+        }
+    }
+
+    [Test]
+    public async Task GetBlobsV4_response_entries_mirror_request_with_unavailable_entries()
+    {
+        System.Collections.BitArray indices = new(BlobCellMask.CellCount);
+        indices.Set(0, true);
+
+        BlobCellsAndProofs available = new()
+        {
+            Available = true,
+            BlobCells = [new byte[SszBlobCell.BlobCellLength]],
+            Proofs = [new byte[SszKzgCommitment.KzgCommitmentLength]],
+            RequestedMask = BlobCellMask.FromIndices([0])
+        };
+
+        _engineModule.engine_getBlobsV4(Arg.Any<byte[][]>(), Arg.Any<System.Collections.BitArray>())
+            .Returns(ResultWrapper<IReadOnlyList<BlobCellsAndProofs?>?>.Success(new BlobCellsAndProofs?[] { available, null }));
+
+        byte[] body = GetBlobsV4RequestWire.Encode(new GetBlobsV4RequestWire
+        {
+            BlobVersionedHashes = [TestItem.KeccakA, TestItem.KeccakB],
+            IndicesBitarray = indices
+        });
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/blobs/v4", body);
+
+        await _middleware.InvokeAsync(ctx);
+
+        Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status200OK));
+        GetBlobsV4ResponseWire.Decode(new ReadOnlySequence<byte>(ResponseBytes(ctx)), out GetBlobsV4ResponseWire decoded);
+        BlobV4EntryWire[]? entries = decoded.Entries;
+        Assert.That(entries, Has.Length.EqualTo(2),
+            "the encoder must emit exactly one entry per engine-result element");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(entries![0].Available, Is.True);
+            Assert.That(entries[1].Available, Is.False, "missing blob surfaces as available=false, not a dropped entry");
+        }
+    }
+
+    [Test]
+    public async Task GetBlobsV4_truncated_body_returns_400_decode_error_without_reaching_engine()
+    {
+        byte[] body = GetBlobsV4RequestWire.Encode(new GetBlobsV4RequestWire
+        {
+            BlobVersionedHashes = [TestItem.KeccakA],
+            IndicesBitarray = new System.Collections.BitArray(BlobCellMask.CellCount)
+        });
+        DefaultHttpContext ctx = MakePostContext("/engine/v1/blobs/v4", body[..^1]);
+
+        await _middleware.InvokeAsync(ctx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ctx.Response.StatusCode, Is.EqualTo(StatusCodes.Status400BadRequest),
+                "a malformed V4 body is a 400 ssz-decode-error like on every other SSZ endpoint");
+            Assert.That(System.Text.Encoding.UTF8.GetString(ResponseBytes(ctx)), Does.Contain("ssz-decode-error"));
+        }
+        await _engineModule.DidNotReceive().engine_getBlobsV4(Arg.Any<byte[][]>(), Arg.Any<System.Collections.BitArray>());
+    }
+
     private static readonly TestCaseData[] BodiesByHashRoutingCases =
     [
         new TestCaseData(EngineApiVersions.PayloadBodiesByHash.V1, "shanghai").SetName("BodiesByHash_shanghai_routes_to_V1"),


### PR DESCRIPTION
## Changes

Adds middleware-level regression coverage for the `engine_getBlobsV4` SSZ endpoint. These invariants hold today only *by construction*; nothing pinned them, so a refactor of `SszCodec.EncodeGetBlobsV4Response` or `GetBlobsHandlerV4` could silently break wire behaviour. No production code is touched.

- `GetBlobsV4_accepts_indices_with_fewer_set_bits_than_hashes` — the `indices` field is a per-blob cell selector (`Bitvector[128]`, `CELLS_PER_EXT_BLOB`); its popcount is independent of the hash count. Fewer set bits than hashes is legal and both hashes and indices reach the engine verbatim → 200.
- `GetBlobsV4_response_entries_mirror_request_with_unavailable_entries` — response entries correspond 1:1 to requested hashes; cells are positional 128-slot arrays with the empty Optional for unrequested indices; a missing blob surfaces as `available=false`, not a dropped entry.
- `GetBlobsV4_truncated_body_returns_400_decode_error_without_reaching_engine` — a malformed V4 body is a 400 `ssz-decode-error` (parity with every other SSZ endpoint) and the engine is never reached.

Context: these tests are the disposition of audit finding **F-28** (`DecodeGetBlobsV4Request`/`EncodeGetBlobsV4Response` length consistency, orig. Info → LOW). On review the finding is **not a defect** — the 128-blob bound is already enforced in `GetBlobsHandlerV4` (returning `TooLargeRequest` → 413, identical to V1/V2), the `indices` bitvector is a per-blob cell selector rather than a per-hash count, and 1:1 request/response correspondence is guaranteed by the handler. This PR locks that behaviour in instead of adding redundant validation.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: Test-only (regression coverage; no production code change)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Full `SszMiddlewareTests` fixture passes (85/85) on current `master`.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No