### PR TITLE
test(eip8141): pin payer exposure, the paymaster cap and the prefix trace rules

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
@@ -229,6 +229,55 @@ public class FrameTxPrefixSimulatorTests
     }
 
     [Test]
+    public void Simulate_TracerAbortsOnAViolation_RejectsWithTheReasonRatherThanDeferring()
+    {
+        // The tracer cancels the interpreter at the first banned opcode, so the violation reaches the
+        // simulator as a cancellation. Read as an ordinary one it would defer, and admission would pool
+        // the transaction the trace rules exist to refuse.
+        using FrameTxPrefixSimulator simulator = CreateOverBuiltEnv(out _, out ITransactionProcessor processor);
+        Violate(processor);
+        processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
+            .Throws(new OperationCanceledException());
+
+        FrameTxSimulationResult result = simulator.Simulate(FrameTx());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Outcome, Is.EqualTo(FrameTxSimulationOutcome.Rejected));
+            Assert.That(result.Indeterminate, Is.False, "a trace violation is a definite verdict on the prefix");
+            Assert.That(result.Reason, Does.Contain("SLOAD outside tx.sender storage"));
+        }
+    }
+
+    [Test]
+    public void Simulate_TracerAbortsOnItsWallClockBound_IsChargedToTheSender()
+    {
+        // The prefix's own wall clock trips the timeout, so revalidation retains it, but it still counts
+        // against the sender rather than reading as this node shedding load.
+        using FrameTxPrefixSimulator simulator = CreateOverBuiltEnv(out _, out ITransactionProcessor processor, timeoutMs: 1);
+        processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
+            .Returns<TransactionResult>(static _ =>
+            {
+                Thread.Sleep(50);
+                throw new OperationCanceledException();
+            });
+
+        FrameTxSimulationResult result = simulator.Simulate(FrameTx());
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Outcome, Is.EqualTo(FrameTxSimulationOutcome.Rejected));
+            Assert.That(result.Indeterminate, Is.True, "a timeout says nothing about the prefix's validity");
+            Assert.That(result.NodeBound, Is.False, "the sender chose the prefix that spent the clock");
+        }
+    }
+
+    /// <summary>Records a trace violation on whichever tracer the simulator hands the processor.</summary>
+    private static void Violate(ITransactionProcessor processor) =>
+        processor.When(static p => p.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>()))
+            .Do(static call => call.ArgAt<ITxTracer>(1).LoadOperationStorage(TestItem.AddressB, UInt256.Zero, ReadOnlySpan<byte>.Empty));
+
+    [Test]
     public void Simulate_AfterDispose_LeavesTheTransactionUndecided()
     {
         FrameTxPrefixSimulator simulator = CreateOverBuiltEnv(out _, out _);
@@ -375,7 +424,8 @@ public class FrameTxPrefixSimulatorTests
     private static FrameTxPrefixSimulator CreateOverBuiltEnv(
         out IReadOnlyTxProcessorSource source,
         out ITransactionProcessor processor,
-        InterfaceLogger? logSink = null)
+        InterfaceLogger? logSink = null,
+        int timeoutMs = 250)
     {
         processor = Substitute.For<ITransactionProcessor>();
         IReadOnlyTxProcessingScope scope = Substitute.For<IReadOnlyTxProcessingScope>();
@@ -388,7 +438,7 @@ public class FrameTxPrefixSimulatorTests
         IReadOnlyTxProcessingEnvFactory envFactory = Substitute.For<IReadOnlyTxProcessingEnvFactory>();
         envFactory.Create().Returns(source);
 
-        return CreateSimulator(envFactory, BlockFinderAtHead(), budgetPerHeadMs: 1000, logSink);
+        return CreateSimulator(envFactory, BlockFinderAtHead(), budgetPerHeadMs: 1000, logSink, timeoutMs);
     }
 
     private static IBlockFinder BlockFinderAtHead()

--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
@@ -235,9 +235,13 @@ public class FrameTxPrefixSimulatorTests
         // simulator as a cancellation. Read as an ordinary one it would defer, and admission would pool
         // the transaction the trace rules exist to refuse.
         using FrameTxPrefixSimulator simulator = CreateOverBuiltEnv(out _, out ITransactionProcessor processor);
-        Violate(processor);
+        // One arrangement, so the tracer can only be reached by the call the simulator itself makes.
         processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
-            .Throws(new OperationCanceledException());
+            .Returns<TransactionResult>(static call =>
+            {
+                call.ArgAt<ITxTracer>(1).LoadOperationStorage(TestItem.AddressB, UInt256.Zero, ReadOnlySpan<byte>.Empty);
+                throw new OperationCanceledException();
+            });
 
         FrameTxSimulationResult result = simulator.Simulate(FrameTx());
 
@@ -271,11 +275,6 @@ public class FrameTxPrefixSimulatorTests
             Assert.That(result.NodeBound, Is.False, "the sender chose the prefix that spent the clock");
         }
     }
-
-    /// <summary>Records a trace violation on whichever tracer the simulator hands the processor.</summary>
-    private static void Violate(ITransactionProcessor processor) =>
-        processor.When(static p => p.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>()))
-            .Do(static call => call.ArgAt<ITxTracer>(1).LoadOperationStorage(TestItem.AddressB, UInt256.Zero, ReadOnlySpan<byte>.Empty));
 
     [Test]
     public void Simulate_AfterDispose_LeavesTheTransactionUndecided()

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -39,6 +39,7 @@ public class FrameTxValidationPrefixSimulationTests
     private static readonly Address Sender = TestItem.AddressA;
     private static readonly Address Sponsor = TestItem.AddressD;
     private static readonly Address Factory = TestItem.AddressB;
+    private static readonly Address IdentityPrecompile = Address.FromNumber(4);
     private static readonly byte[] Salt = new byte[32];
 
     [SetUp]
@@ -216,6 +217,56 @@ public class FrameTxValidationPrefixSimulationTests
             Assert.That(result.TransactionExecuted, Is.True);
             Assert.That(tracer.Payer, Is.EqualTo(Sender));
         }
+    }
+
+    [Test]
+    // A precompile carries no code, so classifying targets on code alone would refuse the one class whose
+    // behaviour no account state can move.
+    public void Simulate_PrefixCallsPrecompile_Allowed() =>
+        AssertPrefixCallTarget(IdentityPrecompile, violates: false);
+
+    [Test]
+    public void Simulate_PrefixCallsDelegatedTarget_RecordsViolation()
+    {
+        // The target is a contract, but its EIP-7702 authority can repoint the designation, so the code
+        // the prefix runs is third-party mutable.
+        DeployContract(TestItem.AddressE, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        DeployContract(TestItem.AddressC, [.. Eip7702Constants.DelegationHeader, .. TestItem.AddressE.Bytes]);
+
+        AssertPrefixCallTarget(TestItem.AddressC, violates: true);
+    }
+
+    // The target sits at a different stack slot for each of these, so the allowed row is what proves the
+    // slot is read rather than the ban firing on whatever else is on the stack.
+    [TestCase(Instruction.EXTCODESIZE, 0, false, TestName = "EXTCODESIZE of a helper contract is allowed")]
+    [TestCase(Instruction.EXTCODESIZE, 0, true, TestName = "EXTCODESIZE of a codeless target is refused")]
+    [TestCase(Instruction.EXTCODEHASH, 0, true, TestName = "EXTCODEHASH of a codeless target is refused")]
+    [TestCase(Instruction.EXTCODECOPY, 3, true, TestName = "EXTCODECOPY of a codeless target is refused")]
+    public void Simulate_PrefixReadsForeignCode_IsClassifiedByTheTarget(Instruction opcode, int extraOperands, bool violates)
+    {
+        if (!violates) DeployContract(TestItem.AddressC, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        Prepare prologue = Prepare.EvmCode;
+        for (int i = 0; i < extraOperands; i++) prologue = prologue.PushData(0);
+        byte[] code = prologue.PushData(TestItem.AddressC).Op(opcode)
+            .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+        DeployContract(Sender, code, 1.Ether);
+
+        (_, FrameTxValidationTracer tracer) = SimulateAllowingAbort(FrameTx(nonce: 0, SelfVerifyFrame()));
+
+        Assert.That(tracer.ViolationReason, violates ? Does.Contain("disallowed target") : Is.Null);
+    }
+
+    private void AssertPrefixCallTarget(Address target, bool violates)
+    {
+        byte[] code = Prepare.EvmCode
+            .StaticCall(target, 50_000)
+            .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+        DeployContract(Sender, code, 1.Ether);
+
+        (_, FrameTxValidationTracer tracer) = SimulateAllowingAbort(FrameTx(nonce: 0, SelfVerifyFrame()));
+
+        Assert.That(tracer.Violated, Is.EqualTo(violates));
     }
 
     // The banned list is the security surface of admission, so it is swept whole: any of these in the
@@ -577,13 +628,20 @@ public class FrameTxValidationPrefixSimulationTests
 
     // The deploy frame is the one non-static prefix frame, so it is the only place a funded CALL is
     // reachable at all: it executes or pushes zero on the caller's balance, which a third party can move.
-    [TestCase(0, false, TestName = "Simulate_DeployFrameMakesAZeroValueCall_Allowed")]
-    [TestCase(1, true, TestName = "Simulate_DeployFrameMakesAValueCarryingCall_RecordsViolation")]
-    public void Simulate_DeployFrameCallCarryingValue_IsRefused(int value, bool violates)
+    // CALLCODE carries its own endowment at the same stack depth, so it reaches the caller's balance the
+    // same way even though it runs the target's code in place.
+    [TestCase(0, false, false, TestName = "Simulate_DeployFrameMakesAZeroValueCall_Allowed")]
+    [TestCase(1, true, false, TestName = "Simulate_DeployFrameMakesAValueCarryingCall_RecordsViolation")]
+    [TestCase(0, false, true, TestName = "Simulate_DeployFrameMakesAZeroValueCallCode_Allowed")]
+    [TestCase(1, true, true, TestName = "Simulate_DeployFrameMakesAValueCarryingCallCode_RecordsViolation")]
+    public void Simulate_DeployFrameCallCarryingValue_IsRefused(int value, bool violates, bool callCode)
     {
         DeployContract(TestItem.AddressC, Prepare.EvmCode.Op(Instruction.STOP).Done);
         byte[] initCode = Prepare.EvmCode.ForInitOf(ApproveCode(TxFrame.ApproveExecutionAndPayment)).Done;
-        byte[] prologue = Prepare.EvmCode.CallWithValue(TestItem.AddressC, 50_000, (UInt256)value).Op(Instruction.POP).Done;
+        byte[] prologue = (callCode
+                ? Prepare.EvmCode.CallCode(TestItem.AddressC, 50_000, (UInt256)value)
+                : Prepare.EvmCode.CallWithValue(TestItem.AddressC, 50_000, (UInt256)value))
+            .Op(Instruction.POP).Done;
         Address deployed = InstallFactory(initCode, prologue);
         FundAccount(deployed, 1.Ether);
         Transaction tx = DeployTx(deployed);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -236,11 +236,12 @@ public class FrameTxValidationPrefixSimulationTests
         AssertPrefixCallTarget(TestItem.AddressC, violates: true);
     }
 
-    // The target sits at a different stack slot for each of these, so the allowed row is what proves the
-    // slot is read rather than the ban firing on whatever else is on the stack.
+    // EXTCODECOPY's operands are all zero, which reads as a forbidden target itself, so only its allowed
+    // row tells a correct target slot from a wrong one; the refused row alone would pass on either.
     [TestCase(Instruction.EXTCODESIZE, 0, false, TestName = "EXTCODESIZE of a helper contract is allowed")]
     [TestCase(Instruction.EXTCODESIZE, 0, true, TestName = "EXTCODESIZE of a codeless target is refused")]
     [TestCase(Instruction.EXTCODEHASH, 0, true, TestName = "EXTCODEHASH of a codeless target is refused")]
+    [TestCase(Instruction.EXTCODECOPY, 3, false, TestName = "EXTCODECOPY of a helper contract is allowed")]
     [TestCase(Instruction.EXTCODECOPY, 3, true, TestName = "EXTCODECOPY of a codeless target is refused")]
     public void Simulate_PrefixReadsForeignCode_IsClassifiedByTheTarget(Instruction opcode, int extraOperands, bool violates)
     {
@@ -257,6 +258,7 @@ public class FrameTxValidationPrefixSimulationTests
         Assert.That(tracer.ViolationReason, violates ? Does.Contain("disallowed target") : Is.Null);
     }
 
+    /// <remarks>Matched on the reason, so an unrelated rule firing first cannot stand in for the target one.</remarks>
     private void AssertPrefixCallTarget(Address target, bool violates)
     {
         byte[] code = Prepare.EvmCode
@@ -266,7 +268,7 @@ public class FrameTxValidationPrefixSimulationTests
 
         (_, FrameTxValidationTracer tracer) = SimulateAllowingAbort(FrameTx(nonce: 0, SelfVerifyFrame()));
 
-        Assert.That(tracer.Violated, Is.EqualTo(violates));
+        Assert.That(tracer.ViolationReason, violates ? Does.Contain("disallowed target") : Is.Null);
     }
 
     // The banned list is the security surface of admission, so it is swept whole: any of these in the

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -258,7 +258,7 @@ public class FrameTxValidationPrefixSimulationTests
         Assert.That(tracer.ViolationReason, violates ? Does.Contain("disallowed target") : Is.Null);
     }
 
-    /// <remarks>Matched on the reason, so an unrelated rule firing first cannot stand in for the target one.</remarks>
+    // Matched on the reason, so an unrelated rule firing first cannot stand in for the target one.
     private void AssertPrefixCallTarget(Address target, bool violates)
     {
         byte[] code = Prepare.EvmCode

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -4208,6 +4208,115 @@ namespace Nethermind.TxPool.Test
             Assert.That(overBound, Is.EqualTo(AcceptTxResult.FrameTxPayerExposureExceeded));
         }
 
+        [Test]
+        public void Frame_transaction_replacement_releases_only_the_reservation_it_displaced()
+        {
+            // Admission adds the bump on top of the incumbent's reservation and leaves the displacement to
+            // the pool, so the ledger settles only once the replaced transaction's removal releases it.
+            _txPool = CreatePool(null, new TestSpecProvider(Eip8141Prototype.Instance));
+
+            // Priced from the transactions themselves rather than scaled off one of them: the reservation
+            // is not linear in the fee, and a balance guessed from a unit cost would not sit on the bound.
+            UInt256 balance = MaxCostOf(SelfPayingFrameTx(nonce: 0, feePerGas: 3)) + MaxCostOf(SelfPayingFrameTx(nonce: 1, feePerGas: 2));
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, balance);
+
+            Assert.That(_txPool.SubmitTx(SelfPayingFrameTx(nonce: 0, feePerGas: 2), TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            AcceptTxResult bump = _txPool.SubmitTx(SelfPayingFrameTx(nonce: 0, feePerGas: 3), TxHandlingOptions.None);
+
+            // The balance leaves room for the bump and one more nonce, and nothing beyond it. Holding the
+            // displaced reservation as well would refuse the second nonce.
+            AcceptTxResult withinBalance = _txPool.SubmitTx(SelfPayingFrameTx(nonce: 1, feePerGas: 2), TxHandlingOptions.None);
+            AcceptTxResult overBalance = _txPool.SubmitTx(SelfPayingFrameTx(nonce: 2, feePerGas: 1), TxHandlingOptions.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(bump, Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(withinBalance, Is.EqualTo(AcceptTxResult.Accepted), "the displaced reservation must have been released");
+                Assert.That(overBalance, Is.EqualTo(AcceptTxResult.FrameTxPayerExposureExceeded), "the bound must still bind, or the case above proves nothing");
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(2), "the bump must have displaced the incumbent rather than joined it");
+            }
+        }
+
+        [Test]
+        public void Frame_transaction_replacement_leaves_its_paymaster_holding_exactly_one_slot()
+        {
+            // The cap counts the bump before the pool displaces the incumbent, so the sponsor is briefly at
+            // two. Settling at anything but one locks it out the moment the survivor leaves.
+            IFrameTxPrefixSimulator simulator = Substitute.For<IFrameTxPrefixSimulator>();
+            simulator.Simulate(Arg.Any<Transaction>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<bool>()).Returns(FrameTxSimulationResult.Accept(TestItem.AddressD));
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance), frameTxPrefixSimulator: simulator);
+
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.PrivateKeyB.Address, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressD, UInt256.MaxValue);
+            _stateProvider.InsertCode([0x60, 0x00], TestItem.AddressD);
+
+            Transaction bump = SponsoredFrameTx(TestItem.PrivateKeyA, TestItem.PrivateKeyD, feePerGas: 2.GWei);
+
+            AcceptTxResult admitted = _txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyA, TestItem.PrivateKeyD), TxHandlingOptions.None);
+            AcceptTxResult replaced = _txPool.SubmitTx(bump, TxHandlingOptions.None);
+            // One pending, so the sponsor is still at the cap: another sender must be turned away.
+            AcceptTxResult whileHeld = _txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyB, TestItem.PrivateKeyD), TxHandlingOptions.None);
+
+            _txPool.RemoveTransaction(bump.Hash);
+            // Repriced so it is a new hash: the one turned away above is remembered as already known.
+            AcceptTxResult afterRemoval = _txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyB, TestItem.PrivateKeyD, feePerGas: 3.GWei), TxHandlingOptions.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(admitted, Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(replaced, Is.EqualTo(AcceptTxResult.Accepted), "a fee bump discounts the slot the incumbent holds");
+                Assert.That(whileHeld, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached), "the survivor still owes the sponsor a slot");
+                Assert.That(afterRemoval, Is.EqualTo(AcceptTxResult.Accepted), "the displaced transaction must not have kept a slot");
+            }
+        }
+
+        [Test]
+        public async Task Frame_transactions_surviving_a_head_leave_both_ledgers_empty_when_drained()
+        {
+            // Drives the pool's own bookkeeping check, which walks both ledgers per head and is compiled
+            // into debug builds only; the release-observable half is that a drained pool re-admits.
+            IFrameTxPrefixSimulator simulator = Substitute.For<IFrameTxPrefixSimulator>();
+            simulator.Simulate(Arg.Any<Transaction>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<bool>()).Returns(FrameTxSimulationResult.Accept(TestItem.AddressD));
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance), frameTxPrefixSimulator: simulator);
+
+            EnsureSenderBalance(TestItem.PrivateKeyB.Address, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressD, UInt256.MaxValue);
+            _stateProvider.InsertCode([0x60, 0x00], TestItem.AddressD);
+
+            // Exactly one self-paying transaction's worth, so a reservation left behind refuses the next one.
+            // The retargeted shape is the dearer of the two, so the plain resubmission below fits it.
+            Transaction selfPaying = SelfPayingFrameTx(nonce: 0, feePerGas: 2, distinctHash: true);
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, MaxCostOf(selfPaying));
+
+            Assert.That(_txPool.SubmitTx(selfPaying, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyB, TestItem.PrivateKeyD), TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).TestObject);
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(2), "both must still be pending, or the check walked an empty pool");
+
+            foreach (Transaction pending in _txPool.GetPendingTransactions())
+            {
+                _txPool.RemoveTransaction(pending.Hash);
+            }
+
+            // Both re-priced or re-shaped, since the pool remembers what it has already seen.
+            AcceptTxResult resubmitted = _txPool.SubmitTx(SelfPayingFrameTx(nonce: 0, feePerGas: 2), TxHandlingOptions.None);
+            AcceptTxResult responsored = _txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyB, TestItem.PrivateKeyD, feePerGas: 3.GWei), TxHandlingOptions.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(resubmitted, Is.EqualTo(AcceptTxResult.Accepted), "the payer's whole balance is free again");
+                Assert.That(responsored, Is.EqualTo(AcceptTxResult.Accepted), "the sponsor's cap slot is free again");
+            }
+        }
+
+        private static UInt256 MaxCostOf(Transaction tx)
+        {
+            Assert.That(FrameTxValidation.TryCalculateMaxCost(tx, Eip8141Prototype.Instance, out UInt256 maxCost), Is.True);
+            return maxCost;
+        }
+
         /// <summary>A self_verify frame tx the payer resolver settles natively, so the exposure gate sees a payer.</summary>
         private Transaction SelfPayingFrameTx(ulong nonce, uint feePerGas, bool distinctHash = false, UInt256[] nonceKeys = null)
         {
@@ -4338,7 +4447,7 @@ namespace Nethermind.TxPool.Test
         }
 
         // An only_verify|pay prefix naming the sponsor: opaque to native resolution, so it is simulated.
-        private Transaction SponsoredFrameTx(PrivateKey senderKey, PrivateKey sponsorKey, UInt256[] nonceKeys = null, ulong? deadline = null)
+        private Transaction SponsoredFrameTx(PrivateKey senderKey, PrivateKey sponsorKey, UInt256[] nonceKeys = null, ulong? deadline = null, UInt256? feePerGas = null)
         {
             // An expiry verifier frame may appear only as the first frame (EIP-8141 "Expiry Verifier Frame").
             TxFrame[] frames = deadline is null
@@ -4367,8 +4476,8 @@ namespace Nethermind.TxPool.Test
                     new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, signer: sponsorKey.Address, default, default),
                 ],
                 GasLimit = 1_000_000,
-                GasPrice = 1.GWei,
-                DecodedMaxFeePerGas = 1.GWei,
+                GasPrice = feePerGas ?? 1.GWei,
+                DecodedMaxFeePerGas = feePerGas ?? 1.GWei,
             };
             // compute_sig_hash covers each entry's scheme/signer/msg and elides only the raw bytes, so the
             // signatures are taken with the entries already installed, then their bytes are filled in.

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -4322,8 +4322,8 @@ namespace Nethermind.TxPool.Test
         {
             Transaction tx = BuildFrameTx(nonce, TestItem.PrivateKeyA.Address, deadline: null,
                 maxPriorityFeePerGas: feePerGas, maxFeePerGas: feePerGas, nonceKeys: nonceKeys);
-            // Naming the sender explicitly is still a self_verify frame and prices identically, so this
-            // varies the hash without touching any input the reservation is computed from.
+            // Naming the sender explicitly is still a self_verify frame, so this varies the hash; the
+            // target costs 12 more intrinsic gas, so the retargeted shape reserves slightly more.
             if (distinctHash)
             {
                 int i = Array.FindIndex(tx.Frames!, f => f.Flags == TxFrame.ApproveExecutionAndPayment);


### PR DESCRIPTION
## Changes

Correctness tests for EIP-8141 admission: payer exposure accounting, the non-canonical paymaster cap, and the validation-prefix trace rules. Tests only — no production code changes. Complementary to #13041, which measures capacity rather than correctness.

**Prefix simulation (`Nethermind.Consensus.Test`)**
- A trace violation aborts the interpreter, so it reaches the simulator as a cancellation. Pinned that it maps to a definite rejection carrying the violation reason; read as an ordinary cancellation it becomes `Undecided` and the transaction is pooled.
- A wall-clock abort stays indeterminate but chargeable to the sender.

**Validation-prefix tracer (`Nethermind.Evm.Test`)**
- Call targets are classified by the target's code: a precompile is allowed, an EIP-7702 delegated contract is not. Both rows match the violation reason, so an unrelated rule halting first cannot stand in for the target one.
- `EXTCODESIZE` / `EXTCODEHASH` / `EXTCODECOPY` read the target from their own stack slot. `EXTCODECOPY`'s operands are all zero, which reads as a forbidden target in its own right, so its *allowed* row is what tells a correct slot from a wrong one; both rows are present.
- `CALLCODE` carries an endowment at the same depth as `CALL`, so it is refused the same way.

**Pool-level ledger symmetry (`Nethermind.TxPool.Test`)**
- A replacement settles the payer's exposure ledger at exactly the survivor's cost, and its sponsor's cap slot at exactly one.
- A pool drained after a head change leaves both ledgers empty; the head change also drives the pool's own per-head bookkeeping check, which is compiled into debug builds only.

## Types of changes

- [x] Testing

## Testing

- Full solution builds clean in release, 0 warnings / 0 errors; CI's code-quality gate reproduced locally with the same flags and positive-controlled by injecting an unused `using` (gate correctly reported `warning IDE0005`).
- `Nethermind.TxPool.Test` 1048 passing in **both** release and debug (the ledger symmetry assert is `#if DEBUG`).
- `Nethermind.Consensus.Test` 243 passing, `Nethermind.Evm.Test` 5596 passing.
- Every new test was negative-controlled as a red/green pair across a single-token perturbation of the mechanism under test. Inverting the violation guard turns the verdict into `Undecided`; mis-setting `_targetStackIndex` for `EXTCODE*` reddens the `EXTCODECOPY` allowed row with `disallowed target 0x0000…0000`; disabling the precompile exemption, the delegation check or the `CALLCODE` value slot each reddens exactly its own rows; suppressing the exposure release or the paymaster decrement reddens the pool-level tests, and in debug also trips the pool's bookkeeping assert.

## Documentation

Requires documentation update: no