### PR TITLE
refactor(evm): one exit test per opcode in the dispatch loops

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeJavaScriptTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeJavaScriptTracerTests.cs
@@ -198,6 +198,44 @@ public class GethLikeJavaScriptTracerTests : VirtualMachineTestsBase
     }
 
     [Test]
+    public void post_step_fires_once_per_step()
+    {
+        // postStep runs from ReportOperationRemainingGas. The interpreter reports that once per
+        // instruction, and the CALL handler reports it once more itself before the child frame runs, so
+        // the one CALL below is the only step that fires postStep twice. Both frames halt on an explicit
+        // opcode, so no instruction picks up the extra end-of-code report either.
+        string userTracer = @"{
+                    steps: 0,
+                    postSteps: 0,
+                    step: function(log, db) { this.steps++ },
+                    postStep: function(log, db) { this.postSteps++ },
+                    fault: function(log, db) { },
+                    result: function(ctx, db) { return this.steps + ':' + this.postSteps }
+                }";
+        TestState.CreateAccount(TestItem.AddressC, 1.Ether);
+        TestState.InsertCode(TestItem.AddressC, Prepare.EvmCode
+            .PushData(0)
+            .PushData(0)
+            .Op(Instruction.RETURN)
+            .Done, Spec);
+        byte[] code = Prepare.EvmCode
+            .Call(TestItem.AddressC, 50000)
+            .Op(Instruction.STOP)
+            .Done;
+
+        using GethLikeBlockJavaScriptTracer tracer = ExecuteBlock(
+                GetTracer(userTracer),
+                code,
+                MainnetSpecProvider.CancunActivation);
+        using GethLikeTxTrace traces = tracer.BuildResult().First();
+
+        string[] counts = ((string)traces.CustomTracerResult!.Value!).Split(':');
+        int steps = int.Parse(counts[0]);
+        Assert.That(steps, Is.GreaterThan(0));
+        Assert.That(int.Parse(counts[1]), Is.EqualTo(steps + 1), "postStep must fire once per step, plus the CALL's own report");
+    }
+
+    [Test]
     public void Js_traces_simple_filter()
     {
         string userTracer = @"{

--- a/src/Nethermind/Nethermind.Evm/EvmException.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmException.cs
@@ -27,7 +27,11 @@ public enum EvmExceptionType
     Other,
     Revert,
     InvalidCode,
-    /// <summary>Not a failure: the frame yielded a child call/create frame and is suspended until it returns.</summary>
+    /// <summary>
+    /// Not a failure: the frame yielded a child call/create frame and is suspended until it returns.
+    /// Never observed outside the dispatch loops, which fold it into the success path before the frame's
+    /// result is built.
+    /// </summary>
     Suspend,
 }
 

--- a/src/Nethermind/Nethermind.Evm/EvmException.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmException.cs
@@ -27,6 +27,8 @@ public enum EvmExceptionType
     Other,
     Revert,
     InvalidCode,
+    /// <summary>Not a failure: the frame yielded a child call/create frame and is suspended until it returns.</summary>
+    Suspend,
 }
 
 public static class EvmExceptionTypeExtensions
@@ -56,6 +58,7 @@ public static class EvmExceptionTypeExtensions
         EvmExceptionType.Other => nameof(EvmExceptionType.Other),
         EvmExceptionType.Revert => nameof(EvmExceptionType.Revert),
         EvmExceptionType.InvalidCode => nameof(EvmExceptionType.InvalidCode),
+        EvmExceptionType.Suspend => nameof(EvmExceptionType.Suspend),
         _ => ((int)type).ToString(),
     };
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -361,7 +361,7 @@ public static partial class EvmInstructions
                 snapshot: in snapshot,
                 newAccountCharged: newAccountCharged);
 
-            return EvmExceptionType.None;
+            return EvmExceptionType.Suspend;
         }
 
         // Jump forward to be unpredicted by the branch predictor.
@@ -405,8 +405,9 @@ public static partial class EvmInstructions
     /// <param name="gas">The gas which is updated by the operation's cost.</param>
     /// <param name="programCounter">Reference to the program counter (unused in this operation).</param>
     /// <returns>
-    /// <see cref="EvmExceptionType.None"/> on success; otherwise, an error such as <see cref="EvmExceptionType.StackUnderflow"/>,
-    /// <see cref="EvmExceptionType.OutOfGas"/>, or <see cref="EvmExceptionType.BadInstruction"/>.
+    /// <see cref="EvmExceptionType.Stop"/> on success, the frame's output staged in
+    /// <see cref="VirtualMachine{TGasPolicy}.ReturnData"/>; otherwise an error such as
+    /// <see cref="EvmExceptionType.StackUnderflow"/> or <see cref="EvmExceptionType.OutOfGas"/>.
     /// </returns>
     [SkipLocalsInit]
     public static EvmExceptionType InstructionReturn<TGasPolicy>(VirtualMachine<TGasPolicy> vm,
@@ -428,7 +429,7 @@ public static partial class EvmInstructions
 
         vm.ReturnData = returnData.ToArray();
 
-        return EvmExceptionType.None;
+        return EvmExceptionType.Stop;
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
@@ -236,7 +236,7 @@ public static partial class EvmInstructions
             snapshot: in snapshot,
             isCreateStateGasCharged: chargeCreateStateGas);
 
-        return EvmExceptionType.None;
+        return EvmExceptionType.Suspend;
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.DispatchSpecialized.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.DispatchSpecialized.cs
@@ -22,7 +22,10 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     /// <summary>Runs the current frame's bytecode until it halts, faults, or yields a child frame.</summary>
     /// <param name="programCounter">On entry the offset to resume from; on exit the offset reached.</param>
-    /// <returns>The halting reason; <c>None</c>, <c>Stop</c> and <c>Revert</c> are normal halts.</returns>
+    /// <returns>
+    /// The halting reason; <c>None</c>, <c>Stop</c> and <c>Revert</c> are normal halts and <c>Suspend</c> a
+    /// yielded child frame.
+    /// </returns>
     /// <remarks>
     /// Implemented per build, split at the loop rather than the differing <c>switch</c>: direct dispatch
     /// only beats the table while the JIT inlines the handlers into the switch.
@@ -55,7 +58,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         EvmExceptionType exceptionType =
             RunDispatchLoop<TTracingInst, TCancelable, TShift, TPush0>(ref stack, ref gas, ref programCounter);
 
-        if (exceptionType is EvmExceptionType.None or EvmExceptionType.Stop or EvmExceptionType.Revert)
+        if (exceptionType is EvmExceptionType.None or EvmExceptionType.Stop or EvmExceptionType.Revert or EvmExceptionType.Suspend)
         {
             if (TTracingInst.IsActive)
                 EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.DispatchSpecialized.std.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.DispatchSpecialized.std.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 #if DEBUG
@@ -187,33 +188,33 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 }
                 pc = opPc;
 
-                if (TGasPolicy.IsOutOfGas(in gas))
-                {
-                    OpCodeCount += opCodeCount;
-                    TGasPolicy.SetOutOfGas(ref gas);
-                    exceptionType = EvmExceptionType.OutOfGas;
-                    goto Halted;
-                }
+                // One exit test per opcode: a fault, Stop/Revert and a suspended child frame all arrive as a
+                // nonzero status, with out-of-gas folded in branch-free. Told apart after the loop.
+                if (ShouldExitFrame(exceptionType, TGasPolicy.IsOutOfGas(in gas)))
+                    break;
+
+                Debug.Assert(ReturnData is null,
+                    "A handler that stages ReturnData must report a non-None status, or the loop runs past the halt");
 
                 TGasPolicy.OnAfterInstructionTrace(in gas);
 
-                if (exceptionType != EvmExceptionType.None)
-                    break;
-
                 if (TTracingInst.IsActive)
                     EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));
-
-                // Only the 0xF0+ family sets ReturnData, so the cheap majority skips the field load.
-                if (instruction >= Instruction.CREATE && ReturnData is not null)
-                {
-                    break;
-                }
             }
 
             OpCodeCount += opCodeCount;
+
+            if (TGasPolicy.IsOutOfGas(in gas))
+            {
+                TGasPolicy.SetOutOfGas(ref gas);
+                exceptionType = EvmExceptionType.OutOfGas;
+            }
+            else if (exceptionType != EvmExceptionType.None)
+            {
+                TGasPolicy.OnAfterInstructionTrace(in gas);
+            }
         }
 
-    Halted:
         programCounter = pc;
         return exceptionType;
     }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.DispatchSpecialized.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.DispatchSpecialized.zkevm.cs
@@ -127,19 +127,16 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 // OnAfterInstructionTrace being empty is UNCHECKED - revisit the skip below if it gains a body.
                 Debug.Assert(outOfGas == TGasPolicy.IsOutOfGas(in gas),
                     "Out-of-gas fast path diverged from TGasPolicy.IsOutOfGas");
-                if (outOfGas)
-                {
-                    OpCodeCount += opCodeCount;
-                    TGasPolicy.SetOutOfGas(ref gas);
-                    exceptionType = EvmExceptionType.OutOfGas;
-                    goto Halted;
-                }
+                // One exit test per opcode: a fault, Stop/Revert and a suspended child frame all arrive as a
+                // nonzero status, with out-of-gas folded in branch-free. Told apart after the loop.
+                if (ShouldExitFrame(exceptionType, outOfGas))
+                    break;
+
+                Debug.Assert(ReturnData is null,
+                    "A handler that stages ReturnData must report a non-None status, or the loop runs past the halt");
 
                 if (typeof(TGasPolicy) != typeof(EthereumGasPolicy))
                     TGasPolicy.OnAfterInstructionTrace(in gas);
-
-                if (exceptionType != EvmExceptionType.None)
-                    break;
 
                 // typeof folds where the inliner gives up on the IsActive getter. == OnFlag, not != OffFlag,
                 // so a third IFlag would fail closed.
@@ -147,18 +144,21 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                     EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));
                 Debug.Assert(typeof(TTracingInst) == typeof(OnFlag) == TTracingInst.IsActive,
                     "Tracing fast path assumes OnFlag/OffFlag are the only dispatch flags");
-
-                // Only the 0xF0+ family sets ReturnData, so the cheap majority skips the field load.
-                if (instruction >= Instruction.CREATE && ReturnData is not null)
-                {
-                    break;
-                }
             }
 
             OpCodeCount += opCodeCount;
+
+            if (TGasPolicy.IsOutOfGas(in gas))
+            {
+                TGasPolicy.SetOutOfGas(ref gas);
+                exceptionType = EvmExceptionType.OutOfGas;
+            }
+            else if (exceptionType != EvmExceptionType.None && typeof(TGasPolicy) != typeof(EthereumGasPolicy))
+            {
+                TGasPolicy.OnAfterInstructionTrace(in gas);
+            }
         }
 
-    Halted:
         programCounter = pc;
         return exceptionType;
     }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Evm.CodeAnalysis;
+
+using static Nethermind.Evm.VirtualMachineStatics;
 
 [assembly: InternalsVisibleTo("Nethermind.Init")]
 
@@ -329,14 +332,17 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                         _ => EvmInstructions.InstructionMCopy<TGasPolicy, OffFlag>(this, ref stack, ref gas, ref mpc),
                     };
 
-                    if (TGasPolicy.IsOutOfGas(in gas))
+                    bool memOutOfGas = TGasPolicy.IsOutOfGas(in gas);
+                    // One exit test, as in the boundary epilogue below.
+                    if (ShouldExitFrame(exceptionType, memOutOfGas))
                     {
-                        OpCodeCount += opCodeCount;
-                        goto OutOfGas;
+                        // Out-of-gas skips the hook, as the checks this replaced did.
+                        if (!memOutOfGas)
+                            TGasPolicy.OnAfterInstructionTrace(in gas);
+                        break;
                     }
 
                     TGasPolicy.OnAfterInstructionTrace(in gas);
-                    if (exceptionType != EvmExceptionType.None) break;
 
                     metered = false;
                     programCounter = entry.Pc + entry.Advance;
@@ -359,19 +365,21 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 exceptionType = opcodeMethods[(int)instruction](this, ref stack, ref gas, ref pc);
                 programCounter = pc;
 
-                if (TGasPolicy.IsOutOfGas(in gas))
+                bool outOfGas = TGasPolicy.IsOutOfGas(in gas);
+                // One exit test per opcode: a fault, Stop/Revert and a suspended child frame all arrive as a
+                // nonzero status, with out-of-gas folded in branch-free; the tail below routes each one.
+                if (ShouldExitFrame(exceptionType, outOfGas))
                 {
-                    OpCodeCount += opCodeCount;
-                    goto OutOfGas;
+                    // Out-of-gas skips the hook, as the checks this replaced did.
+                    if (!outOfGas)
+                        TGasPolicy.OnAfterInstructionTrace(in gas);
+                    break;
                 }
 
+                Debug.Assert(ReturnData is null,
+                    "A handler that stages ReturnData must report a non-None status, or the loop runs past the halt");
+
                 TGasPolicy.OnAfterInstructionTrace(in gas);
-
-                if (exceptionType != EvmExceptionType.None)
-                    break;
-
-                if (ReturnData is not null)
-                    break;
 
                 // Table handlers may consume more than one instruction; recompute the entry from the landing pc.
                 if ((nuint)programCounter >= (nuint)pcToEntry.Length)
@@ -400,7 +408,10 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             OpCodeCount += opCodeCount;
         }
 
-        if (exceptionType is EvmExceptionType.None or EvmExceptionType.Stop or EvmExceptionType.Revert)
+        if (TGasPolicy.IsOutOfGas(in gas))
+            goto OutOfGas;
+
+        if (exceptionType is EvmExceptionType.None or EvmExceptionType.Stop or EvmExceptionType.Revert or EvmExceptionType.Suspend)
         {
             UpdateCurrentState((int)programCounter, in gas, stack.Head);
         }
@@ -499,16 +510,22 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
             exceptionType = opcodeMethods[(int)instruction](this, ref stack, ref gas, ref programCounter);
 
-            if (TGasPolicy.IsOutOfGas(in gas))
-                return new MeteredResult(MeteredOutcome.OutOfGas, (int)programCounter, opCodeCount, entryIndex, metered, exceptionType);
+            bool outOfGas = TGasPolicy.IsOutOfGas(in gas);
+            // One exit test per opcode: a fault, Stop/Revert and a suspended child frame all arrive as a
+            // nonzero status, with out-of-gas folded in branch-free.
+            if (ShouldExitFrame(exceptionType, outOfGas))
+            {
+                if (outOfGas)
+                    return new MeteredResult(MeteredOutcome.OutOfGas, (int)programCounter, opCodeCount, entryIndex, metered, exceptionType);
+
+                TGasPolicy.OnAfterInstructionTrace(in gas);
+                return new MeteredResult(MeteredOutcome.BreakLoop, (int)programCounter, opCodeCount, entryIndex, metered, exceptionType);
+            }
+
+            Debug.Assert(ReturnData is null,
+                "A handler that stages ReturnData must report a non-None status, or the loop runs past the halt");
 
             TGasPolicy.OnAfterInstructionTrace(in gas);
-
-            if (exceptionType != EvmExceptionType.None)
-                return new MeteredResult(MeteredOutcome.BreakLoop, (int)programCounter, opCodeCount, entryIndex, metered, exceptionType);
-
-            if (ReturnData is not null)
-                return new MeteredResult(MeteredOutcome.BreakLoop, (int)programCounter, opCodeCount, entryIndex, metered, exceptionType);
 
             if ((nuint)programCounter >= (nuint)pcToEntry.Length)
             {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Stream.cs
@@ -408,6 +408,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             OpCodeCount += opCodeCount;
         }
 
+        // Every path out of the loop reaches this, but only a handler can have set the flag: a block
+        // precharge that does not fit leaves it clear (TryConsume does not set it) and falls to the metered
+        // loop, which reports a set flag as MeteredOutcome.OutOfGas rather than BreakLoop.
         if (TGasPolicy.IsOutOfGas(in gas))
             goto OutOfGas;
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -65,6 +65,18 @@ public static class VirtualMachineStatics
     internal static readonly Address Ripemd160Address = Address.FromNumber(3);
 
     /// <summary>
+    /// Whether the dispatch loop must leave the frame after an instruction: the handler returned a status
+    /// other than <see cref="EvmExceptionType.None"/>, or the gas policy ran out of gas.
+    /// </summary>
+    /// <remarks>
+    /// Branch-free, so the per-opcode epilogue is a single test; the exit path re-reads the out-of-gas flag
+    /// to tell the two apart, out-of-gas taking priority.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool ShouldExitFrame(EvmExceptionType status, bool outOfGas) =>
+        ((int)status | Unsafe.BitCast<bool, byte>(outOfGas)) != 0;
+
+    /// <summary>
     /// Restores the RIPEMD-160 empty-account touch after a world-state snapshot rollback.
     /// </summary>
     /// <remarks>

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -70,11 +70,12 @@ public static class VirtualMachineStatics
     /// </summary>
     /// <remarks>
     /// Branch-free, so the per-opcode epilogue is a single test; the exit path re-reads the out-of-gas flag
-    /// to tell the two apart, out-of-gas taking priority.
+    /// to tell the two apart, out-of-gas taking priority. Subtracting <see cref="EvmExceptionType.None"/>
+    /// folds away while it is 0 and keeps the fold correct if it is ever renumbered.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool ShouldExitFrame(EvmExceptionType status, bool outOfGas) =>
-        ((int)status | Unsafe.BitCast<bool, byte>(outOfGas)) != 0;
+        (((int)status - (int)EvmExceptionType.None) | Unsafe.BitCast<bool, byte>(outOfGas)) != 0;
 
     /// <summary>
     /// Restores the RIPEMD-160 empty-account touch after a world-state snapshot rollback.


### PR DESCRIPTION
## Changes

- Every interpreter loop's per-opcode epilogue is now a **single** conditional. Where the loops ran
  three tests (the gas policy's out-of-gas flag, the handler status, a `ReturnData` probe), they now
  test one folded status:
  - `VirtualMachineStatics.ShouldExitFrame` ORs the out-of-gas flag into the handler's status
    branch-free, so out-of-gas no longer needs its own `if`.
  - The two opcode families that stage `ReturnData` now say so in their status, so the loops stop
    comparing the opcode against `CREATE` and loading the `ReturnData` field on every opcode:
    `RETURN` returns `Stop` (the frame halts, output staged), and `CALL`/`CREATE` return the new
    `EvmExceptionType.Suspend` when they rent a child frame.
  - The per-outcome epilogue (out-of-gas conversion, the `IGasPolicy` trace hook) moves to a cold
    block after the loop.
- Four epilogues across three loops: `RunDispatchLoop` (`.std` and `.zkevm`), `RunStream`'s boundary
  path and its MSTORE/MLOAD/MCOPY fast path, and `RunMeteredSegment`.
- Each loop's continue path carries a `Debug.Assert(ReturnData is null)` pinning the invariant the
  removed probe used to enforce: a handler that stages `ReturnData` must not report `None`.
- New test `post_step_fires_once_per_step` pins the JS-tracer `postStep` count across a `CALL` and a
  `RETURN` (see Remarks) - the first coverage that hook has had.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

One tracer-visible change (below), covered by a new test; everything else is the existing suites.
All run locally on this branch, rebased onto `7a16e60c49`:

| suite | result |
|---|---|
| `Nethermind.Evm.Test` (release) | 5179 passed, 0 failed, 8 skipped |
| `Nethermind.Evm.Test` (**debug**, so the new asserts are live) | 5190 passed, 0 failed, 8 skipped |
| `Ethereum.Legacy.VM.Test` | 4376 passed, 0 failed |
| `Ethereum.Legacy.Blockchain.Test` | 101,673 passed, 0 failed |
| `Nethermind.Blockchain.Test` | 1762 passed, 0 failed, 6 skipped |
| `Nethermind.JsonRpc.Test` | 1964 passed, 0 failed, 22 skipped |

Both build configurations compile: default and `-p:EnableZkEvm=true`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

### Why

The epilogue is fixed cost on every executed opcode, and it was four conditional branches plus a
field load: the out-of-gas flag, the handler status, and `instruction >= CREATE && ReturnData is not
null` (two branches, and the `ReturnData` load is an 8-byte read the ZisK memory state machine
charges 16 for). None of the three carried information the handler could not have returned itself.

### Behaviour

- Out-of-gas keeps priority over a handler fault, matching the order of the checks it replaces: the
  cold block re-reads the flag before looking at the returned status.
- The loop-side `EndInstructionTrace` on the exit paths is gone. `RunByteCodeCore` already reports the
  remaining gas for every non-fault exit and gas cannot change in between, so **the reported gas value
  is unchanged** - every `ReportOperationRemainingGas` implementation that stores a value is
  first-call-wins (`_gasAlreadySetForCurrentOp`).
- **The number of calls does change, and one tracer acts on each call.**
  `GethLikeJavaScriptTxTracer.ReportOperationRemainingGas` invokes a user tracer's `postStep` every
  time, not just the first, so `CALL`/`CREATE`/`RETURN` used to fire it more than once per step. On the
  test below: master reports 15 `postStep`s for 12 steps, this branch 13 - one per step, plus the CALL's
  own pre-child report from `EvmInstructions.Call.cs`. Fewer duplicate callbacks is the correct
  direction, but it is observable in `debug_traceTransaction` for a custom JS tracer that accumulates in
  `postStep`, hence the new test pinning the count. Reported by review; my original description claimed
  no observable change, which was true of the gas value and not of the callback count.
- `EvmExceptionType.Suspend` never escapes the interpreter: `RunByteCodeCore` and `RunStream` both
  treat it as a normal exit and convert it to a `CallResult` carrying the child frame.
- `RETURN` reporting `Stop` instead of `None` is what the caller already did with it — `None` and
  `Stop` take the same path there, and the output is still routed by `ReturnData`.

### Measurements

**expb, amd64, flat / superblocks, two dispatches with the image order swapped.** Both arms run live
in each dispatch (`docker_images` forced, so no rebuild); `master-7a16e60` is exactly this branch's
base commit. Client processing (SSE):

| arm | position | AVG (ms) | MEDIAN (ms) |
|---|---|---:|---:|
| `master-7a16e60` | run A, first | 856.41 | 821.3 |
| `master-7a16e60` | run B, second | 852.73 | 813.9 |
| this PR | run A, second | 847.02 | 796.1 |
| this PR | run B, first | 824.25 | 787.2 |
| **pooled** | | **-2.21%** | **-3.17%** |

Every PR measurement is below every master measurement, in both metrics and in both orderings, so
the sign is not the position artifact this rig is known for. Runs
[33772347893](https://github.com/NethermindEth/nethermind/actions/runs/33772347893) (master first) and
[33772364416](https://github.com/NethermindEth/nethermind/actions/runs/33772364416) (PR first). The
label-triggered PR-vs-cached-master comparison agrees in direction: superblocks -3.42% AVG, fusaka
-2.50%, realblocks +1.53%.

**Where it does not show.** Two harnesses call it neutral, which is worth stating rather than
omitting:

*x64 `InterpreterLoopBenchmarks`* (MediumRun, two pairs, order alternated) - inside the run-to-run
spread, sign flips between pairs, so its noise floor is wider than a ~2% effect:

| | master | this PR |
|---|---|---|
| ComputeLoop | 65.42 / 67.32 us | 66.46 / 65.51 us |
| NestedCalls | 33.80 / 31.23 us | 32.80 / 31.89 us |

*zkVM guest, block 25,532,382 on ziskemu 1.2.0-alpha* (`-Ot`), master `7a16e60c49` vs this branch:
steps 529,297,613 -> 527,380,544 (**-0.36%**), both reporting `IsSuccess = true` with the same block
root. Real but small, and in the same direction as the block-processing numbers.

That leaves gas-dense block processing as the one workload where the saved per-opcode work is a
measurable fraction of the dispatch path, which is the shape you would expect from removing three
branches and a field load from an epilogue that runs once per executed opcode.
