### PR TITLE
Finalize self-destructs on the frame-transaction path

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -192,25 +192,14 @@ public class FrameTxProcessorTests
         _stateProvider.CommitTree(0);
         DeployContract(reverter, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
 
-        Transaction tx = new()
-        {
-            Type = TxType.FrameTx,
-            ChainId = TestBlockchainIds.ChainId,
-            Nonce = 0,
-            SenderAddress = smartSender,
-            Frames =
-            [
-                new TxFrame(TxFrame.ModeDefault, 0, factory, executionGasLimit: 1_000_000,
-                    stateGasLimit: (ulong)(2 * GasCostOf.NewAccountState + GasCostOf.CodeDepositState * (senderRuntime.Length + childRuntime.Length)),
-                    UInt256.Zero, default),
-                SelfVerifyFrame(),
-                Frame(TxFrame.ModeSender, target: child),
-                new TxFrame(TxFrame.ModePostTx, 0, reverter, executionGasLimit: 200_000, stateGasLimit: 0, UInt256.Zero, default),
-            ],
-            FrameSignatures = [],
-            GasPrice = 1,
-            DecodedMaxFeePerGas = 1,
-        };
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeDefault, 0, factory, executionGasLimit: 1_000_000,
+                stateGasLimit: (ulong)(2 * GasCostOf.NewAccountState + GasCostOf.CodeDepositState * (senderRuntime.Length + childRuntime.Length)),
+                UInt256.Zero, default),
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, target: child),
+            Frame(TxFrame.ModePostTx, target: reverter, stateGasLimit: 0));
+        tx.SenderAddress = smartSender;
 
         TransactionResult result = Process(tx);
 
@@ -218,6 +207,23 @@ public class FrameTxProcessorTests
         Assert.That(_stateProvider.AccountExists(child), Is.True,
             "a contract created in the validation prefix and self-destructed in a rolled-back body frame must be restored, not finalized for deletion");
         Assert.That(_stateProvider.GetCode(child), Is.EqualTo(childRuntime), "the restored contract keeps its runtime code");
+    }
+
+    [Test]
+    public void Execute_PayerlessRevertingPostTxFrame_IsRejectedNotThrown()
+    {
+        Address reverter = TestItem.AddressD;
+        _stateProvider.CreateAccount(Sender, 1.Ether);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+        DeployContract(reverter, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        Transaction tx = FrameTx(nonce: 0, Frame(TxFrame.ModePostTx, target: reverter, stateGasLimit: 0));
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.False, "a frame transaction whose only frame is a reverting POST_TX approves no payer, so it is rejected");
+        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction), "the empty destroy-list snapshot restore on the POST_TX-revert path must not throw before the never-set-a-payer rejection is reached");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -151,6 +151,22 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_FrameCreatesAndSelfDestructsContractInSameTx_DeletesTheCreatedAccount()
+    {
+        byte[] childInitCode = Prepare.EvmCode.PushData(Beneficiary).Op(Instruction.SELFDESTRUCT).Done;
+        byte[] salt = new byte[32];
+        Address child = ContractAddress.From(Observer, salt, childInitCode);
+
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.Create2(childInitCode, salt, UInt256.Zero).Op(Instruction.POP).Op(Instruction.STOP).Done);
+
+        TransactionResult result = Process(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer)));
+
+        Assert.That(result.TransactionExecuted, Is.True, "frame tx creating and self-destructing a contract still executes");
+        Assert.That(_stateProvider.AccountExists(child), Is.False, "a contract created and self-destructed in the same frame tx must be finalized and deleted per EIP-6780, not left in state");
+    }
+
+    [Test]
     public void Execute_BlobCarryingFrameTx_ChargesAndBurnsBlobFee()
     {
         // With base fee 0 the whole gas premium goes to the beneficiary, so the only value that leaves

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -153,17 +153,42 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_FrameCreatesAndSelfDestructsContractInSameTx_DeletesTheCreatedAccount()
     {
-        byte[] childInitCode = Prepare.EvmCode.PushData(Beneficiary).Op(Instruction.SELFDESTRUCT).Done;
+        UInt256 endowment = 3;
+        byte[] childInitCode = Prepare.EvmCode.PushData(Recipient).Op(Instruction.SELFDESTRUCT).Done;
+        byte[] salt = new byte[32];
+        Address child = ContractAddress.From(Observer, salt, childInitCode);
+
+        _stateProvider.CreateAccount(Recipient, 1);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode.Create2(childInitCode, salt, endowment).Op(Instruction.POP).Op(Instruction.STOP).Done, endowment);
+
+        TransactionResult result = Process(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer)));
+
+        Assert.That(result.TransactionExecuted, Is.True, "frame tx creating and self-destructing a contract still executes");
+        Assert.That(_stateProvider.GetBalance(Recipient), Is.EqualTo((UInt256)1 + endowment), "the endowed child was created and its self-destruct transferred the balance, so a vacuous pass where the CREATE2 never ran is ruled out");
+        Assert.That(_stateProvider.AccountExists(child), Is.False, "a contract created and self-destructed in the same frame tx must be finalized and deleted per EIP-6780, not left in state");
+    }
+
+    [Test]
+    public void CallAndRestore_FrameSelfDestructsSameTxContract_DoesNotLeakTheDestroyMarkAcrossTheRestore()
+    {
+        byte[] childInitCode = Prepare.EvmCode.PushData(Recipient).Op(Instruction.SELFDESTRUCT).Done;
         byte[] salt = new byte[32];
         Address child = ContractAddress.From(Observer, salt, childInitCode);
 
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Observer, Prepare.EvmCode.Create2(childInitCode, salt, UInt256.Zero).Op(Instruction.POP).Op(Instruction.STOP).Done);
 
-        TransactionResult result = Process(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer)));
+        TransactionResult result = CallAndRestore(FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer)));
+        Assert.That(result.TransactionExecuted, Is.True, "the CallAndRestore run executes the self-destructing frame");
 
-        Assert.That(result.TransactionExecuted, Is.True, "frame tx creating and self-destructing a contract still executes");
-        Assert.That(_stateProvider.AccountExists(child), Is.False, "a contract created and self-destructed in the same frame tx must be finalized and deleted per EIP-6780, not left in state");
+        _stateProvider.CreateAccount(child, 0);
+        _stateProvider.Set(new StorageCell(child, 0), [7]);
+        _stateProvider.Commit(Spec);
+
+        AssertStorage(child, 0, 7, "CallAndRestore runs with Commit|Restore, so the frame destroy must journal rather than take the un-committed O(1) mark; otherwise the destroyed-this-round set survives the restore and silently drops this later write to the same address");
     }
 
     [Test]
@@ -224,6 +249,7 @@ public class FrameTxProcessorTests
 
         Assert.That(result.TransactionExecuted, Is.False, "a frame transaction whose only frame is a reverting POST_TX approves no payer, so it is rejected");
         Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction), "the empty destroy-list snapshot restore on the POST_TX-revert path must not throw before the never-set-a-payer rejection is reached");
+        Assert.That(result.ErrorDescription, Does.Contain("never set a payer"), "rejection is the payer gate reached after the destroy-list rewind, not an earlier well-formedness pre-check");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -167,6 +167,60 @@ public class FrameTxProcessorTests
     }
 
     [Test]
+    public void Execute_PrefixCreatedContractSelfDestructedInBody_PostTxReverts_RestoresTheContract()
+    {
+        Address factory = TestItem.AddressF;
+        Address reverter = TestItem.AddressD;
+
+        byte[] senderRuntime = ApproveCode(TxFrame.ApproveExecutionAndPayment);
+        byte[] senderInit = Prepare.EvmCode.ForInitOf(senderRuntime).Done;
+        byte[] senderSalt = new byte[32];
+        Address smartSender = ContractAddress.From(factory, senderSalt, senderInit);
+
+        byte[] childRuntime = Prepare.EvmCode.PushData(Beneficiary).Op(Instruction.SELFDESTRUCT).Done;
+        byte[] childInit = Prepare.EvmCode.ForInitOf(childRuntime).Done;
+        byte[] childSalt = new byte[32];
+        childSalt[31] = 1;
+        Address child = ContractAddress.From(factory, childSalt, childInit);
+
+        DeployContract(factory, Prepare.EvmCode
+            .Create2(senderInit, senderSalt, UInt256.Zero).Op(Instruction.POP)
+            .Create2(childInit, childSalt, UInt256.Zero).Op(Instruction.POP)
+            .Op(Instruction.STOP).Done);
+        _stateProvider.CreateAccount(smartSender, 1.Ether);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+        DeployContract(reverter, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            Nonce = 0,
+            SenderAddress = smartSender,
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeDefault, 0, factory, executionGasLimit: 1_000_000,
+                    stateGasLimit: (ulong)(2 * GasCostOf.NewAccountState + GasCostOf.CodeDepositState * (senderRuntime.Length + childRuntime.Length)),
+                    UInt256.Zero, default),
+                SelfVerifyFrame(),
+                Frame(TxFrame.ModeSender, target: child),
+                new TxFrame(TxFrame.ModePostTx, 0, reverter, executionGasLimit: 200_000, stateGasLimit: 0, UInt256.Zero, default),
+            ],
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.True, "a POST_TX revert leaves the frame transaction included");
+        Assert.That(_stateProvider.AccountExists(child), Is.True,
+            "a contract created in the validation prefix and self-destructed in a rolled-back body frame must be restored, not finalized for deletion");
+        Assert.That(_stateProvider.GetCode(child), Is.EqualTo(childRuntime), "the restored contract keeps its runtime code");
+    }
+
+    [Test]
     public void Execute_BlobCarryingFrameTx_ChargesAndBurnsBlobFee()
     {
         // With base fee 0 the whole gas premium goes to the beneficiary, so the only value that leaves

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -506,10 +506,22 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         }
 
         // EIP-7928: fee accounting touches the beneficiary regardless of premium, so the credit is
-        // unconditional as in PayFees. PayFees' EIP-6780 self-destruct guard has no analogue here, the
-        // frame path never finalizing its destroy list.
+        // unconditional as in PayFees.
         UInt256 fees = premiumPerGas * (UInt256)spentGas;
         WorldState.AddToBalanceAndCreateIfNotExists(header.GasBeneficiary!, fees, spec);
+
+        // EIP-6780: finalize committed frames' self-destructs (reverted/unrolled entries already dropped from the tracker).
+        if (accessTracker.DestroyList.Count > 0)
+        {
+            bool commitDestroys = opts.HasFlag(ExecutionOptions.Commit) || (!opts.HasFlag(ExecutionOptions.SkipValidation) && !spec.IsEip658Enabled);
+            bool removeSelfdestructBurn = spec.IsEip8246Enabled;
+            bool trackBalance = spec.IsEip7708Enabled || removeSelfdestructBurn;
+            foreach (Address toBeDestroyed in accessTracker.DestroyList)
+            {
+                UInt256 destroyedBalance = trackBalance ? WorldState.GetBalance(toBeDestroyed) : default;
+                DestroyAccount(WorldState, toBeDestroyed, in destroyedBalance, commitDestroys, removeSelfdestructBurn);
+            }
+        }
 
         // CommitAndRestore asks for both, but a commit clears the journals the snapshot indexes into; the
         // frame path journals the whole transaction, so the restore alone suffices.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -521,10 +521,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         {
             bool commitDestroys = opts.HasFlag(ExecutionOptions.Commit) || (!opts.HasFlag(ExecutionOptions.SkipValidation) && !spec.IsEip658Enabled);
             bool removeSelfdestructBurn = spec.IsEip8246Enabled;
-            bool trackBalance = spec.IsEip7708Enabled || removeSelfdestructBurn;
             foreach (Address toBeDestroyed in accessTracker.DestroyList)
             {
-                UInt256 destroyedBalance = trackBalance ? WorldState.GetBalance(toBeDestroyed) : default;
+                UInt256 destroyedBalance = removeSelfdestructBurn ? WorldState.GetBalance(toBeDestroyed) : default;
                 DestroyAccount(WorldState, toBeDestroyed, in destroyedBalance, commitDestroys, removeSelfdestructBurn);
             }
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -229,14 +229,14 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         long batchStartRefund = 0;
         long batchStartStateGas = 0;
         int batchStartJournal = 0;
-        int batchStartDestroys = 0;
+        int batchStartDestroys = accessTracker.DestroyList.TakeSnapshot();
 
         Snapshot prefixEndSnapshot = txSnapshot;
         int prefixEndIndex = -1;
         long prefixEndRefund = 0;
         long prefixEndStateGas = 0;
         int prefixEndJournal = 0;
-        int prefixEndDestroys = 0;
+        int prefixEndDestroys = accessTracker.DestroyList.TakeSnapshot();
         bool postTxReverted = false;
         // EIP-161: once any frame touches RIPEMD-160, the touch outlives every later rollback that
         // leaves the transaction valid, so it is tracked for the whole transaction rather than per frame.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
@@ -519,8 +520,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // EIP-6780: finalize committed frames' self-destructs.
         if (accessTracker.DestroyList.Count > 0)
         {
-            bool commitDestroys = opts.HasFlag(ExecutionOptions.Commit) || (!opts.HasFlag(ExecutionOptions.SkipValidation) && !spec.IsEip658Enabled);
+            bool commitDestroys = opts.HasFlag(ExecutionOptions.Commit) && !opts.HasFlag(ExecutionOptions.Restore);
             bool removeSelfdestructBurn = spec.IsEip8246Enabled;
+            Debug.Assert(removeSelfdestructBurn && spec.GasCosts.DestroyRefund == 0,
+                "frame-tx self-destruct finalization assumes EIP-8246 (balance kept, no burn log) and a zero post-EIP-3529 destroy refund, so it emits no burn log, adds no refund and needs no canonical ordering");
             foreach (Address toBeDestroyed in accessTracker.DestroyList)
             {
                 UInt256 destroyedBalance = removeSelfdestructBurn ? WorldState.GetBalance(toBeDestroyed) : default;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -229,12 +229,14 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         long batchStartRefund = 0;
         long batchStartStateGas = 0;
         int batchStartJournal = 0;
+        int batchStartDestroys = 0;
 
         Snapshot prefixEndSnapshot = txSnapshot;
         int prefixEndIndex = -1;
         long prefixEndRefund = 0;
         long prefixEndStateGas = 0;
         int prefixEndJournal = 0;
+        int prefixEndDestroys = 0;
         bool postTxReverted = false;
         // EIP-161: once any frame touches RIPEMD-160, the touch outlives every later rollback that
         // leaves the transaction valid, so it is tracked for the whole transaction rather than per frame.
@@ -256,6 +258,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 batchStartRefund = refundCounter;
                 batchStartStateGas = totalFrameStateGasUsed;
                 batchStartJournal = frameContext.StateGasJournalCheckpoint;
+                batchStartDestroys = accessTracker.DestroyList.TakeSnapshot();
             }
 
             // Transient storage is discarded between frames (EIP-8141 § Cross-frame interactions).
@@ -347,6 +350,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 // A failed assertion discards the body down to the validation prefix, overriding any
                 // batch unroll, but unlike a VERIFY revert it leaves the transaction valid.
                 WorldState.Restore(prefixEndSnapshot);
+                accessTracker.DestroyList.Restore(prefixEndDestroys);
                 VirtualMachineStatics.RestoreRipemdTouch(WorldState, spec, shouldRestoreRipemdTouch);
                 refundCounter = prefixEndRefund;
 
@@ -385,6 +389,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     prefixEndRefund = refundCounter;
                     prefixEndStateGas = totalFrameStateGasUsed;
                     prefixEndJournal = frameContext.StateGasJournalCheckpoint;
+                    prefixEndDestroys = accessTracker.DestroyList.TakeSnapshot();
                 }
             }
             else if (!inBatch)
@@ -428,6 +433,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                         prefixEndSnapshot = batchStartSnapshot;
                         prefixEndIndex = batchStartIndex - 1;
                         prefixEndRefund = batchStartRefund;
+                        prefixEndDestroys = batchStartDestroys;
                         prefixEndStateGas = batchStartStateGas;
                         prefixEndJournal = batchStartJournal;
                     }
@@ -510,7 +516,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         UInt256 fees = premiumPerGas * (UInt256)spentGas;
         WorldState.AddToBalanceAndCreateIfNotExists(header.GasBeneficiary!, fees, spec);
 
-        // EIP-6780: finalize committed frames' self-destructs (reverted/unrolled entries already dropped from the tracker).
+        // EIP-6780: finalize committed frames' self-destructs.
         if (accessTracker.DestroyList.Count > 0)
         {
             bool commitDestroys = opts.HasFlag(ExecutionOptions.Commit) || (!opts.HasFlag(ExecutionOptions.SkipValidation) && !spec.IsEip658Enabled);


### PR DESCRIPTION
The frame execution loop built its own settlement but never consumed `substate.DestroyList`, so an account **created and `SELFDESTRUCT`ed inside the same frame transaction** (the EIP-6780 case that still deletes) kept its code, storage and nonce, while any EIP-6780 client deletes it — a state-root divergence. No test touched the combination.

**Fix:** finalize the surviving destroy list after fees, mirroring the regular path. Reverted frames and unrolled atomic batches already drop their entries via the access tracker's snapshot restore, so the surviving list is exactly the committed destroys.

**Why no refund/burn-log branch is needed here:**
- EIP-3529 is `required` by EIP-8141 -> `DestroyRefund` is 0, nothing to refund.
- EIP-8246 is carried by every fork that composes EIP-8141 (via Amsterdam) -> the self-destruct burn *and its log* are removed, so there is no burn log to place in the per-frame receipt model.

The balance/commit handling still mirrors `DestroyAccount` for any spec. Regression test asserts the created-and-destroyed account is deleted; it fails without the finalization (account left with nonce 1). Addresses H1 on #12526.