### PR TITLE
fix(test): align TrieReassemblerTests with non-nullable IDb.GetAll

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/TrieReassemblerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/TrieReassemblerTests.cs
@@ -290,9 +290,8 @@ public class TrieReassemblerTests
         foreach (FlatDbColumns col in new[] { FlatDbColumns.StateTopNodes, FlatDbColumns.StateNodes })
         {
             IDb db = _columnsDb.GetColumnDb(col);
-            foreach (KeyValuePair<byte[], byte[]?> kvp in db.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in db.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
                 if (node.NodeType != NodeType.Leaf)
@@ -404,9 +403,8 @@ public class TrieReassemblerTests
         {
             IDb columnDb = _columnsDb.GetColumnDb(col);
             List<byte[]> toDelete = [];
-            foreach (KeyValuePair<byte[], byte[]?> kvp in columnDb.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in columnDb.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
                 if (node.NodeType != NodeType.Leaf && filter(node))
@@ -419,9 +417,8 @@ public class TrieReassemblerTests
         {
             IDb fallbackDb = _columnsDb.GetColumnDb(FlatDbColumns.FallbackNodes);
             List<byte[]> toDelete = [];
-            foreach (KeyValuePair<byte[], byte[]?> kvp in fallbackDb.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in fallbackDb.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
 
@@ -441,9 +438,8 @@ public class TrieReassemblerTests
         {
             IDb columnDb = _columnsDb.GetColumnDb(FlatDbColumns.StorageNodes);
             List<byte[]> toDelete = [];
-            foreach (KeyValuePair<byte[], byte[]?> kvp in columnDb.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in columnDb.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
                 if (filter(node))
@@ -456,9 +452,8 @@ public class TrieReassemblerTests
         {
             IDb fallbackDb = _columnsDb.GetColumnDb(FlatDbColumns.FallbackNodes);
             List<byte[]> toDelete = [];
-            foreach (KeyValuePair<byte[], byte[]?> kvp in fallbackDb.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in fallbackDb.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
 


### PR DESCRIPTION
## Changes

- Fix `master` build (`CS8619`): #12945 added tests iterating `IDb.GetAll()` as `KeyValuePair<byte[], byte[]?>`, but #12155 narrowed it to `KeyValuePair<byte[], byte[]>`, and structs have no variance conversion. Both PRs were green alone — #12945 was branched before #12155 landed and merged after it.
- Drop the redundant `kvp.Value is null` guards — `GetAll()` never yields null values.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Build-related changes
