### PR TITLE
chore: bump Nethermind.Numerics.Int256 to 1.7.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,7 @@
     <PackageVersion Include="Nethermind.Libp2p" Version="1.0.0-preview.45" />
     <PackageVersion Include="Nethermind.Libp2p.Protocols.PubsubPeerDiscovery" Version="1.0.0-preview.45" />
     <PackageVersion Include="Nethermind.MclBindings" Version="1.0.5" />
-    <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.6.0" />
+    <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.7.0" />
     <PackageVersion Include="Nethermind.TurboPForBindings" Version="1.0.0" />
     <PackageVersion Include="Nethermind.Zkvm.Abstractions" Version="1.0.0-preview.2" />
     <PackageVersion Include="Nethermind.ZiskOS.Runtime" Version="1.0.0-preview.8" />

--- a/nix/nuget-deps.json
+++ b/nix/nuget-deps.json
@@ -811,8 +811,8 @@
   },
   {
     "pname": "Nethermind.Numerics.Int256",
-    "version": "1.6.0",
-    "hash": "sha256-vmEuQU3EGJgNi01AVaOtSCz0DolTfTrUeGCMD/A3nwY="
+    "version": "1.7.0",
+    "hash": "sha256-FXapSQQnBbunYsUlnvSTKnBDBUcWfoH2teNBlKuShrQ="
   },
   {
     "pname": "Nethermind.TurboPForBindings",

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -719,7 +719,7 @@
           "Microsoft.IdentityModel.JsonWebTokens": "[8.22.0, )",
           "Nethermind.Crypto.SecP256k1": "[1.6.0, )",
           "Nethermind.Logging": "[1.40.0-unstable, )",
-          "Nethermind.Numerics.Int256": "[1.6.0, )",
+          "Nethermind.Numerics.Int256": "[1.7.0, )",
           "Nethermind.Serialization.Ssz": "[1.40.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
           "System.IO.Hashing": "[10.0.11, )",
@@ -1133,7 +1133,7 @@
       "nethermind.serialization.ssz": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Numerics.Int256": "[1.6.0, )"
+          "Nethermind.Numerics.Int256": "[1.7.0, )"
         }
       },
       "nethermind.shutter": {
@@ -1628,9 +1628,9 @@
       },
       "Nethermind.Numerics.Int256": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "QwsEoB/UKDo7g/gbGjqIvOb1ddxOG27O7YEJWxu84V74beSV4mWWhiq9KjdSuCVQeuR1HKLSVrbOH4KsIRe6MQ==",
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "7SHjmk09HTDvC6beXoqf/1OmE4jfnEt3BJhicOKk/WpJzdzFxKnozg6SGxLfXZmRxWEhr1fvDwtp2ppUUdp2/w==",
         "dependencies": {
           "System.IO.Hashing": "10.0.10"
         }


### PR DESCRIPTION
## Changes

- Bump `Nethermind.Numerics.Int256` from 1.6.0 to [1.7.0](https://github.com/NethermindEth/int256/releases/tag/v1.7.0) in `Directory.Packages.props`
- Regenerate `Nethermind.Runner/packages.lock.json` for the new version

1.7.0 is int256 `main` since v1.6.0: PRs #102–#115 (ARM64 big-endian conversion, constructor SIMD, `MultiplyMod`, narrow 256x256 multiply, `CompareTo`, division/modulus fast paths, funnel shifts, add/sub speculative carry, widening multiply, `Multiply` limb-shape dispatch, negativity gates, `Mod` without quotient).

## Types of changes

#### What types of changes does your code introduce?

- [x] Optimization
- [x] Build-related changes

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Same-session A/B of master 990aa67 against master + this package on both benchmark boxes (the package was validated as the `1.6.0-candidate` staging build of the same int256 `main` commit), full report: https://claude.ai/code/artifact/65210ae2-78a6-4956-a2cd-a149383c7c58

| workload | amd64 | arm64 |
|---|---|---|
| heavy multicall `eth_call`, per-call p50 (unsaturated) | −8 to −9% | −4 to −5% |
| heavy multicall, saturated capacity | +4% | +1.6% |
| 497-record private `eth_call` corpus, avg @100 rps | −3.6% | −1.0% |
| expb fusaka, AVG block processing | −1.2% | −0.8% |

Response parity 497/497 identical to master on both ISAs, zero RPC failures, no exceptions or invalid blocks in expb. Runs: 33743051298, 33743054278, 33745055608, 33743048477 (amd64); 33758182596, 33758185952, 33758189398, 33758179441 (arm64).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
