### PR TITLE
fix(optimism): isolate batch derivation failures in the CL driver

### DIFF
--- a/src/Nethermind/Nethermind.Optimism.Test/CL/DriverTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/DriverTests.cs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Optimism.CL;
+using Nethermind.Optimism.CL.Decoding;
+using Nethermind.Optimism.CL.Derivation;
+using Nethermind.Optimism.CL.L1Bridge;
+using Nethermind.Optimism.Rpc;
+using Nethermind.Serialization.Rlp;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Optimism.Test.CL;
+
+public class DriverTests
+{
+    private const ulong L2BlockTime = 2;
+    private const ulong FirstBlockNumber = 1;
+    private static readonly Hash256 OriginHash = TestItem.KeccakA;
+
+    /// <summary>Span-batch payload of a legacy transaction: <c>rlp(value, gasPrice, data)</c>.</summary>
+    private static readonly byte[] ValidTx = Rlp.Encode(Rlp.OfZero, Rlp.OfZero, Rlp.OfEmptyByteArray).Bytes;
+
+    /// <summary>Same shape, but <c>value</c> is a list where a scalar is required, so decoding throws.</summary>
+    private static readonly byte[] MalformedTx = Rlp.Encode(Rlp.OfEmptyList, Rlp.OfZero, Rlp.OfEmptyByteArray).Bytes;
+
+    [SetUp]
+    public void SetUp() => TxDecoder.Instance.RegisterDecoder(new OptimismTxDecoder<Transaction>());
+
+    private static IEnumerable<TestCaseData> UnderivableBatches()
+    {
+        yield return new TestCaseData(Batch(OriginHash, (TxType.Blob, ValidTx))) { TestName = "UnknownTxType" };
+        yield return new TestCaseData(Batch(OriginHash, (TxType.Legacy, MalformedTx))) { TestName = "MalformedTxData" };
+        yield return new TestCaseData(Batch(TestItem.KeccakB, (TxType.Legacy, ValidTx))) { TestName = "L1OriginMismatch" };
+    }
+
+    [TestCaseSource(nameof(UnderivableBatches))]
+    public async Task Batch_that_cannot_be_derived_does_not_stop_derivation(BatchV1 underivable)
+    {
+        Driver driver = BuildDriver(out List<ulong> imported, underivable, Batch(OriginHash, (TxType.Legacy, ValidTx)));
+
+        await driver.Run(Timeout);
+
+        Assert.That(imported, Is.EqualTo(new ulong[] { FirstBlockNumber }));
+    }
+
+    [Test]
+    public async Task Batch_failing_on_a_later_block_imports_nothing()
+    {
+        BatchV1 secondBlockFails = Batch(OriginHash, (TxType.Legacy, ValidTx), (TxType.Blob, ValidTx));
+        Driver driver = BuildDriver(out List<ulong> imported, secondBlockFails);
+
+        await driver.Run(Timeout);
+
+        Assert.That(imported, Is.Empty);
+    }
+
+    /// <summary>A batch of one block per supplied transaction, all sharing a single L1 origin.</summary>
+    private static BatchV1 Batch(Hash256 originHash, params (TxType Type, byte[] Data)[] txs)
+    {
+        ulong[] oneTxPerBlock = new ulong[txs.Length];
+        TxType[] types = new TxType[txs.Length];
+        ReadOnlyMemory<byte>[] data = new ReadOnlyMemory<byte>[txs.Length];
+        (UInt256 R, UInt256 S)[] signatures = new (UInt256, UInt256)[txs.Length];
+        Address[] tos = new Address[txs.Length];
+        for (int i = 0; i < txs.Length; i++)
+        {
+            oneTxPerBlock[i] = 1;
+            types[i] = txs[i].Type;
+            data[i] = txs[i].Data;
+            signatures[i] = (UInt256.One, UInt256.One);
+            tos[i] = TestItem.AddressA;
+        }
+
+        return new BatchV1
+        {
+            RelTimestamp = FirstBlockNumber * L2BlockTime,
+            L1OriginNum = 0,
+            ParentCheck = new byte[20],
+            L1OriginCheck = originHash.Bytes[..20].ToArray(),
+            BlockCount = (ulong)txs.Length,
+            OriginBits = 0,
+            BlockTxCounts = oneTxPerBlock,
+            Txs = new BatchV1.Transactions
+            {
+                ContractCreationBits = 0,
+                YParityBits = 0,
+                ProtectedBits = 0,
+                Signatures = signatures,
+                Tos = tos,
+                Data = data,
+                Types = types,
+                TotalLegacyTxCount = (ulong)txs.Length,
+                Nonces = new ulong[txs.Length],
+                Gases = new ulong[txs.Length],
+            }
+        };
+    }
+
+    /// <remarks>
+    /// Drives the real <see cref="DerivationPipeline"/>, which <see cref="Driver"/> constructs itself.
+    /// The batch channel is completed up front, so <see cref="Driver.Run"/> returns once the given batches
+    /// have been handled and <paramref name="imported"/> can be asserted without polling.
+    /// </remarks>
+    private static Driver BuildDriver(out List<ulong> imported, params BatchV1[] batches)
+    {
+        Channel<(BatchV1, ulong)> batchChannel = Channel.CreateUnbounded<(BatchV1, ulong)>();
+        foreach (BatchV1 batch in batches) batchChannel.Writer.TryWrite((batch, 0));
+        batchChannel.Writer.Complete();
+
+        IDecodingPipeline decodingPipeline = Substitute.For<IDecodingPipeline>();
+        decodingPipeline.DecodedBatchesReader.Returns(batchChannel.Reader);
+
+        L1Block origin = new()
+        {
+            ExtraData = [],
+            Hash = OriginHash,
+            ParentHash = Hash256.Zero,
+            MixHash = Hash256.Zero,
+            ParentBeaconBlockRoot = Hash256.Zero,
+            Timestamp = 1,
+            Number = 0,
+            BaseFeePerGas = 1,
+            ExcessBlobGas = 0,
+        };
+
+        IL1Bridge l1Bridge = Substitute.For<IL1Bridge>();
+        // Never completes, so the run loop only reacts to batches.
+        l1Bridge.Step(Arg.Any<CancellationToken>()).Returns(new TaskCompletionSource<L1BridgeStepResult>(TaskCreationOptions.RunContinuationsAsynchronously).Task);
+        l1Bridge.GetBlock(Arg.Any<ulong>(), Arg.Any<CancellationToken>()).Returns(origin);
+        l1Bridge.GetReceiptsByBlockHash(Arg.Any<Hash256>(), Arg.Any<CancellationToken>()).Returns([]);
+
+        IL2Api l2Api = Substitute.For<IL2Api>();
+        l2Api.GetBlockByNumber(Arg.Any<ulong>()).Returns(ParentBlock);
+
+        List<ulong> importedBlocks = [];
+        imported = importedBlocks;
+        IExecutionEngineManager engine = Substitute.For<IExecutionEngineManager>();
+        engine.ProcessNewDerivedPayloadAttributes(Arg.Any<PayloadAttributesRef>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                ulong number = call.Arg<PayloadAttributesRef>().Number;
+                importedBlocks.Add(number);
+                return Task.FromResult<BlockId?>(new BlockId { Number = number, Hash = Hash256.Zero });
+            });
+
+        return new Driver(
+            l1Bridge,
+            decodingPipeline,
+            new CLChainSpecEngineParameters
+            {
+                L2BlockTime = L2BlockTime,
+                SystemConfigProxy = TestItem.AddressB,
+                OptimismPortalProxy = TestItem.AddressC,
+            },
+            engine,
+            l2Api,
+            TestBlockchainIds.ChainId,
+            l2GenesisTimestamp: 0,
+            LimboLogs.Instance);
+    }
+
+    private static L2Block ParentBlock => new()
+    {
+        Hash = Hash256.Zero,
+        ParentHash = Hash256.Zero,
+        StateRoot = Keccak.EmptyTreeHash,
+        PayloadAttributesRef = new PayloadAttributesRef
+        {
+            Number = FirstBlockNumber - 1,
+            SystemConfig = new SystemConfig { EIP1559Params = new byte[8] },
+            L1BlockInfo = L1BlockInfo.Empty,
+            PayloadAttributes = new OptimismPayloadAttributes
+            {
+                PrevRandao = Hash256.Zero,
+                SuggestedFeeRecipient = Address.Zero,
+                Withdrawals = [],
+                Transactions = [],
+            }
+        }
+    };
+
+    private static CancellationToken Timeout => new CancellationTokenSource(TimeSpan.FromSeconds(30)).Token;
+}

--- a/src/Nethermind/Nethermind.Optimism/CL/Driver.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Driver.cs
@@ -72,7 +72,16 @@ public class Driver : IDisposable
                 if (nextBatchReady.IsCompleted)
                 {
                     (BatchV1 decodedBatch, ulong batchOrigin) = await _decodingPipeline.DecodedBatchesReader.ReadAsync(token);
-                    await ProcessDecodedBatch(decodedBatch, batchOrigin, token);
+                    try
+                    {
+                        await ProcessDecodedBatch(decodedBatch, batchOrigin, token);
+                    }
+                    catch (Exception e) when (e is not OperationCanceledException)
+                    {
+                        // Skip the batch instead of ending derivation. The batch is stored on L1, so
+                        // failing here would halt the node again on every restart.
+                        if (_logger.IsWarn) _logger.Warn($"Skipping batch that failed to derive: {e}");
+                    }
                     continue;
                 }
 
@@ -184,13 +193,18 @@ public class Driver : IDisposable
 
         L2Block l2Parent = await _l2Api.GetBlockByNumber(firstBlockNumber - 1);
 
-        IAsyncEnumerator<PayloadAttributesRef> derivedPayloadAttributes = _derivationPipeline
-            .DerivePayloadAttributes(l2Parent, decodedBatch, token)
-            .GetAsyncEnumerator(token);
-        BlockId? lastDerivedBlock = null;
-        while (await derivedPayloadAttributes.MoveNextAsync())
+        // Derive the whole batch before importing any of it. Transactions are decoded lazily per block,
+        // so a failure in a later block would otherwise leave the batch half-imported.
+        List<PayloadAttributesRef> derivedPayloadAttributes = [];
+        await foreach (PayloadAttributesRef payloadAttributes in
+                       _derivationPipeline.DerivePayloadAttributes(l2Parent, decodedBatch, token))
         {
-            PayloadAttributesRef payloadAttributes = derivedPayloadAttributes.Current;
+            derivedPayloadAttributes.Add(payloadAttributes);
+        }
+
+        BlockId? lastDerivedBlock = null;
+        foreach (PayloadAttributesRef payloadAttributes in derivedPayloadAttributes)
+        {
             BlockId? derivedBlock = await _executionEngineManager.ProcessNewDerivedPayloadAttributes(payloadAttributes, token);
             if (derivedBlock is null)
             {


### PR DESCRIPTION
A single batch that failed to derive stopped Optimism CL derivation for the life of the process. The batch stays on L1, so the node replayed it and halted again on every restart. A plain L1 reorg is enough to trigger it: `GetL1Origins` returns null and `DerivationPipeline` throws.

## Changes

- Derive a batch in full before importing any of it (`Driver.ProcessDecodedBatch`). Transactions are decoded lazily per block by `BatchV1.ToSingularBatches`, so a failure in a later block left the batch half-imported, with `_currentDerivedBlock` advanced past blocks that no later batch could follow.
- Log and skip a batch that fails to derive instead of ending derivation (`Driver.Run`). The only handler sat outside the loop, so any throw made `Run` return and nothing restarts it. Scoped to the `ProcessDecodedBatch` call rather than the whole loop body, so a repeatedly failing L1 connection cannot spin, and `OperationCanceledException` still propagates so shutdown exits.
- Add `DriverTests`, the first test coverage for `Driver`.


## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks
The stall was silent. p2p and the decoding pipeline keep running under `Task.WhenAll`, so the nodelooked healthy while it had stopped deriving.

The enshrined CL is off by default (`Optimism.ClEnabled = false`) and hidden from the docs, so this affects only nodes that opt into it.

`await foreach` also disposes the derivation enumerator, which the previous `GetAsyncEnumerator` call never did.

Dropping a batch whole leaves a gap, and the next batch then fails the ordering check until a valid batch or a `Reset` arrives. Pre-existing and out of scope; this PR only stops one batch from permanently ending derivation.