### PR TITLE
fix: eth_maxPriorityFeePerGas returned a gas price

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/GasPriceOracleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/GasPriceOracleTests.cs
@@ -426,10 +426,10 @@ namespace Nethermind.JsonRpc.Test.Modules
         public void GetMaxPriorityGasFeeEstimate_IfNoTipAboveIgnoreUnder_DoesNotUseGasPriceEstimate(ulong? lastMaxPriorityFeePerGas, ulong expected)
         {
             Transaction[] transactions =
-            {
+            [
                 Build.A.Transaction.WithMaxFeePerGas(100.GWei).WithMaxPriorityFeePerGas(1).WithType(TxType.EIP1559).TestObject,
                 Build.A.Transaction.WithMaxFeePerGas(100.GWei).WithMaxPriorityFeePerGas(1).WithType(TxType.EIP1559).TestObject
-            };
+            ];
             Block headBlock = Build.A.Block.Genesis.WithTransactions(transactions).WithBaseFeePerGas(10.GWei).TestObject;
             IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
             blockFinder.FindBlock(0UL).Returns(headBlock);
@@ -437,6 +437,33 @@ namespace Nethermind.JsonRpc.Test.Modules
             GasPriceOracle gasPriceOracle = new(blockFinder, GetSpecProviderWithEip1559EnabledAs(true), LimboLogs.Instance)
             {
                 _gasPriceEstimation = new(null, 100.GWei),
+                _maxPriorityFeePerGasEstimation = new(null, lastMaxPriorityFeePerGas)
+            };
+
+            UInt256 estimate = gasPriceOracle.GetMaxPriorityGasFeeEstimate();
+
+            Assert.That(estimate, Is.EqualTo((UInt256)expected));
+        }
+
+        [TestCase(null, 20UL)]
+        [TestCase(25UL, 25UL)]
+        public void GetMaxPriorityGasFeeEstimate_IfSomeBlocksHaveNoTips_SubstituteIsSampledAlongsideTheTips(ulong? lastMaxPriorityFeePerGas, ulong expected)
+        {
+            Transaction[] transactions =
+            [
+                Build.A.Transaction.WithMaxFeePerGas(100).WithMaxPriorityFeePerGas(10).WithType(TxType.EIP1559).TestObject,
+                Build.A.Transaction.WithMaxFeePerGas(100).WithMaxPriorityFeePerGas(20).WithType(TxType.EIP1559).TestObject,
+                Build.A.Transaction.WithMaxFeePerGas(100).WithMaxPriorityFeePerGas(30).WithType(TxType.EIP1559).TestObject
+            ];
+            Block headBlock = Build.A.Block.WithNumber(1).WithTransactions(transactions).WithBaseFeePerGas(10).TestObject;
+            Block blockWithoutTransactions = Build.A.Block.Genesis.WithBaseFeePerGas(10).TestObject;
+            IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+            blockFinder.FindBlock(1UL).Returns(headBlock);
+            blockFinder.FindBlock(0UL).Returns(blockWithoutTransactions);
+            blockFinder.Head.Returns(headBlock);
+            GasPriceOracle gasPriceOracle = new(blockFinder, GetSpecProviderWithEip1559EnabledAs(true), LimboLogs.Instance)
+            {
+                _gasPriceEstimation = new(null, 100),
                 _maxPriorityFeePerGasEstimation = new(null, lastMaxPriorityFeePerGas)
             };
 

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/GasPriceOracleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/GasPriceOracleTests.cs
@@ -420,5 +420,44 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             Assert.That(results, Is.EquivalentTo(expected));
         }
+
+        [TestCase(null, 1UL)]
+        [TestCase(5UL, 5UL)]
+        public void GetMaxPriorityGasFeeEstimate_IfNoTipAboveIgnoreUnder_DoesNotUseGasPriceEstimate(ulong? lastMaxPriorityFeePerGas, ulong expected)
+        {
+            Transaction[] transactions =
+            {
+                Build.A.Transaction.WithMaxFeePerGas(100.GWei).WithMaxPriorityFeePerGas(1).WithType(TxType.EIP1559).TestObject,
+                Build.A.Transaction.WithMaxFeePerGas(100.GWei).WithMaxPriorityFeePerGas(1).WithType(TxType.EIP1559).TestObject
+            };
+            Block headBlock = Build.A.Block.Genesis.WithTransactions(transactions).WithBaseFeePerGas(10.GWei).TestObject;
+            IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+            blockFinder.FindBlock(0UL).Returns(headBlock);
+            blockFinder.Head.Returns(headBlock);
+            GasPriceOracle gasPriceOracle = new(blockFinder, GetSpecProviderWithEip1559EnabledAs(true), LimboLogs.Instance)
+            {
+                _gasPriceEstimation = new(null, 100.GWei),
+                _maxPriorityFeePerGasEstimation = new(null, lastMaxPriorityFeePerGas)
+            };
+
+            UInt256 estimate = gasPriceOracle.GetMaxPriorityGasFeeEstimate();
+
+            Assert.That(estimate, Is.EqualTo((UInt256)expected));
+        }
+
+        [TestCase(null)]
+        [TestCase(100ul)]
+        public void GetMaxPriorityGasFeeEstimate_EmptyChain_BaseFeeNotIncluded(ulong? minGasPrice)
+        {
+            Block headBlock = Build.A.Block.WithBaseFeePerGas(10.GWei).TestObject;
+            IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+            blockFinder.FindBlock(0UL).Returns(headBlock);
+            blockFinder.Head.Returns(headBlock);
+            GasPriceOracle gasPriceOracle = new(blockFinder, GetSpecProviderWithEip1559EnabledAs(true), LimboLogs.Instance, minGasPrice);
+
+            UInt256 estimate = gasPriceOracle.GetMaxPriorityGasFeeEstimate();
+
+            Assert.That(estimate, Is.EqualTo(minGasPrice ?? 1.Wei));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/GasPriceOracleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/GasPriceOracleTests.cs
@@ -486,5 +486,35 @@ namespace Nethermind.JsonRpc.Test.Modules
 
             Assert.That(estimate, Is.EqualTo(minGasPrice ?? 1.Wei));
         }
+
+        [Test]
+        public async ValueTask GasPriceEstimate_IfHeadBodyIsMissing_FallsBackToMinimumGasPrice()
+        {
+            IBlockFinder blockFinder = GetBlockFinderWithoutBodies();
+            GasPriceOracle gasPriceOracle = new(blockFinder, GetSpecProviderWithEip1559EnabledAs(true), LimboLogs.Instance);
+
+            UInt256 estimate = await gasPriceOracle.GetGasPriceEstimate();
+
+            Assert.That(estimate, Is.EqualTo((10.GWei + 1.Wei) * 110 / 100));
+        }
+
+        [Test]
+        public void GetMaxPriorityGasFeeEstimate_IfHeadBodyIsMissing_FallsBackToMinGasPrice()
+        {
+            IBlockFinder blockFinder = GetBlockFinderWithoutBodies();
+            GasPriceOracle gasPriceOracle = new(blockFinder, GetSpecProviderWithEip1559EnabledAs(true), LimboLogs.Instance);
+
+            UInt256 estimate = gasPriceOracle.GetMaxPriorityGasFeeEstimate();
+
+            Assert.That(estimate, Is.EqualTo(1.Wei));
+        }
+
+        /// <summary>Head header is known but every body lookup fails, as on a node whose bodies were pruned.</summary>
+        private static IBlockFinder GetBlockFinderWithoutBodies()
+        {
+            IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
+            blockFinder.Head.Returns(Build.A.Block.WithNumber(1).WithBaseFeePerGas(10.GWei).TestObject);
+            return blockFinder;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/EthRpcModule.cs
@@ -154,8 +154,8 @@ public partial class EthRpcModule(
 
     public ResultWrapper<UInt256?> eth_maxPriorityFeePerGas()
     {
-        UInt256 gasPriceWithBaseFee = _gasPriceOracle.GetMaxPriorityGasFeeEstimate();
-        return ResultWrapper<UInt256?>.Success(gasPriceWithBaseFee);
+        UInt256 maxPriorityFeePerGas = _gasPriceOracle.GetMaxPriorityGasFeeEstimate();
+        return ResultWrapper<UInt256?>.Success(maxPriorityFeePerGas);
     }
 
     public ResultWrapper<FeeHistoryResults> eth_feeHistory(ulong blockCount, BlockParameter newestBlock, double[] rewardPercentiles) => _feeHistoryOracle.GetFeeHistory(blockCount, newestBlock, rewardPercentiles);

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/GasPrice/GasPriceOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/GasPrice/GasPriceOracle.cs
@@ -94,7 +94,13 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
                 do
                 {
                     if (_logger.IsTrace) _logger.Trace($"GasPriceOracle - searching for block number {currentBlockNumber}");
-                    yield return _blockFinder.FindBlock(currentBlockNumber)!;
+                    Block? block = _blockFinder.FindBlock(currentBlockNumber);
+                    if (block is null)
+                    {
+                        yield break;
+                    }
+
+                    yield return block;
                 } while (currentBlockNumber-- != 0);
             }
 

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/GasPrice/GasPriceOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/GasPrice/GasPriceOracle.cs
@@ -56,7 +56,8 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
 
         internal IEnumerable<UInt256> GetGasPricesFromRecentBlocks(ulong blockNumber) =>
             GetGasPricesFromRecentBlocks(blockNumber, BlockLimit,
-            static (transaction, eip1559Enabled, baseFee) => transaction.CalculateEffectiveGasPrice(eip1559Enabled, baseFee));
+            static (transaction, eip1559Enabled, baseFee) => transaction.CalculateEffectiveGasPrice(eip1559Enabled, baseFee),
+            baseFeePerGas => FallbackGasPrice(baseFeePerGas));
 
         public virtual UInt256 GetMaxPriorityGasFeeEstimate()
         {
@@ -74,9 +75,10 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
 
             IEnumerable<UInt256> gasPricesWithFee = GetGasPricesFromRecentBlocks(headBlock.Number,
                 EthGasPriceConstants.DefaultBlocksLimitMaxPriorityFeePerGas,
-                static (transaction, eip1559Enabled, baseFee) => transaction.CalculateMaxPriorityFeePerGas(eip1559Enabled, baseFee));
+                static (transaction, eip1559Enabled, baseFee) => transaction.CalculateMaxPriorityFeePerGas(eip1559Enabled, baseFee),
+                _ => _maxPriorityFeePerGasEstimation.LastPrice ?? _minGasPrice);
 
-            UInt256 gasPriceEstimate = GetGasPriceAtPercentile(gasPricesWithFee.ToList()) ?? _maxPriorityFeePerGasEstimation.LastPrice ?? GetMinimumGasPrice(headBlock.BaseFeePerGas);
+            UInt256 gasPriceEstimate = GetGasPriceAtPercentile(gasPricesWithFee.ToList()) ?? _maxPriorityFeePerGasEstimation.LastPrice ?? _minGasPrice;
             gasPriceEstimate = UInt256.Min(gasPriceEstimate!, EthGasPriceConstants.MaxGasPrice);
             _maxPriorityFeePerGasEstimation.Set(headBlockHash, gasPriceEstimate);
             return gasPriceEstimate!;
@@ -86,7 +88,9 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
 
         private delegate UInt256 CalculateGas(Transaction transaction, bool eip1559, UInt256 baseFee);
 
-        private IEnumerable<UInt256> GetGasPricesFromRecentBlocks(ulong blockNumber, int numberOfBlocks, CalculateGas calculateGasFromTransaction)
+        private delegate UInt256 CalculateFallback(UInt256 baseFeePerGas);
+
+        private IEnumerable<UInt256> GetGasPricesFromRecentBlocks(ulong blockNumber, int numberOfBlocks, CalculateGas calculateGasFromTransaction, CalculateFallback calculateFallback)
         {
             IEnumerable<Block> GetBlocks(ulong currentBlockNumber)
             {
@@ -97,10 +101,10 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
                 } while (currentBlockNumber-- != 0);
             }
 
-            return GetGasPricesFromRecentBlocks(GetBlocks(blockNumber), numberOfBlocks, calculateGasFromTransaction);
+            return GetGasPricesFromRecentBlocks(GetBlocks(blockNumber), numberOfBlocks, calculateGasFromTransaction, calculateFallback);
         }
 
-        private IEnumerable<UInt256> GetGasPricesFromRecentBlocks(IEnumerable<Block> blocks, int blocksToGoBack, CalculateGas calculateGasFromTransaction)
+        private IEnumerable<UInt256> GetGasPricesFromRecentBlocks(IEnumerable<Block> blocks, int blocksToGoBack, CalculateGas calculateGasFromTransaction, CalculateFallback calculateFallback)
         {
             int txCount = 0;
 
@@ -130,7 +134,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
                 if (txFromCurrentBlock == 0)
                 {
                     blocksToGoBack--;
-                    yield return FallbackGasPrice(currentBlock.BaseFeePerGas);
+                    yield return calculateFallback(currentBlock.BaseFeePerGas);
                 }
 
                 if (txFromCurrentBlock > 1 || txCount + blocksToGoBack >= SoftTxThreshold)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/GasPrice/GasPriceOracle.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Eth/GasPrice/GasPriceOracle.cs
@@ -56,8 +56,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
 
         internal IEnumerable<UInt256> GetGasPricesFromRecentBlocks(ulong blockNumber) =>
             GetGasPricesFromRecentBlocks(blockNumber, BlockLimit,
-            static (transaction, eip1559Enabled, baseFee) => transaction.CalculateEffectiveGasPrice(eip1559Enabled, baseFee),
-            baseFeePerGas => FallbackGasPrice(baseFeePerGas));
+            static (transaction, eip1559Enabled, baseFee) => transaction.CalculateEffectiveGasPrice(eip1559Enabled, baseFee));
 
         public virtual UInt256 GetMaxPriorityGasFeeEstimate()
         {
@@ -76,7 +75,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
             IEnumerable<UInt256> gasPricesWithFee = GetGasPricesFromRecentBlocks(headBlock.Number,
                 EthGasPriceConstants.DefaultBlocksLimitMaxPriorityFeePerGas,
                 static (transaction, eip1559Enabled, baseFee) => transaction.CalculateMaxPriorityFeePerGas(eip1559Enabled, baseFee),
-                _ => _maxPriorityFeePerGasEstimation.LastPrice ?? _minGasPrice);
+                _maxPriorityFeePerGasEstimation.LastPrice ?? _minGasPrice);
 
             UInt256 gasPriceEstimate = GetGasPriceAtPercentile(gasPricesWithFee.ToList()) ?? _maxPriorityFeePerGasEstimation.LastPrice ?? _minGasPrice;
             gasPriceEstimate = UInt256.Min(gasPriceEstimate!, EthGasPriceConstants.MaxGasPrice);
@@ -88,9 +87,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
 
         private delegate UInt256 CalculateGas(Transaction transaction, bool eip1559, UInt256 baseFee);
 
-        private delegate UInt256 CalculateFallback(UInt256 baseFeePerGas);
-
-        private IEnumerable<UInt256> GetGasPricesFromRecentBlocks(ulong blockNumber, int numberOfBlocks, CalculateGas calculateGasFromTransaction, CalculateFallback calculateFallback)
+        private IEnumerable<UInt256> GetGasPricesFromRecentBlocks(ulong blockNumber, int numberOfBlocks, CalculateGas calculateGasFromTransaction, UInt256? substituteForEmptyBlock = null)
         {
             IEnumerable<Block> GetBlocks(ulong currentBlockNumber)
             {
@@ -101,10 +98,10 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
                 } while (currentBlockNumber-- != 0);
             }
 
-            return GetGasPricesFromRecentBlocks(GetBlocks(blockNumber), numberOfBlocks, calculateGasFromTransaction, calculateFallback);
+            return GetGasPricesFromRecentBlocks(GetBlocks(blockNumber), numberOfBlocks, calculateGasFromTransaction, substituteForEmptyBlock);
         }
 
-        private IEnumerable<UInt256> GetGasPricesFromRecentBlocks(IEnumerable<Block> blocks, int blocksToGoBack, CalculateGas calculateGasFromTransaction, CalculateFallback calculateFallback)
+        private IEnumerable<UInt256> GetGasPricesFromRecentBlocks(IEnumerable<Block> blocks, int blocksToGoBack, CalculateGas calculateGasFromTransaction, UInt256? substituteForEmptyBlock)
         {
             int txCount = 0;
 
@@ -134,7 +131,7 @@ namespace Nethermind.JsonRpc.Modules.Eth.GasPrice
                 if (txFromCurrentBlock == 0)
                 {
                     blocksToGoBack--;
-                    yield return calculateFallback(currentBlock.BaseFeePerGas);
+                    yield return substituteForEmptyBlock ?? FallbackGasPrice(currentBlock.BaseFeePerGas);
                 }
 
                 if (txFromCurrentBlock > 1 || txCount + blocksToGoBack >= SoftTxThreshold)


### PR DESCRIPTION
## Changes

`eth_maxPriorityFeePerGas` could return a gas price. On the execution-apis test chain
it returned `0x711e8d3`, the same value as `eth_gasPrice`, where reth and Besu return
`0x1`.

Both methods build their estimate with the same `GetGasPricesFromRecentBlocks` loop. A
block with no usable samples contributes `FallbackGasPrice`, which is the cached gas
price or `(minGasPrice + baseFee) * 1.1`. That number contains the base fee, and it went
into the priority fee sample set as if it were a tip. `IgnoreUnder` is 2 wei, the same
as geth, so on a chain where transactions pay 1 wei tips every block takes that path and
the whole sample set is gas prices.

The old result also changed with call order. For one head block with a 10 GWei base fee,
the method returned 11000000001 wei when called first and the full gas price when called
after `eth_gasPrice`.

- `GetGasPricesFromRecentBlocks` takes the substitute as a delegate. The gas price path
  keeps `FallbackGasPrice` and its output does not change.
- The priority fee path substitutes `_maxPriorityFeePerGasEstimation.LastPrice ??
  _minGasPrice`. geth does the same with its last suggested tip
  (`eth/gasprice/gasprice.go:202-208`).
- The last fallback in `GetMaxPriorityGasFeeEstimate` uses that expression instead of
  `GetMinimumGasPrice(headBlock.BaseFeePerGas)`.

`IgnoreUnder`, the block walk, the percentile and the per-block transaction cap do not
change.

Replayed through hive `rpc-compat` on the execution-apis chain (54 blocks, every tip
1 wei, head base fee 27399063 wei):

| | before | after |
| --- | --- | --- |
| `eth_gasPrice` | 0x711e8d3 | 0x711e8d3 |
| `eth_maxPriorityFeePerGas` | 0x711e8d3 | 0x1 |

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

No test called `GetMaxPriorityGasFeeEstimate` before. This adds two parameterized tests
to `GasPriceOracleTests`, four cases in total. All four fail on master. The first
returns 100000000000, the seeded gas price; the empty-chain cases return
`(minGasPrice + baseFee) * 1.1`.

`Nethermind.JsonRpc.Test` passes in full (1963 passed, 22 pre-existing skips).
`Nethermind.Taiko.Test` passes.

The existing `eth_maxPriorityFeePerGas` check in `EthRpcModuleTests` passes before and
after. Its chain and its `MinGasPrice` both produce 0x1, so it cannot tell the two
apart. It is unchanged.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

`eth_maxPriorityFeePerGas` no longer includes the base fee. On networks where tips are
below 2 wei, such as devnets and private chains, it returns `Blocks.MinGasPrice`
(default 1 wei) instead of a gas price. Mainnet values do not change in practice.

## Remarks

Surge (Taiko) inherits this change. On a Surge chain with real tips the result is
unchanged, since the percentile is over real samples. Where no block yields a tip above
`IgnoreUnder`, the tip drops from the Surge gas-price estimate to `Blocks.MinGasPrice`.
`eth_fillTransaction` therefore no longer carries the L1 submission cost into an
EIP-1559 transaction through the tip. If that is wanted, it belongs in
`EIP1559TransactionForRpc.FillDefaults`, which today never reads `context.GasPrice`.

The final fallback in `GetMaxPriorityGasFeeEstimate` is not reachable in practice.
`GetGasPriceAtPercentile` returns null only for an empty list, and the loop yields a
sample or a substitute for every block. It is changed for consistency and has no test.
