### PR TITLE
Reduce Kademlia discovery traffic on healthy tables

### DIFF
--- a/src/Nethermind/Nethermind.Kademlia/README.md
+++ b/src/Nethermind/Nethermind.Kademlia/README.md
@@ -61,6 +61,6 @@ Call `AddOrRefresh` when an authenticated node sends a valid protocol message, a
 
 Use `LookupNodesClosest(key, token)` when the caller needs the final closest set. Use `LookupNodes(key, token, maxResults)` or `IKademliaDiscovery<TKey, TNode>.DiscoverNodes(...)` when the caller wants candidates streamed as soon as lookups find them.
 
-`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled or lookups keep admitting nodes, and backs off exponentially up to five minutes once a filled table stops learning anything new.
+`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled. Once the table is healthy, it backs off exponentially to a 30-second productive pace while admissions continue. Successive admission-free windows may extend that toward a five-minute worst-case ceiling, although shared inbound and concurrent-job admissions normally return a live node to the productive range sooner.
 
 Dispose `NodeHealthTracker<TKey, TNode, TKadKey>` when the host shuts down, or let the dependency-injection container that owns it dispose it.

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -12,10 +12,13 @@ namespace Nethermind.Kademlia;
 /// Runs active random Kademlia lookups and streams discovered nodes.
 /// </summary>
 /// <remarks>
-/// Jobs iterate at <see cref="MinimumIterationDuration"/> while the routing table is still underfilled or while
-/// lookups keep admitting nodes into it. Once the table is filled and a lookup admits nothing, the job doubles its
-/// interval up to <see cref="MaximumIterationDuration"/>, so a node with a healthy table stops behaving like a
-/// crawler. Periodic bootstrap and bucket refresh in <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
+/// Jobs iterate at <see cref="MinimumIterationDuration"/> while the routing table is still underfilled. Once the table
+/// is healthy, each job backs off to <see cref="MaximumProductiveIterationDuration"/> while nodes are still being
+/// admitted. Sustained admission-free windows may extend the interval toward <see cref="MaximumIterationDuration"/>,
+/// which bounds worst-case staleness rather than describing the usual steady state. Periodic bootstrap and bucket
+/// refresh in <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
+/// Routing-table occupancy deliberately controls this protocol-independent loop because it cannot observe whether
+/// downstream consumers accept emitted nodes or establish peer connections.
 /// </remarks>
 public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     IKademlia<TKey, TNode> kademlia,
@@ -31,15 +34,32 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
 {
     private static readonly TimeSpan MinimumIterationDuration = TimeSpan.FromSeconds(1);
 
+    /// <summary>Maximum age of an occupancy read reused across discovery jobs.</summary>
+    /// <remarks>
+    /// Must not exceed <see cref="MinimumIterationDuration"/> so caching does not retain a stale occupancy decision
+    /// beyond the bootstrap interval. Expiry does not wake a job that is already waiting.
+    /// </remarks>
+    private static readonly TimeSpan OccupancyCacheDuration = TimeSpan.FromSeconds(1);
+
     /// <summary>
-    /// Longest interval an idle job backs off to.
+    /// Longest interval used while a healthy routing table is still admitting nodes.
     /// </summary>
     /// <remarks>
-    /// The lookup rate is inversely proportional to this cap, so almost all of the saving is already banked by the
-    /// first few doublings: a one-minute cap removes 98% of the one-second crawl rate and this one removes 99.7%,
-    /// while a half-hour cap would buy a further 0.3% at six times the worst-case delay. Because a reset only
-    /// applies to the next iteration and never wakes a sleeping job, this cap alone bounds how long a job can go
-    /// without looking up, whatever else happens in the table meanwhile.
+    /// At the default <c>Discovery.ConcurrentDiscoveryJob</c> of ten jobs this keeps one active random walk starting
+    /// about every three seconds, while preventing ordinary routing churn from pinning every job at the one-second
+    /// bootstrap pace.
+    /// </remarks>
+    private static readonly TimeSpan MaximumProductiveIterationDuration = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Longest interval an admission-free job can back off to.
+    /// </summary>
+    /// <remarks>
+    /// Shared admissions normally return a live node to the productive range before this ceiling. The lookup rate is
+    /// inversely proportional to the cap, so almost all of the saving is already banked by the first few doublings:
+    /// a one-minute cap removes 98% of the one-second crawl rate and this one removes 99.7%, while a half-hour cap
+    /// would buy a further 0.3% at six times the worst-case delay. Because a reset only applies to the next iteration
+    /// and never wakes a sleeping job, this cap alone bounds how long a job can go without looking up.
     /// </remarks>
     private static readonly TimeSpan MaximumIterationDuration = TimeSpan.FromMinutes(5);
 
@@ -48,8 +68,8 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// </summary>
     /// <remarks>
     /// Buckets only split once they overflow, so a table that saturated its reachable neighbourhood settles above
-    /// 90% of its slots. A table holding only a handful of contacts, such as one still bootstrapping or one whose
-    /// peers were just evicted for being unresponsive, stays below this ratio and keeps discovering at full speed.
+    /// 90% of its slots. A table whose peers were evicted for being unresponsive falls below this ratio and resumes
+    /// discovering at full speed.
     /// </remarks>
     private const int HealthyOccupancyDivisor = 3;
 
@@ -65,8 +85,13 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
 
     private readonly ILogger _logger = loggerFactory.CreateLogger<RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>>();
     private readonly TKadKey _currentNodeHash = keyOperator.GetNodeHash(kademliaConfig.CurrentNodeId);
+    private readonly int _kSize = kademliaConfig.KSize;
     private readonly int _maxDistance = distance.MaxDistance;
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+    private readonly Lock _occupancyLock = new();
+    private long _lastOccupancyTimestamp;
+    private bool _hasCachedOccupancy;
+    private bool _cachedUnderfilled;
 
     /// <inheritdoc/>
     public IAsyncEnumerable<TNode> DiscoverNodes(int concurrentDiscoveryJobs, int lookupResultLimit, CancellationToken token)
@@ -126,7 +151,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     {
         TimeSpan iterationDuration = MinimumIterationDuration;
         // Carried across iterations so that the window covers the paced wait as well as the lookup; a job at the
-        // maximum interval is asleep for nearly all of its iteration, and admissions made then must still reset it.
+        // maximum interval is asleep for nearly all of its iteration, and admissions made then must restore productive pacing.
         long admissionsSeen = admissions.Count;
         while (!token.IsCancellationRequested)
         {
@@ -175,24 +200,46 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     }
 
     /// <summary>
-    /// Returns the pace for the next iteration, resetting it when the last lookup was worth running.
+    /// Returns the pace for the next iteration, retaining a sustainable crawl rate while the table changes.
     /// </summary>
     /// <param name="current">Pace the finished iteration ran at.</param>
     /// <param name="admittedNodes">Whether the routing table admitted a node since the previous iteration decided its pace.</param>
     private TimeSpan NextIterationDuration(TimeSpan current, bool admittedNodes)
     {
-        if (admittedNodes || IsUnderfilled())
+        if (IsUnderfilled())
         {
             return MinimumIterationDuration;
         }
 
-        return TimeSpan.FromTicks(Math.Min(current.Ticks * 2, MaximumIterationDuration.Ticks));
+        TimeSpan maximum = admittedNodes ? MaximumProductiveIterationDuration : MaximumIterationDuration;
+        return TimeSpan.FromTicks(Math.Min(current.Ticks * 2, maximum.Ticks));
     }
 
+    /// <summary>Whether the shared occupancy snapshot requires bootstrap-paced discovery.</summary>
+    /// <remarks>
+    /// A cold table has one bucket, so it must first collect a full bucket's worth of nodes before the fill ratio applies.
+    /// Networks with fewer than <see cref="KademliaConfig{TNode}.KSize"/> reachable nodes deliberately remain at
+    /// <see cref="MinimumIterationDuration"/> without a time limit.
+    /// </remarks>
     private bool IsUnderfilled()
     {
-        RoutingTableOccupancy occupancy = routingTable.GetOccupancy();
-        return occupancy.NodeCount * HealthyOccupancyDivisor < occupancy.Capacity;
+        lock (_occupancyLock)
+        {
+            long timestamp = _timeProvider.GetTimestamp();
+            // Coalesce discovery jobs because GetOccupancy may walk the full table under its mutation lock.
+            if (_hasCachedOccupancy &&
+                _timeProvider.GetElapsedTime(_lastOccupancyTimestamp, timestamp) < OccupancyCacheDuration)
+            {
+                return _cachedUnderfilled;
+            }
+
+            RoutingTableOccupancy occupancy = routingTable.GetOccupancy();
+            _cachedUnderfilled = occupancy.NodeCount < _kSize ||
+                occupancy.NodeCount * HealthyOccupancyDivisor < occupancy.Capacity;
+            _lastOccupancyTimestamp = timestamp;
+            _hasCachedOccupancy = true;
+            return _cachedUnderfilled;
+        }
     }
 
     /// <summary>
@@ -202,8 +249,8 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// <remarks>
     /// Jobs compare this counter across their whole iteration, so admissions made by a concurrent job or by inbound
     /// traffic count too. Attributing an admission to the lookup that caused it would mean threading a lookup
-    /// identity through every protocol adapter, and the imprecision is one-sided: an admission this job did not
-    /// cause still means the table is changing, and reading it as productive only keeps discovery eager.
+    /// identity through every protocol adapter. An admission this job did not cause can therefore keep it at the
+    /// sustainable productive pace, but cannot return it to the one-second bootstrap pace once the table is healthy.
     /// </remarks>
     private sealed class AdmissionCounter
     {

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -9,8 +9,10 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging.Abstractions;
+using Autofac;
+using Nethermind.Core;
 using Nethermind.Kademlia;
+using Nethermind.Network.Discovery.Kademlia;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Discovery.Test.Kademlia;
@@ -29,7 +31,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_stream_nodes_from_random_lookup(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(2).ToListAsync(token);
 
@@ -46,7 +49,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_not_run_any_job_when_disabled(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         List<int> nodes = await discovery.DiscoverNodes(0, 2, token).ToListAsync(token);
 
@@ -62,7 +66,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_pace_iterations_to_minimum_iteration_duration(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(4).ToListAsync(token);
@@ -79,7 +84,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_not_delay_when_lookup_exceeds_minimum_iteration_duration(CancellationToken token)
     {
         TestKademlia kademlia = new() { LookupDelay = TimeSpan.FromMilliseconds(1100) };
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(3).ToListAsync(token);
@@ -91,11 +97,12 @@ public class RandomWalkKademliaDiscoveryTests
         }
     }
 
-    [Test]
+    [TestCase(15, 16)]
+    [TestCase(21, 64)]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_keep_minimum_pace_while_table_is_underfilled(CancellationToken token)
+    public async Task DiscoverNodes_should_keep_minimum_pace_while_table_is_underfilled(int nodeCount, int capacity, CancellationToken token)
     {
-        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(5, 16) };
+        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(nodeCount, capacity) };
 
         TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 4, token);
 
@@ -104,9 +111,9 @@ public class RandomWalkKademliaDiscoveryTests
 
     [Test]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_back_off_when_filled_table_admits_nothing(CancellationToken token)
+    public async Task DiscoverNodes_should_back_off_when_filled_table_admits_nothing([Values(16, 48)] int capacity, CancellationToken token)
     {
-        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(16, capacity) };
 
         TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 11, token);
 
@@ -118,49 +125,169 @@ public class RandomWalkKademliaDiscoveryTests
         ]);
     }
 
-    [Test]
+    [TestCaseSource(nameof(ProductivePacingCases))]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_reset_pace_when_lookup_admits_a_node(CancellationToken token)
+    public async Task DiscoverNodes_should_bound_productive_filled_table_pace(
+        int[] admittingLookups,
+        int iterations,
+        int[] expectedDelaySeconds,
+        CancellationToken token)
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
-        TestKademlia kademlia = new() { OnLookup = lookup => { if (lookup == 3) routingTable.RaiseNodeAdded(42); } };
+        TestKademlia kademlia = new()
+        {
+            OnLookup = lookup =>
+            {
+                if (Array.IndexOf(admittingLookups, lookup) >= 0)
+                {
+                    routingTable.RaiseNodeAdded(42);
+                }
+            }
+        };
 
-        TimeSpan[] delays = await RunIterations(kademlia, routingTable, iterations: 5, token);
+        TimeSpan[] delays = await RunIterations(kademlia, routingTable, iterations, token);
 
-        AssertPacedBy(delays, [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), OneSecond, TimeSpan.FromSeconds(2)]);
+        AssertPacedBy(delays, Array.ConvertAll(expectedDelaySeconds, static seconds => TimeSpan.FromSeconds(seconds)));
     }
 
     /// <summary>
     /// A backed-off job spends nearly all of its iteration waiting, so an admission arriving from inbound traffic or
-    /// another job while it waits has to reset it just as one during its own lookup does.
+    /// another job while it waits has to restore productive pacing just as one during its own lookup does.
     /// </summary>
     [Test]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_reset_pace_when_a_node_is_admitted_while_waiting(CancellationToken token)
+    public async Task DiscoverNodes_should_return_to_productive_pace_when_a_node_is_admitted_while_waiting(CancellationToken token)
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
 
-        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 5, token,
-            onDelayRequested: wait => { if (wait == 2) routingTable.RaiseNodeAdded(42); });
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 8, token,
+            onDelayRequested: wait => { if (wait == 5) routingTable.RaiseNodeAdded(42); });
 
-        AssertPacedBy(delays, [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), OneSecond, TimeSpan.FromSeconds(2)]);
+        AssertPacedBy(delays, [
+            TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60)
+        ]);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_return_to_minimum_pace_when_table_becomes_underfilled(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 8, token,
+            onDelayRequested: wait =>
+            {
+                if (wait == 5)
+                {
+                    routingTable.Occupancy = new RoutingTableOccupancy(5, 16);
+                }
+            });
+
+        AssertPacedBy(delays, [
+            TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32), OneSecond, OneSecond
+        ]);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_share_cached_routing_table_occupancy_between_jobs(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        await RunPacingChecks(routingTable, checks: 4, token, concurrentJobs: 4);
+
+        Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(1));
+    }
+
+    [TestCase(999, 1, 4)]
+    [TestCase(1000, 2, 1)]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_expire_cached_routing_table_occupancy_after_one_second(
+        int elapsedMilliseconds,
+        int expectedOccupancyCalls,
+        int expectedDelaySeconds,
+        CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        TimeSpan[] delays = await RunPacingChecks(routingTable, checks: 2, token,
+            timeAdvance: TimeSpan.FromMilliseconds(elapsedMilliseconds),
+            onDelayRequested: wait => { if (wait == 1) routingTable.Occupancy = new RoutingTableOccupancy(0, 16); });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(expectedOccupancyCalls));
+            Assert.That(delays, Is.EqualTo(new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(expectedDelaySeconds) }));
+        }
+    }
+
+    private static async Task<TimeSpan[]> RunPacingChecks(
+        RoutingTableStub routingTable,
+        int checks,
+        CancellationToken token,
+        int concurrentJobs = 1,
+        TimeSpan? timeAdvance = null,
+        Action<int>? onDelayRequested = null)
+    {
+        TaskCompletionSource completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        NoWaitTimeProvider timeProvider = new()
+        {
+            TimeAdvance = timeAdvance ?? TimeSpan.Zero,
+            CompletedTimers = checks - concurrentJobs,
+            OnDelayRequested = wait =>
+            {
+                onDelayRequested?.Invoke(wait);
+                if (wait == checks) completed.TrySetResult();
+            }
+        };
+        using IContainer container = CreateContainer(new TestKademlia(), routingTable, timeProvider);
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
+
+        // Leave enough channel space for every lookup and park each job only after it has checked occupancy.
+        await using IAsyncEnumerator<int> nodes = discovery.DiscoverNodes(concurrentJobs, checks * NodesPerLookup, token).GetAsyncEnumerator(token);
+        Assert.That(await nodes.MoveNextAsync(), Is.True);
+        await completed.Task.WaitAsync(token);
+        return timeProvider.RequestedDelays;
     }
 
     /// <summary>Asserts that the first iterations waited for exactly the expected paces.</summary>
     private static void AssertPacedBy(TimeSpan[] delays, TimeSpan[] expected) =>
         Assert.That(delays.Take(expected.Length).ToArray(), Is.EqualTo(expected));
 
-    private static RandomWalkKademliaDiscovery<int, int, int> CreateDiscovery(
+    private static IEnumerable<TestCaseData> ProductivePacingCases()
+    {
+        yield return new TestCaseData(
+                new[] { 6 },
+                8,
+                new[] { 2, 4, 8, 16, 32, 30, 60 })
+            .SetName("DiscoverNodes_returns_to_productive_pace_when_lookup_admits_a_node");
+        yield return new TestCaseData(
+                new[] { 1, 2, 3, 4, 5, 6, 7 },
+                7,
+                new[] { 2, 4, 8, 16, 30, 30 })
+            .SetName("DiscoverNodes_limits_continuously_productive_filled_table_pace");
+        yield return new TestCaseData(
+                new[] { 10 },
+                12,
+                new[] { 2, 4, 8, 16, 32, 64, 128, 256, 300, 30, 60 })
+            .SetName("DiscoverNodes_returns_from_idle_ceiling_to_productive_pace");
+    }
+
+    private static IContainer CreateContainer(
         TestKademlia kademlia,
         RoutingTableStub routingTable,
         TimeProvider? timeProvider = null) =>
-        new(kademlia,
-            routingTable,
-            IntKeyOperator.Instance,
-            Int32KademliaDistance.Instance,
-            new KademliaConfig<int> { CurrentNodeId = 0 },
-            NullLoggerFactory.Instance,
-            timeProvider);
+        new ContainerBuilder()
+            .AddModule(new KademliaModule<int, int, int>())
+            .AddSingleton<IKademlia<int, int>>(kademlia)
+            .AddSingleton<IRoutingTable<int, int>>(routingTable)
+            .AddSingleton<IKeyOperator<int, int, int>>(IntKeyOperator.Instance)
+            .AddSingleton<IKademliaDistance<int>>(Int32KademliaDistance.Instance)
+            .AddSingleton(new KademliaConfig<int> { CurrentNodeId = 0 })
+            .AddSingleton(timeProvider ?? TimeProvider.System)
+            .Build();
 
     /// <summary>
     /// Runs the requested number of lookup iterations and returns the paced delays each of them asked for.
@@ -176,45 +303,69 @@ public class RandomWalkKademliaDiscoveryTests
         CancellationToken token,
         Action<int>? onDelayRequested = null)
     {
-        NoWaitTimeProvider timeProvider = new() { OnDelayRequested = onDelayRequested };
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, routingTable, timeProvider);
+        NoWaitTimeProvider timeProvider = new()
+        {
+            OnDelayRequested = onDelayRequested
+        };
+        using IContainer container = CreateContainer(kademlia, routingTable, timeProvider);
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
-        await discovery.DiscoverNodes(1, NodesPerLookup, token).Take(iterations * NodesPerLookup).ToListAsync(token);
+        await discovery.DiscoverNodes(1, NodesPerLookup, token)
+            .Take(iterations * NodesPerLookup).ToListAsync(token);
 
         return timeProvider.RequestedDelays;
     }
 
     /// <summary>
-    /// Runs timers immediately while recording the delay that was asked for, on a clock that never advances.
+    /// Records paced delays and advances the clock only when a timer is requested.
     /// </summary>
     /// <remarks>
-    /// Freezing <see cref="GetTimestamp"/> makes the measured lookup time zero, so a job asks for exactly the pace it
-    /// chose rather than the pace minus however long the test machine took.
+    /// Lookup time stays zero regardless of the test machine's speed. Timers beyond <see cref="CompletedTimers"/>
+    /// stay pending until discovery is disposed, allowing tests to inspect a fixed number of completed pacing checks.
     /// </remarks>
     private sealed class NoWaitTimeProvider : TimeProvider
     {
         private readonly ConcurrentQueue<TimeSpan> _requestedDelays = new();
+        private long _timestamp;
+        private int _timerCount;
 
         public TimeSpan[] RequestedDelays => _requestedDelays.ToArray();
+
+        public int CompletedTimers { get; init; } = int.MaxValue;
+
+        /// <summary>Clock advance per timer request: <c>null</c> uses the requested delay; <see cref="TimeSpan.Zero"/> freezes it.</summary>
+        public TimeSpan? TimeAdvance { get; init; }
 
         /// <summary>Called as a job starts waiting, with the one-based ordinal of that wait.</summary>
         public Action<int>? OnDelayRequested { get; init; }
 
-        public override long GetTimestamp() => 0;
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => Volatile.Read(ref _timestamp);
 
         public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
         {
             _requestedDelays.Enqueue(dueTime);
-            OnDelayRequested?.Invoke(_requestedDelays.Count);
-            return System.CreateTimer(callback, state, TimeSpan.Zero, period);
+            int timer = Interlocked.Increment(ref _timerCount);
+            Interlocked.Add(ref _timestamp, (TimeAdvance ?? dueTime).Ticks);
+            OnDelayRequested?.Invoke(timer);
+            return System.CreateTimer(callback, state, timer <= CompletedTimers ? TimeSpan.Zero : Timeout.InfiniteTimeSpan, period);
         }
     }
 
     private sealed class RoutingTableStub : IRoutingTable<int, int>
     {
-        public RoutingTableOccupancy Occupancy { get; init; } = new(0, 16);
+        private int _getOccupancyCalls;
 
-        public RoutingTableOccupancy GetOccupancy() => Occupancy;
+        public RoutingTableOccupancy Occupancy { get; set; } = new(0, 16);
+
+        public int GetOccupancyCalls => Volatile.Read(ref _getOccupancyCalls);
+
+        public RoutingTableOccupancy GetOccupancy()
+        {
+            Interlocked.Increment(ref _getOccupancyCalls);
+            return Occupancy;
+        }
 
         public void RaiseNodeAdded(int node) => OnNodeAdded?.Invoke(this, node);
 


### PR DESCRIPTION
It's a small release only fix, a bigger change that also optimizes bootnode is here: https://github.com/NethermindEth/nethermind/pull/13122

## Changes

- Keep the one-second active random-walk cadence only while the Kademlia routing table is underfilled.
- Back healthy productive tables off exponentially to a 30-second ceiling, while retaining the existing five-minute idle ceiling.
- Add regression coverage for continuous and intermittent admissions and recovery when the table becomes underfilled.
- Align the Kademlia integration documentation with the three pacing states.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- The new pacing cases produce three failures against the released implementation and all pass with this change.
- The complete release-branch discovery suite passes with 361 successful tests and one pre-existing skipped test. The 16 focused pacing cases include deterministic parked-worker cache sharing, cached versus refreshed pacing at 999/1000 ms, and separate cold-start/fill-ratio boundaries.
- The main and benchmark solutions compile with warnings treated as errors, and the self-contained Linux x64 client publishes successfully. The Ethereum test solution remains unable to build in this workspace because the src/tests submodule fixtures are absent.
- In a same-host Hoodi A/B using the same populated discovery database, ports, and disabled block processing/synchronization, the official release averaged 152.55 KiB/s of discovery traffic over the matched first two minutes; this build averaged 15.16 KiB/s, a 90.1% reduction. Its final five-minute window held at 19.81 KiB/s with 30 peers and no runtime error signals.

## Documentation

#### Requires documentation update

- [x] Yes
- [ ] No

The Kademlia README now describes the bootstrap, productive, and idle pacing states.

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Active Kademlia discovery now backs off on healthy routing tables instead of ordinary routing churn keeping all discovery jobs at the one-second bootstrap cadence, substantially reducing discovery traffic.

## Remarks

This branch is based directly on the 2.0.0-rc release commit and contains only the Kademlia pacing correction, its focused tests, and matching documentation.