### PR TITLE
Guard the frame-tx refund cast and drop a redundant gas-cap condition

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -255,7 +255,7 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
             return FrameTxValidation.FrameGasOverflow;
         }
 
-        if ((releaseSpec.IsEip8037Enabled || releaseSpec.IsEip8141Enabled) && executionReservation > Eip7825Constants.DefaultTxGasLimitCap)
+        if (executionReservation > Eip7825Constants.DefaultTxGasLimitCap)
         {
             return FrameTxValidation.FrameExecutionGasExceedsCap(executionReservation, Eip7825Constants.DefaultTxGasLimitCap);
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -475,7 +475,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         ulong grossGasBeforeCorrection = intrinsicGas + totalFrameGasUsed;
         ulong stateGasCorrectionApplied = (ulong)Math.Max(0, stateGasCorrection);
         ulong grossGas = grossGasBeforeCorrection > stateGasCorrectionApplied ? grossGasBeforeCorrection - stateGasCorrectionApplied : 0;
-        ulong gasAfterRefund = grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)refundCounter, spec);
+        ulong gasAfterRefund = grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)Math.Max(0, refundCounter), spec);
         ulong blockStateGas = (ulong)Math.Max(0, totalFrameStateGasUsed - stateGasCorrection);
         ulong blockRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockExecutionGas(gasAfterRefund, blockStateGas, floorGas);
         ulong spentGas = blockRegularGas + blockStateGas;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -475,6 +475,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         ulong grossGasBeforeCorrection = intrinsicGas + totalFrameGasUsed;
         ulong stateGasCorrectionApplied = (ulong)Math.Max(0, stateGasCorrection);
         ulong grossGas = grossGasBeforeCorrection > stateGasCorrectionApplied ? grossGasBeforeCorrection - stateGasCorrectionApplied : 0;
+        System.Diagnostics.Debug.Assert(refundCounter >= 0, $"frame-tx settlement invariant violated: negative refund counter ({refundCounter}).");
         ulong gasAfterRefund = grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)Math.Max(0, refundCounter), spec);
         ulong blockStateGas = (ulong)Math.Max(0, totalFrameStateGasUsed - stateGasCorrection);
         ulong blockRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockExecutionGas(gasAfterRefund, blockStateGas, floorGas);


### PR DESCRIPTION
Two small fixes from review feedback on the frame-transaction settlement path.

**Refund counter cast.** `CalculateClaimableRefund` takes an unsigned refund; the frame path passed `(ulong)refundCounter` where `refundCounter` is `long` and can legitimately go negative (EIP-3529 `-CLEARS`). A negative value casts to ~2^64, so the claimable refund returns the full cap. Not reachable on the current frame ordering, but the regular settlement path deliberately keeps the value signed, so this mirrors that: clamp to zero before the cast.

**Redundant gas-cap condition.** The `(IsEip8037Enabled || IsEip8141Enabled)` guard on the frame execution-gas-cap check is always true — the composite frame-tx validator only runs under `IsEip8141Enabled` — so the condition is dead and removed.

Built clean; frame test suites to follow.