### PR TITLE
fix(eip8141): keep a restored frame tx counting against its sponsor

### DIFF
--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -375,8 +375,8 @@ public static class FrameTxValidation
     /// still keyed. Derived from the frame layout alone, never from state. The target is resolved as the processor
     /// resolves it, so omitting it is not a second, uncapped encoding of the same transaction, and a sender paying
     /// for itself — the self-relay prefix included — uses no paymaster and is bounded by its own balance instead.
-    /// A frameless pool record instead answers from <see cref="Transaction.PersistedPaymaster"/>, unset after a
-    /// reload — <c>null</c> then means unknown, not unsponsored.
+    /// A frameless pool record instead answers from <see cref="Transaction.PersistedPaymaster"/>, which it carries
+    /// across a reload so the cap counts the record the same either side of one.
     /// </remarks>
     public static Address? GetPrefixPaymaster(Transaction transaction)
     {

--- a/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
@@ -271,6 +271,9 @@ public class LightTxDecoderTests
             Assert.That(decoded.NonceKeys, Is.EqualTo(keys));
             Assert.That(decoded.PayerAddress, Is.EqualTo(withPayer ? TestItem.AddressB : null));
             Assert.That(decoded.PayerExposure, Is.EqualTo(withPayer ? (UInt256)12_345 : null));
+            // The shape a build before the sponsor slot writes: it has to price as unsponsored at restore and
+            // at release alike, so the record releases nothing it never took.
+            Assert.That(decoded.PersistedPaymaster, Is.Null);
         }
     }
 
@@ -308,6 +311,86 @@ public class LightTxDecoderTests
             Assert.That(decoded.PayerAddress, Is.EqualTo(TestItem.AddressB));
             Assert.That(decoded.PayerExposure, Is.EqualTo(UInt256.Zero));
         }
+    }
+
+    // The sponsor is derived from the frames, which a reloaded record no longer has, so the cap can only
+    // count it again if the record carries it. The payer slot ahead of it may be empty.
+    [TestCase(true, TestName = "a sponsor alongside a payer")]
+    [TestCase(false, TestName = "a sponsor with the payer slot left empty")]
+    public void Round_trip_carries_the_paymaster_in_the_trailing_group(bool withPayer)
+    {
+        Transaction tx = BlobCarryingTx(TxType.FrameTx, paymaster: TestItem.AddressF);
+        if (withPayer)
+        {
+            tx.PayerAddress = TestItem.AddressB;
+            tx.PayerExposure = 99;
+        }
+
+        LightTransaction decoded = LightTxDecoder.Decode(LightTxDecoder.Encode(tx));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.PersistedPaymaster, Is.EqualTo(TestItem.AddressF));
+            Assert.That(decoded.PayerAddress, Is.EqualTo(withPayer ? TestItem.AddressB : null));
+            Assert.That(decoded.PayerExposure, Is.EqualTo(withPayer ? (UInt256)99 : UInt256.Zero));
+        }
+    }
+
+    // An unsponsored record must keep the exact bytes an earlier build gives it, so the slot costs only itself.
+    [Test]
+    public void A_paymaster_grows_the_record_by_its_own_slot_alone()
+    {
+        Transaction withPayer = BlobCarryingTx(TxType.FrameTx);
+        withPayer.PayerAddress = TestItem.AddressB;
+        withPayer.PayerExposure = 1;
+        Transaction sponsored = BlobCarryingTx(TxType.FrameTx, paymaster: TestItem.AddressF);
+        sponsored.PayerAddress = TestItem.AddressB;
+        sponsored.PayerExposure = 1;
+
+        int grownBy = LightTxDecoder.Encode(sponsored).Length - LightTxDecoder.Encode(withPayer).Length;
+
+        Assert.That(grownBy, Is.EqualTo(21), "the 21-byte address and nothing else");
+    }
+
+    // The slots are read against the group end, so a build that appends one must not make every record
+    // written by it unreadable to this one.
+    [Test]
+    public void A_record_carrying_an_unknown_trailing_slot_still_decodes()
+    {
+        Transaction tx = BlobCarryingTx(TxType.FrameTx, paymaster: TestItem.AddressF);
+        tx.PayerAddress = TestItem.AddressB;
+        tx.PayerExposure = 1;
+        byte[] extended = WithExtraTrailingSlot(LightTxDecoder.Encode(tx));
+
+        LightTransaction decoded = LightTxDecoder.Decode(extended);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.PersistedPaymaster, Is.EqualTo(TestItem.AddressF));
+            Assert.That(decoded.PayerAddress, Is.EqualTo(TestItem.AddressB));
+        }
+    }
+
+    /// <summary>Appends one slot to the record's trailing group, as a later build would.</summary>
+    private static byte[] WithExtraTrailingSlot(byte[] record)
+    {
+        // The group closes the record, so its short-form header is the one byte whose declared length runs
+        // exactly to the end.
+        int header = -1;
+        for (int i = record.Length - 1; i >= 0; i--)
+        {
+            if (record[i] is >= 0xC0 and <= 0xF7 && record[i] - 0xC0 == record.Length - i - 1)
+            {
+                header = i;
+                break;
+            }
+        }
+
+        Assert.That(header, Is.GreaterThanOrEqualTo(0), "the record must end in a short-form trailing group");
+
+        byte[] extended = [.. record, 0x2A];
+        extended[header]++;
+        return extended;
     }
 
     // A legacy record whose flat list is empty leaves the group zero-length, and IsSequenceNext is an
@@ -362,7 +445,7 @@ public class LightTxDecoderTests
         Assert.That(grownBy, Is.EqualTo(1 + 1 + 21 + 1));
     }
 
-    private static Transaction BlobCarryingTx(TxType type, ulong? deadline = null, UInt256[] nonceKeys = null)
+    private static Transaction BlobCarryingTx(TxType type, ulong? deadline = null, UInt256[] nonceKeys = null, Address paymaster = null)
     {
         byte[][] versionedHashes = [new byte[32]];
         Transaction tx = new()
@@ -387,6 +470,12 @@ public class LightTxDecoderTests
         {
             tx.Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default)];
             tx.FrameSignatures = [];
+        }
+
+        if (paymaster is not null)
+        {
+            // The first payment-approving frame of the prefix is the sponsor, so it has to lead the self-relay one.
+            tx.Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApprovePayment, paymaster, gasLimit: 60_000, UInt256.Zero, default), .. tx.Frames!];
         }
 
         if (deadline is not null)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -4792,17 +4792,15 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        // EIP8141-GAP: this pins a known bypass, not correct behaviour. A reloaded record carries no paymaster,
-        // so it takes no slot; the key cannot be persisted until the light-record trailing-field layout is settled
-        // (two adjacent optional sequences are ambiguous), which is why the fix is not here. Asserted so that a
-        // half-fix encoding the key on write but not on read fails here rather than silently under-counting.
+        // The reloaded record is frameless, so its sponsor has to come back off the record itself. The cases
+        // mirror the pre-restart ones exactly: a restart that dropped the sponsor would hand out a free slot.
         [Test]
-        public void Restored_blob_carrying_frame_tx_bypasses_the_sponsor_cap_until_its_key_is_persisted()
+        public async Task Restored_blob_carrying_frame_tx_still_counts_against_its_sponsor()
         {
             TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.StorageWithReorgs, PersistentBlobStorageSize = 10, BlobCacheSize = 10 };
             BlobTxStorage blobTxStorage = new();
             _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: blobTxStorage);
-            foreach (PrivateKey sender in new[] { TestItem.PrivateKeyA, TestItem.PrivateKeyB, TestItem.PrivateKeyC, TestItem.PrivateKeyD })
+            foreach (PrivateKey sender in new[] { TestItem.PrivateKeyA, TestItem.PrivateKeyB, TestItem.PrivateKeyC })
             {
                 EnsureSenderBalance(sender.Address, UInt256.MaxValue);
             }
@@ -4818,17 +4816,20 @@ namespace Nethermind.TxPool.Test
             _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: blobTxStorage);
             Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1), "the reloaded record is what the rest reads against");
 
+            // Brings the debug bookkeeping check over the seeded ledger, where a slot taken for a record the
+            // check cannot see again would show up as a mismatch rather than as a wrong verdict below.
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).WithTimestamp(1_000).TestObject);
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1), "nothing about the new head invalidates the reloaded record");
+
             AcceptTxResult afterRestart = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyB), TxHandlingOptions.None);
-            AcceptTxResult beyondTheHole = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyC), TxHandlingOptions.None);
 
             _txPool.RemoveTransaction(restored.Hash);
-            AcceptTxResult afterRestoredRemoval = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyD), TxHandlingOptions.None);
+            AcceptTxResult afterRestoredRemoval = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyC), TxHandlingOptions.None);
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(afterRestart, Is.EqualTo(AcceptTxResult.Accepted), "the bypass: the reloaded record has no sponsor to count");
-                Assert.That(beyondTheHole, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached), "the bypass costs one slot per restart rather than being unbounded");
-                Assert.That(afterRestoredRemoval, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached), "a record that took no slot must at least not free one");
+                Assert.That(afterRestart, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached), "the reloaded record still holds its sponsor's slot");
+                Assert.That(afterRestoredRemoval, Is.EqualTo(AcceptTxResult.Accepted), "removing the reloaded record frees the slot it took");
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTransaction.cs
@@ -90,7 +90,8 @@ public class LightTransaction : Transaction
         ulong? expiryDeadline = null,
         UInt256[]? nonceKeys = null,
         Address? payerAddress = null,
-        UInt256? payerExposure = null)
+        UInt256? payerExposure = null,
+        Address? paymaster = null)
     {
         Type = type;
         Hash = hash;
@@ -113,6 +114,8 @@ public class LightTransaction : Transaction
         // admission took rather than nothing.
         PayerAddress = payerAddress;
         PayerExposure = payerExposure;
+        // The sponsor slot the record still occupies, so the cap counts it again after a reload.
+        PersistedPaymaster = paymaster;
         _size = size;
     }
 

--- a/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
+++ b/src/Nethermind/Nethermind.TxPool/LightTxDecoder.cs
@@ -49,16 +49,20 @@ public class LightTxDecoder : TxDecoder<Transaction>
             : Rlp.LengthOfSequence(content);
     }
 
-    /// <summary>Content length of the grouped form, or zero for a record that needs no payer.</summary>
+    /// <summary>Content length of the grouped form, or zero for a record that needs neither payer nor paymaster.</summary>
     private static int TrailingContentLength(Transaction tx)
     {
-        if (tx.PayerAddress is null) return 0;
+        Address? paymaster = FrameTxValidation.GetPrefixPaymaster(tx);
+        if (tx.PayerAddress is null && paymaster is null) return 0;
 
         // Slot 0 is always the keys list, so its sequence header is what tells this form from the flat
         // nonce_keys list a payerless record still writes, whose first element is a scalar.
         return (tx.NonceKeys is { } nonceKeys ? FrameTxNonceCalldata.KeysLength(nonceKeys) : Rlp.LengthOfSequence(0))
                + Rlp.LengthOf(tx.PayerAddress)
-               + Rlp.LengthOf(tx.PayerExposure ?? default);
+               + Rlp.LengthOf(tx.PayerExposure ?? default)
+               // Written only when there is a sponsor, so a record without one keeps the exact bytes an
+               // earlier build gives it.
+               + (paymaster is null ? 0 : Rlp.LengthOf(paymaster));
     }
 
     public static byte[] Encode(Transaction tx)
@@ -104,6 +108,9 @@ public class LightTxDecoder : TxDecoder<Transaction>
             // A payer that never reached the exposure gate holds no reservation, which this record does not
             // distinguish from a zero one: reserving, releasing and restoring zero are all no-ops.
             writer.Encode(tx.PayerExposure ?? default);
+            // The sponsor the pending-paymaster cap counts against, unrecoverable after a reload because the
+            // frames that named it are gone.
+            if (FrameTxValidation.GetPrefixPaymaster(tx) is Address paymaster) writer.Encode(paymaster);
         }
 
         return bytes;
@@ -154,6 +161,7 @@ public class LightTxDecoder : TxDecoder<Transaction>
         UInt256[]? nonceKeys = null;
         Address? payerAddress = null;
         UInt256? payerExposure = null;
+        Address? paymaster = null;
         if (ctx.PeekNumberOfItemsRemaining(maxSearch: 1) == 1)
         {
             // Legacy records end in a flat nonce_keys list, whose first element is a scalar; the grouped form
@@ -166,8 +174,13 @@ public class LightTxDecoder : TxDecoder<Transaction>
             if (trailingLength > 0 && ctx.IsSequenceNext())
             {
                 nonceKeys = DecodeKeysOrNull(ref ctx);
-                if (ctx.Position < end) payerAddress = ctx.DecodeAddress();
+                // Nullable: a record carrying a sponsor but no payer still has to fill the slot ahead of it.
+                if (ctx.Position < end) payerAddress = ctx.DecodeAddressOrNull();
                 if (ctx.Position < end) payerExposure = ctx.DecodeUInt256();
+                if (ctx.Position < end) paymaster = ctx.DecodeAddressOrNull();
+                // Positional slots read against the group end, so a slot a later build appends is skipped
+                // here rather than making the whole record unreadable.
+                ctx.Position = end;
             }
             else
             {
@@ -199,7 +212,8 @@ public class LightTxDecoder : TxDecoder<Transaction>
             expiryDeadline,
             nonceKeys,
             payerAddress,
-            payerExposure);
+            payerExposure,
+            paymaster);
     }
 
     private static void EncodeAvailableCellMask(Transaction tx, ref RlpWriter writer)

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -233,6 +233,13 @@ namespace Nethermind.TxPool
                     {
                         _payerExposure.Restore(payer, reserved);
                     }
+
+                    // Taken again rather than re-judged, for the same reason: the slot was granted at admission,
+                    // and a record whose slot went untaken would release one it never held when it leaves.
+                    if (GetPaymaster(restored) is Address paymaster)
+                    {
+                        _pendingPaymasters.Reserve(paymaster);
+                    }
                 }
             }
 
@@ -553,8 +560,7 @@ namespace Nethermind.TxPool
         }
 
 #if DEBUG
-        // A restored record's payer is persisted, so it is inside this check's reach. Its paymaster is not:
-        // LightTxDecoder drops it, so GetPaymaster prices null here and at release alike.
+        // A restored record's payer and paymaster are both persisted, so it is inside this check's reach.
         private static void AccumulateFrameTxBookkeeping(
             Transaction[] snapshot, Dictionary<AddressAsKey, UInt256> exposure, Dictionary<AddressAsKey, int> paymasters, ref int expiring)
         {


### PR DESCRIPTION
> Stacked on #13118 — review that one first; this PR's diff is the fix alone.

## The defect

The pending-paymaster cap is derived from the frame list. A reloaded pool record is frameless, so on restore it took no slot and on removal released none: **every restart handed each sponsor a free slot**, and the cap was under-enforced from then on.

This was pinned as a known bypass, deferred because the light-record trailing-field layout was not yet settled (two adjacent optional sequences could not be told apart). That layout has since landed as a single grouped form, so the stated blocker is discharged and the slot can be persisted positionally alongside the payer.

## Changes

- `LightTxDecoder` — the sponsor becomes a fourth slot of the trailing group, written **only when there is one**, so an unsponsored record keeps the exact bytes an earlier build gives it. The payer slot ahead of it is now read as nullable, so a sponsor can stand without a payer.
- `LightTransaction` — carries the sponsor back off the record.
- `TxPool` — the restore loop re-takes the slot while seeding the ledger, next to the payer exposure already restored there. Taken again rather than re-judged, for the same reason the exposure is: the slot was granted at admission, and a record whose slot went untaken would release one it never held when it leaves.
- Also consume the remainder of the group after the known slots. They are read positionally against the group end, so a slot appended by a later build would otherwise make the whole record unreadable here rather than merely unread.

Two comments that described the old behaviour are corrected.

## Verification

`Restored_blob_carrying_frame_tx_still_counts_against_its_sponsor` replaces the test that pinned the bypass, and mirrors the pre-restart cases exactly. Reverting the production change alone fails **both** of its assertions:

```
Assert.That(afterRestart, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached))
Assert.That(afterRestoredRemoval, Is.EqualTo(AcceptTxResult.Accepted))
```

It also raises a head after the restore, which brings the debug bookkeeping check over the seeded ledger. That check is `#if DEBUG`, so it is invisible to a release run; a deliberate double-reserve on restore trips it with `Paymaster … counts 2 pending, but 1 pooled transactions name it`, confirming it is live on this path rather than merely passing.

Decoder-level cases cover the round trip with and without a payer, that the slot grows an unsponsored record by nothing and a sponsored one by the address alone, and that a record carrying an unknown trailing slot still decodes — the last fails if the consume-the-rest is removed.

`Nethermind.TxPool.Test` passes in **both release and debug** (1056 passed, 4 skipped). Full release build clean; lint gate in CI form passes, positive-controlled.

## Compatibility

A record written by this build carries one extra slot. A build without the consume-the-rest will skip such a record rather than fail to start — the pool is a cache, and `GetAll` already tolerates unreadable records.

## Types of changes

- [x] Bug fix
- [x] Tests

## Testing

Regression test confirmed to fail without the fix, as above.