### PR TITLE
test(eip8141): pin the structural and ordering rules of frame transaction admission

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -876,12 +876,7 @@ public class TxValidatorTests
             BlobVersionedHashes = carriesBlobs ? [[KzgPolynomialCommitments.KzgBlobHashVersionV1, .. new byte[31]]] : null,
         };
 
-        TxDecoder decoder = TxDecoder.Instance;
-        byte[] bytes = new byte[decoder.GetLength(tx, RlpBehaviors.None)];
-        RlpWriter writer = new(bytes);
-        decoder.Encode(ref writer, tx);
-        RlpReader reader = new(bytes);
-        Transaction decoded = decoder.Decode(ref reader)!;
+        Transaction decoded = TxDecoderRoundtrip.Roundtrip(tx);
 
         TxValidator txValidator = new(TestBlockchainIds.ChainId);
         ValidationResult result = txValidator.IsWellFormed(decoded, Eip8141Prototype.Instance);
@@ -1488,4 +1483,88 @@ public class FrameTxPostTxModeGateTests
 
         return FrameTxFieldsTxValidator.Instance.IsWellFormed(tx, spec);
     }
+}
+
+/// <summary>The EIP-8141 frame-count and transaction gas-cap bounds, applied through the whole
+/// frame-transaction validator rather than the stateless check alone.</summary>
+/// <remarks>The decoder bounds the frame count off the wire; a transaction built field by field over the
+/// JSON-RPC surface never meets it, so the validator is the only gate it passes.</remarks>
+[TestFixture]
+public class FrameTxStructuralAdmissionTests
+{
+    [TestCase(0, false, TestName = "an empty frame list is rejected")]
+    [TestCase(1, true, TestName = "a single frame is admitted")]
+    [TestCase(Eip8141Constants.MaxFrames, true, TestName = "the maximum frame count is admitted")]
+    [TestCase(Eip8141Constants.MaxFrames + 1, false, TestName = "one frame beyond the maximum is rejected")]
+    public void IsWellFormed_BoundsTheFrameCount(int frameCount, bool expected)
+    {
+        // Zero-gas frames, so raising MaxFrames cannot make this case fail on the transaction gas cap instead.
+        TxFrame[] frames = new TxFrame[frameCount];
+        for (int i = 0; i < frames.Length; i++)
+        {
+            frames[i] = i == 0 ? SelfVerify(0) : Execution(0);
+        }
+
+        ValidationResult result = Validate(OnChain(frames));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.AsBool, Is.EqualTo(expected), result.Error);
+            Assert.That(result.Error, expected ? Is.Null : Is.EqualTo(FrameTxValidation.MissingFrames));
+        }
+    }
+
+    [Test]
+    public void IsWellFormed_AbsentFrameList_IsRejected()
+    {
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            SenderAddress = TestItem.AddressA,
+            FrameSignatures = [],
+        };
+
+        Assert.That(Validate(tx).Error, Is.EqualTo(FrameTxValidation.MissingFrames));
+    }
+
+    // The intrinsic cost is charged before any frame runs, so the cap bites the frame budgets earlier than
+    // their bare sum suggests.
+    [TestCase(0ul, true, TestName = "a reservation at the transaction gas cap is admitted")]
+    [TestCase(1ul, false, TestName = "a reservation one gas beyond the cap is rejected")]
+    public void IsWellFormed_BoundsTheExecutionReservationByTheTransactionGasCap(ulong overshoot, bool expected)
+    {
+        ulong cap = Eip7825Constants.DefaultTxGasLimitCap;
+        Transaction tx = OnChain(SelfVerify(FrameExecutionHeadroom(cap) + overshoot));
+
+        ValidationResult result = Validate(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(FrameTxValidation.TryCalculateBlockGasReservations(tx, Eip8141Prototype.Instance, out ulong reservation, out _), Is.True);
+            Assert.That(reservation, Is.EqualTo(cap + overshoot), "the case must sit exactly on the cap boundary");
+            Assert.That(result.AsBool, Is.EqualTo(expected), result.Error);
+            Assert.That(result.Error, expected ? Is.Null : Is.EqualTo(FrameTxValidation.FrameExecutionGasExceedsCap(cap + overshoot, cap)));
+        }
+    }
+
+    /// <summary>The execution gas a single-frame transaction may budget before its reservation reaches <paramref name="cap"/>.</summary>
+    private static ulong FrameExecutionHeadroom(ulong cap)
+    {
+        Transaction probe = OnChain(SelfVerify(0));
+        Assert.That(FrameTxValidation.TryCalculateBlockGasReservations(probe, Eip8141Prototype.Instance, out ulong intrinsicOnly, out _),
+            Is.True, "an unpriced probe would silently hand back the whole cap as headroom");
+        return cap - intrinsicOnly;
+    }
+
+    /// <summary>A frame transaction on the validator's own chain, so the chain-id gate cannot claim the case first.</summary>
+    private static Transaction OnChain(params TxFrame[] frames)
+    {
+        Transaction tx = FrameTx(frames);
+        tx.ChainId = TestBlockchainIds.ChainId;
+        return tx;
+    }
+
+    private static ValidationResult Validate(Transaction tx) =>
+        new TxValidator(TestBlockchainIds.ChainId).IsWellFormed(tx, Eip8141Prototype.Instance);
 }

--- a/src/Nethermind/Nethermind.Core.Test/Builders/FrameTxTestFrames.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/FrameTxTestFrames.cs
@@ -1,8 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Buffers.Binary;
+using Nethermind.Core.Crypto;
+using Nethermind.Crypto;
 using Nethermind.Int256;
+using Nethermind.Serialization.Rlp;
 
 namespace Nethermind.Core.Test.Builders;
 
@@ -26,6 +30,25 @@ public static class FrameTxTestFrames
     /// <summary>A secp256k1 entry of the right shape, carrying placeholder signature bytes.</summary>
     public static TxFrameSignature Secp256k1Signature(Address signer) =>
         new(TxFrameSignature.SchemeSecp256k1, signer, default, new byte[TxFrameSignature.Secp256k1SignatureLength]);
+
+    /// <summary>Installs a single secp256k1 entry over <paramref name="tx"/>'s canonical signature hash.</summary>
+    /// <remarks>compute_sig_hash covers the entry's scheme, signer and msg, so a placeholder is installed and
+    /// replaced rather than returned for the caller to install.</remarks>
+    public static void SignSecp256k1(Transaction tx, PrivateKey key, Address? signer)
+    {
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, signer, default, default)];
+        byte[] raw = Secp256k1SignatureBytes(new Ecdsa().Sign(key, FrameTxSigHash.ComputeValue(tx)));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, signer, default, raw)];
+    }
+
+    /// <summary>A signature in the EIP-8141 <c>v || r || s</c> encoding, <c>v</c> being the 0/1 recovery id.</summary>
+    public static byte[] Secp256k1SignatureBytes(Signature signature)
+    {
+        byte[] bytes = new byte[TxFrameSignature.Secp256k1SignatureLength];
+        bytes[0] = signature.RecoveryId;
+        signature.Bytes.CopyTo(bytes.AsSpan(1));
+        return bytes;
+    }
 
     public static TxFrame SelfVerify(ulong gasLimit = 1_000) =>
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit, UInt256.Zero, default);

--- a/src/Nethermind/Nethermind.Core.Test/Builders/TxDecoderRoundtrip.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/TxDecoderRoundtrip.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.Core.Test.Builders;
+
+/// <summary>Encodes a transaction and decodes it back, so a test can exercise the decoder-built form.</summary>
+/// <remarks>Fields a decoder derives rather than carries — the frame calldata statistics among them — are set
+/// only on the returned transaction, never on a caller-built one.</remarks>
+public static class TxDecoderRoundtrip
+{
+    public static Transaction Roundtrip(Transaction transaction)
+    {
+        TxDecoder decoder = TxDecoder.Instance;
+        byte[] bytes = new byte[decoder.GetLength(transaction, RlpBehaviors.None)];
+        RlpWriter writer = new(bytes);
+        decoder.Encode(ref writer, transaction);
+        RlpReader reader = new(bytes);
+        return decoder.Decode(ref reader)!;
+    }
+}

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -97,10 +97,20 @@ public class FrameTxValidationTests
         yield return Case("ExecutionApprovalTargetsSenderExplicitly_Valid",
             static tx => tx.Frames = [Frame(mode: TxFrame.ModeVerify, flags: TxFrame.ApproveExecution, target: TestItem.AddressA)],
             null);
+        // Only the execution bit binds the target; a payment-only approval may name a third party.
+        yield return Case("PaymentApprovalTargetsThirdParty_Valid",
+            static tx => tx.Frames = [Frame(mode: TxFrame.ModeVerify, flags: TxFrame.ApprovePayment, target: TestItem.AddressB)],
+            null);
+        yield return Case("ExecutionAndPaymentApprovalTargetsThirdParty_ExecutionApprovalWrongTarget",
+            static tx => tx.Frames = [Frame(mode: TxFrame.ModeVerify, flags: TxFrame.ApproveExecutionAndPayment, target: TestItem.AddressB)],
+            FrameTxValidation.ExecutionApprovalWrongTarget);
 
         // if frame.flags & ATOMIC_BATCH_FLAG: assert i + 1 < len(tx.frames)
         yield return Case("AtomicBatchFlagOnLastFrame_AtomicBatchOnLastFrame",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag)],
+            FrameTxValidation.AtomicBatchOnLastFrame);
+        yield return Case("AtomicBatchFlagOnSoleFrame_AtomicBatchOnLastFrame",
+            static tx => tx.Frames = [Frame(flags: TxFrame.AtomicBatchFlag)],
             FrameTxValidation.AtomicBatchOnLastFrame);
         yield return Case("AtomicBatchFlagOnInnerFrame_Valid",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag), DefaultModeFrame()],
@@ -134,11 +144,22 @@ public class FrameTxValidationTests
         yield return Case("BatchWithoutApprovalScope_Valid",
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: TxFrame.AtomicBatchFlag), DefaultModeFrame()],
             null);
+        // The whole flags byte at its maximum is scope plus batch, which the batch rule refuses together.
+        yield return Case("FrameFlagsSeven_ApprovalScopeInAtomicBatch",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(flags: 7), DefaultModeFrame()],
+            FrameTxValidation.ApprovalScopeInAtomicBatch);
 
         // total_frame_gas accumulated across frames must not overflow 2^64 - 1
         yield return Case("TotalFrameGasOverflows_FrameGasOverflow",
             static tx => tx.Frames = [Frame(gasLimit: ulong.MaxValue), Frame(gasLimit: 1)],
             FrameTxValidation.FrameGasOverflow);
+        // The two limits of a single frame are summed first, so one frame alone can overflow.
+        yield return Case("FrameExecutionPlusStateGasOverflows_FrameGasOverflow",
+            static tx => tx.Frames = [new TxFrame(TxFrame.ModeDefault, flags: 0, target: null, ulong.MaxValue, 1, UInt256.Zero, default)],
+            FrameTxValidation.FrameGasOverflow);
+        yield return Case("TotalFrameGasAtItsMaximum_Valid",
+            static tx => tx.Frames = [Frame(gasLimit: ulong.MaxValue - 1), Frame(gasLimit: 1)],
+            null);
 
         // Signature scheme must be ARBITRARY, SECP256K1, or P256.
         yield return Case("UnknownSignatureScheme_InvalidSignatureScheme",
@@ -146,6 +167,12 @@ public class FrameTxValidationTests
             FrameTxValidation.InvalidSignatureScheme);
         yield return Case("Secp256k1SignatureWithExplicitSigner_Valid",
             static tx => tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, TestItem.AddressB, default, new byte[65])],
+            null);
+        yield return Case("P256SignatureWithExplicitSigner_Valid",
+            static tx => tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeP256, TestItem.AddressB, default, new byte[128])],
+            null);
+        yield return Case("ArbitrarySignatureWithoutSigner_Valid",
+            static tx => tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, new byte[7])],
             null);
 
         // For ARBITRARY, signer MUST be empty.
@@ -156,6 +183,12 @@ public class FrameTxValidationTests
         // msg is empty (canonical hash) or an explicit non-zero 32-byte digest.
         yield return Case("SignatureMsgSixteenBytes_InvalidMsgLength",
             static tx => tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, new byte[16], new byte[65])],
+            FrameTxValidation.InvalidMsgLength);
+        yield return Case("SignatureMsgThirtyOneBytes_InvalidMsgLength",
+            static tx => tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, new byte[31], new byte[65])],
+            FrameTxValidation.InvalidMsgLength);
+        yield return Case("SignatureMsgThirtyThreeBytes_InvalidMsgLength",
+            static tx => tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, new byte[33], new byte[65])],
             FrameTxValidation.InvalidMsgLength);
         yield return Case("SignatureMsgZeroDigest_ZeroDigestMsg",
             static tx => tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, new byte[32], new byte[65])],
@@ -188,6 +221,13 @@ public class FrameTxValidationTests
         yield return Case("ExpiryFrameWithStateGas_InvalidExpiryFrame",
             static tx => tx.Frames = [new TxFrame(TxFrame.ModeVerify, flags: 0, Eip8141Constants.ExpiryVerifierAddress, 30_000, 1, UInt256.Zero, new byte[Eip8141Constants.ExpiryDataLength])],
             FrameTxValidation.InvalidExpiryFrame);
+        yield return Case("ExpiryFrameWithLongData_InvalidExpiryFrame",
+            static tx => tx.Frames = [Frame(mode: TxFrame.ModeVerify, target: Eip8141Constants.ExpiryVerifierAddress, data: new byte[Eip8141Constants.ExpiryDataLength + 1])],
+            FrameTxValidation.InvalidExpiryFrame);
+        // The mode rule claims a valued expiry frame first, so its own value rule never decides one.
+        yield return Case("ExpiryFrameWithValue_ValueOutsideSenderMode",
+            static tx => tx.Frames = [Frame(mode: TxFrame.ModeVerify, target: Eip8141Constants.ExpiryVerifierAddress, value: UInt256.One, data: new byte[Eip8141Constants.ExpiryDataLength])],
+            FrameTxValidation.ValueOutsideSenderMode);
         yield return Case("TwoExpiryFrames_MultipleExpiryFrames",
             static tx => tx.Frames = [SelfVerifyFrame(), ExpiryFrame(), ExpiryFrame()],
             FrameTxValidation.MultipleExpiryFrames);
@@ -196,6 +236,15 @@ public class FrameTxValidationTests
         yield return Case("DefaultModeCallToExpiryVerifier_Valid",
             static tx => tx.Frames = [Frame(mode: TxFrame.ModeDefault, target: Eip8141Constants.ExpiryVerifierAddress, data: new byte[3])],
             null);
+
+        // Frame ordering is a public-mempool rule, not a validity one: a block carrying any of these stays
+        // valid, and the pool filters are what refuse them.
+        yield return Case("SenderFrameAheadOfTheApproval_Valid",
+            static tx => tx.Frames = [Frame(mode: TxFrame.ModeSender, target: TestItem.AddressB), SelfVerifyFrame()], null);
+        yield return Case("VerifyFrameBehindTheValidationPrefix_Valid",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModeSender, target: TestItem.AddressB), SelfVerifyFrame()], null);
+        yield return Case("ExpiryFrameBehindTheLeadingFrame_Valid",
+            static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModeSender, target: TestItem.AddressB), ExpiryFrame()], null);
     }
 
     private static TestCaseData Case(string name, Action<Transaction> mutate, string? expectedError) =>

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxCalldataStatsFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxCalldataStatsFilterTests.cs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.TxPool.Filters;
+using NSubstitute;
+using NUnit.Framework;
+using static Nethermind.Core.Test.Builders.FrameTxTestFrames;
+
+namespace Nethermind.TxPool.Test;
+
+/// <summary>The calldata a frame transaction is priced on, for the transactions that never met the decoder.
+/// The filter rejects nothing, so every case is about what it measured.</summary>
+internal class FrameTxCalldataStatsFilterTests
+{
+    // The expected counts are the bytes the fields encode to, spelled out rather than taken from the
+    // measurement under test: nonce_keys as a list, then the sequence number.
+    [TestCase(1ul, 0, 3, TestName = "Accept_MeasuresASingleByteNonceKey")]
+    [TestCase(0x0100ul, 1, 4, TestName = "Accept_CountsTheZeroByteOfATwoByteNonceKey")]
+    public void Accept_MeasuresTheNonceKeyCalldataOfALocallyBuiltTransaction(ulong nonceKey, int zeroBytes, int nonZeroBytes)
+    {
+        Transaction tx = FrameTx(TestItem.AddressA, [], SelfVerify(PrefixFrameGas));
+        tx.NonceKeys = [(UInt256)nonceKey];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tx.FrameCalldataStats, Is.EqualTo((ZeroBytes: 0, NonZeroBytes: 0)),
+                "a field-built transaction starts unmeasured, or the case proves nothing");
+            Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(tx.FrameCalldataStats, Is.EqualTo((zeroBytes, nonZeroBytes)));
+        }
+    }
+
+    // One reference of all-0xff hashes and a one-byte slot encodes to 71 bytes with no zero among them.
+    [Test]
+    public void Accept_MeasuresTheRecentRootReferenceCalldataOfALocallyBuiltTransaction()
+    {
+        Transaction tx = FrameTx(TestItem.AddressA, [], SelfVerify(PrefixFrameGas));
+        tx.RecentRootReferences = [Reference()];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tx.ReferenceCalldataStats, Is.EqualTo((ZeroBytes: 0, NonZeroBytes: 0)),
+                "a field-built transaction starts unmeasured, or the case proves nothing");
+            Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(tx.ReferenceCalldataStats, Is.EqualTo((ZeroBytes: 0, NonZeroBytes: 71)));
+        }
+    }
+
+    // The decoder measures off the wire. A transaction built field by field must reach the same reading,
+    // or the pool and the processor price the same transaction differently.
+    [Test]
+    public void Accept_ReachesTheReadingTheDecoderTakesOffTheWire()
+    {
+        Transaction built = FrameTx(TestItem.AddressA, [], SelfVerify(PrefixFrameGas));
+        built.ChainId = TestBlockchainIds.ChainId;
+        built.NonceKeys = [UInt256.One, (UInt256)0x0100];
+        built.RecentRootReferences = [Reference()];
+
+        Transaction decoded = TxDecoderRoundtrip.Roundtrip(built);
+        Accept(built);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.FrameCalldataStats.NonZeroBytes, Is.GreaterThan(0), "the decoder must have measured something");
+            Assert.That(built.FrameCalldataStats, Is.EqualTo(decoded.FrameCalldataStats));
+            Assert.That(built.ReferenceCalldataStats, Is.EqualTo(decoded.ReferenceCalldataStats));
+        }
+    }
+
+    [Test]
+    public void Accept_LeavesTheNonceCalldataOfALegacyNonceTransactionUnmeasured()
+    {
+        // Without a key set there is no nonce calldata to charge for; measuring one would price a field
+        // the transaction does not carry.
+        Transaction tx = FrameTx(TestItem.AddressA, [], SelfVerify(PrefixFrameGas));
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+        Assert.That(tx.FrameCalldataStats, Is.EqualTo((ZeroBytes: 0, NonZeroBytes: 0)));
+    }
+
+    [Test]
+    public void Accept_LeavesANonFrameTransactionAlone()
+    {
+        Transaction tx = Build.A.Transaction.WithType(TxType.EIP1559).WithSenderAddress(TestItem.AddressA).TestObject;
+        tx.RecentRootReferences = [Reference()];
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+        Assert.That(tx.ReferenceCalldataStats, Is.EqualTo((ZeroBytes: 0, NonZeroBytes: 0)));
+    }
+
+    [Test]
+    public void Accept_MakesThePoolPriceTheCalldataTheProcessorPrices()
+    {
+        // The pool prices a field-built transaction before this filter runs, so an unmeasured reading would
+        // be memoized and every derived bound would under-count.
+        IReleaseSpec spec = ReleaseSpecSubstitute.Create();
+        spec.IsEip8250Enabled.Returns(true);
+        spec.IsEip8272Enabled.Returns(true);
+        Transaction tx = FrameTx(TestItem.AddressA, [], SelfVerify(PrefixFrameGas));
+        tx.NonceKeys = [UInt256.One];
+        tx.RecentRootReferences = [Reference()];
+
+        Assert.That(FrameTxValidation.TryCalculateGasBudget(tx, spec, out ulong unmeasured, out _, out _), Is.True);
+        Accept(tx);
+
+        Assert.That(FrameTxValidation.TryCalculateGasBudget(tx, spec, out ulong measured, out _, out _), Is.True);
+        Assert.That(measured, Is.GreaterThan(unmeasured));
+    }
+
+    /// <summary>A reference whose every byte is non-zero, so its encoded length is its non-zero count.</summary>
+    private static RecentRootReference Reference() =>
+        new(ValueKeccak.MaxValue, slot: 1, ValueKeccak.MaxValue);
+
+    private static AcceptTxResult Accept(Transaction tx)
+    {
+        FrameTxCalldataStatsFilter filter = new();
+        TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>(), Eip8141Prototype.Instance);
+        return filter.Accept(tx, ref state, TxHandlingOptions.None);
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxSignatureFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxSignatureFilterTests.cs
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Logging;
+using Nethermind.Specs.Forks;
+using Nethermind.TxPool.Filters;
+using NSubstitute;
+using NUnit.Framework;
+using static Nethermind.Core.Test.Builders.FrameTxTestFrames;
+
+namespace Nethermind.TxPool.Test;
+
+/// <summary>The EIP-8141 <c>validate_signature</c> gate as the pool applies it: a frame transaction carries an
+/// explicit sender, so this is the only place a bad signature is caught before admission.</summary>
+// The cases assert against the shared rejection counter.
+[NonParallelizable]
+internal class FrameTxSignatureFilterTests
+{
+    private static readonly IEthereumEcdsa EthereumEcdsa = new EthereumEcdsa(TestBlockchainIds.ChainId);
+
+    private static IEnumerable<TestCaseData> SignatureCases()
+    {
+        static TestCaseData Case(string name, Func<Transaction> build, string? expectedError) =>
+            new TestCaseData(build, expectedError).SetName($"Accept_{name}");
+
+        yield return Case("AnAbsentSignatureListPassesVacuously",
+            static () => FrameTx(TestItem.AddressA, [], SelfVerify(PrefixFrameGas)), null);
+
+        yield return Case("ASignatureByTheSenderIsAdmissible",
+            static () => Signed(TestItem.PrivateKeyA, signer: null), null);
+
+        yield return Case("ASignatureNamingItsOwnSignerIsAdmissible",
+            static () => Signed(TestItem.PrivateKeyB, signer: TestItem.PrivateKeyB.Address), null);
+
+        yield return Case("ASignatureOverAnExplicitDigestIsAdmissible",
+            static () => SignedOverDigest(TestItem.PrivateKeyB), null);
+
+        yield return Case("ASignatureByAnotherKeyIsRejected",
+            static () => Signed(TestItem.PrivateKeyB, signer: TestItem.PrivateKeyC.Address),
+            FrameTxSignatureValidator.InvalidSecp256k1Signer);
+
+        yield return Case("ASignatureOfTheWrongLengthIsRejected",
+            static () => FrameTx(TestItem.AddressA,
+                [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, TestItem.AddressA, default, new byte[64])],
+                SelfVerify(PrefixFrameGas)),
+            FrameTxSignatureValidator.InvalidSignatureLength);
+
+        yield return Case("ALegacyRecoveryIdIsRejected", static () =>
+        {
+            Transaction tx = Signed(TestItem.PrivateKeyA, signer: null);
+            byte[] raw = tx.FrameSignatures![0].Signature.ToArray();
+            raw[0] += 27;
+            tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, raw)];
+            return tx;
+        }, FrameTxSignatureValidator.NonCanonicalSignature);
+
+        // The signature hash covers the frame list, so the pool must refuse a payload edited after signing.
+        yield return Case("AFrameEditedAfterSigningIsRejected", static () =>
+        {
+            Transaction tx = Signed(TestItem.PrivateKeyA, signer: null);
+            tx.Frames = [SelfVerify(PrefixFrameGas), Execution()];
+            return tx;
+        }, FrameTxSignatureValidator.InvalidSecp256k1Signer);
+
+        // An ARBITRARY witness is verified by frame code, so the pool only checks its shape.
+        yield return Case("AnArbitraryWitnessIsLeftToFrameCode",
+            static () => FrameTx(TestItem.AddressA,
+                [new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, new byte[] { 0xde, 0xad })],
+                SelfVerify(PrefixFrameGas)),
+            null);
+    }
+
+    [TestCaseSource(nameof(SignatureCases))]
+    public void Accept_AppliesValidateSignatureBeforeAdmission(Func<Transaction> build, string? expectedError)
+    {
+        Transaction tx = build();
+        long before = Metrics.PendingTransactionsFrameTxSignatureInvalid;
+
+        AcceptTxResult result = Accept(tx, out bool verified);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result == AcceptTxResult.Accepted, Is.EqualTo(expectedError is null), result.ToString());
+            if (expectedError is not null)
+            {
+                Assert.That(result.ToString(), Does.Contain(expectedError));
+            }
+
+            Assert.That(verified, Is.EqualTo(expectedError is null));
+            Assert.That(Metrics.PendingTransactionsFrameTxSignatureInvalid,
+                Is.EqualTo(expectedError is null ? before : before + 1));
+        }
+    }
+
+    [Test]
+    public void Accept_LeavesANonFrameTransactionAlone()
+    {
+        Transaction tx = Build.A.Transaction.WithType(TxType.EIP1559).WithSenderAddress(TestItem.AddressA).TestObject;
+
+        Assert.That(Accept(tx, out bool verified), Is.EqualTo(AcceptTxResult.Accepted));
+        Assert.That(verified, Is.True);
+    }
+
+    private static AcceptTxResult Accept(Transaction tx, out bool signaturesVerified)
+    {
+        IChainHeadSpecProvider specProvider = Substitute.For<IChainHeadSpecProvider>();
+        specProvider.GetCurrentHeadSpec().Returns(Eip8141Prototype.Instance);
+        FrameTxSignatureFilter filter = new(specProvider, EthereumEcdsa, LimboLogs.Instance.GetClassLogger<FrameTxSignatureFilterTests>());
+        TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>(), Eip8141Prototype.Instance);
+
+        AcceptTxResult result = filter.Accept(tx, ref state, TxHandlingOptions.None);
+        signaturesVerified = state.FrameSignaturesVerified;
+        return result;
+    }
+
+    private static Transaction Signed(PrivateKey key, Address? signer)
+    {
+        Transaction tx = FrameTx(TestItem.AddressA, [], SelfVerify(PrefixFrameGas));
+        SignSecp256k1(tx, key, signer);
+        return tx;
+    }
+
+    private static Transaction SignedOverDigest(PrivateKey key)
+    {
+        byte[] digest = new byte[Hash256.Size];
+        digest[31] = 1;
+        Transaction tx = FrameTx(TestItem.AddressA, [], SelfVerify(PrefixFrameGas));
+        // An explicit digest is signed as given, so the entry needs no canonical-hash round trip.
+        byte[] raw = Secp256k1SignatureBytes(new Ecdsa().Sign(key, new ValueHash256(digest)));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, key.Address, digest, raw)];
+        return tx;
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -3042,6 +3042,66 @@ namespace Nethermind.TxPool.Test
                 Is.EqualTo(AcceptTxResult.FrameTxMisplacedExpiryFrame));
         }
 
+        // The decoder bounds the frame count off the wire; a locally submitted transaction never meets it,
+        // so the transaction validator is the pool's only gate on the count.
+        [TestCase(Eip8141Constants.MaxFrames - 1, true, TestName = "SubmitTx_FrameTransactionAtTheMaximumFrameCount_IsAccepted")]
+        [TestCase(Eip8141Constants.MaxFrames, false, TestName = "SubmitTx_FrameTransactionBeyondTheMaximumFrameCount_IsRejected")]
+        public void SubmitTx_FrameTransactionFrameCount_IsBoundedAtIngress(int trailingFrames, bool expectedAccepted)
+        {
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance));
+            TxFrame[] trailing = new TxFrame[trailingFrames];
+            for (int i = 0; i < trailing.Length; i++)
+            {
+                trailing[i] = new TxFrame(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, gasLimit: 0, UInt256.Zero, Array.Empty<byte>());
+            }
+
+            AcceptTxResult result = _txPool.SubmitTx(SelfVerifyFrameTx(trailing), TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result == AcceptTxResult.Accepted, Is.EqualTo(expectedAccepted), result.ToString());
+                // Accepted carries no message, so only the rejection has a reason to name.
+                if (!expectedAccepted) Assert.That(result.ToString(), Does.Contain(FrameTxValidation.MissingFrames));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(expectedAccepted ? 1 : 0));
+            }
+        }
+
+        private static IEnumerable<TestCaseData> MalformedFrameLayoutCases()
+        {
+            static TxFrame Sender(byte flags = TxFrame.ApproveScopeNone, UInt256 value = default) =>
+                new(TxFrame.ModeSender, flags, TestItem.AddressB, gasLimit: 1_000, value, Array.Empty<byte>());
+
+            yield return new TestCaseData(new[] { Sender(TxFrame.AtomicBatchFlag) }, FrameTxValidation.AtomicBatchOnLastFrame)
+                .SetName("SubmitTx_AtomicBatchFlagOnTheLastFrame_IsRejected");
+            yield return new TestCaseData(new[] { Sender(TxFrame.AtomicBatchFlag), Sender(TxFrame.ApprovePayment) }, FrameTxValidation.ApprovalScopeInAtomicBatch)
+                .SetName("SubmitTx_ApprovalScopeOnABatchedFrame_IsRejected");
+            yield return new TestCaseData(
+                    new[] { new TxFrame(TxFrame.ModeDefault, TxFrame.ApproveScopeNone, TestItem.AddressB, gasLimit: 1_000, UInt256.One, Array.Empty<byte>()) },
+                    FrameTxValidation.ValueOutsideSenderMode)
+                .SetName("SubmitTx_ValueOnANonSenderFrame_IsRejected");
+            yield return new TestCaseData(
+                    new[] { new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, TestItem.AddressB, gasLimit: 1_000, UInt256.Zero, Array.Empty<byte>()) },
+                    FrameTxValidation.ExecutionApprovalWrongTarget)
+                .SetName("SubmitTx_ExecutionApprovalNamingAThirdParty_IsRejected");
+        }
+
+        // Frame-shape rules reach the pool through the transaction validator, so each must reject at ingress
+        // rather than waiting for block production to discover it.
+        [TestCaseSource(nameof(MalformedFrameLayoutCases))]
+        public void SubmitTx_MalformedFrameLayout_IsRejectedAtIngress(TxFrame[] trailingFrames, string expectedError)
+        {
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance));
+
+            AcceptTxResult result = _txPool.SubmitTx(SelfVerifyFrameTx(trailingFrames), TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result == AcceptTxResult.Accepted, Is.False, result.ToString());
+                Assert.That(result.ToString(), Does.Contain(expectedError));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
+            }
+        }
+
         private Transaction SelfVerifyFrameTx(params TxFrame[] trailingFrames)
         {
             Transaction frameTx = new()
@@ -3475,14 +3535,8 @@ namespace Nethermind.TxPool.Test
         {
             PrivateKey key = defect == FrameSignatureDefect.ForeignSigner ? TestItem.PrivateKeyB : TestItem.PrivateKeyA;
             Address signer = TestItem.PrivateKeyA.Address;
-            // compute_sig_hash covers the entry's scheme/signer/msg and elides only the raw bytes, so
-            // the hash is taken with the entry already installed.
-            tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, signer, default, default)];
-            Signature signature = new Ecdsa().Sign(key, FrameTxSigHash.ComputeValue(tx));
-
-            byte[] bytes = new byte[TxFrameSignature.Secp256k1SignatureLength];
-            bytes[0] = signature.RecoveryId;
-            signature.Bytes.CopyTo(bytes.AsSpan(1));
+            FrameTxTestFrames.SignSecp256k1(tx, key, signer);
+            byte[] bytes = tx.FrameSignatures![0].Signature.ToArray();
 
             switch (defect)
             {
@@ -4407,14 +4461,9 @@ namespace Nethermind.TxPool.Test
             return tx;
         }
 
-        private static TxFrameSignature Secp256k1FrameSignature(PrivateKey key, in ValueHash256 sigHash, Address signer)
-        {
-            Signature signature = new Ecdsa().Sign(key, sigHash);
-            byte[] bytes = new byte[TxFrameSignature.Secp256k1SignatureLength];
-            bytes[0] = signature.RecoveryId;
-            signature.Bytes.CopyTo(bytes.AsSpan(1));
-            return new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, signer, default, bytes);
-        }
+        private static TxFrameSignature Secp256k1FrameSignature(PrivateKey key, in ValueHash256 sigHash, Address signer) =>
+            new(TxFrameSignature.SchemeSecp256k1, signer, default,
+                FrameTxTestFrames.Secp256k1SignatureBytes(new Ecdsa().Sign(key, sigHash)));
 
         [Test]
         public async Task Over_value_keyed_tx_does_not_dump_a_valid_plain_tx_from_the_same_sender()


### PR DESCRIPTION
## Changes

Tests only — no production code is touched. This closes the structural and ordering gaps in EIP-8141 frame transaction admission, auditing each rule against the specification's constraints block, expiry-verifier rules and mempool structural rules.

- **`FrameTxSignatureFilter`** had no fixture of its own. New `FrameTxSignatureFilterTests` pins the sender-resolved signer, an explicitly named signer, an explicit 32-byte digest, a foreign signer, a wrong-length signature, a legacy recovery id, a payload edited after signing, an `ARBITRARY` witness left to frame code, and the pre-validation flag the simulation filter reads.
- **`FrameTxCalldataStatsFilter`** had no fixture of its own. New `FrameTxCalldataStatsFilterTests` pins that the nonce-key and reference calldata of a transaction built field by field is measured, that a legacy-nonce transaction is left unmeasured, that a non-frame transaction is untouched, and that the pool reprices on the measured reading rather than the memo taken before it.
- **Frame count and the transaction gas cap** through the whole frame-transaction validator: 0, 1, 64 and 65 frames, and the execution reservation exactly on and one gas beyond the cap. The cap had no test anywhere.
- **Pool ingress**: the frame count and four frame-shape constraints must reject when the transaction is submitted, not when a block is built. The decoder bounds the count off the wire, so a locally submitted transaction meets only the validator.
- **Constraint matrix** additions: the payment-only approval that may name a third party, the whole flags byte at its maximum, a single-frame atomic batch, a frame whose two gas limits overflow between themselves, the total at its maximum, the highest signature scheme, 31- and 33-byte digests, `P256` and `ARBITRARY` entries, and an over-long expiry frame.
- **Ordering is recorded as a public-mempool rule, not a validity one**: a sender frame ahead of the approval, a VERIFY frame behind the prefix and a trailing expiry frame all validate, and the pool filters are what refuse them.

Every case was confirmed to fail against a deliberately broken production check before being kept.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: tests

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.TxPool.Test` green in release and debug (1066), `Nethermind.Core.Test` green (6247), `Nethermind.Blockchain.Test` validators green (303). Full release build and the CI lint gate are clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
