### PR TITLE
test(eip8141): cover the frame expiry filter and the reloaded deadline

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/ExpiredFrameTxFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ExpiredFrameTxFilterTests.cs
@@ -27,6 +27,8 @@ internal class ExpiredFrameTxFilterTests
             .SetName("a deadline equal to the head timestamp is still admissible");
         yield return new TestCaseData(HeadTimestamp + 1, AcceptTxResult.Accepted)
             .SetName("a deadline one second ahead of the head is admissible");
+        yield return new TestCaseData(0UL, AcceptTxResult.FrameTxExpired)
+            .SetName("a zero deadline is a deadline, not the absent-deadline encoding");
     }
 
     // The predeploy reverts only once the head timestamp is strictly past the deadline, so the boundary
@@ -41,19 +43,6 @@ internal class ExpiredFrameTxFilterTests
             Assert.That(Accept(FrameTx(ExpiryAt(deadline), SelfVerify())), Is.EqualTo(expected));
             Assert.That(Metrics.PendingTransactionsFrameTxExpired,
                 Is.EqualTo(expected == AcceptTxResult.Accepted ? before : before + 1));
-        }
-    }
-
-    // Zero is a deadline like any other, not the absent-deadline encoding.
-    [Test]
-    public void Accept_RejectsAZeroDeadlineRatherThanReadingItAsAbsent()
-    {
-        long before = Metrics.PendingTransactionsFrameTxExpired;
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(Accept(FrameTx(ExpiryAt(deadline: 0), SelfVerify())), Is.EqualTo(AcceptTxResult.FrameTxExpired));
-            Assert.That(Metrics.PendingTransactionsFrameTxExpired, Is.EqualTo(before + 1));
         }
     }
 
@@ -72,8 +61,16 @@ internal class ExpiredFrameTxFilterTests
     // The deadline is read from the leading frame alone, which is what the placement filter ahead of this one
     // guarantees; a trailing expiry frame is that filter's rejection, never a silent pass on an elapsed deadline.
     [Test]
-    public void Accept_ReadsTheDeadlineFromTheLeadingFrameOnly() =>
-        Assert.That(Accept(FrameTx(SelfVerify(), ExpiryAt(HeadTimestamp - 1))), Is.EqualTo(AcceptTxResult.Accepted));
+    public void Accept_ReadsTheDeadlineFromTheLeadingFrameOnly()
+    {
+        long before = Metrics.PendingTransactionsFrameTxExpired;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Accept(FrameTx(SelfVerify(), ExpiryAt(HeadTimestamp - 1))), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(Metrics.PendingTransactionsFrameTxExpired, Is.EqualTo(before));
+        }
+    }
 
     [Test]
     public void Accept_LeavesANonFrameTransactionAlone()

--- a/src/Nethermind/Nethermind.TxPool.Test/ExpiredFrameTxFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/ExpiredFrameTxFilterTests.cs
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Specs.Forks;
+using Nethermind.TxPool.Filters;
+using NSubstitute;
+using NUnit.Framework;
+using static Nethermind.Core.Test.Builders.FrameTxTestFrames;
+
+namespace Nethermind.TxPool.Test;
+
+// The cases assert against the shared rejection counter.
+[NonParallelizable]
+internal class ExpiredFrameTxFilterTests
+{
+    private const ulong HeadTimestamp = 1_500;
+
+    private static IEnumerable<TestCaseData> DeadlineCases()
+    {
+        yield return new TestCaseData(HeadTimestamp - 1, AcceptTxResult.FrameTxExpired)
+            .SetName("a deadline one second behind the head is rejected");
+        yield return new TestCaseData(HeadTimestamp, AcceptTxResult.Accepted)
+            .SetName("a deadline equal to the head timestamp is still admissible");
+        yield return new TestCaseData(HeadTimestamp + 1, AcceptTxResult.Accepted)
+            .SetName("a deadline one second ahead of the head is admissible");
+    }
+
+    // The predeploy reverts only once the head timestamp is strictly past the deadline, so the boundary
+    // second belongs to the transaction.
+    [TestCaseSource(nameof(DeadlineCases))]
+    public void Accept_TreatsTheDeadlineAsInclusive(ulong deadline, AcceptTxResult expected)
+    {
+        long before = Metrics.PendingTransactionsFrameTxExpired;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Accept(FrameTx(ExpiryAt(deadline), SelfVerify())), Is.EqualTo(expected));
+            Assert.That(Metrics.PendingTransactionsFrameTxExpired,
+                Is.EqualTo(expected == AcceptTxResult.Accepted ? before : before + 1));
+        }
+    }
+
+    // Zero is a deadline like any other, not the absent-deadline encoding.
+    [Test]
+    public void Accept_RejectsAZeroDeadlineRatherThanReadingItAsAbsent()
+    {
+        long before = Metrics.PendingTransactionsFrameTxExpired;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Accept(FrameTx(ExpiryAt(deadline: 0), SelfVerify())), Is.EqualTo(AcceptTxResult.FrameTxExpired));
+            Assert.That(Metrics.PendingTransactionsFrameTxExpired, Is.EqualTo(before + 1));
+        }
+    }
+
+    [Test]
+    public void Accept_LeavesAFrameTransactionWithoutAnExpiryFrameAlone()
+    {
+        long before = Metrics.PendingTransactionsFrameTxExpired;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Accept(FrameTx(SelfVerify(), Execution())), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(Metrics.PendingTransactionsFrameTxExpired, Is.EqualTo(before));
+        }
+    }
+
+    // The deadline is read from the leading frame alone, which is what the placement filter ahead of this one
+    // guarantees; a trailing expiry frame is that filter's rejection, never a silent pass on an elapsed deadline.
+    [Test]
+    public void Accept_ReadsTheDeadlineFromTheLeadingFrameOnly() =>
+        Assert.That(Accept(FrameTx(SelfVerify(), ExpiryAt(HeadTimestamp - 1))), Is.EqualTo(AcceptTxResult.Accepted));
+
+    [Test]
+    public void Accept_LeavesANonFrameTransactionAlone()
+    {
+        Transaction tx = Build.A.Transaction.WithType(TxType.EIP1559).WithSenderAddress(TestItem.AddressA).TestObject;
+
+        Assert.That(Accept(tx), Is.EqualTo(AcceptTxResult.Accepted));
+    }
+
+    private static AcceptTxResult Accept(Transaction tx)
+    {
+        IChainHeadInfoProvider headInfo = Substitute.For<IChainHeadInfoProvider>();
+        headInfo.HeadTimestamp.Returns(HeadTimestamp);
+
+        ExpiredFrameTxFilter filter = new(headInfo, LimboLogs.Instance.GetClassLogger<ExpiredFrameTxFilterTests>());
+        TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>(), Eip8141Prototype.Instance);
+        return filter.Accept(tx, ref state, TxHandlingOptions.None);
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -4915,17 +4915,40 @@ namespace Nethermind.TxPool.Test
                 "an expired blob-carrying frame tx must be evicted from the blob pool on a new head");
         }
 
+        // With persistent storage the live pool already holds the frameless light record, not the submitted
+        // transaction, so the sweep reads the deadline the record carried off rather than the frames.
+        [TestCase(1_000UL, 0, TestName = "a live light record behind the head expires")]
+        [TestCase(1_500UL, 1, TestName = "a live light record at the head timestamp survives")]
+        public async Task Expiring_blob_carrying_frame_tx_expires_from_the_persistent_pool_without_a_restart(ulong deadline, int expectedPending)
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.StorageWithReorgs, PersistentBlobStorageSize = 10, BlobCacheSize = 10 };
+            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: new BlobTxStorage());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            Transaction tx = BuildBlobFrameTx(nonce: 0, blobCount: 1, deadline: deadline, withSidecar: true);
+            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(1_500).TestObject);
+
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(expectedPending),
+                "the pooled light record must carry the deadline its frames held");
+        }
+
         // The deadline lives in the frames, which a reloaded light record does not have — so without it
-        // persisted the sweep cannot see the transaction and it never leaves the pool.
-        [Test]
-        public async Task Expired_blob_carrying_frame_tx_is_evicted_after_a_restart()
+        // persisted the sweep cannot see the transaction and it never leaves the pool. The boundary cases pin
+        // that it comes back as itself: a deadline reloaded a second either side still evicts on the past case.
+        [TestCase(1_000UL, 0, TestName = "a reloaded deadline behind the head still expires")]
+        [TestCase(1_500UL, 1, TestName = "a reloaded deadline equal to the head timestamp survives")]
+        [TestCase(1_501UL, 1, TestName = "a reloaded deadline ahead of the head survives")]
+        public async Task Expired_blob_carrying_frame_tx_is_evicted_after_a_restart(ulong deadline, int expectedPending)
         {
             TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.StorageWithReorgs, PersistentBlobStorageSize = 10, BlobCacheSize = 10 };
             BlobTxStorage blobTxStorage = new();
             _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: blobTxStorage);
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
 
-            Transaction tx = BuildBlobFrameTx(nonce: 0, blobCount: 1, deadline: 1_000, withSidecar: true);
+            Transaction tx = BuildBlobFrameTx(nonce: 0, blobCount: 1, deadline: deadline, withSidecar: true);
             Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
 
             // A fresh pool over the same storage stands in for a node restart.
@@ -4934,8 +4957,8 @@ namespace Nethermind.TxPool.Test
 
             await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(1_500).TestObject);
 
-            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(0),
-                "a reloaded blob-carrying frame tx must still expire out of the pool");
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(expectedPending),
+                "a reloaded blob-carrying frame tx must expire on exactly the deadline it was persisted with");
         }
 
         // Restoring the pool evicts as it goes and each eviction decrements the expiry count, so the count must be

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -4915,33 +4915,19 @@ namespace Nethermind.TxPool.Test
                 "an expired blob-carrying frame tx must be evicted from the blob pool on a new head");
         }
 
-        // With persistent storage the live pool already holds the frameless light record, not the submitted
-        // transaction, so the sweep reads the deadline the record carried off rather than the frames.
-        [TestCase(1_000UL, 0, TestName = "a live light record behind the head expires")]
-        [TestCase(1_500UL, 1, TestName = "a live light record at the head timestamp survives")]
-        public async Task Expiring_blob_carrying_frame_tx_expires_from_the_persistent_pool_without_a_restart(ulong deadline, int expectedPending)
-        {
-            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.StorageWithReorgs, PersistentBlobStorageSize = 10, BlobCacheSize = 10 };
-            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: new BlobTxStorage());
-            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+        /// <summary>Head timestamp the expiry cases below are stated against, so each deadline names its own
+        /// side of the boundary rather than repeating a literal the head could drift away from.</summary>
+        private const ulong ExpiryHeadTimestamp = 1_500;
 
-            Transaction tx = BuildBlobFrameTx(nonce: 0, blobCount: 1, deadline: deadline, withSidecar: true);
-            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
-            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1));
-
-            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(1_500).TestObject);
-
-            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(expectedPending),
-                "the pooled light record must carry the deadline its frames held");
-        }
-
-        // The deadline lives in the frames, which a reloaded light record does not have — so without it
-        // persisted the sweep cannot see the transaction and it never leaves the pool. The boundary cases pin
-        // that it comes back as itself: a deadline reloaded a second either side still evicts on the past case.
-        [TestCase(1_000UL, 0, TestName = "a reloaded deadline behind the head still expires")]
-        [TestCase(1_500UL, 1, TestName = "a reloaded deadline equal to the head timestamp survives")]
-        [TestCase(1_501UL, 1, TestName = "a reloaded deadline ahead of the head survives")]
-        public async Task Expired_blob_carrying_frame_tx_is_evicted_after_a_restart(ulong deadline, int expectedPending)
+        // With persistent storage the pool holds the frameless light record, not the submitted transaction, so
+        // the sweep reads the deadline that record carries: built at admission, or decoded off disk after a restart.
+        [TestCase(ExpiryHeadTimestamp - 1, 0, false, TestName = "a live light record behind the head expires")]
+        [TestCase(ExpiryHeadTimestamp, 1, false, TestName = "a live light record at the head timestamp survives")]
+        [TestCase(ExpiryHeadTimestamp + 1, 1, false, TestName = "a live light record ahead of the head survives")]
+        [TestCase(ExpiryHeadTimestamp - 1, 0, true, TestName = "a reloaded deadline behind the head still expires")]
+        [TestCase(ExpiryHeadTimestamp, 1, true, TestName = "a reloaded deadline at the head timestamp survives")]
+        [TestCase(ExpiryHeadTimestamp + 1, 1, true, TestName = "a reloaded deadline ahead of the head survives")]
+        public async Task Expiring_blob_carrying_frame_tx_expires_on_the_deadline_its_record_carries(ulong deadline, int expectedPending, bool restart)
         {
             TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.StorageWithReorgs, PersistentBlobStorageSize = 10, BlobCacheSize = 10 };
             BlobTxStorage blobTxStorage = new();
@@ -4951,14 +4937,18 @@ namespace Nethermind.TxPool.Test
             Transaction tx = BuildBlobFrameTx(nonce: 0, blobCount: 1, deadline: deadline, withSidecar: true);
             Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
 
-            // A fresh pool over the same storage stands in for a node restart.
-            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: blobTxStorage);
-            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1), "the transaction must survive the restart");
+            if (restart)
+            {
+                // A fresh pool over the same storage stands in for a node restart.
+                _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: blobTxStorage);
+            }
 
-            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(1_500).TestObject);
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1), "the transaction must be pooled before the head moves");
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(ExpiryHeadTimestamp).TestObject);
 
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(expectedPending),
-                "a reloaded blob-carrying frame tx must expire on exactly the deadline it was persisted with");
+                "the pooled record must expire on exactly the deadline it carries");
         }
 
         // Restoring the pool evicts as it goes and each eviction decrements the expiry count, so the count must be


### PR DESCRIPTION
## Changes

`ExpiredFrameTxFilter` had no test naming it anywhere in the repo, and its rejection metric was asserted nowhere. This adds direct cases for it, and closes two boundary gaps in the pool-level expiry coverage.

- **`ExpiredFrameTxFilterTests`** (new) — the inclusive deadline boundary (behind / equal to / ahead of the head), a zero deadline read as a deadline rather than as absent, the leading-frame-only read that the placement filter ahead of it guarantees, a frame transaction without an expiry frame, and a non-frame transaction. Each case also pins the rejection metric.
- **`Expired_blob_carrying_frame_tx_is_evicted_after_a_restart`** — was pinned only with a deadline well behind the head, so a deadline that came back a second off would still have evicted and the test would still have passed. Now driven over the boundary.
- **`Expiring_blob_carrying_frame_tx_expires_from_the_persistent_pool_without_a_restart`** (new) — with persistent blob storage the live pool already holds the frameless light record, so the sweep reads the carried deadline rather than the frames. Nothing covered that path before a restart.

The expiry predicate is strict greater-than throughout, so a deadline equal to the head timestamp is still valid; the predeploy reverts only once the timestamp is past it. The new cases assert that side of the boundary as well as the elapsed one.

## Verification

Each case was confirmed to fail against a deliberately broken build before being kept:

| Injected defect | Case that failed |
|---|---|
| `HeadTimestamp > deadline` relaxed to `>=` | deadline equal to the head timestamp |
| deadline read from any frame rather than the leading one | leading-frame-only read |
| persisted deadline off by one | live light record at the head timestamp |

`Nethermind.TxPool.Test` passes in both release and debug (1056 passed, 4 skipped). Full release build clean, and the lint gate in its CI form passes and was positive-controlled.

## Types of changes

- [x] Tests

## Testing

Tests added; no production code changes in this PR.