### PR TITLE
fix(eip8141): reject a VERIFY frame behind an unrecognized validation prefix

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Builders/FrameTxTestFrames.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/FrameTxTestFrames.cs
@@ -71,6 +71,11 @@ public static class FrameTxTestFrames
     public static TxFrame PostTx(ulong gasLimit = 1_000) =>
         new(TxFrame.ModePostTx, TxFrame.ApproveScopeNone, TestItem.AddressB, gasLimit, UInt256.Zero, default);
 
+    /// <summary>A VERIFY frame carrying no approval scope: a validation step ahead of the approving frame.</summary>
+    /// <remarks>The prefix grammar names no shape starting with one, so a layout leading with it is unrecognized.</remarks>
+    public static TxFrame ExtraVerify(ulong gasLimit = 1_000) =>
+        new(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, TestItem.AddressC, gasLimit, UInt256.Zero, default);
+
     /// <remarks>Approving flags on a DEFAULT frame make the layout unrecognized rather than ending the prefix.</remarks>
     public static TxFrame ApprovingDefault(ulong gasLimit = 1_000) =>
         new(TxFrame.ModeDefault, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit, UInt256.Zero, default);

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -320,22 +320,34 @@ public static class FrameTxValidation
     }
 
     /// <summary>
-    /// True if <paramref name="transaction"/> carries a <c>VERIFY</c> frame behind its recognized
-    /// validation prefix, which EIP-8141 bars from the public mempool.
+    /// True if <paramref name="transaction"/> carries a <c>VERIFY</c> frame behind its validation prefix,
+    /// which EIP-8141 bars from the public mempool.
     /// </summary>
     /// <remarks>
     /// A public-mempool rule, not a validity rule: a VERIFY frame past the prefix can revert on state the pool never
-    /// validated, invalidating the whole transaction. Layouts matching no recognized prefix are not covered.
+    /// validated, invalidating the whole transaction. The bound is taken at the first frame permitted to approve
+    /// payment, at or before the frame that actually installs the payer, so it errs towards refusing a layout whose
+    /// approving frame would not have installed one rather than admitting a frame behind the real prefix.
     /// </remarks>
     public static bool HasVerifyFrameAfterPrefix(Transaction transaction)
     {
         TxFrame[] frames = transaction.Frames ?? [];
-        if (RecognizedPrefixLength(frames, transaction.SenderAddress) is not int prefixLength)
+        int prefixEnd = -1;
+        for (int i = 0; i < frames.Length; i++)
+        {
+            if ((frames[i].Flags & TxFrame.ApprovePayment) != 0)
+            {
+                prefixEnd = i;
+                break;
+            }
+        }
+
+        if (prefixEnd < 0)
         {
             return false;
         }
 
-        for (int i = prefixLength; i < frames.Length; i++)
+        for (int i = prefixEnd + 1; i < frames.Length; i++)
         {
             if (frames[i].Mode == TxFrame.ModeVerify)
             {

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -96,6 +96,39 @@ public class FrameTxValidationPrefixSimulationTests
         }
     }
 
+    private static IEnumerable<TestCaseData> UnrecognizedPrefixCases()
+    {
+        TxFrame extraVerify = new(TxFrame.ModeVerify, flags: 0, TestItem.AddressC, gasLimit: 200_000, UInt256.Zero, default);
+        TxFrame deploy = new(TxFrame.ModeDefault, flags: 0, TestItem.AddressC, gasLimit: 200_000, UInt256.Zero, default);
+        TxFrame trailingVerify = new(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 200_000, UInt256.Zero, default);
+
+        yield return new TestCaseData(new[] { extraVerify, SelfVerifyFrame(), trailingVerify }, true)
+            .SetName("Simulate_ExtraLeadingVerifyFrame_ResolvesPayerBehindAnUnrecognizedLayout");
+        // The prefix admits one opening deploy frame, and only ahead of a VERIFY frame.
+        yield return new TestCaseData(new[] { deploy, deploy, SelfVerifyFrame(), trailingVerify }, false)
+            .SetName("Simulate_SecondLeadingDeployFrame_EndsThePrefixBeforeAnyPayer");
+    }
+
+    // What the prefix loop admits is a leading run of VERIFY frames, which is wider than the layouts
+    // RecognizedPrefixLength names: the trailing VERIFY frame of an admitted one is never simulated.
+    [TestCaseSource(nameof(UnrecognizedPrefixCases))]
+    public void Simulate_LayoutOutsideTheRecognizedGrammar_ResolvesAPayerOnlyFromALeadingVerifyRun(TxFrame[] frames, bool expectedPayer)
+    {
+        DeployContract(TestItem.AddressC, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+        Transaction tx = FrameTx(nonce: 0, frames);
+
+        (TransactionResult result, FrameTxValidationTracer tracer) = Simulate(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.EqualTo(expectedPayer), result.ErrorDescription);
+            Assert.That(tracer.Payer, expectedPayer ? Is.EqualTo(Sender) : Is.Null);
+            Assert.That(FrameTxValidation.HasVerifyFrameAfterPrefix(tx), Is.True,
+                "the pool bound must claim the trailing VERIFY frame the simulation never reaches");
+        }
+    }
+
     [Test]
     public void Simulate_PrefixNeverSetsPayer_Rejected()
     {

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyAfterPrefixFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxVerifyAfterPrefixFilterTest.cs
@@ -38,10 +38,20 @@ internal class FrameTxVerifyAfterPrefixFilterTest
             .SetName("a trailing expiry frame is rejected as a VERIFY frame behind the prefix");
         yield return new TestCaseData(new[] { OnlyVerify(), Pay(), Execution(), Pay() }, AcceptTxResult.FrameTxVerifyAfterPrefix)
             .SetName("a VERIFY frame behind a paymaster prefix is rejected");
-        // A layout matching none of the recognized prefixes has no boundary to sit behind; the rules
-        // that reject it do so on their own terms.
+        // Nothing can approve payment ahead of the only approving frame, so there is no prefix to sit behind.
         yield return new TestCaseData(new[] { Execution(), SelfVerify() }, AcceptTxResult.Accepted)
-            .SetName("an unrecognized layout is left to the other rules");
+            .SetName("a layout whose only approving frame is last has nothing behind it");
+        // A leading VERIFY frame the grammar does not name leaves the layout unrecognized, and simulation
+        // admits it, so its trailing VERIFY frame would otherwise reach the pool unjudged.
+        yield return new TestCaseData(new[] { ExtraVerify(), SelfVerify(), Execution(), OnlyVerify() }, AcceptTxResult.FrameTxVerifyAfterPrefix)
+            .SetName("a VERIFY frame behind an unrecognized prefix is rejected");
+        yield return new TestCaseData(new[] { ExtraVerify(), SelfVerify(), Execution() }, AcceptTxResult.Accepted)
+            .SetName("an unrecognized prefix without a trailing VERIFY frame is admissible");
+        yield return new TestCaseData(new[] { OnlyVerify(), ExtraVerify(), Pay(), Execution(), OnlyVerify() }, AcceptTxResult.FrameTxVerifyAfterPrefix)
+            .SetName("a VERIFY frame behind a paymaster prefix carrying an extra check is rejected");
+        // The boundary is the approval flag rather than the mode, which carries no scope of its own.
+        yield return new TestCaseData(new[] { ApprovingDefault(), Execution(), OnlyVerify() }, AcceptTxResult.FrameTxVerifyAfterPrefix)
+            .SetName("a VERIFY frame behind an approving DEFAULT frame is rejected");
     }
 
     [TestCaseSource(nameof(PrefixCases))]

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -3102,7 +3102,42 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        private Transaction SelfVerifyFrameTx(params TxFrame[] trailingFrames)
+        // Simulation admits this layout and stops at the payer, so it never reaches the trailing VERIFY frame
+        // that can invalidate the transaction later. FrameTxValidationPrefixSimulationTests runs the real one.
+        [TestCase(false, TestName = "SubmitTx_UnrecognizedPrefixWithATrailingSenderFrame_IsAccepted")]
+        [TestCase(true, TestName = "SubmitTx_UnrecognizedPrefixWithATrailingVerifyFrame_IsRejected")]
+        public void SubmitTx_FrameTransactionBehindAnUnrecognizedPrefix_IsJudgedOnItsTrailingFrame(bool trailingVerify)
+        {
+            IFrameTxPrefixSimulator simulator = Substitute.For<IFrameTxPrefixSimulator>();
+            simulator.Simulate(Arg.Any<Transaction>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<bool>())
+                .Returns(FrameTxSimulationResult.Accept(TestItem.PrivateKeyA.Address));
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance), frameTxPrefixSimulator: simulator);
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+
+            TxFrame trailing = trailingVerify
+                ? new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 1_000, UInt256.Zero, Array.Empty<byte>())
+                : new TxFrame(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, gasLimit: 1_000, UInt256.Zero, Array.Empty<byte>());
+
+            AcceptTxResult result = _txPool.SubmitTx(UnrecognizedPrefixFrameTx(trailing), TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(trailingVerify ? AcceptTxResult.FrameTxVerifyAfterPrefix : AcceptTxResult.Accepted));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(trailingVerify ? 0 : 1));
+            }
+        }
+
+        /// <summary>A leading VERIFY frame carrying no approval scope, which the prefix grammar does not name.</summary>
+        private Transaction UnrecognizedPrefixFrameTx(params TxFrame[] trailingFrames) =>
+            SignedFrameTx([FrameTxTestFrames.ExtraVerify(), SelfVerifyPrefixFrame(), .. trailingFrames]);
+
+        private Transaction SelfVerifyFrameTx(params TxFrame[] trailingFrames) =>
+            SignedFrameTx([SelfVerifyPrefixFrame(), .. trailingFrames]);
+
+        private static TxFrame SelfVerifyPrefixFrame() =>
+            new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, Array.Empty<byte>());
+
+        private Transaction SignedFrameTx(TxFrame[] frames)
         {
             Transaction frameTx = new()
             {
@@ -3110,11 +3145,7 @@ namespace Nethermind.TxPool.Test
                 ChainId = _specProvider.ChainId,
                 Nonce = 0,
                 SenderAddress = TestItem.PrivateKeyA.Address,
-                Frames =
-                [
-                    new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, Array.Empty<byte>()),
-                    .. trailingFrames,
-                ],
+                Frames = frames,
                 FrameSignatures = [],
                 GasLimit = 1_000_000,
                 GasPrice = 1.GWei,


### PR DESCRIPTION
## Changes

`FrameTxVerifyAfterPrefixFilter` refuses a `VERIFY` frame behind the validation prefix, because such a frame can revert on state the pool never validated and invalidate the whole transaction. The bound was derived from the recognized prefix grammar, and returned "no VERIFY frame behind the prefix" whenever the layout matched none of the recognized shapes.

The set of layouts the prefix simulation admits is wider than the set the grammar names. The simulation loop walks a **leading run of `VERIFY` frames** — plus at most one opening `deploy` frame, and only where the next frame is a `VERIFY` one — and stops at the first payer. The grammar names only two shapes of that run (`self_verify`, and `only_verify` immediately followed by `pay`). Any other leading `VERIFY` run is simulated, accepted, and left unjudged behind the payer: e.g. `[verify(no scope), self_verify, user_op, only_verify]`, where the extra leading frame runs a validation step of its own before the approving frame. `FrameTxValidationPrefixSimulationTests` pins that layout resolving a payer through the real processor, so the claim rests on the real prefix loop rather than on a substituted simulator.

The fix takes the boundary from the first frame permitted to approve payment. A frame without the payment bit cannot approve payment, so that index is at or before the frame that actually installs the payer — the bound therefore sits at or before the real end of the prefix, never past it, which is what makes it sound. It is the same boundary on every layout the grammar recognizes, so no accepted transaction changes verdict; it additionally covers the layouts the grammar does not recognize, and frames that may approve payment in any mode rather than only `VERIFY` ones. The deliberate cost is that it can refuse a layout whose approving frame would not in fact have installed the payer — the alternative is deciding that by simulation, which is what this bound exists to avoid.

## Why the tests landed separately

#13117 carried the structural-admission tests and is already merged. Those document behaviour that was **already correct** — the previously untested signature and calldata filters, the frame-count boundaries, the EIP-7825 transaction gas cap — so they were green on arrival, as tests for working code should be. The tests that expose this defect ship here instead, with the fix that makes them pass, per the repo rule that a bugfix carries its regression test. That is why #13117 was not red.

## Regression coverage

Four cases in `FrameTxVerifyAfterPrefixFilterTest`, two pool-level cases, and two real-processor cases in `FrameTxValidationPrefixSimulationTests` (one layout that resolves a payer outside the grammar, one that does not). All six rejection and reachability cases were confirmed to fail with `FrameTxValidation.cs` reverted and the tests kept.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.TxPool.Test` green in release and debug (1096), `Nethermind.Core.Test` green (6246), `FrameTxValidationPrefixSimulationTests` green (72). Full release build and the CI lint gate are clean. The changed method has one caller, an incoming pool filter, so no block-validation or processing path is affected.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
