### PR TITLE
perf(state): auto-scale flat block cache with system memory

### DIFF
--- a/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/FlatDbConfig.cs
@@ -29,7 +29,7 @@ public class FlatDbConfig : IFlatDbConfig
     public long PersistenceWriteBufferFloor { get; set; } = 16.MiB;
     public int TrieWarmerWorkerCount { get; set; } = -1;
     public int WarmReadConcurrency { get; set; } = -1;
-    public ulong BlockCacheSizeBudget { get; set; } = 1UL.GiB;
+    public ulong BlockCacheSizeBudget { get; set; } = 0;
     public long CompactionOffset { get; set; } = -1;
     public ulong TrieCacheMemoryBudget { get; set; } = 512UL.MiB;
     public bool EnableLongFinality { get; set; } = true;

--- a/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
+++ b/src/Nethermind/Nethermind.Db/IFlatDbConfig.cs
@@ -7,7 +7,7 @@ namespace Nethermind.Db;
 
 public interface IFlatDbConfig : IConfig
 {
-    [ConfigItem(Description = "Block cache size budget", DefaultValue = "1073741824")]
+    [ConfigItem(Description = "Block cache size budget in bytes for the flat state columns. 0 to auto-scale to system memory / 8, clamped between 1 GiB and 32 GiB. Explicit values are used as-is.", DefaultValue = "0")]
     ulong BlockCacheSizeBudget { get; set; }
 
     [ConfigItem(Description = "Fixed compaction schedule offset in blocks. When 0 or greater, overrides the per-instance offset in the metadata DB, which is neither read nor updated. Only the value modulo CompactSize matters. -1 to use the stored offset, generating a random one when absent.", DefaultValue = "-1")]

--- a/src/Nethermind/Nethermind.Init/Modules/FlatRocksDbConfigAdjuster.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatRocksDbConfigAdjuster.cs
@@ -18,11 +18,35 @@ namespace Nethermind.Init.Modules;
 internal class FlatRocksDbConfigAdjuster(
     IRocksDbConfigFactory rocksDbConfigFactory,
     IFlatDbConfig flatDbConfig,
+    IHardwareInfo hardwareInfo,
     IDisposableStack disposeStack,
     ILogManager logManager)
     : IRocksDbConfigFactory
 {
+    private const int AutoScaleMemoryDivisor = 8;
+    private static readonly ulong AutoScaleFloor = 1UL.GiB;
+    private static readonly ulong AutoScaleCap = 32UL.GiB;
+
     private readonly ILogger _logger = logManager.GetClassLogger<FlatRocksDbConfigAdjuster>();
+    private ulong? _blockCacheSizeBudget;
+
+    internal ulong BlockCacheSizeBudget => _blockCacheSizeBudget ??= ResolveBlockCacheSizeBudget();
+
+    private ulong ResolveBlockCacheSizeBudget()
+    {
+        ulong totalMemory = (ulong)Math.Max(hardwareInfo.AvailableMemoryBytes, 0);
+        ulong configured = flatDbConfig.BlockCacheSizeBudget;
+        if (configured != 0)
+        {
+            if (configured > totalMemory / 2 && _logger.IsWarn)
+                _logger.Warn($"Flat db block cache budget of {configured / 1UL.MiB:N0} MB exceeds half of the {totalMemory / 1UL.MiB:N0} MB of system memory");
+            return configured;
+        }
+
+        ulong budget = Math.Clamp(totalMemory / AutoScaleMemoryDivisor, AutoScaleFloor, AutoScaleCap);
+        if (_logger.IsInfo) _logger.Info($"Auto-scaled flat db block cache budget to {budget / 1UL.MiB:N0} MB based on {totalMemory / 1UL.MiB:N0} MB of system memory");
+        return budget;
+    }
 
     public IRocksDbConfig GetForDatabase(string databaseName, string? columnName)
     {
@@ -43,7 +67,7 @@ internal class FlatRocksDbConfigAdjuster(
             IntPtr? cacheHandle = null;
             if (columnName == nameof(FlatDbColumns.Account))
             {
-                ulong cacheCapacity = (ulong)(flatDbConfig.BlockCacheSizeBudget * 0.3);
+                ulong cacheCapacity = (ulong)(BlockCacheSizeBudget * 0.3);
                 if (_logger.IsInfo) _logger.Info($"Setting {(cacheCapacity / 1UL.MiB):N0} MB of block cache to account");
                 HyperClockCacheWrapper cacheWrapper = new(cacheCapacity);
                 cacheHandle = cacheWrapper.Handle;
@@ -52,7 +76,7 @@ internal class FlatRocksDbConfigAdjuster(
 
             if (columnName == nameof(FlatDbColumns.Storage))
             {
-                ulong cacheCapacity = (ulong)(flatDbConfig.BlockCacheSizeBudget * 0.7);
+                ulong cacheCapacity = (ulong)(BlockCacheSizeBudget * 0.7);
                 if (_logger.IsInfo) _logger.Info($"Setting {(cacheCapacity / 1UL.MiB):N0} MB of block cache to storage");
                 HyperClockCacheWrapper cacheWrapper = new(cacheCapacity);
                 cacheHandle = cacheWrapper.Handle;

--- a/src/Nethermind/Nethermind.Runner.Test/Module/FlatRocksDbConfigAdjusterTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Module/FlatRocksDbConfigAdjusterTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Test;
 using Nethermind.Db;
 using Nethermind.Db.Rocks.Config;
 using Nethermind.Init.Modules;
@@ -18,6 +19,7 @@ public class FlatRocksDbConfigAdjusterTests
 {
     private IRocksDbConfigFactory _baseFactory = null!;
     private IFlatDbConfig _flatDbConfig = null!;
+    private IHardwareInfo _hardwareInfo = null!;
     private IDisposableStack _disposeStack = null!;
     private IRocksDbConfig _baseConfig = null!;
 
@@ -26,6 +28,7 @@ public class FlatRocksDbConfigAdjusterTests
     {
         _baseFactory = Substitute.For<IRocksDbConfigFactory>();
         _flatDbConfig = Substitute.For<IFlatDbConfig>();
+        _hardwareInfo = new TestHardwareInfo(64L << 30);
         _disposeStack = Substitute.For<IDisposableStack>();
         _baseConfig = Substitute.For<IRocksDbConfig>();
 
@@ -41,7 +44,7 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.Flat);
         _flatDbConfig.BlockCacheSizeBudget.Returns(1_000_000_000UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         IRocksDbConfig result = adjuster.GetForDatabase("State0", null);
 
@@ -54,7 +57,7 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.Flat);
         _flatDbConfig.BlockCacheSizeBudget.Returns(1_000_000_000UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         IRocksDbConfig result = adjuster.GetForDatabase(nameof(DbNames.Flat), nameof(FlatDbColumns.Metadata));
 
@@ -69,7 +72,7 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.FlatInTrie);
         _flatDbConfig.BlockCacheSizeBudget.Returns(1_000_000_000UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         IRocksDbConfig result = adjuster.GetForDatabase(nameof(DbNames.Flat), nameof(FlatDbColumns.Metadata));
 
@@ -84,7 +87,7 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.Flat);
         _flatDbConfig.HistoryRetentionBlocks.Returns(450_000UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         IRocksDbConfig result = adjuster.GetForDatabase(Nethermind.Init.Modules.ContainerBuilderExtensions.GetTitleDbName(DbNames.FlatHistory), nameof(FlatHistoryColumns.AccountHistory));
 
@@ -98,7 +101,7 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.Flat);
         _flatDbConfig.HistoryRetentionBlocks.Returns(0UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         IRocksDbConfig result = adjuster.GetForDatabase(Nethermind.Init.Modules.ContainerBuilderExtensions.GetTitleDbName(DbNames.FlatHistory), nameof(FlatHistoryColumns.AccountHistory));
 
@@ -111,10 +114,24 @@ public class FlatRocksDbConfigAdjusterTests
         _flatDbConfig.Layout.Returns(FlatLayout.Flat);
         _flatDbConfig.BlockCacheSizeBudget.Returns(1_000_000_000UL);
 
-        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _disposeStack, LimboLogs.Instance);
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, _hardwareInfo, _disposeStack, LimboLogs.Instance);
 
         adjuster.GetForDatabase(nameof(DbNames.Flat), nameof(FlatDbColumns.Account));
 
         _baseFactory.Received(1).GetForDatabase(nameof(DbNames.Flat), nameof(FlatDbColumns.Account));
+    }
+
+    [TestCase(0UL, 4L << 30, 1UL << 30)] // auto: total / 8 clamped up to the 1 GiB floor
+    [TestCase(0UL, 64L << 30, 8UL << 30)] // auto: total / 8
+    [TestCase(0UL, 512L << 30, 32UL << 30)] // auto: total / 8 clamped down to the 32 GiB cap
+    [TestCase(1_000_000_000UL, 512L << 30, 1_000_000_000UL)] // explicit value passes through unchanged
+    [TestCase(48UL << 30, 64L << 30, 48UL << 30)] // explicit value above half of total memory still passes through
+    public void BlockCacheSizeBudget_ResolvesFromConfigAndSystemMemory(ulong configured, long availableMemory, ulong expected)
+    {
+        _flatDbConfig.BlockCacheSizeBudget.Returns(configured);
+
+        FlatRocksDbConfigAdjuster adjuster = new(_baseFactory, _flatDbConfig, new TestHardwareInfo(availableMemory), _disposeStack, LimboLogs.Instance);
+
+        Assert.That(adjuster.BlockCacheSizeBudget, Is.EqualTo(expected));
     }
 }


### PR DESCRIPTION
## Changes

- Change the default `FlatDb.BlockCacheSizeBudget` from 1 GiB to `0`, where `0` resolves once at startup to available system memory / 8, clamped to 1-32 GiB.
- Preserve explicit non-zero cache budgets unchanged and warn when an explicit value exceeds half of detected memory.
- Keep the existing 30/70 account/storage cache split and add coverage for the auto-scale floor, proportional value, cap, and explicit overrides.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `FlatRocksDbConfigAdjusterTests`: 11 passed, 0 failed, 0 skipped.
- `git diff --check` passes.
- The test project compiled successfully as part of the focused test run.

### EXPB benchmark

AMD64 reproducible runner, flat Fusaka payloads, `amount=1000`, `delay=0`, five runs per immutable image. Candidate commit `e3575718a5`; exact parent/base commit `7e6f459efe`.

| Image | Run means (ms) | Five-run average |
|---|---|---:|
| Candidate, auto-scaled to 5,991 MiB | 28.30, 28.01, 28.48, 28.11, 28.20 | **28.220 ms** |
| Exact base, fixed 1 GiB | 28.16, 28.02, 27.95, 28.22, 27.98 | **28.066 ms** |

The candidate is 0.154 ms / 0.55% slower, within the observed run-to-run variance. This benchmark does not establish a performance improvement and no run reached the original sub-25 ms target. All ten cells recorded 999 client-side samples, exactly zero exceptions, zero invalid-block/unhandled/fatal matches, and normal shutdown and cleanup markers.

Benchmark run: https://github.com/NethermindEth/nethermind/actions/runs/33738620176

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

The default now scales the flat-state block cache with detected memory and can therefore reserve more memory than the previous fixed 1 GiB default. Explicit non-zero values retain the prior behavior.

## Remarks

This is the clean config-only replacement for closed draft #13104. It contains no RocksDB bindings migration or unrelated flat-state/trie changes. It remains a draft because the requested EXPB workload shows no latency improvement; review should assess the operational value of memory-aware sizing separately.
