### PR TITLE
Reduce Bootnode memory and Nethermind discovery traffic

### DIFF
--- a/src/Nethermind/Nethermind.Kademlia/README.md
+++ b/src/Nethermind/Nethermind.Kademlia/README.md
@@ -61,6 +61,6 @@ Call `AddOrRefresh` when an authenticated node sends a valid protocol message, a
 
 Use `LookupNodesClosest(key, token)` when the caller needs the final closest set. Use `LookupNodes(key, token, maxResults)` or `IKademliaDiscovery<TKey, TNode>.DiscoverNodes(...)` when the caller wants candidates streamed as soon as lookups find them.
 
-`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled. Once the table is healthy, it backs off exponentially to a 30-second productive pace while admissions continue, and up to five minutes when the table stops learning anything new.
+`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled. Once the table is healthy, it backs off exponentially to a 30-second productive pace while admissions continue. Successive admission-free windows may extend that toward a five-minute worst-case ceiling, although shared inbound and concurrent-job admissions normally return a live node to the productive range sooner.
 
 Dispose `NodeHealthTracker<TKey, TNode, TKadKey>` when the host shuts down, or let the dependency-injection container that owns it dispose it.

--- a/src/Nethermind/Nethermind.Kademlia/README.md
+++ b/src/Nethermind/Nethermind.Kademlia/README.md
@@ -61,6 +61,6 @@ Call `AddOrRefresh` when an authenticated node sends a valid protocol message, a
 
 Use `LookupNodesClosest(key, token)` when the caller needs the final closest set. Use `LookupNodes(key, token, maxResults)` or `IKademliaDiscovery<TKey, TNode>.DiscoverNodes(...)` when the caller wants candidates streamed as soon as lookups find them.
 
-`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled or lookups keep admitting nodes, and backs off exponentially up to five minutes once a filled table stops learning anything new.
+`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled. Once the table is healthy, it backs off exponentially to a 30-second productive pace while admissions continue, and up to five minutes when the table stops learning anything new.
 
 Dispose `NodeHealthTracker<TKey, TNode, TKadKey>` when the host shuts down, or let the dependency-injection container that owns it dispose it.

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -12,10 +12,10 @@ namespace Nethermind.Kademlia;
 /// Runs active random Kademlia lookups and streams discovered nodes.
 /// </summary>
 /// <remarks>
-/// Jobs iterate at <see cref="MinimumIterationDuration"/> while the routing table is still underfilled or while
-/// lookups keep admitting nodes into it. Once the table is filled and a lookup admits nothing, the job doubles its
-/// interval up to <see cref="MaximumIterationDuration"/>, so a node with a healthy table stops behaving like a
-/// crawler. Periodic bootstrap and bucket refresh in <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
+/// Jobs iterate at <see cref="MinimumIterationDuration"/> while the routing table is still underfilled. Once the table
+/// is healthy, each job backs off to <see cref="MaximumProductiveIterationDuration"/> while nodes are still being
+/// admitted and to <see cref="MaximumIterationDuration"/> when idle. Periodic bootstrap and bucket refresh in
+/// <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
 /// </remarks>
 public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     IKademlia<TKey, TNode> kademlia,
@@ -30,6 +30,15 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     where TKadKey : notnull
 {
     private static readonly TimeSpan MinimumIterationDuration = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Longest interval used while a healthy routing table is still admitting nodes.
+    /// </summary>
+    /// <remarks>
+    /// At the default ten jobs this keeps one active random walk starting about every three seconds, while preventing
+    /// ordinary routing churn from pinning every job at the one-second bootstrap pace.
+    /// </remarks>
+    private static readonly TimeSpan MaximumProductiveIterationDuration = TimeSpan.FromSeconds(30);
 
     /// <summary>
     /// Longest interval an idle job backs off to.
@@ -175,18 +184,19 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     }
 
     /// <summary>
-    /// Returns the pace for the next iteration, resetting it when the last lookup was worth running.
+    /// Returns the pace for the next iteration, retaining a sustainable crawl rate while the table changes.
     /// </summary>
     /// <param name="current">Pace the finished iteration ran at.</param>
     /// <param name="admittedNodes">Whether the routing table admitted a node since the previous iteration decided its pace.</param>
     private TimeSpan NextIterationDuration(TimeSpan current, bool admittedNodes)
     {
-        if (admittedNodes || IsUnderfilled())
+        if (IsUnderfilled())
         {
             return MinimumIterationDuration;
         }
 
-        return TimeSpan.FromTicks(Math.Min(current.Ticks * 2, MaximumIterationDuration.Ticks));
+        TimeSpan maximum = admittedNodes ? MaximumProductiveIterationDuration : MaximumIterationDuration;
+        return TimeSpan.FromTicks(Math.Min(current.Ticks * 2, maximum.Ticks));
     }
 
     private bool IsUnderfilled()
@@ -202,8 +212,8 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// <remarks>
     /// Jobs compare this counter across their whole iteration, so admissions made by a concurrent job or by inbound
     /// traffic count too. Attributing an admission to the lookup that caused it would mean threading a lookup
-    /// identity through every protocol adapter, and the imprecision is one-sided: an admission this job did not
-    /// cause still means the table is changing, and reading it as productive only keeps discovery eager.
+    /// identity through every protocol adapter. An admission this job did not cause can therefore keep it at the
+    /// sustainable productive pace, but cannot return it to the one-second bootstrap pace once the table is healthy.
     /// </remarks>
     private sealed class AdmissionCounter
     {

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -14,8 +14,9 @@ namespace Nethermind.Kademlia;
 /// <remarks>
 /// Jobs iterate at <see cref="MinimumIterationDuration"/> while the routing table is still underfilled. Once the table
 /// is healthy, each job backs off to <see cref="MaximumProductiveIterationDuration"/> while nodes are still being
-/// admitted and to <see cref="MaximumIterationDuration"/> when idle. Periodic bootstrap and bucket refresh in
-/// <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
+/// admitted. Sustained admission-free windows may extend the interval toward <see cref="MaximumIterationDuration"/>,
+/// which bounds worst-case staleness rather than describing the usual steady state. Periodic bootstrap and bucket
+/// refresh in <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
 /// Routing-table occupancy deliberately controls this protocol-independent loop because it cannot observe whether
 /// downstream consumers accept emitted nodes or establish peer connections.
 /// </remarks>
@@ -44,14 +45,14 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     private static readonly TimeSpan MaximumProductiveIterationDuration = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Longest interval an idle job backs off to.
+    /// Longest interval an admission-free job can back off to.
     /// </summary>
     /// <remarks>
-    /// The lookup rate is inversely proportional to this cap, so almost all of the saving is already banked by the
-    /// first few doublings: a one-minute cap removes 98% of the one-second crawl rate and this one removes 99.7%,
-    /// while a half-hour cap would buy a further 0.3% at six times the worst-case delay. Because a reset only
-    /// applies to the next iteration and never wakes a sleeping job, this cap alone bounds how long a job can go
-    /// without looking up, whatever else happens in the table meanwhile.
+    /// Shared admissions normally return a live node to the productive range before this ceiling. The lookup rate is
+    /// inversely proportional to the cap, so almost all of the saving is already banked by the first few doublings:
+    /// a one-minute cap removes 98% of the one-second crawl rate and this one removes 99.7%, while a half-hour cap
+    /// would buy a further 0.3% at six times the worst-case delay. Because a reset only applies to the next iteration
+    /// and never wakes a sleeping job, this cap alone bounds how long a job can go without looking up.
     /// </remarks>
     private static readonly TimeSpan MaximumIterationDuration = TimeSpan.FromMinutes(5);
 
@@ -79,6 +80,10 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     private readonly TKadKey _currentNodeHash = keyOperator.GetNodeHash(kademliaConfig.CurrentNodeId);
     private readonly int _maxDistance = distance.MaxDistance;
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+    private readonly Lock _occupancyLock = new();
+    private long _lastOccupancyTimestamp;
+    private bool _hasCachedOccupancy;
+    private bool _cachedUnderfilled;
 
     /// <inheritdoc/>
     public IAsyncEnumerable<TNode> DiscoverNodes(int concurrentDiscoveryJobs, int lookupResultLimit, CancellationToken token)
@@ -204,8 +209,22 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
 
     private bool IsUnderfilled()
     {
-        RoutingTableOccupancy occupancy = routingTable.GetOccupancy();
-        return occupancy.NodeCount * HealthyOccupancyDivisor < occupancy.Capacity;
+        lock (_occupancyLock)
+        {
+            long timestamp = _timeProvider.GetTimestamp();
+            // Coalesce discovery jobs because GetOccupancy may walk the full table under its mutation lock.
+            if (_hasCachedOccupancy &&
+                _timeProvider.GetElapsedTime(_lastOccupancyTimestamp, timestamp) < MinimumIterationDuration)
+            {
+                return _cachedUnderfilled;
+            }
+
+            RoutingTableOccupancy occupancy = routingTable.GetOccupancy();
+            _cachedUnderfilled = occupancy.NodeCount * HealthyOccupancyDivisor < occupancy.Capacity;
+            _lastOccupancyTimestamp = timestamp;
+            _hasCachedOccupancy = true;
+            return _cachedUnderfilled;
+        }
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -33,6 +33,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     where TKadKey : notnull
 {
     private static readonly TimeSpan MinimumIterationDuration = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan OccupancyCacheDuration = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// Longest interval used while a healthy routing table is still admitting nodes.
@@ -214,7 +215,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
             long timestamp = _timeProvider.GetTimestamp();
             // Coalesce discovery jobs because GetOccupancy may walk the full table under its mutation lock.
             if (_hasCachedOccupancy &&
-                _timeProvider.GetElapsedTime(_lastOccupancyTimestamp, timestamp) < MinimumIterationDuration)
+                _timeProvider.GetElapsedTime(_lastOccupancyTimestamp, timestamp) < OccupancyCacheDuration)
             {
                 return _cachedUnderfilled;
             }

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -16,6 +16,8 @@ namespace Nethermind.Kademlia;
 /// is healthy, each job backs off to <see cref="MaximumProductiveIterationDuration"/> while nodes are still being
 /// admitted and to <see cref="MaximumIterationDuration"/> when idle. Periodic bootstrap and bucket refresh in
 /// <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
+/// Routing-table occupancy deliberately controls this protocol-independent loop because it cannot observe whether
+/// downstream consumers accept emitted nodes or establish peer connections.
 /// </remarks>
 public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     IKademlia<TKey, TNode> kademlia,
@@ -35,8 +37,9 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// Longest interval used while a healthy routing table is still admitting nodes.
     /// </summary>
     /// <remarks>
-    /// At the default ten jobs this keeps one active random walk starting about every three seconds, while preventing
-    /// ordinary routing churn from pinning every job at the one-second bootstrap pace.
+    /// At the default <c>Discovery.ConcurrentDiscoveryJob</c> of ten jobs this keeps one active random walk starting
+    /// about every three seconds, while preventing ordinary routing churn from pinning every job at the one-second
+    /// bootstrap pace.
     /// </remarks>
     private static readonly TimeSpan MaximumProductiveIterationDuration = TimeSpan.FromSeconds(30);
 

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -61,9 +61,10 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// Reciprocal of the bucket-slot fill ratio the table must reach before idle lookups may slow down.
     /// </summary>
     /// <remarks>
+    /// A cold table has one bucket, so it must first collect a full bucket's worth of nodes before this ratio applies.
     /// Buckets only split once they overflow, so a table that saturated its reachable neighbourhood settles above
-    /// 90% of its slots. A table holding only a handful of contacts, such as one still bootstrapping or one whose
-    /// peers were just evicted for being unresponsive, stays below this ratio and keeps discovering at full speed.
+    /// 90% of its slots. A table whose peers were evicted for being unresponsive falls below this ratio and resumes
+    /// discovering at full speed.
     /// </remarks>
     private const int HealthyOccupancyDivisor = 3;
 
@@ -79,6 +80,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
 
     private readonly ILogger _logger = loggerFactory.CreateLogger<RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>>();
     private readonly TKadKey _currentNodeHash = keyOperator.GetNodeHash(kademliaConfig.CurrentNodeId);
+    private readonly int _kSize = kademliaConfig.KSize;
     private readonly int _maxDistance = distance.MaxDistance;
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
     private readonly Lock _occupancyLock = new();
@@ -221,7 +223,8 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
             }
 
             RoutingTableOccupancy occupancy = routingTable.GetOccupancy();
-            _cachedUnderfilled = occupancy.NodeCount * HealthyOccupancyDivisor < occupancy.Capacity;
+            _cachedUnderfilled = occupancy.NodeCount < _kSize ||
+                occupancy.NodeCount * HealthyOccupancyDivisor < occupancy.Capacity;
             _lastOccupancyTimestamp = timestamp;
             _hasCachedOccupancy = true;
             return _cachedUnderfilled;

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -62,6 +62,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// </summary>
     /// <remarks>
     /// A cold table has one bucket, so it must first collect a full bucket's worth of nodes before this ratio applies.
+    /// Networks with fewer than KSize reachable nodes therefore stay at the minimum interval.
     /// Buckets only split once they overflow, so a table that saturated its reachable neighbourhood settles above
     /// 90% of its slots. A table whose peers were evicted for being unresponsive falls below this ratio and resumes
     /// discovering at full speed.
@@ -146,7 +147,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     {
         TimeSpan iterationDuration = MinimumIterationDuration;
         // Carried across iterations so that the window covers the paced wait as well as the lookup; a job at the
-        // maximum interval is asleep for nearly all of its iteration, and admissions made then must still reset it.
+        // maximum interval is asleep for nearly all of its iteration, and admissions made then must restore productive pacing.
         long admissionsSeen = admissions.Count;
         while (!token.IsCancellationRequested)
         {

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -183,6 +183,17 @@ public class RandomWalkKademliaDiscoveryTests
         ]);
     }
 
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_cache_routing_table_occupancy_within_minimum_interval(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        await RunIterations(new TestKademlia(), routingTable, iterations: 4, token, advanceTime: false);
+
+        Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(1));
+    }
+
     /// <summary>Asserts that the first iterations waited for exactly the expected paces.</summary>
     private static void AssertPacedBy(TimeSpan[] delays, TimeSpan[] expected) =>
         Assert.That(delays[..expected.Length], Is.EqualTo(expected));
@@ -230,9 +241,14 @@ public class RandomWalkKademliaDiscoveryTests
         RoutingTableStub routingTable,
         int iterations,
         CancellationToken token,
-        Action<int>? onDelayRequested = null)
+        Action<int>? onDelayRequested = null,
+        bool advanceTime = true)
     {
-        NoWaitTimeProvider timeProvider = new() { OnDelayRequested = onDelayRequested };
+        NoWaitTimeProvider timeProvider = new()
+        {
+            OnDelayRequested = onDelayRequested,
+            AdvanceTime = advanceTime
+        };
         RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, routingTable, timeProvider);
 
         await discovery.DiscoverNodes(1, NodesPerLookup, token).Take(iterations * NodesPerLookup).ToListAsync(token);
@@ -250,27 +266,44 @@ public class RandomWalkKademliaDiscoveryTests
     private sealed class NoWaitTimeProvider : TimeProvider
     {
         private readonly ConcurrentQueue<TimeSpan> _requestedDelays = new();
+        private long _timestamp;
 
         public TimeSpan[] RequestedDelays => _requestedDelays.ToArray();
+
+        public bool AdvanceTime { get; init; } = true;
 
         /// <summary>Called as a job starts waiting, with the one-based ordinal of that wait.</summary>
         public Action<int>? OnDelayRequested { get; init; }
 
-        public override long GetTimestamp() => 0;
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => Volatile.Read(ref _timestamp);
 
         public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
         {
             _requestedDelays.Enqueue(dueTime);
             OnDelayRequested?.Invoke(_requestedDelays.Count);
+            if (AdvanceTime)
+            {
+                Interlocked.Add(ref _timestamp, dueTime.Ticks);
+            }
             return System.CreateTimer(callback, state, TimeSpan.Zero, period);
         }
     }
 
     private sealed class RoutingTableStub : IRoutingTable<int, int>
     {
+        private int _getOccupancyCalls;
+
         public RoutingTableOccupancy Occupancy { get; set; } = new(0, 16);
 
-        public RoutingTableOccupancy GetOccupancy() => Occupancy;
+        public int GetOccupancyCalls => Volatile.Read(ref _getOccupancyCalls);
+
+        public RoutingTableOccupancy GetOccupancy()
+        {
+            Interlocked.Increment(ref _getOccupancyCalls);
+            return Occupancy;
+        }
 
         public void RaiseNodeAdded(int node) => OnNodeAdded?.Invoke(this, node);
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -121,7 +121,7 @@ public class RandomWalkKademliaDiscoveryTests
     [TestCaseSource(nameof(ProductivePacingCases))]
     [CancelAfter(10000)]
     public async Task DiscoverNodes_should_bound_productive_filled_table_pace(
-        bool admitEveryLookup,
+        int[] admittingLookups,
         int iterations,
         int[] expectedDelaySeconds,
         CancellationToken token)
@@ -131,7 +131,7 @@ public class RandomWalkKademliaDiscoveryTests
         {
             OnLookup = lookup =>
             {
-                if (admitEveryLookup || lookup == 6)
+                if (Array.IndexOf(admittingLookups, lookup) >= 0)
                 {
                     routingTable.RaiseNodeAdded(42);
                 }
@@ -140,7 +140,7 @@ public class RandomWalkKademliaDiscoveryTests
 
         TimeSpan[] delays = await RunIterations(kademlia, routingTable, iterations, token);
 
-        AssertPacedBy(delays, expectedDelaySeconds.Select(value => TimeSpan.FromSeconds(value)).ToArray());
+        AssertPacedBy(delays, Array.ConvertAll(expectedDelaySeconds, static seconds => TimeSpan.FromSeconds(seconds)));
     }
 
     /// <summary>
@@ -185,20 +185,25 @@ public class RandomWalkKademliaDiscoveryTests
 
     /// <summary>Asserts that the first iterations waited for exactly the expected paces.</summary>
     private static void AssertPacedBy(TimeSpan[] delays, TimeSpan[] expected) =>
-        Assert.That(delays.Take(expected.Length).ToArray(), Is.EqualTo(expected));
+        Assert.That(delays[..expected.Length], Is.EqualTo(expected));
 
     private static IEnumerable<TestCaseData> ProductivePacingCases()
     {
         yield return new TestCaseData(
-                false,
+                new[] { 6 },
                 8,
                 new[] { 2, 4, 8, 16, 32, 30, 60 })
             .SetName("DiscoverNodes_returns_to_productive_pace_when_lookup_admits_a_node");
         yield return new TestCaseData(
-                true,
+                new[] { 1, 2, 3, 4, 5, 6, 7 },
                 7,
                 new[] { 2, 4, 8, 16, 30, 30 })
             .SetName("DiscoverNodes_limits_continuously_productive_filled_table_pace");
+        yield return new TestCaseData(
+                new[] { 10 },
+                12,
+                new[] { 2, 4, 8, 16, 32, 64, 128, 256, 300, 30, 60 })
+            .SetName("DiscoverNodes_returns_from_idle_ceiling_to_productive_pace");
     }
 
     private static RandomWalkKademliaDiscovery<int, int, int> CreateDiscovery(

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -118,37 +118,88 @@ public class RandomWalkKademliaDiscoveryTests
         ]);
     }
 
-    [Test]
+    [TestCaseSource(nameof(ProductivePacingCases))]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_reset_pace_when_lookup_admits_a_node(CancellationToken token)
+    public async Task DiscoverNodes_should_bound_productive_filled_table_pace(
+        bool admitEveryLookup,
+        int iterations,
+        int[] expectedDelaySeconds,
+        CancellationToken token)
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
-        TestKademlia kademlia = new() { OnLookup = lookup => { if (lookup == 3) routingTable.RaiseNodeAdded(42); } };
+        TestKademlia kademlia = new()
+        {
+            OnLookup = lookup =>
+            {
+                if (admitEveryLookup || lookup == 6)
+                {
+                    routingTable.RaiseNodeAdded(42);
+                }
+            }
+        };
 
-        TimeSpan[] delays = await RunIterations(kademlia, routingTable, iterations: 5, token);
+        TimeSpan[] delays = await RunIterations(kademlia, routingTable, iterations, token);
 
-        AssertPacedBy(delays, [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), OneSecond, TimeSpan.FromSeconds(2)]);
+        AssertPacedBy(delays, expectedDelaySeconds.Select(value => TimeSpan.FromSeconds(value)).ToArray());
     }
 
     /// <summary>
     /// A backed-off job spends nearly all of its iteration waiting, so an admission arriving from inbound traffic or
-    /// another job while it waits has to reset it just as one during its own lookup does.
+    /// another job while it waits has to restore productive pacing just as one during its own lookup does.
     /// </summary>
     [Test]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_reset_pace_when_a_node_is_admitted_while_waiting(CancellationToken token)
+    public async Task DiscoverNodes_should_return_to_productive_pace_when_a_node_is_admitted_while_waiting(CancellationToken token)
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
 
-        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 5, token,
-            onDelayRequested: wait => { if (wait == 2) routingTable.RaiseNodeAdded(42); });
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 8, token,
+            onDelayRequested: wait => { if (wait == 5) routingTable.RaiseNodeAdded(42); });
 
-        AssertPacedBy(delays, [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), OneSecond, TimeSpan.FromSeconds(2)]);
+        AssertPacedBy(delays, [
+            TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60)
+        ]);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_return_to_minimum_pace_when_table_becomes_underfilled(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 8, token,
+            onDelayRequested: wait =>
+            {
+                if (wait == 5)
+                {
+                    routingTable.Occupancy = new RoutingTableOccupancy(5, 16);
+                }
+            });
+
+        AssertPacedBy(delays, [
+            TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32), OneSecond, OneSecond
+        ]);
     }
 
     /// <summary>Asserts that the first iterations waited for exactly the expected paces.</summary>
     private static void AssertPacedBy(TimeSpan[] delays, TimeSpan[] expected) =>
         Assert.That(delays.Take(expected.Length).ToArray(), Is.EqualTo(expected));
+
+    private static IEnumerable<TestCaseData> ProductivePacingCases()
+    {
+        yield return new TestCaseData(
+                false,
+                8,
+                new[] { 2, 4, 8, 16, 32, 30, 60 })
+            .SetName("DiscoverNodes_returns_to_productive_pace_when_lookup_admits_a_node");
+        yield return new TestCaseData(
+                true,
+                7,
+                new[] { 2, 4, 8, 16, 30, 30 })
+            .SetName("DiscoverNodes_limits_continuously_productive_filled_table_pace");
+    }
 
     private static RandomWalkKademliaDiscovery<int, int, int> CreateDiscovery(
         TestKademlia kademlia,
@@ -212,7 +263,7 @@ public class RandomWalkKademliaDiscoveryTests
 
     private sealed class RoutingTableStub : IRoutingTable<int, int>
     {
-        public RoutingTableOccupancy Occupancy { get; init; } = new(0, 16);
+        public RoutingTableOccupancy Occupancy { get; set; } = new(0, 16);
 
         public RoutingTableOccupancy GetOccupancy() => Occupancy;
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -93,9 +93,9 @@ public class RandomWalkKademliaDiscoveryTests
 
     [Test]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_keep_minimum_pace_while_table_is_underfilled(CancellationToken token)
+    public async Task DiscoverNodes_should_keep_minimum_pace_until_table_has_a_full_bucket_of_nodes(CancellationToken token)
     {
-        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(5, 16) };
+        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(15, 16) };
 
         TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 4, token);
 
@@ -185,13 +185,30 @@ public class RandomWalkKademliaDiscoveryTests
 
     [Test]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_cache_routing_table_occupancy_within_minimum_interval(CancellationToken token)
+    public async Task DiscoverNodes_should_share_cached_routing_table_occupancy_between_jobs(CancellationToken token)
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
 
-        await RunIterations(new TestKademlia(), routingTable, iterations: 4, token, advanceTime: false);
+        await RunIterations(new TestKademlia(), routingTable, iterations: 4, token,
+            advanceTime: false, concurrentJobs: 4);
 
         Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(1));
+    }
+
+    [TestCase(999, 1)]
+    [TestCase(1000, 2)]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_expire_cached_routing_table_occupancy_after_one_second(
+        int elapsedMilliseconds,
+        int expectedOccupancyCalls,
+        CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        await RunIterations(new TestKademlia(), routingTable, iterations: 2, token,
+            timeAdvance: TimeSpan.FromMilliseconds(elapsedMilliseconds));
+
+        Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(expectedOccupancyCalls));
     }
 
     /// <summary>Asserts that the first iterations waited for exactly the expected paces.</summary>
@@ -242,16 +259,20 @@ public class RandomWalkKademliaDiscoveryTests
         int iterations,
         CancellationToken token,
         Action<int>? onDelayRequested = null,
-        bool advanceTime = true)
+        bool advanceTime = true,
+        int concurrentJobs = 1,
+        TimeSpan? timeAdvance = null)
     {
         NoWaitTimeProvider timeProvider = new()
         {
             OnDelayRequested = onDelayRequested,
-            AdvanceTime = advanceTime
+            AdvanceTime = advanceTime,
+            TimeAdvance = timeAdvance
         };
         RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, routingTable, timeProvider);
 
-        await discovery.DiscoverNodes(1, NodesPerLookup, token).Take(iterations * NodesPerLookup).ToListAsync(token);
+        await discovery.DiscoverNodes(concurrentJobs, NodesPerLookup, token)
+            .Take(iterations * NodesPerLookup).ToListAsync(token);
 
         return timeProvider.RequestedDelays;
     }
@@ -272,6 +293,8 @@ public class RandomWalkKademliaDiscoveryTests
 
         public bool AdvanceTime { get; init; } = true;
 
+        public TimeSpan? TimeAdvance { get; init; }
+
         /// <summary>Called as a job starts waiting, with the one-based ordinal of that wait.</summary>
         public Action<int>? OnDelayRequested { get; init; }
 
@@ -285,7 +308,7 @@ public class RandomWalkKademliaDiscoveryTests
             OnDelayRequested?.Invoke(_requestedDelays.Count);
             if (AdvanceTime)
             {
-                Interlocked.Add(ref _timestamp, dueTime.Ticks);
+                Interlocked.Add(ref _timestamp, (TimeAdvance ?? dueTime).Ticks);
             }
             return System.CreateTimer(callback, state, TimeSpan.Zero, period);
         }

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -91,22 +91,24 @@ public class RandomWalkKademliaDiscoveryTests
         }
     }
 
-    [Test]
+    [TestCase(15, 16)]
+    [TestCase(21, 64)]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_keep_minimum_pace_until_table_has_a_full_bucket_of_nodes(CancellationToken token)
+    public async Task DiscoverNodes_should_keep_minimum_pace_while_table_is_underfilled(int nodeCount, int capacity, CancellationToken token)
     {
-        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(15, 16) };
+        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(nodeCount, capacity) };
 
         TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 4, token);
 
         AssertPacedBy(delays, [OneSecond, OneSecond, OneSecond]);
     }
 
-    [Test]
+    [TestCase(16, 16)]
+    [TestCase(16, 48)]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_back_off_when_filled_table_admits_nothing(CancellationToken token)
+    public async Task DiscoverNodes_should_back_off_when_filled_table_admits_nothing(int nodeCount, int capacity, CancellationToken token)
     {
-        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(nodeCount, capacity) };
 
         TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 11, token);
 
@@ -189,26 +191,59 @@ public class RandomWalkKademliaDiscoveryTests
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
 
-        await RunIterations(new TestKademlia(), routingTable, iterations: 4, token,
-            advanceTime: false, concurrentJobs: 4);
+        await RunPacingChecks(routingTable, checks: 4, token, concurrentJobs: 4);
 
         Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(1));
     }
 
-    [TestCase(999, 1)]
-    [TestCase(1000, 2)]
+    [TestCase(999, 1, 4)]
+    [TestCase(1000, 2, 1)]
     [CancelAfter(10000)]
     public async Task DiscoverNodes_should_expire_cached_routing_table_occupancy_after_one_second(
         int elapsedMilliseconds,
         int expectedOccupancyCalls,
+        int expectedDelaySeconds,
         CancellationToken token)
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
 
-        await RunIterations(new TestKademlia(), routingTable, iterations: 2, token,
-            timeAdvance: TimeSpan.FromMilliseconds(elapsedMilliseconds));
+        TimeSpan[] delays = await RunPacingChecks(routingTable, checks: 2, token,
+            timeAdvance: TimeSpan.FromMilliseconds(elapsedMilliseconds),
+            onDelayRequested: wait => { if (wait == 1) routingTable.Occupancy = new RoutingTableOccupancy(0, 16); });
 
-        Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(expectedOccupancyCalls));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(expectedOccupancyCalls));
+            Assert.That(delays, Is.EqualTo(new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(expectedDelaySeconds) }));
+        }
+    }
+
+    private static async Task<TimeSpan[]> RunPacingChecks(
+        RoutingTableStub routingTable,
+        int checks,
+        CancellationToken token,
+        int concurrentJobs = 1,
+        TimeSpan? timeAdvance = null,
+        Action<int>? onDelayRequested = null)
+    {
+        TaskCompletionSource completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        NoWaitTimeProvider timeProvider = new()
+        {
+            TimeAdvance = timeAdvance ?? TimeSpan.Zero,
+            CompletedTimers = checks - concurrentJobs,
+            OnDelayRequested = wait =>
+            {
+                onDelayRequested?.Invoke(wait);
+                if (wait == checks) completed.TrySetResult();
+            }
+        };
+        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(new TestKademlia(), routingTable, timeProvider);
+
+        // Leave enough channel space for every lookup and park each job only after it has checked occupancy.
+        await using IAsyncEnumerator<int> nodes = discovery.DiscoverNodes(concurrentJobs, checks * NodesPerLookup, token).GetAsyncEnumerator(token);
+        Assert.That(await nodes.MoveNextAsync(), Is.True);
+        await completed.Task.WaitAsync(token);
+        return timeProvider.RequestedDelays;
     }
 
     /// <summary>Asserts that the first iterations waited for exactly the expected paces.</summary>
@@ -258,40 +293,36 @@ public class RandomWalkKademliaDiscoveryTests
         RoutingTableStub routingTable,
         int iterations,
         CancellationToken token,
-        Action<int>? onDelayRequested = null,
-        bool advanceTime = true,
-        int concurrentJobs = 1,
-        TimeSpan? timeAdvance = null)
+        Action<int>? onDelayRequested = null)
     {
         NoWaitTimeProvider timeProvider = new()
         {
-            OnDelayRequested = onDelayRequested,
-            AdvanceTime = advanceTime,
-            TimeAdvance = timeAdvance
+            OnDelayRequested = onDelayRequested
         };
         RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, routingTable, timeProvider);
 
-        await discovery.DiscoverNodes(concurrentJobs, NodesPerLookup, token)
+        await discovery.DiscoverNodes(1, NodesPerLookup, token)
             .Take(iterations * NodesPerLookup).ToListAsync(token);
 
         return timeProvider.RequestedDelays;
     }
 
     /// <summary>
-    /// Runs timers immediately while recording the delay that was asked for, on a clock that never advances.
+    /// Records paced delays and advances the clock only when a timer is requested.
     /// </summary>
     /// <remarks>
-    /// Freezing <see cref="GetTimestamp"/> makes the measured lookup time zero, so a job asks for exactly the pace it
-    /// chose rather than the pace minus however long the test machine took.
+    /// Lookup time stays zero regardless of the test machine's speed. Timers beyond <see cref="CompletedTimers"/>
+    /// stay pending until discovery is disposed, allowing tests to inspect a fixed number of completed pacing checks.
     /// </remarks>
     private sealed class NoWaitTimeProvider : TimeProvider
     {
         private readonly ConcurrentQueue<TimeSpan> _requestedDelays = new();
         private long _timestamp;
+        private int _timerCount;
 
         public TimeSpan[] RequestedDelays => _requestedDelays.ToArray();
 
-        public bool AdvanceTime { get; init; } = true;
+        public int CompletedTimers { get; init; } = int.MaxValue;
 
         public TimeSpan? TimeAdvance { get; init; }
 
@@ -305,12 +336,10 @@ public class RandomWalkKademliaDiscoveryTests
         public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
         {
             _requestedDelays.Enqueue(dueTime);
-            OnDelayRequested?.Invoke(_requestedDelays.Count);
-            if (AdvanceTime)
-            {
-                Interlocked.Add(ref _timestamp, (TimeAdvance ?? dueTime).Ticks);
-            }
-            return System.CreateTimer(callback, state, TimeSpan.Zero, period);
+            int timer = Interlocked.Increment(ref _timerCount);
+            Interlocked.Add(ref _timestamp, (TimeAdvance ?? dueTime).Ticks);
+            OnDelayRequested?.Invoke(timer);
+            return System.CreateTimer(callback, state, timer <= CompletedTimers ? TimeSpan.Zero : Timeout.InfiniteTimeSpan, period);
         }
     }
 

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -9,8 +9,10 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging.Abstractions;
+using Autofac;
+using Nethermind.Core;
 using Nethermind.Kademlia;
+using Nethermind.Network.Discovery.Kademlia;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Discovery.Test.Kademlia;
@@ -29,7 +31,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_stream_nodes_from_random_lookup(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(2).ToListAsync(token);
 
@@ -46,7 +49,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_not_run_any_job_when_disabled(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         List<int> nodes = await discovery.DiscoverNodes(0, 2, token).ToListAsync(token);
 
@@ -62,7 +66,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_pace_iterations_to_minimum_iteration_duration(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(4).ToListAsync(token);
@@ -79,7 +84,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_not_delay_when_lookup_exceeds_minimum_iteration_duration(CancellationToken token)
     {
         TestKademlia kademlia = new() { LookupDelay = TimeSpan.FromMilliseconds(1100) };
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(3).ToListAsync(token);
@@ -103,12 +109,11 @@ public class RandomWalkKademliaDiscoveryTests
         AssertPacedBy(delays, [OneSecond, OneSecond, OneSecond]);
     }
 
-    [TestCase(16, 16)]
-    [TestCase(16, 48)]
+    [Test]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_back_off_when_filled_table_admits_nothing(int nodeCount, int capacity, CancellationToken token)
+    public async Task DiscoverNodes_should_back_off_when_filled_table_admits_nothing([Values(16, 48)] int capacity, CancellationToken token)
     {
-        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(nodeCount, capacity) };
+        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(16, capacity) };
 
         TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 11, token);
 
@@ -237,7 +242,8 @@ public class RandomWalkKademliaDiscoveryTests
                 if (wait == checks) completed.TrySetResult();
             }
         };
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(new TestKademlia(), routingTable, timeProvider);
+        using IContainer container = CreateContainer(new TestKademlia(), routingTable, timeProvider);
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         // Leave enough channel space for every lookup and park each job only after it has checked occupancy.
         await using IAsyncEnumerator<int> nodes = discovery.DiscoverNodes(concurrentJobs, checks * NodesPerLookup, token).GetAsyncEnumerator(token);
@@ -269,17 +275,19 @@ public class RandomWalkKademliaDiscoveryTests
             .SetName("DiscoverNodes_returns_from_idle_ceiling_to_productive_pace");
     }
 
-    private static RandomWalkKademliaDiscovery<int, int, int> CreateDiscovery(
+    private static IContainer CreateContainer(
         TestKademlia kademlia,
         RoutingTableStub routingTable,
         TimeProvider? timeProvider = null) =>
-        new(kademlia,
-            routingTable,
-            IntKeyOperator.Instance,
-            Int32KademliaDistance.Instance,
-            new KademliaConfig<int> { CurrentNodeId = 0 },
-            NullLoggerFactory.Instance,
-            timeProvider);
+        new ContainerBuilder()
+            .AddModule(new KademliaModule<int, int, int>())
+            .AddSingleton<IKademlia<int, int>>(kademlia)
+            .AddSingleton<IRoutingTable<int, int>>(routingTable)
+            .AddSingleton<IKeyOperator<int, int, int>>(IntKeyOperator.Instance)
+            .AddSingleton<IKademliaDistance<int>>(Int32KademliaDistance.Instance)
+            .AddSingleton(new KademliaConfig<int> { CurrentNodeId = 0 })
+            .AddSingleton(timeProvider ?? TimeProvider.System)
+            .Build();
 
     /// <summary>
     /// Runs the requested number of lookup iterations and returns the paced delays each of them asked for.
@@ -299,7 +307,8 @@ public class RandomWalkKademliaDiscoveryTests
         {
             OnDelayRequested = onDelayRequested
         };
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, routingTable, timeProvider);
+        using IContainer container = CreateContainer(kademlia, routingTable, timeProvider);
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         await discovery.DiscoverNodes(1, NodesPerLookup, token)
             .Take(iterations * NodesPerLookup).ToListAsync(token);

--- a/tools/Bootnode/Nethermind.Bootnode.Test/BootnodeMetricsTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/BootnodeMetricsTests.cs
@@ -4,7 +4,6 @@
 using Nethermind.Network;
 using NUnit.Framework;
 using Prometheus;
-using System.Reflection;
 using System.Text;
 using PrometheusMetrics = Prometheus.Metrics;
 
@@ -114,14 +113,14 @@ public class BootnodeMetricsTests
             new BootnodeKademliaBucketSnapshot("discv4", 0, 1, $"prefix-old-{id}", 1),
             new BootnodeKademliaBucketSnapshot("discv4", 1, 1, $"prefix-current-{id}", 2)
         ]);
-        Gauge.Child staleChild = GetKademliaBucketMetric("discv4", "0", "1", $"prefix-old-{id}");
+        Gauge.Child staleChild = BootnodeMetrics.KademliaBucketNodes.WithLabels("discv4", "0", "1", $"prefix-old-{id}");
         metrics.UpdateKademliaBucketStats(
         [
             new BootnodeKademliaBucketSnapshot("discv4", 1, 1, $"prefix-current-{id}", 3)
         ]);
 
         string scrape = await ScrapeMetrics();
-        Gauge.Child recreatedChild = GetKademliaBucketMetric("discv4", "0", "1", $"prefix-old-{id}");
+        Gauge.Child recreatedChild = BootnodeMetrics.KademliaBucketNodes.WithLabels("discv4", "0", "1", $"prefix-old-{id}");
 
         using (Assert.EnterMultipleScope())
         {
@@ -155,13 +154,6 @@ public class BootnodeMetricsTests
         using MemoryStream stream = new();
         await PrometheusMetrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
         return Encoding.UTF8.GetString(stream.ToArray());
-    }
-
-    private static Gauge.Child GetKademliaBucketMetric(string protocol, string bucket, string depth, string prefix)
-    {
-        FieldInfo field = typeof(BootnodeMetrics).GetField("KademliaBucketNodes", BindingFlags.NonPublic | BindingFlags.Static)!;
-        Gauge gauge = (Gauge)field.GetValue(null)!;
-        return gauge.WithLabels(protocol, bucket, depth, prefix);
     }
 
     private sealed class StaticBucketSource(BootnodeKademliaBucketSnapshot bucket) : IBootnodeKademliaBucketSource

--- a/tools/Bootnode/Nethermind.Bootnode.Test/BootnodeMetricsTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/BootnodeMetricsTests.cs
@@ -3,6 +3,8 @@
 
 using Nethermind.Network;
 using NUnit.Framework;
+using Prometheus;
+using System.Reflection;
 using System.Text;
 using PrometheusMetrics = Prometheus.Metrics;
 
@@ -102,7 +104,7 @@ public class BootnodeMetricsTests
     }
 
     [Test]
-    public async Task UpdateKademliaBucketStats_unpublishes_removed_buckets()
+    public async Task UpdateKademliaBucketStats_removes_stale_metric_children()
     {
         string id = Guid.NewGuid().ToString("N");
         BootnodeMetrics metrics = new();
@@ -112,18 +114,23 @@ public class BootnodeMetricsTests
             new BootnodeKademliaBucketSnapshot("discv4", 0, 1, $"prefix-old-{id}", 1),
             new BootnodeKademliaBucketSnapshot("discv4", 1, 1, $"prefix-current-{id}", 2)
         ]);
+        Gauge.Child staleChild = GetKademliaBucketMetric("discv4", "0", "1", $"prefix-old-{id}");
         metrics.UpdateKademliaBucketStats(
         [
             new BootnodeKademliaBucketSnapshot("discv4", 1, 1, $"prefix-current-{id}", 3)
         ]);
 
         string scrape = await ScrapeMetrics();
+        Gauge.Child recreatedChild = GetKademliaBucketMetric("discv4", "0", "1", $"prefix-old-{id}");
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(scrape, Does.Contain($"prefix-current-{id}"));
             Assert.That(scrape, Does.Not.Contain($"prefix-old-{id}"));
+            Assert.That(recreatedChild, Is.Not.SameAs(staleChild));
         }
+
+        recreatedChild.Remove();
     }
 
     [Test]
@@ -148,6 +155,13 @@ public class BootnodeMetricsTests
         using MemoryStream stream = new();
         await PrometheusMetrics.DefaultRegistry.CollectAndExportAsTextAsync(stream);
         return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static Gauge.Child GetKademliaBucketMetric(string protocol, string bucket, string depth, string prefix)
+    {
+        FieldInfo field = typeof(BootnodeMetrics).GetField("KademliaBucketNodes", BindingFlags.NonPublic | BindingFlags.Static)!;
+        Gauge gauge = (Gauge)field.GetValue(null)!;
+        return gauge.WithLabels(protocol, bucket, depth, prefix);
     }
 
     private sealed class StaticBucketSource(BootnodeKademliaBucketSnapshot bucket) : IBootnodeKademliaBucketSource

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
@@ -73,7 +73,12 @@ public class DiscoveredNodeStoreTests
 
         store.AddOrUpdate(node, "discv4", isActive: true);
 
-        Assert.That(store.GetActiveNodes().Single().Host, Is.EqualTo(node.Host));
+        NodeDto[] activeNodes = store.GetActiveNodes();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(activeNodes, Has.Length.EqualTo(1));
+            Assert.That(activeNodes[0].Host, Is.EqualTo(node.Host));
+        }
     }
 
     [TestCase(false)]
@@ -192,9 +197,10 @@ public class DiscoveredNodeStoreTests
         GC.KeepAlive(store);
     }
 
-    [TestCase(1ul)]
-    [TestCase(2ul)]
-    public void Lower_or_equal_enr_sequence_does_not_replace_retained_enr(ulong candidateSequence)
+    [TestCase(1ul, false)]
+    [TestCase(2ul, false)]
+    [TestCase(3ul, true)]
+    public void Enr_sequence_controls_retained_enr_replacement(ulong candidateSequence, bool shouldReplace)
     {
         using PrivateKeyGenerator generator = new();
         using PrivateKey privateKey = generator.Generate();
@@ -205,11 +211,13 @@ public class DiscoveredNodeStoreTests
         store.AddOrUpdate(original, "discv5", isActive: true);
         store.AddOrUpdate(candidate, "discv5", isActive: true);
 
-        NodeDto retainedNode = store.GetAllNodes().Single();
+        NodeDto[] retainedNodes = store.GetAllNodes();
+        NodeRecord expected = shouldReplace ? candidate.Enr! : original.Enr!;
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(retainedNodes, Has.Length.EqualTo(1));
             Assert.That(candidate.Enr!.ToString(), Is.Not.EqualTo(original.Enr!.ToString()));
-            Assert.That(retainedNode.Enr, Is.EqualTo(original.Enr.ToString()));
+            Assert.That(retainedNodes[0].Enr, Is.EqualTo(expected.ToString()));
         }
     }
 
@@ -226,7 +234,12 @@ public class DiscoveredNodeStoreTests
 
         store.AddOrUpdate(node, "discv5", isActive: true);
 
-        Assert.That(store.GetAllNodes().Single().Enr, Is.Null);
+        NodeDto[] retainedNodes = store.GetAllNodes();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(retainedNodes, Has.Length.EqualTo(1));
+            Assert.That(retainedNodes[0].Enr, Is.Null);
+        }
     }
 
     [Test]

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
@@ -24,7 +24,8 @@ public class DiscoveredNodeStoreTests
         DiscoveredNodeStore store = new();
 
         DiscoverySnapshot configuredSnapshot = store.AddConfiguredBootnodes([networkNode]);
-        DiscoverySnapshot activeSnapshot = store.AddOrUpdate(node, "discv4", isActive: true);
+        store.AddOrUpdate(node, "discv4", isActive: true);
+        DiscoverySnapshot activeSnapshot = store.CreateSnapshot();
         NodeDto activeNode = store.GetActiveNodes().Single();
 
         using (Assert.EnterMultipleScope())
@@ -78,11 +79,12 @@ public class DiscoveredNodeStoreTests
             store.Remove(secondNode, "discv5");
         }
 
-        DiscoverySnapshot snapshot = store.AddOrUpdate(thirdNode, "discv4", isActive: true);
+        store.AddOrUpdate(thirdNode, "discv4", isActive: true);
+        DiscoverySnapshot snapshot = store.CreateSnapshot();
         NodeDto[] retainedNodes = store.GetAllNodes();
         NodeDto[] activeRetainedNodes = store.GetActiveNodes();
-        string[] retainedNodeIds = retainedNodes.Select(static node => node.NodeId).ToArray();
-        string[] activeRetainedNodeIds = activeRetainedNodes.Select(static node => node.NodeId).ToArray();
+        string[] retainedNodeIds = Array.ConvertAll(retainedNodes, static node => node.NodeId);
+        string[] activeRetainedNodeIds = Array.ConvertAll(activeRetainedNodes, static node => node.NodeId);
 
         using (Assert.EnterMultipleScope())
         {
@@ -116,7 +118,8 @@ public class DiscoveredNodeStoreTests
 
         store.AddConfiguredBootnodes([configuredNetworkNode]);
         store.AddOrUpdate(firstNode, "discv4", isActive: false);
-        DiscoverySnapshot snapshot = store.AddOrUpdate(secondNode, "discv5", isActive: false);
+        store.AddOrUpdate(secondNode, "discv5", isActive: false);
+        DiscoverySnapshot snapshot = store.CreateSnapshot();
         NodeDto[] retainedNodes = store.GetAllNodes(limit: 2);
         string[] retainedNodeIds = new string[retainedNodes.Length];
         for (int i = 0; i < retainedNodes.Length; i++)
@@ -182,11 +185,13 @@ public class DiscoveredNodeStoreTests
 
         store.AddOrUpdate(node, "discv4", isActive: true);
         store.AddOrUpdate(node, "discv5", isActive: true);
-        DiscoverySnapshot discv4Removed = store.Remove(node, "discv4");
+        store.Remove(node, "discv4");
+        DiscoverySnapshot discv4Removed = store.CreateSnapshot();
         NodeDto[] activeNodes = store.GetActiveNodes();
         Assert.That(activeNodes, Has.Length.EqualTo(1));
         NodeDto retainedNode = activeNodes[0];
-        DiscoverySnapshot discv5Removed = store.Remove(node, "discv5");
+        store.Remove(node, "discv5");
+        DiscoverySnapshot discv5Removed = store.CreateSnapshot();
 
         using (Assert.EnterMultipleScope())
         {

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
@@ -59,6 +59,23 @@ public class DiscoveredNodeStoreTests
         }
     }
 
+    [TestCase("127.0.0.1")]
+    [TestCase("::ffff:127.0.0.1")]
+    [TestCase("2001:db8::1")]
+    public void Node_dto_host_matches_node_host(string address)
+    {
+        using PrivateKeyGenerator generator = new();
+        using PrivateKey privateKey = generator.Generate();
+        Node node = Node.FromDiscoveryEndpoint(
+            privateKey.PublicKey,
+            new IPEndPoint(IPAddress.Parse(address), 30303));
+        DiscoveredNodeStore store = new();
+
+        store.AddOrUpdate(node, "discv4", isActive: true);
+
+        Assert.That(store.GetActiveNodes().Single().Host, Is.EqualTo(node.Host));
+    }
+
     [TestCase(false)]
     [TestCase(true)]
     public void Retention_limit_prunes_inactive_nodes_before_active_nodes(bool deactivateAfterAdd)
@@ -175,6 +192,43 @@ public class DiscoveredNodeStoreTests
         GC.KeepAlive(store);
     }
 
+    [TestCase(1ul)]
+    [TestCase(2ul)]
+    public void Lower_or_equal_enr_sequence_does_not_replace_retained_enr(ulong candidateSequence)
+    {
+        using PrivateKeyGenerator generator = new();
+        using PrivateKey privateKey = generator.Generate();
+        Node original = CreateNodeWithEnr(privateKey, sequence: 2, udpPort: 30303);
+        Node candidate = CreateNodeWithEnr(privateKey, candidateSequence, udpPort: 30304);
+        DiscoveredNodeStore store = new();
+
+        store.AddOrUpdate(original, "discv5", isActive: true);
+        store.AddOrUpdate(candidate, "discv5", isActive: true);
+
+        NodeDto retainedNode = store.GetAllNodes().Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(candidate.Enr!.ToString(), Is.Not.EqualTo(original.Enr!.ToString()));
+            Assert.That(retainedNode.Enr, Is.EqualTo(original.Enr.ToString()));
+        }
+    }
+
+    [Test]
+    public void Unsigned_enr_is_not_retained()
+    {
+        using PrivateKeyGenerator generator = new();
+        using PrivateKey privateKey = generator.Generate();
+        Node node = new(privateKey.PublicKey, "127.0.0.1", 30303)
+        {
+            Enr = new NodeRecord()
+        };
+        DiscoveredNodeStore store = new();
+
+        store.AddOrUpdate(node, "discv5", isActive: true);
+
+        Assert.That(store.GetAllNodes().Single().Enr, Is.Null);
+    }
+
     [Test]
     public void Removing_one_protocol_keeps_node_active_on_the_other_protocol()
     {
@@ -230,6 +284,17 @@ public class DiscoveredNodeStoreTests
 
     private static Node CreateNode(PrivateKey privateKey, int port) =>
         new(privateKey.PublicKey, "127.0.0.1", port);
+
+    private static Node CreateNodeWithEnr(PrivateKey privateKey, ulong sequence, int udpPort)
+    {
+        NodeRecord nodeRecord = new() { EnrSequence = sequence };
+        nodeRecord.SetEntry(new SecP256k1Entry(privateKey.CompressedPublicKey));
+        nodeRecord.SetEntry(new UdpEntry(udpPort));
+        new NodeRecordSigner(new Ecdsa(), privateKey).Sign(nodeRecord);
+        Node node = CreateNode(privateKey, udpPort);
+        node.SetVerifiedEnr(nodeRecord);
+        return node;
+    }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static (WeakReference<Node>, WeakReference<NodeRecord>, string) AddNodeWithEnr(DiscoveredNodeStore store)

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Buffers.Text;
 using System.Net;
 using System.Runtime.CompilerServices;
 using Nethermind.Config;
@@ -243,6 +244,23 @@ public class DiscoveredNodeStoreTests
     }
 
     [Test]
+    public void Enr_formatting_does_not_allocate_an_intermediate_encoding()
+    {
+        byte[] rlp = new byte[300];
+        _ = DiscoveredNodeStore.ToEnrString(rlp);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        string enr = DiscoveredNodeStore.ToEnrString(rlp);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(enr, Is.EqualTo($"enr:{Base64Url.EncodeToString(rlp)}"));
+            Assert.That(allocated, Is.LessThanOrEqualTo(enr.Length * sizeof(char) + 128));
+        }
+    }
+
+    [Test]
     public void Removing_one_protocol_keeps_node_active_on_the_other_protocol()
     {
         using PrivateKeyGenerator generator = new();
@@ -277,17 +295,28 @@ public class DiscoveredNodeStoreTests
         using PrivateKey firstKey = generator.Generate();
         using PrivateKey secondKey = generator.Generate();
         using PrivateKey thirdKey = generator.Generate();
+        Node firstNode = CreateNode(firstKey, 30303);
+        Node secondNodeEntry = CreateNode(secondKey, 30304);
+        Node thirdNode = CreateNode(thirdKey, 30305);
         DiscoveredNodeStore store = new();
-        store.AddOrUpdate(CreateNode(firstKey, 30303), "discv4", isActive: true);
-        store.AddOrUpdate(CreateNode(secondKey, 30304), "discv4", isActive: true);
-        store.AddOrUpdate(CreateNode(thirdKey, 30305), "discv5", isActive: false);
+        store.AddOrUpdate(firstNode, "discv4", isActive: true);
+        store.AddOrUpdate(secondNodeEntry, "discv4", isActive: true);
+        store.AddOrUpdate(thirdNode, "discv5", isActive: false);
 
         NodeDto[] allNodes = store.GetAllNodes(limit: 3);
         NodeDto[] secondNode = store.GetAllNodes(offset: 1, limit: 1);
         NodeDto[] secondActiveNode = store.GetActiveNodes(offset: 1, limit: 1);
+        string[] expectedOrder =
+        [
+            firstNode.IdHash.ToString(),
+            secondNodeEntry.IdHash.ToString(),
+            thirdNode.IdHash.ToString()
+        ];
+        Array.Sort(expectedOrder, StringComparer.Ordinal);
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(Array.ConvertAll(allNodes, static node => node.IdHash), Is.EqualTo(expectedOrder));
             Assert.That(secondNode, Has.Length.EqualTo(1));
             Assert.That(secondNode[0].IdHash, Is.EqualTo(allNodes[1].IdHash));
             Assert.That(secondActiveNode, Has.Length.EqualTo(1));

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Net;
+using System.Runtime.CompilerServices;
 using Nethermind.Config;
 using Nethermind.Crypto;
+using Nethermind.Network.Enr;
 using Nethermind.Stats.Model;
 using NUnit.Framework;
 
@@ -150,6 +152,27 @@ public class DiscoveredNodeStoreTests
     }
 
     [Test]
+    public void Retained_node_does_not_keep_discovery_graph_alive()
+    {
+        DiscoveredNodeStore store = new();
+        (WeakReference<Node> nodeReference, WeakReference<NodeRecord> enrReference, string enr) = AddNodeWithEnr(store);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        NodeDto retainedNode = store.GetAllNodes().Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(nodeReference.TryGetTarget(out _), Is.False);
+            Assert.That(enrReference.TryGetTarget(out _), Is.False);
+            Assert.That(retainedNode.Enr, Is.EqualTo(enr));
+        }
+
+        GC.KeepAlive(store);
+    }
+
+    [Test]
     public void Removing_one_protocol_keeps_node_active_on_the_other_protocol()
     {
         using PrivateKeyGenerator generator = new();
@@ -202,4 +225,19 @@ public class DiscoveredNodeStoreTests
 
     private static Node CreateNode(PrivateKey privateKey, int port) =>
         new(privateKey.PublicKey, "127.0.0.1", port);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference<Node>, WeakReference<NodeRecord>, string) AddNodeWithEnr(DiscoveredNodeStore store)
+    {
+        using PrivateKeyGenerator generator = new();
+        using PrivateKey privateKey = generator.Generate();
+        NodeRecord nodeRecord = new();
+        nodeRecord.SetEntry(new SecP256k1Entry(privateKey.CompressedPublicKey));
+        new NodeRecordSigner(new Ecdsa(), privateKey).Sign(nodeRecord);
+        Node node = new(privateKey.PublicKey, "127.0.0.1", 30303);
+        node.SetVerifiedEnr(nodeRecord);
+        string enr = nodeRecord.ToString();
+        store.AddOrUpdate(node, "discv5", isActive: true);
+        return (new WeakReference<Node>(node), new WeakReference<NodeRecord>(nodeRecord), enr);
+    }
 }

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
@@ -5,6 +5,7 @@ using System.Buffers.Text;
 using System.Net;
 using System.Runtime.CompilerServices;
 using Nethermind.Config;
+using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
 using Nethermind.Network.Enr;
 using Nethermind.Stats.Model;
@@ -75,11 +76,8 @@ public class DiscoveredNodeStoreTests
         store.AddOrUpdate(node, "discv4", isActive: true);
 
         NodeDto[] activeNodes = store.GetActiveNodes();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(activeNodes, Has.Length.EqualTo(1));
-            Assert.That(activeNodes[0].Host, Is.EqualTo(node.Host));
-        }
+        Assert.That(activeNodes, Has.Length.EqualTo(1));
+        Assert.That(activeNodes[0].Host, Is.EqualTo(node.Host));
     }
 
     [TestCase(false)]
@@ -214,9 +212,9 @@ public class DiscoveredNodeStoreTests
 
         NodeDto[] retainedNodes = store.GetAllNodes();
         NodeRecord expected = shouldReplace ? candidate.Enr! : original.Enr!;
+        Assert.That(retainedNodes, Has.Length.EqualTo(1));
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(retainedNodes, Has.Length.EqualTo(1));
             Assert.That(candidate.Enr!.ToString(), Is.Not.EqualTo(original.Enr!.ToString()));
             Assert.That(retainedNodes[0].Enr, Is.EqualTo(expected.ToString()));
         }
@@ -236,11 +234,8 @@ public class DiscoveredNodeStoreTests
         store.AddOrUpdate(node, "discv5", isActive: true);
 
         NodeDto[] retainedNodes = store.GetAllNodes();
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(retainedNodes, Has.Length.EqualTo(1));
-            Assert.That(retainedNodes[0].Enr, Is.Null);
-        }
+        Assert.That(retainedNodes, Has.Length.EqualTo(1));
+        Assert.That(retainedNodes[0].Enr, Is.Null);
     }
 
     [Test]
@@ -314,13 +309,53 @@ public class DiscoveredNodeStoreTests
         ];
         Array.Sort(expectedOrder, StringComparer.Ordinal);
 
+        Assert.That(secondNode, Has.Length.EqualTo(1));
+        Assert.That(secondActiveNode, Has.Length.EqualTo(1));
+        Assert.That(allNodes, Has.Length.EqualTo(3));
         using (Assert.EnterMultipleScope())
         {
             Assert.That(Array.ConvertAll(allNodes, static node => node.IdHash), Is.EqualTo(expectedOrder));
-            Assert.That(secondNode, Has.Length.EqualTo(1));
             Assert.That(secondNode[0].IdHash, Is.EqualTo(allNodes[1].IdHash));
-            Assert.That(secondActiveNode, Has.Length.EqualTo(1));
             Assert.That(secondActiveNode[0].Active, Is.True);
+        }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Node_queries_match_global_order_across_bucket_boundaries(bool activeOnly)
+    {
+        DiscoveredNodeStore store = new();
+        Random random = new(42);
+        List<string> expectedHashes = [];
+        byte[] publicKeyBytes = new byte[PublicKey.LengthInBytes];
+        for (int i = 0; i < 8192; i++)
+        {
+            random.NextBytes(publicKeyBytes);
+            Node node = new(new PublicKey(publicKeyBytes), "127.0.0.1", 30303);
+            bool active = i % 3 != 0;
+            store.AddOrUpdate(node, "discv4", isActive: true);
+            if (!active) store.Remove(node, "discv4");
+            if (!activeOnly || active) expectedHashes.Add(node.IdHash.ToString());
+        }
+
+        expectedHashes.Sort(StringComparer.Ordinal);
+        string[] expected = expectedHashes.ToArray();
+        int boundary = expected.Length / 2;
+        while (boundary < expected.Length && expected[boundary][..5] == expected[boundary - 1][..5]) boundary++;
+        Assert.That(boundary, Is.LessThan(expected.Length));
+        int insideBucket = boundary;
+        while (insideBucket < expected.Length && expected[insideBucket][..5] != expected[insideBucket - 1][..5]) insideBucket++;
+        Assert.That(insideBucket, Is.LessThan(expected.Length));
+
+        foreach (int offset in new[] { 0, boundary - 1, boundary, insideBucket, expected.Length - 3, expected.Length, expected.Length + 1 })
+        {
+            foreach (int limit in new[] { 1, 37, 1000 })
+            {
+                NodeDto[] page = activeOnly ? store.GetActiveNodes(offset, limit) : store.GetAllNodes(offset, limit);
+                int start = Math.Min(offset, expected.Length);
+                Assert.That(Array.ConvertAll(page, static node => node.IdHash),
+                    Is.EqualTo(expected.AsSpan(start, Math.Min(limit, expected.Length - start)).ToArray()), $"offset={offset}, limit={limit}");
+            }
         }
     }
 

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
@@ -61,10 +61,8 @@ public class DiscoveredNodeStoreTests
         }
     }
 
-    [TestCase("127.0.0.1")]
-    [TestCase("::ffff:127.0.0.1")]
-    [TestCase("2001:db8::1")]
-    public void Node_dto_host_matches_node_host(string address)
+    [Test]
+    public void Node_dto_host_matches_node_host([Values("127.0.0.1", "::ffff:127.0.0.1", "2001:db8::1")] string address)
     {
         using PrivateKeyGenerator generator = new();
         using PrivateKey privateKey = generator.Generate();
@@ -320,9 +318,8 @@ public class DiscoveredNodeStoreTests
         }
     }
 
-    [TestCase(false)]
-    [TestCase(true)]
-    public void Node_queries_match_global_order_across_bucket_boundaries(bool activeOnly)
+    [Test]
+    public void Node_queries_match_global_order_across_bucket_boundaries([Values] bool activeOnly)
     {
         DiscoveredNodeStore store = new();
         Random random = new(42);

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveryContainerTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveryContainerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Autofac;
+using DotNetty.Buffers;
 using System.Net;
 using Nethermind.Config;
 using Nethermind.Crypto;
@@ -9,6 +10,7 @@ using Nethermind.Logging;
 using Nethermind.Network;
 using Nethermind.Network.Discovery;
 using Nethermind.Network.Enr;
+using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
 namespace Nethermind.Bootnode.Test;
@@ -16,6 +18,32 @@ namespace Nethermind.Bootnode.Test;
 [TestFixture]
 public class DiscoveryContainerTests
 {
+    [Test]
+    public void ConfigureNetworkBuffers_uses_single_small_shared_arena()
+    {
+        IByteBufferAllocator originalDefault = NethermindBuffers.Default;
+        IByteBufferAllocator originalDiscovery = NethermindBuffers.DiscoveryAllocator;
+
+        try
+        {
+            DiscoveryContainer.ConfigureNetworkBuffers();
+
+            PooledByteBufferAllocator allocator = (PooledByteBufferAllocator)NethermindBuffers.DiscoveryAllocator;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(NethermindBuffers.Default, Is.SameAs(allocator));
+                Assert.That(allocator.Metric.HeapArenas(), Has.Count.EqualTo(1));
+                Assert.That(allocator.Metric.DirectArenas(), Has.Count.EqualTo(1));
+                Assert.That(allocator.Metric.ChunkSize, Is.EqualTo(2 * 1024 * 1024));
+            }
+        }
+        finally
+        {
+            NethermindBuffers.Default = originalDefault;
+            NethermindBuffers.DiscoveryAllocator = originalDiscovery;
+        }
+    }
+
     [Test]
     public async Task Build_registers_bucket_sources_for_enabled_protocols()
     {

--- a/tools/Bootnode/Nethermind.Bootnode/BootnodeMetrics.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/BootnodeMetrics.cs
@@ -61,9 +61,24 @@ internal sealed class BootnodeMetrics
         "Bootnode identity information.",
         new GaugeConfiguration { LabelNames = ["enode", "enr", "seq", "node_id", "address"] });
 
-    public void RecordSeen(string protocol) => DiscoveredNodes.WithLabels(protocol).Inc();
+    private static readonly Counter.Child DiscoveredDiscv4Nodes = DiscoveredNodes.WithLabels("discv4");
+    private static readonly Counter.Child DiscoveredDiscv5Nodes = DiscoveredNodes.WithLabels("discv5");
+    private static readonly Counter.Child RemovedDiscv4Nodes = RemovedNodes.WithLabels("discv4");
+    private static readonly Counter.Child RemovedDiscv5Nodes = RemovedNodes.WithLabels("discv5");
+    private static readonly Gauge.Child ActiveAllNodes = ActiveNodes.WithLabels("all");
+    private static readonly Gauge.Child AllAllNodes = AllNodes.WithLabels("all");
+    private static readonly Gauge.Child ActiveDiscv4Nodes = ActiveNodes.WithLabels("discv4");
+    private static readonly Gauge.Child AllDiscv4Nodes = AllNodes.WithLabels("discv4");
+    private static readonly Gauge.Child ActiveDiscv5Nodes = ActiveNodes.WithLabels("discv5");
+    private static readonly Gauge.Child AllDiscv5Nodes = AllNodes.WithLabels("discv5");
+    private static readonly Gauge.Child ActiveBothNodes = ActiveNodes.WithLabels("both");
+    private static readonly Gauge.Child AllBothNodes = AllNodes.WithLabels("both");
+    private static readonly Gauge.Child ActiveConfiguredNodes = ActiveNodes.WithLabels("configured");
+    private static readonly Gauge.Child AllConfiguredNodes = AllNodes.WithLabels("configured");
 
-    public void RecordRemoved(string protocol) => RemovedNodes.WithLabels(protocol).Inc();
+    public void RecordSeen(string protocol) => GetProtocolCounter(DiscoveredNodes, DiscoveredDiscv4Nodes, DiscoveredDiscv5Nodes, protocol).Inc();
+
+    public void RecordRemoved(string protocol) => GetProtocolCounter(RemovedNodes, RemovedDiscv4Nodes, RemovedDiscv5Nodes, protocol).Inc();
 
     public void SetIdentity(BootnodeIdentity identity)
     {
@@ -83,7 +98,9 @@ internal sealed class BootnodeMetrics
 
             if (_publishedIdentity is { } previous)
             {
-                IdentityInfo.WithLabels(previous.Enode, previous.Enr, previous.EnrSequence, previous.NodeId, previous.Address).Unpublish();
+                Gauge.Child previousIdentity = IdentityInfo.WithLabels(previous.Enode, previous.Enr, previous.EnrSequence, previous.NodeId, previous.Address);
+                previousIdentity.Unpublish();
+                previousIdentity.Remove();
             }
 
             IdentityInfo.WithLabels(key.Enode, key.Enr, key.EnrSequence, key.NodeId, key.Address).Set(1);
@@ -175,9 +192,10 @@ internal sealed class BootnodeMetrics
             {
                 if (!currentBuckets.Contains(publishedBucket))
                 {
-                    KademliaBucketNodes
-                        .WithLabels(publishedBucket.Protocol, publishedBucket.Bucket, publishedBucket.Depth, publishedBucket.Prefix)
-                        .Unpublish();
+                    Gauge.Child previousBucket = KademliaBucketNodes
+                        .WithLabels(publishedBucket.Protocol, publishedBucket.Bucket, publishedBucket.Depth, publishedBucket.Prefix);
+                    previousBucket.Unpublish();
+                    previousBucket.Remove();
                 }
             }
 
@@ -191,17 +209,28 @@ internal sealed class BootnodeMetrics
 
     public void UpdateSnapshot(DiscoverySnapshot snapshot)
     {
-        ActiveNodes.WithLabels("all").Set(snapshot.ActiveCount);
-        AllNodes.WithLabels("all").Set(snapshot.AllCount);
-        ActiveNodes.WithLabels("discv4").Set(snapshot.ActiveDiscv4Count);
-        AllNodes.WithLabels("discv4").Set(snapshot.AllDiscv4Count);
-        ActiveNodes.WithLabels("discv5").Set(snapshot.ActiveDiscv5Count);
-        AllNodes.WithLabels("discv5").Set(snapshot.AllDiscv5Count);
-        ActiveNodes.WithLabels("both").Set(snapshot.ActiveBothCount);
-        AllNodes.WithLabels("both").Set(snapshot.AllBothCount);
-        ActiveNodes.WithLabels("configured").Set(snapshot.ActiveConfiguredCount);
-        AllNodes.WithLabels("configured").Set(snapshot.AllConfiguredCount);
+        ActiveAllNodes.Set(snapshot.ActiveCount);
+        AllAllNodes.Set(snapshot.AllCount);
+        ActiveDiscv4Nodes.Set(snapshot.ActiveDiscv4Count);
+        AllDiscv4Nodes.Set(snapshot.AllDiscv4Count);
+        ActiveDiscv5Nodes.Set(snapshot.ActiveDiscv5Count);
+        AllDiscv5Nodes.Set(snapshot.AllDiscv5Count);
+        ActiveBothNodes.Set(snapshot.ActiveBothCount);
+        AllBothNodes.Set(snapshot.AllBothCount);
+        ActiveConfiguredNodes.Set(snapshot.ActiveConfiguredCount);
+        AllConfiguredNodes.Set(snapshot.AllConfiguredCount);
     }
+
+    private static Counter.Child GetProtocolCounter(
+        Counter counter,
+        Counter.Child discv4Counter,
+        Counter.Child discv5Counter,
+        string protocol) => protocol switch
+        {
+            "discv4" => discv4Counter,
+            "discv5" => discv5Counter,
+            _ => counter.WithLabels(protocol)
+        };
 
     private readonly record struct BucketMetricKey(string Protocol, string Bucket, string Depth, string Prefix);
 

--- a/tools/Bootnode/Nethermind.Bootnode/BootnodeMetrics.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/BootnodeMetrics.cs
@@ -51,7 +51,7 @@ internal sealed class BootnodeMetrics
         "Total discovery UDP traffic handled by the bootnode.",
         new CounterConfiguration { LabelNames = ["direction"] });
 
-    private static readonly Gauge KademliaBucketNodes = PrometheusMetrics.CreateGauge(
+    internal static readonly Gauge KademliaBucketNodes = PrometheusMetrics.CreateGauge(
         "nethermind_bootnode_kademlia_bucket_nodes",
         "Number of nodes in each bootnode Kademlia routing-table bucket.",
         new GaugeConfiguration { LabelNames = ["protocol", "bucket", "depth", "prefix"] });
@@ -61,6 +61,7 @@ internal sealed class BootnodeMetrics
         "Bootnode identity information.",
         new GaugeConfiguration { LabelNames = ["enode", "enr", "seq", "node_id", "address"] });
 
+    // These fixed-label children are process-lifetime caches; only uncached dynamic children are removed below.
     private static readonly Counter.Child DiscoveredDiscv4Nodes = DiscoveredNodes.WithLabels("discv4");
     private static readonly Counter.Child DiscoveredDiscv5Nodes = DiscoveredNodes.WithLabels("discv5");
     private static readonly Counter.Child RemovedDiscv4Nodes = RemovedNodes.WithLabels("discv4");

--- a/tools/Bootnode/Nethermind.Bootnode/BootnodeMetrics.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/BootnodeMetrics.cs
@@ -61,25 +61,25 @@ internal sealed class BootnodeMetrics
         "Bootnode identity information.",
         new GaugeConfiguration { LabelNames = ["enode", "enr", "seq", "node_id", "address"] });
 
-    // These fixed-label children are process-lifetime caches; only uncached dynamic children are removed below.
+    // High-frequency fixed-label counters are process-lifetime caches.
     private static readonly Counter.Child DiscoveredDiscv4Nodes = DiscoveredNodes.WithLabels("discv4");
     private static readonly Counter.Child DiscoveredDiscv5Nodes = DiscoveredNodes.WithLabels("discv5");
     private static readonly Counter.Child RemovedDiscv4Nodes = RemovedNodes.WithLabels("discv4");
     private static readonly Counter.Child RemovedDiscv5Nodes = RemovedNodes.WithLabels("discv5");
-    private static readonly Gauge.Child ActiveAllNodes = ActiveNodes.WithLabels("all");
-    private static readonly Gauge.Child AllAllNodes = AllNodes.WithLabels("all");
-    private static readonly Gauge.Child ActiveDiscv4Nodes = ActiveNodes.WithLabels("discv4");
-    private static readonly Gauge.Child AllDiscv4Nodes = AllNodes.WithLabels("discv4");
-    private static readonly Gauge.Child ActiveDiscv5Nodes = ActiveNodes.WithLabels("discv5");
-    private static readonly Gauge.Child AllDiscv5Nodes = AllNodes.WithLabels("discv5");
-    private static readonly Gauge.Child ActiveBothNodes = ActiveNodes.WithLabels("both");
-    private static readonly Gauge.Child AllBothNodes = AllNodes.WithLabels("both");
-    private static readonly Gauge.Child ActiveConfiguredNodes = ActiveNodes.WithLabels("configured");
-    private static readonly Gauge.Child AllConfiguredNodes = AllNodes.WithLabels("configured");
 
-    public void RecordSeen(string protocol) => GetProtocolCounter(DiscoveredNodes, DiscoveredDiscv4Nodes, DiscoveredDiscv5Nodes, protocol).Inc();
+    public void RecordSeen(string protocol) => (protocol switch
+    {
+        "discv4" => DiscoveredDiscv4Nodes,
+        "discv5" => DiscoveredDiscv5Nodes,
+        _ => DiscoveredNodes.WithLabels(protocol)
+    }).Inc();
 
-    public void RecordRemoved(string protocol) => GetProtocolCounter(RemovedNodes, RemovedDiscv4Nodes, RemovedDiscv5Nodes, protocol).Inc();
+    public void RecordRemoved(string protocol) => (protocol switch
+    {
+        "discv4" => RemovedDiscv4Nodes,
+        "discv5" => RemovedDiscv5Nodes,
+        _ => RemovedNodes.WithLabels(protocol)
+    }).Inc();
 
     public void SetIdentity(BootnodeIdentity identity)
     {
@@ -210,28 +210,17 @@ internal sealed class BootnodeMetrics
 
     public void UpdateSnapshot(DiscoverySnapshot snapshot)
     {
-        ActiveAllNodes.Set(snapshot.ActiveCount);
-        AllAllNodes.Set(snapshot.AllCount);
-        ActiveDiscv4Nodes.Set(snapshot.ActiveDiscv4Count);
-        AllDiscv4Nodes.Set(snapshot.AllDiscv4Count);
-        ActiveDiscv5Nodes.Set(snapshot.ActiveDiscv5Count);
-        AllDiscv5Nodes.Set(snapshot.AllDiscv5Count);
-        ActiveBothNodes.Set(snapshot.ActiveBothCount);
-        AllBothNodes.Set(snapshot.AllBothCount);
-        ActiveConfiguredNodes.Set(snapshot.ActiveConfiguredCount);
-        AllConfiguredNodes.Set(snapshot.AllConfiguredCount);
+        ActiveNodes.WithLabels("all").Set(snapshot.ActiveCount);
+        AllNodes.WithLabels("all").Set(snapshot.AllCount);
+        ActiveNodes.WithLabels("discv4").Set(snapshot.ActiveDiscv4Count);
+        AllNodes.WithLabels("discv4").Set(snapshot.AllDiscv4Count);
+        ActiveNodes.WithLabels("discv5").Set(snapshot.ActiveDiscv5Count);
+        AllNodes.WithLabels("discv5").Set(snapshot.AllDiscv5Count);
+        ActiveNodes.WithLabels("both").Set(snapshot.ActiveBothCount);
+        AllNodes.WithLabels("both").Set(snapshot.AllBothCount);
+        ActiveNodes.WithLabels("configured").Set(snapshot.ActiveConfiguredCount);
+        AllNodes.WithLabels("configured").Set(snapshot.AllConfiguredCount);
     }
-
-    private static Counter.Child GetProtocolCounter(
-        Counter counter,
-        Counter.Child discv4Counter,
-        Counter.Child discv5Counter,
-        string protocol) => protocol switch
-        {
-            "discv4" => discv4Counter,
-            "discv5" => discv5Counter,
-            _ => counter.WithLabels(protocol)
-        };
 
     private readonly record struct BucketMetricKey(string Protocol, string Bucket, string Depth, string Prefix);
 

--- a/tools/Bootnode/Nethermind.Bootnode/BootnodeRuntime.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/BootnodeRuntime.cs
@@ -66,7 +66,7 @@ internal sealed class BootnodeRuntime(
             await foreach (Node node in source.NodeSource.DiscoverNodes(cancellationToken))
             {
                 metrics.RecordSeen(source.Protocol);
-                metrics.UpdateSnapshot(nodeStore.AddOrUpdate(node, source.Protocol, isActive: true));
+                nodeStore.AddOrUpdate(node, source.Protocol, isActive: true);
                 if (_logger.IsDebug) _logger.Debug($"Discovered {source.Protocol} node {node:s}");
             }
 
@@ -94,12 +94,14 @@ internal sealed class BootnodeRuntime(
             metrics.UpdateDiscoveryMessageCounters();
             metrics.UpdateDiscoveryTrafficCounters();
             metrics.UpdateKademliaBucketStats(bucketRegistry.CreateSnapshot());
+            metrics.UpdateSnapshot(nodeStore.CreateSnapshot());
 
             while (await timer.WaitForNextTickAsync(cancellationToken))
             {
                 metrics.UpdateDiscoveryMessageCounters();
                 metrics.UpdateDiscoveryTrafficCounters();
                 metrics.UpdateKademliaBucketStats(bucketRegistry.CreateSnapshot());
+                metrics.UpdateSnapshot(nodeStore.CreateSnapshot());
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -114,7 +116,7 @@ internal sealed class BootnodeRuntime(
     private void OnNodeRemoved(string protocol, NodeEventArgs args)
     {
         metrics.RecordRemoved(protocol);
-        metrics.UpdateSnapshot(nodeStore.Remove(args.Node, protocol));
+        nodeStore.Remove(args.Node, protocol);
         if (_logger.IsDebug) _logger.Debug($"Removed discovery node {args.Node:s}");
     }
 

--- a/tools/Bootnode/Nethermind.Bootnode/DiscoveredNodeStore.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/DiscoveredNodeStore.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Buffers.Text;
+using System.Diagnostics;
 using System.Net;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
@@ -18,8 +19,8 @@ internal sealed class DiscoveredNodeStore
     internal const int MaxNodePageSize = 1_000;
 
     private readonly Dictionary<Hash256, TrackedNode> _nodes;
-    private readonly RetentionList _activeRetentionOrder = new();
-    private readonly RetentionList _inactiveRetentionOrder = new();
+    private readonly RetentionList _activeRetentionOrder = new(active: true);
+    private readonly RetentionList _inactiveRetentionOrder = new(active: false);
     private readonly SortedSet<Hash256> _orderedNodes = [];
     private readonly SortedSet<Hash256> _orderedActiveNodes = [];
     private readonly Lock _lock = new();
@@ -42,7 +43,7 @@ internal sealed class DiscoveredNodeStore
         _nodes = new Dictionary<Hash256, TrackedNode>(maxRetainedNodes);
     }
 
-    public DiscoverySnapshot AddOrUpdate(Node node, string protocol, bool isActive)
+    public void AddOrUpdate(Node node, string protocol, bool isActive)
     {
         NodeProtocol parsedProtocol = ParseProtocol(protocol);
         DateTimeOffset now = DateTimeOffset.UtcNow;
@@ -72,7 +73,6 @@ internal sealed class DiscoveredNodeStore
 
             UpdateRetentionOrder(trackedNode, after);
             PruneRetainedNodes();
-            return CreateSnapshotCore();
         }
     }
 
@@ -90,7 +90,7 @@ internal sealed class DiscoveredNodeStore
         return CreateSnapshot();
     }
 
-    public DiscoverySnapshot Remove(Node node, string protocol)
+    public void Remove(Node node, string protocol)
     {
         NodeProtocol parsedProtocol = ParseProtocol(protocol);
         lock (_lock)
@@ -105,8 +105,6 @@ internal sealed class DiscoveredNodeStore
                 UpdateRetentionOrder(trackedNode, after);
                 PruneRetainedNodes();
             }
-
-            return CreateSnapshotCore();
         }
     }
 
@@ -245,7 +243,6 @@ internal sealed class DiscoveredNodeStore
             GetRetentionOrder(trackedNode.RetainedAsActive).Remove(trackedNode);
         }
 
-        trackedNode.RetainedAsActive = active;
         GetRetentionOrder(active).AddLast(trackedNode);
     }
 
@@ -294,7 +291,11 @@ internal sealed class DiscoveredNodeStore
             SortedSet<Hash256> orderedNodes = activeOnly ? _orderedActiveNodes : _orderedNodes;
             foreach (Hash256 idHash in orderedNodes)
             {
-                TrackedNode trackedNode = _nodes[idHash];
+                if (!_nodes.TryGetValue(idHash, out TrackedNode? trackedNode))
+                {
+                    continue;
+                }
+
                 if (matchedNodes++ < offset)
                 {
                     continue;
@@ -305,6 +306,11 @@ internal sealed class DiscoveredNodeStore
                 {
                     break;
                 }
+            }
+
+            if (resultIndex != resultCount)
+            {
+                Array.Resize(ref nodeViews, resultIndex);
             }
         }
 
@@ -475,6 +481,7 @@ internal sealed class DiscoveredNodeStore
             new(
                 NodeId.AsSpan().ToHexString(withZeroX: false),
                 IdHash.ToString(),
+                // Match Node.Host formatting without retaining the discovery Node graph.
                 Host.IsIPv4MappedToIPv6 ? Host.MapToIPv4().ToString() : Host.ToString(),
                 TcpPort,
                 DiscoveryPort,
@@ -488,7 +495,7 @@ internal sealed class DiscoveredNodeStore
                 SeenCount);
     }
 
-    private sealed class RetentionList
+    private sealed class RetentionList(bool active)
     {
         public TrackedNode? First { get; private set; }
         public TrackedNode? Last { get; private set; }
@@ -496,9 +503,11 @@ internal sealed class DiscoveredNodeStore
 
         public void AddLast(TrackedNode node)
         {
+            Debug.Assert(!node.IsInRetentionOrder);
             node.PreviousRetentionNode = Last;
             node.NextRetentionNode = null;
             node.IsInRetentionOrder = true;
+            node.RetainedAsActive = active;
             if (Last is null)
             {
                 First = node;
@@ -512,8 +521,10 @@ internal sealed class DiscoveredNodeStore
             Count++;
         }
 
+        /// <remarks>The caller must ensure <paramref name="node"/> belongs to this list.</remarks>
         public void Remove(TrackedNode node)
         {
+            Debug.Assert(node.IsInRetentionOrder && node.RetainedAsActive == active);
             if (node.PreviousRetentionNode is null)
             {
                 First = node.NextRetentionNode;

--- a/tools/Bootnode/Nethermind.Bootnode/DiscoveredNodeStore.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/DiscoveredNodeStore.cs
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Concurrent;
+using System.Buffers.Text;
+using System.Net;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Network.Enr;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Bootnode;
@@ -14,10 +17,9 @@ internal sealed class DiscoveredNodeStore
     internal const int DefaultNodePageSize = 1_000;
     internal const int MaxNodePageSize = 1_000;
 
-    private readonly ConcurrentDictionary<Hash256, TrackedNode> _nodes = new();
-    private readonly LinkedList<Hash256> _activeRetentionOrder = new();
-    private readonly LinkedList<Hash256> _inactiveRetentionOrder = new();
-    private readonly Dictionary<Hash256, RetentionEntry> _retentionEntries = [];
+    private readonly Dictionary<Hash256, TrackedNode> _nodes;
+    private readonly RetentionList _activeRetentionOrder = new();
+    private readonly RetentionList _inactiveRetentionOrder = new();
     private readonly SortedSet<Hash256> _orderedNodes = [];
     private readonly SortedSet<Hash256> _orderedActiveNodes = [];
     private readonly Lock _lock = new();
@@ -37,26 +39,30 @@ internal sealed class DiscoveredNodeStore
     {
         BootnodeOptionValidation.ValidatePositive(nameof(maxRetainedNodes), maxRetainedNodes);
         _maxRetainedNodes = maxRetainedNodes;
+        _nodes = new Dictionary<Hash256, TrackedNode>(maxRetainedNodes);
     }
 
     public DiscoverySnapshot AddOrUpdate(Node node, string protocol, bool isActive)
     {
+        NodeProtocol parsedProtocol = ParseProtocol(protocol);
         DateTimeOffset now = DateTimeOffset.UtcNow;
 
         lock (_lock)
         {
             TrackedNodeSnapshot after;
+            TrackedNode trackedNode;
             if (_nodes.TryGetValue(node.IdHash, out TrackedNode? existing))
             {
+                trackedNode = existing;
                 TrackedNodeSnapshot before = existing.CreateSnapshot();
-                existing.Update(node, protocol, now, isActive);
+                existing.Update(node, parsedProtocol, now, isActive);
                 after = existing.CreateSnapshot();
                 ApplyTransition(before, after);
                 UpdateActiveIndex(node.IdHash, after.Active);
             }
             else
             {
-                TrackedNode trackedNode = TrackedNode.Create(node, protocol, now, isActive);
+                trackedNode = TrackedNode.Create(node, parsedProtocol, now, isActive);
                 _nodes[node.IdHash] = trackedNode;
                 _orderedNodes.Add(node.IdHash);
                 after = trackedNode.CreateSnapshot();
@@ -64,7 +70,7 @@ internal sealed class DiscoveredNodeStore
                 UpdateActiveIndex(node.IdHash, after.Active);
             }
 
-            UpdateRetentionOrder(node.IdHash, after);
+            UpdateRetentionOrder(trackedNode, after);
             PruneRetainedNodes();
             return CreateSnapshotCore();
         }
@@ -86,16 +92,17 @@ internal sealed class DiscoveredNodeStore
 
     public DiscoverySnapshot Remove(Node node, string protocol)
     {
+        NodeProtocol parsedProtocol = ParseProtocol(protocol);
         lock (_lock)
         {
             if (_nodes.TryGetValue(node.IdHash, out TrackedNode? trackedNode))
             {
                 TrackedNodeSnapshot before = trackedNode.CreateSnapshot();
-                trackedNode.MarkInactive(protocol, DateTimeOffset.UtcNow);
+                trackedNode.MarkInactive(parsedProtocol, DateTimeOffset.UtcNow);
                 TrackedNodeSnapshot after = trackedNode.CreateSnapshot();
                 ApplyTransition(before, after);
                 UpdateActiveIndex(node.IdHash, after.Active);
-                UpdateRetentionOrder(node.IdHash, after);
+                UpdateRetentionOrder(trackedNode, after);
                 PruneRetainedNodes();
             }
 
@@ -105,12 +112,15 @@ internal sealed class DiscoveredNodeStore
 
     public string? GetProtocol(Node node)
     {
-        if (_nodes.TryGetValue(node.IdHash, out TrackedNode? trackedNode))
+        lock (_lock)
         {
-            return trackedNode.GetProtocol();
-        }
+            if (_nodes.TryGetValue(node.IdHash, out TrackedNode? trackedNode))
+            {
+                return trackedNode.GetProtocol();
+            }
 
-        return null;
+            return null;
+        }
     }
 
     public NodeDto[] GetActiveNodes(int offset = 0, int limit = DefaultNodePageSize) => GetNodes(activeOnly: true, offset, limit);
@@ -123,7 +133,7 @@ internal sealed class DiscoveredNodeStore
         {
             lock (_lock)
             {
-                return _retentionEntries.Count;
+                return _activeRetentionOrder.Count + _inactiveRetentionOrder.Count;
             }
         }
     }
@@ -189,19 +199,19 @@ internal sealed class DiscoveredNodeStore
 
         switch (snapshot.Protocol)
         {
-            case "discv4":
+            case NodeProtocol.Discv4:
                 _allDiscv4Count += delta;
                 if (snapshot.Active) _activeDiscv4Count += delta;
                 break;
-            case "discv5":
+            case NodeProtocol.Discv5:
                 _allDiscv5Count += delta;
                 if (snapshot.Active) _activeDiscv5Count += delta;
                 break;
-            case "both":
+            case NodeProtocol.Both:
                 _allBothCount += delta;
                 if (snapshot.Active) _activeBothCount += delta;
                 break;
-            case "configured":
+            case NodeProtocol.Configured:
                 _allConfiguredCount += delta;
                 if (snapshot.Active) _activeConfiguredCount += delta;
                 break;
@@ -212,58 +222,52 @@ internal sealed class DiscoveredNodeStore
     {
         while (_allCount > _maxRetainedNodes)
         {
-            LinkedListNode<Hash256>? oldestNode = _inactiveRetentionOrder.First ?? _activeRetentionOrder.First;
+            TrackedNode? oldestNode = _inactiveRetentionOrder.First ?? _activeRetentionOrder.First;
             if (oldestNode is null)
             {
                 return;
             }
 
-            RemoveRetentionEntry(oldestNode.Value);
-            _orderedNodes.Remove(oldestNode.Value);
-            _orderedActiveNodes.Remove(oldestNode.Value);
-            if (_nodes.TryRemove(oldestNode.Value, out TrackedNode? trackedNode))
+            RemoveRetentionEntry(oldestNode);
+            _orderedNodes.Remove(oldestNode.IdHash);
+            _orderedActiveNodes.Remove(oldestNode.IdHash);
+            if (_nodes.Remove(oldestNode.IdHash))
             {
-                RemoveFromSnapshot(trackedNode.CreateSnapshot());
+                RemoveFromSnapshot(oldestNode.CreateSnapshot());
             }
         }
     }
 
-    private void TouchRetentionOrder(Hash256 idHash, bool active)
+    private void TouchRetentionOrder(TrackedNode trackedNode, bool active)
     {
-        LinkedListNode<Hash256> node;
-        if (_retentionEntries.TryGetValue(idHash, out RetentionEntry existingEntry))
+        if (trackedNode.IsInRetentionOrder)
         {
-            GetRetentionOrder(existingEntry.Active).Remove(existingEntry.Node);
-            node = existingEntry.Node;
-        }
-        else
-        {
-            node = new LinkedListNode<Hash256>(idHash);
+            GetRetentionOrder(trackedNode.RetainedAsActive).Remove(trackedNode);
         }
 
-        GetRetentionOrder(active).AddLast(node);
-        _retentionEntries[idHash] = new RetentionEntry(node, active);
+        trackedNode.RetainedAsActive = active;
+        GetRetentionOrder(active).AddLast(trackedNode);
     }
 
-    private void UpdateRetentionOrder(Hash256 idHash, TrackedNodeSnapshot snapshot)
+    private void UpdateRetentionOrder(TrackedNode trackedNode, TrackedNodeSnapshot snapshot)
     {
         if (snapshot.IsBootnode)
         {
-            RemoveRetentionEntry(idHash);
+            RemoveRetentionEntry(trackedNode);
             return;
         }
 
-        TouchRetentionOrder(idHash, snapshot.Active);
+        TouchRetentionOrder(trackedNode, snapshot.Active);
     }
 
-    private LinkedList<Hash256> GetRetentionOrder(bool active) =>
+    private RetentionList GetRetentionOrder(bool active) =>
         active ? _activeRetentionOrder : _inactiveRetentionOrder;
 
-    private void RemoveRetentionEntry(Hash256 idHash)
+    private void RemoveRetentionEntry(TrackedNode trackedNode)
     {
-        if (_retentionEntries.Remove(idHash, out RetentionEntry entry))
+        if (trackedNode.IsInRetentionOrder)
         {
-            GetRetentionOrder(entry.Active).Remove(entry.Node);
+            GetRetentionOrder(trackedNode.RetainedAsActive).Remove(trackedNode);
         }
     }
 
@@ -274,35 +278,38 @@ internal sealed class DiscoveredNodeStore
             throw new ArgumentOutOfRangeException(offset < 0 ? nameof(offset) : nameof(limit), error);
         }
 
-        List<TrackedNodeView> nodeViews;
+        TrackedNodeView[] nodeViews;
         lock (_lock)
         {
             int nodeCount = activeOnly ? _activeCount : _allCount;
-            nodeViews = new List<TrackedNodeView>(Math.Min(limit, nodeCount));
+            int resultCount = Math.Min(limit, Math.Max(0, nodeCount - offset));
+            if (resultCount == 0)
+            {
+                return [];
+            }
+
+            nodeViews = new TrackedNodeView[resultCount];
             int matchedNodes = 0;
+            int resultIndex = 0;
             SortedSet<Hash256> orderedNodes = activeOnly ? _orderedActiveNodes : _orderedNodes;
             foreach (Hash256 idHash in orderedNodes)
             {
-                if (!_nodes.TryGetValue(idHash, out TrackedNode? trackedNode))
-                {
-                    continue;
-                }
-
+                TrackedNode trackedNode = _nodes[idHash];
                 if (matchedNodes++ < offset)
                 {
                     continue;
                 }
 
-                nodeViews.Add(trackedNode.CreateView());
-                if (nodeViews.Count == limit)
+                nodeViews[resultIndex++] = trackedNode.CreateView();
+                if (resultIndex == resultCount)
                 {
                     break;
                 }
             }
         }
 
-        NodeDto[] nodes = new NodeDto[nodeViews.Count];
-        for (int i = 0; i < nodeViews.Count; i++)
+        NodeDto[] nodes = new NodeDto[nodeViews.Length];
+        for (int i = 0; i < nodeViews.Length; i++)
         {
             nodes[i] = nodeViews[i].ToDto();
         }
@@ -324,158 +331,243 @@ internal sealed class DiscoveredNodeStore
 
     private sealed class TrackedNode
     {
-        private readonly Lock _lock = new();
-        private Node _node;
-        private string _protocol;
+        private readonly byte[] _nodeId;
+        private IPAddress _host;
+        private int _tcpPort;
+        private int _discoveryPort;
+        private NodeProtocol _protocols;
+        private NodeProtocol _activeProtocols;
         private bool _isBootnode;
         private string? _configuredEnode;
-        private bool _activeDiscv4;
-        private bool _activeDiscv5;
-        private bool _activeConfigured;
-        private DateTimeOffset _lastSeenUtc;
+        private byte[]? _enrRlp;
+        private ulong _enrSequence;
+        private long _lastSeenUtcTicks;
         private int _seenCount;
 
-        private TrackedNode(Node node, string protocol, DateTimeOffset now, bool isActive)
+        private TrackedNode(Node node, NodeProtocol protocol, DateTimeOffset now, bool isActive)
         {
-            _node = node;
-            _protocol = protocol;
+            IdHash = node.IdHash;
+            _nodeId = node.Id.Bytes;
+            _host = node.Address.Address;
+            _tcpPort = node.Port;
+            _discoveryPort = node.DiscoveryPort;
+            _protocols = protocol;
             _isBootnode = node.IsBootnode;
             _configuredEnode = node.IsBootnode ? node.ToString(Node.Format.ENode) : null;
+            UpdateEnr(node);
             SetProtocolActive(protocol, isActive);
-            FirstSeenUtc = now;
-            _lastSeenUtc = now;
+            FirstSeenUtcTicks = now.UtcTicks;
+            _lastSeenUtcTicks = now.UtcTicks;
             _seenCount = 1;
         }
 
-        private DateTimeOffset FirstSeenUtc { get; }
+        public Hash256 IdHash { get; }
+        public bool IsActive => _activeProtocols != NodeProtocol.None;
+        public bool IsInRetentionOrder { get; set; }
+        public bool RetainedAsActive { get; set; }
+        public TrackedNode? PreviousRetentionNode { get; set; }
+        public TrackedNode? NextRetentionNode { get; set; }
+        private long FirstSeenUtcTicks { get; }
 
-        public static TrackedNode Create(Node node, string protocol, DateTimeOffset now, bool isActive) =>
+        public static TrackedNode Create(Node node, NodeProtocol protocol, DateTimeOffset now, bool isActive) =>
             new(node, protocol, now, isActive);
 
-        public void Update(Node node, string protocol, DateTimeOffset now, bool isActive)
+        public void Update(Node node, NodeProtocol protocol, DateTimeOffset now, bool isActive)
         {
-            lock (_lock)
+            if (node.IsBootnode)
             {
-                if (node.IsBootnode)
-                {
-                    _configuredEnode ??= node.ToString(Node.Format.ENode);
-                }
-
-                _node = node;
-                _isBootnode |= node.IsBootnode;
-                _protocol = MergeProtocol(_protocol, protocol);
-                if (isActive)
-                {
-                    SetProtocolActive(protocol, isActive: true);
-                }
-                _lastSeenUtc = now;
-                _seenCount++;
+                _configuredEnode ??= node.ToString(Node.Format.ENode);
             }
+
+            SetEndpoint(node);
+            UpdateEnr(node);
+            _isBootnode |= node.IsBootnode;
+            _protocols |= protocol;
+            if (isActive)
+            {
+                SetProtocolActive(protocol, isActive: true);
+            }
+
+            _lastSeenUtcTicks = now.UtcTicks;
+            _seenCount++;
         }
 
-        public void MarkInactive(string protocol, DateTimeOffset now)
+        public void MarkInactive(NodeProtocol protocol, DateTimeOffset now)
         {
-            lock (_lock)
-            {
-                SetProtocolActive(protocol, isActive: false);
-                _lastSeenUtc = now;
-            }
+            SetProtocolActive(protocol, isActive: false);
+            _lastSeenUtcTicks = now.UtcTicks;
         }
 
-        public string GetProtocol()
+        public string GetProtocol() => ProtocolToString(GetProtocolCore());
+
+        public TrackedNodeSnapshot CreateSnapshot() => new(GetProtocolCore(), IsActive, _isBootnode);
+
+        public TrackedNodeView CreateView() =>
+            new(
+                _nodeId,
+                IdHash,
+                _host,
+                _tcpPort,
+                _discoveryPort,
+                _configuredEnode,
+                _enrRlp,
+                GetProtocolCore(),
+                IsActive,
+                _isBootnode,
+                FirstSeenUtcTicks,
+                _lastSeenUtcTicks,
+                _seenCount);
+
+        private NodeProtocol GetProtocolCore()
         {
-            lock (_lock)
-            {
-                return _protocol;
-            }
+            NodeProtocol discoveryProtocols = _protocols & NodeProtocol.Both;
+            return discoveryProtocols == NodeProtocol.None ? NodeProtocol.Configured : discoveryProtocols;
         }
 
-        public TrackedNodeSnapshot CreateSnapshot()
+        private void SetEndpoint(Node node)
         {
-            lock (_lock)
-            {
-                return new TrackedNodeSnapshot(_protocol, IsActiveCore, _isBootnode);
-            }
+            _host = node.Address.Address;
+            _tcpPort = node.Port;
+            _discoveryPort = node.DiscoveryPort;
         }
 
-        public TrackedNodeView CreateView()
+        private void UpdateEnr(Node node)
         {
-            lock (_lock)
+            NodeRecord? enr = node.Enr;
+            if (enr?.Signature is null || (_enrRlp is not null && enr.EnrSequence <= _enrSequence))
             {
-                return new TrackedNodeView(
-                    _node,
-                    _protocol,
-                    IsActiveCore,
-                    FirstSeenUtc,
-                    _lastSeenUtc,
-                    _seenCount,
-                    _isBootnode,
-                    _configuredEnode);
+                return;
             }
+
+            _enrRlp = enr.ToRlpBytes();
+            _enrSequence = enr.EnrSequence;
         }
 
-        private bool IsActiveCore => _activeDiscv4 || _activeDiscv5 || _activeConfigured;
-
-        private void SetProtocolActive(string protocol, bool isActive)
+        private void SetProtocolActive(NodeProtocol protocol, bool isActive)
         {
-            switch (protocol)
+            if (isActive)
             {
-                case "discv4":
-                    _activeDiscv4 = isActive;
-                    break;
-                case "discv5":
-                    _activeDiscv5 = isActive;
-                    break;
-                case "both":
-                    _activeDiscv4 = isActive;
-                    _activeDiscv5 = isActive;
-                    break;
-                case "configured":
-                    _activeConfigured = isActive;
-                    break;
-                default:
-                    throw new ArgumentException($"Unsupported discovery protocol '{protocol}'.", nameof(protocol));
+                _activeProtocols |= protocol;
             }
-        }
-
-        private static string MergeProtocol(string current, string next)
-        {
-            if (current == next)
+            else
             {
-                return current;
+                _activeProtocols &= ~protocol;
             }
-
-            if (current == "configured")
-            {
-                return next;
-            }
-
-            if (next == "configured")
-            {
-                return current;
-            }
-
-            return "both";
         }
     }
 
     private readonly record struct TrackedNodeView(
-        Node Node,
-        string Protocol,
+        byte[] NodeId,
+        Hash256 IdHash,
+        IPAddress Host,
+        int TcpPort,
+        int DiscoveryPort,
+        string? Enode,
+        byte[]? EnrRlp,
+        NodeProtocol Protocol,
         bool Active,
-        DateTimeOffset FirstSeenUtc,
-        DateTimeOffset LastSeenUtc,
-        int SeenCount,
         bool IsBootnode,
-        string? ConfiguredEnode)
+        long FirstSeenUtcTicks,
+        long LastSeenUtcTicks,
+        int SeenCount)
     {
         public NodeDto ToDto() =>
-            NodeDto.FromNode(Node, Protocol, Active, FirstSeenUtc, LastSeenUtc, SeenCount, IsBootnode, ConfiguredEnode);
+            new(
+                NodeId.AsSpan().ToHexString(withZeroX: false),
+                IdHash.ToString(),
+                Host.IsIPv4MappedToIPv6 ? Host.MapToIPv4().ToString() : Host.ToString(),
+                TcpPort,
+                DiscoveryPort,
+                Enode,
+                EnrRlp is null ? null : string.Concat("enr:", Base64Url.EncodeToString(EnrRlp)),
+                ProtocolToString(Protocol),
+                Active,
+                IsBootnode,
+                new DateTimeOffset(FirstSeenUtcTicks, TimeSpan.Zero),
+                new DateTimeOffset(LastSeenUtcTicks, TimeSpan.Zero),
+                SeenCount);
     }
 
-    private readonly record struct TrackedNodeSnapshot(string Protocol, bool Active, bool IsBootnode);
+    private sealed class RetentionList
+    {
+        public TrackedNode? First { get; private set; }
+        public TrackedNode? Last { get; private set; }
+        public int Count { get; private set; }
 
-    private readonly record struct RetentionEntry(LinkedListNode<Hash256> Node, bool Active);
+        public void AddLast(TrackedNode node)
+        {
+            node.PreviousRetentionNode = Last;
+            node.NextRetentionNode = null;
+            node.IsInRetentionOrder = true;
+            if (Last is null)
+            {
+                First = node;
+            }
+            else
+            {
+                Last.NextRetentionNode = node;
+            }
+
+            Last = node;
+            Count++;
+        }
+
+        public void Remove(TrackedNode node)
+        {
+            if (node.PreviousRetentionNode is null)
+            {
+                First = node.NextRetentionNode;
+            }
+            else
+            {
+                node.PreviousRetentionNode.NextRetentionNode = node.NextRetentionNode;
+            }
+
+            if (node.NextRetentionNode is null)
+            {
+                Last = node.PreviousRetentionNode;
+            }
+            else
+            {
+                node.NextRetentionNode.PreviousRetentionNode = node.PreviousRetentionNode;
+            }
+
+            node.PreviousRetentionNode = null;
+            node.NextRetentionNode = null;
+            node.IsInRetentionOrder = false;
+            Count--;
+        }
+    }
+
+    private static NodeProtocol ParseProtocol(string protocol) => protocol switch
+    {
+        "discv4" => NodeProtocol.Discv4,
+        "discv5" => NodeProtocol.Discv5,
+        "both" => NodeProtocol.Both,
+        "configured" => NodeProtocol.Configured,
+        _ => throw new ArgumentException($"Unsupported discovery protocol '{protocol}'.", nameof(protocol))
+    };
+
+    private static string ProtocolToString(NodeProtocol protocol) => protocol switch
+    {
+        NodeProtocol.Discv4 => "discv4",
+        NodeProtocol.Discv5 => "discv5",
+        NodeProtocol.Both => "both",
+        NodeProtocol.Configured => "configured",
+        _ => throw new ArgumentOutOfRangeException(nameof(protocol), protocol, null)
+    };
+
+    [Flags]
+    private enum NodeProtocol : byte
+    {
+        None = 0,
+        Discv4 = 1,
+        Discv5 = 2,
+        Both = Discv4 | Discv5,
+        Configured = 4
+    }
+
+    private readonly record struct TrackedNodeSnapshot(NodeProtocol Protocol, bool Active, bool IsBootnode);
 }
 
 internal readonly record struct DiscoverySnapshot(

--- a/tools/Bootnode/Nethermind.Bootnode/DiscoveredNodeStore.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/DiscoveredNodeStore.cs
@@ -14,6 +14,7 @@ namespace Nethermind.Bootnode;
 
 internal sealed class DiscoveredNodeStore
 {
+    private const string EnrPrefix = "enr:";
     private const int DefaultMaxRetainedNodes = 100_000;
     internal const int DefaultNodePageSize = 1_000;
     internal const int MaxNodePageSize = 1_000;
@@ -21,8 +22,8 @@ internal sealed class DiscoveredNodeStore
     private readonly Dictionary<Hash256, TrackedNode> _nodes;
     private readonly RetentionList _activeRetentionOrder = new(active: true);
     private readonly RetentionList _inactiveRetentionOrder = new(active: false);
-    private readonly SortedSet<Hash256> _orderedNodes = [];
-    private readonly SortedSet<Hash256> _orderedActiveNodes = [];
+    private readonly BucketedNodeIndex _orderedNodes = new();
+    private readonly BucketedNodeIndex _orderedActiveNodes = new();
     private readonly Lock _lock = new();
     private readonly int _maxRetainedNodes;
     private int _activeCount;
@@ -162,6 +163,13 @@ internal sealed class DiscoveredNodeStore
         return true;
     }
 
+    internal static string ToEnrString(byte[] rlp) =>
+        string.Create(EnrPrefix.Length + Base64Url.GetEncodedLength(rlp.Length), rlp, static (chars, state) =>
+        {
+            EnrPrefix.CopyTo(chars);
+            Base64Url.EncodeToChars(state, chars[EnrPrefix.Length..]);
+        });
+
     private DiscoverySnapshot CreateSnapshotCore() =>
         new(
             _activeCount,
@@ -286,26 +294,18 @@ internal sealed class DiscoveredNodeStore
             }
 
             nodeViews = new TrackedNodeView[resultCount];
-            int matchedNodes = 0;
             int resultIndex = 0;
-            SortedSet<Hash256> orderedNodes = activeOnly ? _orderedActiveNodes : _orderedNodes;
-            foreach (Hash256 idHash in orderedNodes)
+            BucketedNodeIndex.Enumerator enumerator =
+                (activeOnly ? _orderedActiveNodes : _orderedNodes).GetEnumerator(offset);
+            while (resultIndex < resultCount && enumerator.MoveNext())
             {
+                Hash256 idHash = enumerator.Current;
                 if (!_nodes.TryGetValue(idHash, out TrackedNode? trackedNode))
                 {
                     continue;
                 }
 
-                if (matchedNodes++ < offset)
-                {
-                    continue;
-                }
-
                 nodeViews[resultIndex++] = trackedNode.CreateView();
-                if (resultIndex == resultCount)
-                {
-                    break;
-                }
             }
 
             if (resultIndex != resultCount)
@@ -332,6 +332,100 @@ internal sealed class DiscoveredNodeStore
         else
         {
             _orderedActiveNodes.Remove(idHash);
+        }
+    }
+
+    private sealed class BucketedNodeIndex
+    {
+        // High-bit buckets preserve hash order while making offset seeks independent of the number of skipped nodes.
+        private const int BucketCount = 1 << 12;
+        private readonly List<Hash256>?[] _buckets = new List<Hash256>?[BucketCount];
+
+        public void Add(Hash256 idHash)
+        {
+            int bucketIndex = GetBucketIndex(idHash);
+            List<Hash256> bucket = _buckets[bucketIndex] ??= [];
+            int index = bucket.BinarySearch(idHash);
+            if (index < 0)
+            {
+                bucket.Insert(~index, idHash);
+            }
+        }
+
+        public void Remove(Hash256 idHash)
+        {
+            int bucketIndex = GetBucketIndex(idHash);
+            List<Hash256>? bucket = _buckets[bucketIndex];
+            if (bucket is null)
+            {
+                return;
+            }
+
+            int index = bucket.BinarySearch(idHash);
+            if (index >= 0)
+            {
+                bucket.RemoveAt(index);
+                if (bucket.Count == 0)
+                {
+                    _buckets[bucketIndex] = null;
+                }
+            }
+        }
+
+        public Enumerator GetEnumerator(int offset) => new(_buckets, offset);
+
+        private static int GetBucketIndex(Hash256 idHash)
+        {
+            ReadOnlySpan<byte> bytes = idHash.Bytes;
+            return (bytes[0] << 4) | (bytes[1] >> 4);
+        }
+
+        public struct Enumerator
+        {
+            private readonly List<Hash256>?[] _buckets;
+            private int _bucketIndex;
+            private int _nodeIndex;
+
+            public Hash256 Current { get; private set; }
+
+            public Enumerator(List<Hash256>?[] buckets, int offset)
+            {
+                _buckets = buckets;
+                _bucketIndex = 0;
+                _nodeIndex = -1;
+                Current = null!;
+
+                while (_bucketIndex < buckets.Length)
+                {
+                    int bucketCount = buckets[_bucketIndex]?.Count ?? 0;
+                    if (offset < bucketCount)
+                    {
+                        _nodeIndex = offset - 1;
+                        return;
+                    }
+
+                    offset -= bucketCount;
+                    _bucketIndex++;
+                }
+            }
+
+            public bool MoveNext()
+            {
+                while (_bucketIndex < _buckets.Length)
+                {
+                    List<Hash256>? bucket = _buckets[_bucketIndex];
+                    if (bucket is not null && ++_nodeIndex < bucket.Count)
+                    {
+                        Current = bucket[_nodeIndex];
+                        return true;
+                    }
+
+                    _bucketIndex++;
+                    _nodeIndex = -1;
+                }
+
+                return false;
+            }
         }
     }
 
@@ -486,7 +580,7 @@ internal sealed class DiscoveredNodeStore
                 TcpPort,
                 DiscoveryPort,
                 Enode,
-                EnrRlp is null ? null : string.Concat("enr:", Base64Url.EncodeToString(EnrRlp)),
+                EnrRlp is null ? null : ToEnrString(EnrRlp),
                 ProtocolToString(Protocol),
                 Active,
                 IsBootnode,

--- a/tools/Bootnode/Nethermind.Bootnode/DiscoveryContainer.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/DiscoveryContainer.cs
@@ -20,6 +20,7 @@ using Nethermind.Network.Discovery.Discv4.Messages;
 using Nethermind.Network.Discovery.Discv4.Serializers;
 using Nethermind.Network.Discovery.Discv5;
 using Nethermind.Network.Discovery.Kademlia;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 
@@ -27,6 +28,11 @@ namespace Nethermind.Bootnode;
 
 internal static class DiscoveryContainer
 {
+    internal static void ConfigureNetworkBuffers() =>
+        NethermindBuffers.Default = NethermindBuffers.DiscoveryAllocator = NethermindBuffers.CreateAllocator(
+            arenaOrder: 8,
+            arenaCount: 1);
+
     public static async Task<IContainer> BuildAsync(
         BootnodeOptions options,
         ILogManager logManager,

--- a/tools/Bootnode/Nethermind.Bootnode/DiscoveryContainer.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/DiscoveryContainer.cs
@@ -49,6 +49,8 @@ internal static class DiscoveryContainer
         BootnodeKademliaBucketRegistry bucketRegistry,
         CancellationToken cancellationToken)
     {
+        ConfigureNetworkBuffers();
+
         NetworkConfig networkConfig = new()
         {
             DiscoveryPort = options.DiscoveryPort,

--- a/tools/Bootnode/Nethermind.Bootnode/DiscoveryContainer.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/DiscoveryContainer.cs
@@ -28,6 +28,14 @@ namespace Nethermind.Bootnode;
 
 internal static class DiscoveryContainer
 {
+    /// <summary>
+    /// Points the general and discovery buffers at one small pooled allocator.
+    /// </summary>
+    /// <remarks>
+    /// A bootnode only serializes discovery traffic, so one arena of 2 MiB chunks replaces the process-wide default's
+    /// per-core 16 MiB arenas. This must run before anything allocates from <see cref="NethermindBuffers.Default"/>, or
+    /// the default allocator's chunks remain reachable.
+    /// </remarks>
     internal static void ConfigureNetworkBuffers() =>
         NethermindBuffers.Default = NethermindBuffers.DiscoveryAllocator = NethermindBuffers.CreateAllocator(
             arenaOrder: 8,

--- a/tools/Bootnode/Nethermind.Bootnode/NodeDtos.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/NodeDtos.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Stats.Model;
-
 namespace Nethermind.Bootnode;
 
 internal sealed record NodeDto(
@@ -18,32 +16,7 @@ internal sealed record NodeDto(
     bool IsBootnode,
     DateTimeOffset FirstSeenUtc,
     DateTimeOffset LastSeenUtc,
-    int SeenCount)
-{
-    public static NodeDto FromNode(
-        Node node,
-        string protocol,
-        bool active,
-        DateTimeOffset firstSeenUtc,
-        DateTimeOffset lastSeenUtc,
-        int seenCount,
-        bool isBootnode,
-        string? configuredEnode) =>
-        new(
-            node.Id.ToString(false),
-            node.IdHash.ToString(),
-            node.Host,
-            node.Port,
-            node.DiscoveryPort,
-            configuredEnode ?? (protocol == "configured" ? node.ToString(Node.Format.ENode) : null),
-            node.Enr?.ToString(),
-            protocol,
-            active,
-            isBootnode,
-            firstSeenUtc,
-            lastSeenUtc,
-            seenCount);
-}
+    int SeenCount);
 
 internal sealed record BootnodeIdentity(string Enode, string Enr, ulong EnrSequence, string NodeId, string Address);
 

--- a/tools/Bootnode/Nethermind.Bootnode/Program.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/Program.cs
@@ -238,7 +238,6 @@ rootCommand.SetAction(async (parseResult, cancellationToken) =>
         ProcessExitSource processExitSource = new(shutdownSource.Token);
 
         BootnodeKademliaBucketRegistry bucketRegistry = new();
-        DiscoveryContainer.ConfigureNetworkBuffers();
         await using IContainer container = await DiscoveryContainer.BuildAsync(options, logManager, nodeKey, processExitSource, bucketRegistry, shutdownSource.Token);
         IDiscoveryApp discoveryApp = container.Resolve<IDiscoveryApp>();
         BootnodeDiscoverySource[] discoverySources = ResolveDiscoverySources(container, options.DiscoveryVersion);

--- a/tools/Bootnode/Nethermind.Bootnode/Program.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/Program.cs
@@ -238,6 +238,7 @@ rootCommand.SetAction(async (parseResult, cancellationToken) =>
         ProcessExitSource processExitSource = new(shutdownSource.Token);
 
         BootnodeKademliaBucketRegistry bucketRegistry = new();
+        DiscoveryContainer.ConfigureNetworkBuffers();
         await using IContainer container = await DiscoveryContainer.BuildAsync(options, logManager, nodeKey, processExitSource, bucketRegistry, shutdownSource.Token);
         IDiscoveryApp discoveryApp = container.Resolve<IDiscoveryApp>();
         BootnodeDiscoverySource[] discoverySources = ResolveDiscoverySources(container, options.DiscoveryVersion);


### PR DESCRIPTION
## Changes

<img width="1093" height="299" alt="image" src="https://github.com/user-attachments/assets/2f641ce0-bf46-4b92-bde1-54dec4d56017" />
<img width="1242" height="297" alt="image" src="https://github.com/user-attachments/assets/973dbcae-50c3-4ebf-9736-10c35689fadf" />

- Replace retained discovery `Node` and `NodeRecord` object graphs with compact node metadata, canonical ENR RLP, protocol flags, UTC ticks, and intrusive active/inactive retention lists.
- Use one pre-sized dictionary under the store lock and compact sorted all/active indexes while preserving the 100,000-node cap, inactive-first eviction, configured-bootnode exemption, deterministic node-ID-hash ordering, and REST/JSON-RPC pagination behavior.
- Materialize node IDs, ENR strings, timestamps, and DTOs only at the API boundary.
- Move node-count gauge refreshes from every discovery mutation to the existing one-second metrics loop, cache fixed Prometheus children, and remove stale dynamic identity and Kademlia label children.
- Give the standalone discovery transport and RLP path one shared allocator with one heap/direct arena and 2 MiB chunks instead of the process-wide default pool.
- Prevent routing-table admissions from pinning active Kademlia random walks at the one-second bootstrap cadence. Underfilled tables remain at one second, healthy productive tables back off to 30 seconds, and healthy idle tables continue backing off to five minutes. This intentionally applies to standalone Bootnodes and regular Nethermind clients.
- Add regressions for retained-object reachability, ENR sequence retention, unsigned ENRs, host formatting parity, retention behavior, metric cleanup, allocator sharing, productive/idle pacing including recovery from the idle ceiling, and recovery when a routing table becomes underfilled; document the three pacing states.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- All 116 Bootnode tests pass, including deep all/active pagination over 8,192 deterministic nodes across hash-bucket boundaries.
- The complete discovery suite passes with 466 successful tests and one pre-existing skipped test. Cache tests park each worker after its occupancy check, verify cached versus refreshed pacing at 999/1000 ms, and cover both the cold-start floor and split-table fill ratio. Deliberately broken cache reuse and bucket ordering each fail the corresponding regressions before restoration.
- The Bootnode, main, and benchmark solutions compile with warnings treated as errors. The local Ethereum test solution cannot complete because this workspace does not contain the `src/tests` submodule fixtures; its failures are missing-resource errors.
- At the 100,000-node retention cap, live measurements showed 43.7% lower working set, 46.0% lower private memory, and 67.8% lower managed memory. The shared DotNetty pool retained one 2 MiB array instead of twelve 16 MiB arrays.
- Stable high-offset pagination, node-ID-hash ordering, REST/JSON-RPC parity, active-page integrity, and canonical ENR output were verified at the cap. Twenty concurrent 1,000-node high-offset requests completed with 153.9 ms median and 231.3 ms maximum latency.
- After the pacing correction, Bootnode discovery traffic fell from 144.0 KB/s to 51.2 KB/s and CPU from 0.214 to 0.092 cores. Discv5 `FindNode` sends fell from 57.6/s to 10.1/s while discv4/discv5 routing occupancy remained 95.1%/86.4% and the node census continued growing.
- A regular Hoodi client was warm-started from its populated discovery database with no live peer connections. The corrected build recovered to 30 peers while discovery traffic fell from 152.55 KiB/s on the official 2.0.0 RC to 15.16 KiB/s, a 90.1% reduction; its final five-minute window averaged 19.81 KiB/s.
- Fresh Hoodi peering succeeded with Nethermind, Geth, Besu, Reth, Nimbus EL, and Erigon when the tested Bootnode was their only bootstrap source and built-in/default discovery sources were suppressed.
- The live process remained healthy through `/status`, `/metrics`, Prometheus, and Grafana, with no repeated operational lines or exception, invalid-block, fatal, error, queue-full, or packet-drop signals.

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

The Kademlia integration README documents the new bootstrap, productive, and idle pacing behavior.

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Bootnode retained-node memory and shared Nethermind active-discovery traffic/CPU usage are substantially reduced without changing configuration or the 100,000-node retention limit.

## Remarks

The implementation was exercised on a live dual-stack Bootnode and on a regular Hoodi client, then applied cleanly to current `master` and rebuilt and retested there. The shared pacing policy is intentional: routing-table occupancy is the protocol-independent signal available to this loop, and a warm client with a healthy persisted table still recovered its full 30-peer target after losing all live connections. The API census remains intentionally in memory and therefore starts empty after a restart, as it did before this change; routing-table and identity persistence are unchanged.
