### PR TITLE
fix(build): align TrieReassembler test loops with non-nullable IDb.GetAll

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/Sync/TrieReassemblerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/Sync/TrieReassemblerTests.cs
@@ -290,9 +290,8 @@ public class TrieReassemblerTests
         foreach (FlatDbColumns col in new[] { FlatDbColumns.StateTopNodes, FlatDbColumns.StateNodes })
         {
             IDb db = _columnsDb.GetColumnDb(col);
-            foreach (KeyValuePair<byte[], byte[]?> kvp in db.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in db.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
                 if (node.NodeType != NodeType.Leaf)
@@ -404,9 +403,8 @@ public class TrieReassemblerTests
         {
             IDb columnDb = _columnsDb.GetColumnDb(col);
             List<byte[]> toDelete = [];
-            foreach (KeyValuePair<byte[], byte[]?> kvp in columnDb.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in columnDb.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
                 if (node.NodeType != NodeType.Leaf && filter(node))
@@ -419,9 +417,8 @@ public class TrieReassemblerTests
         {
             IDb fallbackDb = _columnsDb.GetColumnDb(FlatDbColumns.FallbackNodes);
             List<byte[]> toDelete = [];
-            foreach (KeyValuePair<byte[], byte[]?> kvp in fallbackDb.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in fallbackDb.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
 
@@ -441,9 +438,8 @@ public class TrieReassemblerTests
         {
             IDb columnDb = _columnsDb.GetColumnDb(FlatDbColumns.StorageNodes);
             List<byte[]> toDelete = [];
-            foreach (KeyValuePair<byte[], byte[]?> kvp in columnDb.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in columnDb.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
                 if (filter(node))
@@ -456,9 +452,8 @@ public class TrieReassemblerTests
         {
             IDb fallbackDb = _columnsDb.GetColumnDb(FlatDbColumns.FallbackNodes);
             List<byte[]> toDelete = [];
-            foreach (KeyValuePair<byte[], byte[]?> kvp in fallbackDb.GetAll())
+            foreach (KeyValuePair<byte[], byte[]> kvp in fallbackDb.GetAll())
             {
-                if (kvp.Value is null) continue;
                 TrieNode node = new(NodeType.Unknown, kvp.Value);
                 node.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
 


### PR DESCRIPTION
## Changes

`master` currently does not compile. `Nethermind.State.Flat.Test` fails with five `CS8619` errors in `TrieReassemblerTests.cs` (lines 293, 407, 422, 444, 459):

```
error CS8619: Nullability of reference types in value of type 'KeyValuePair<byte[], byte[]>'
doesn't match target type 'KeyValuePair<byte[], byte[]?>'
```

This is a collision between two PRs that were each green on their own branch:

- **#12155 "Enable nullables in 7 foundation projects"** (`01638962f2`) narrowed `IDb.GetAll` to `IEnumerable<KeyValuePair<byte[], byte[]>>` — a non-nullable value. That commit changes exactly this one line in `Nethermind.Db/IDb.cs`.
- **#12945 "feat(sync): bal healing"** (`7e6f459efe`) added `TrieReassemblerTests`, whose loops declare the iteration variable as `KeyValuePair<byte[], byte[]?>` and guard with `if (kvp.Value is null) continue;`.

Neither branch saw the other. Merged, they do not build.

This PR takes the interface at its word and drops the `?` from the five loop variables, along with the `is null` guard that followed each one. **Those guards were dead code**: no `IDb.GetAll` implementation can yield a null value.

- `MemDb.Set` maps a null value to `Remove(key)`, so the backing dictionary never holds one.
- `SnapshotableMemDb.GetAll` filters explicitly — `if (value is not null)` — before adding to its result.
- `DbOnTheRocks.GetAllCore` projects `iterator.Value()` over live entries.
- `ReadOnlyDb`, `FullPruningDb`, `NullDb`, `SimpleFilePublicKeyDb`, `RpcDb` and the compressing decorator already declare the non-nullable element type.

These tests specifically run against `SnapshotableMemColumnsDb<FlatDbColumns>`, whose column DBs are `SnapshotableMemDb` — the implementation that filters nulls out by construction — so the removed branch was unreachable for this fixture in particular.

No `!` suppression and no cast: the annotation now matches what the implementations actually do.

Scope is the build break only. A full `Nethermind.slnx` Release build was clean apart from these five errors, so this is the only breakage on `master` right now.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring/Code cleanup
- [ ] Performance improvement
- [ ] Other (please describe):

## Testing

Requires testing

- [ ] Yes
- [x] No

If yes, did you write tests?

- [ ] Yes
- [ ] No

Notes on testing

Verified locally:

- `dotnet build src/Nethermind/Nethermind.slnx -c Release` — **0 errors** (fails with 5 before this change).
- `dotnet test src/Nethermind/Nethermind.State.Flat.Test` — passes.
- Code-lint build (`EnforceCodeStyleInBuild` + `GenerateDocumentationFile` with the workflow's `NoWarn` list) produces no new `IDE`/`CA` warnings.
- `dotnet format whitespace --verify-no-changes` — clean.

## Documentation

Requires documentation update

- [ ] Yes
- [x] No

Requires explanation in Release Notes

- [ ] Yes
- [x] No
