### PR TITLE
test(eip8141): pin why the validation prefix walks deliberately disagree

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -247,6 +247,75 @@ public class FrameTxValidationTests
             static tx => tx.Frames = [SelfVerifyFrame(), Frame(mode: TxFrame.ModeSender, target: TestItem.AddressB), ExpiryFrame()], null);
     }
 
+    private static IEnumerable<TestCaseData> PrefixWalkCases()
+    {
+        static TestCaseData Walk(string name, TxFrame[] frames, bool boundaryFound, Address? paymaster, ulong workGas) =>
+            new TestCaseData(frames, boundaryFound, paymaster, workGas).SetName($"PrefixWalks_{name}");
+
+        // Frame gas limits are distinct powers of two, so the summed validation work names exactly which
+        // frames the recognized-prefix walk counted.
+        static TxFrame At(byte mode, byte flags, Address? target, ulong gas) =>
+            new(mode, flags, target, gas, UInt256.Zero, default);
+
+        Address sponsor = TestItem.AddressC;
+
+        // All three agree: a recognized prefix, its approving frame, and its priced length.
+        yield return Walk("SelfRelay_AllThreeAgree",
+            [At(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, null, 1), At(TxFrame.ModeSender, 0, TestItem.AddressB, 2)],
+            true, null, 1);
+        yield return Walk("CanonicalPaymasterBehindADeploy_AllThreeAgree",
+            [ExpiryFrame(1), At(TxFrame.ModeDefault, 0, TestItem.AddressD, 2), At(TxFrame.ModeVerify, TxFrame.ApproveExecution, null, 4),
+             At(TxFrame.ModeVerify, TxFrame.ApprovePayment, sponsor, 8), At(TxFrame.ModeSender, 0, TestItem.AddressB, 16)],
+            true, sponsor, 15);
+
+        // No frame may approve payment at all, so there is no boundary for a trailing VERIFY frame to sit behind.
+        yield return Walk("NoApprovingFrame_NoBoundaryToSitBehind",
+            [At(TxFrame.ModeVerify, TxFrame.ApproveExecution, null, 1), At(TxFrame.ModeSender, 0, TestItem.AddressB, 2)],
+            false, null, 3);
+        yield return Walk("LoneDeployFrame_NoBoundaryToSitBehind",
+            [At(TxFrame.ModeDefault, 0, TestItem.AddressD, 1)],
+            false, null, 1);
+
+        // An extra leading VERIFY frame: the boundary and the payer still agree, the grammar no longer matches.
+        yield return Walk("ExtraLeadingVerifyFrame_GrammarAloneDiverges",
+            [At(TxFrame.ModeVerify, 0, TestItem.AddressD, 1), At(TxFrame.ModeVerify, TxFrame.ApprovePayment, sponsor, 2), At(TxFrame.ModeSender, 0, TestItem.AddressB, 4)],
+            true, sponsor, 7);
+        yield return Walk("CheckBetweenOnlyVerifyAndPay_GrammarAloneDiverges",
+            [At(TxFrame.ModeVerify, TxFrame.ApproveExecution, null, 1), At(TxFrame.ModeVerify, 0, TestItem.AddressD, 2),
+             At(TxFrame.ModeVerify, TxFrame.ApprovePayment, sponsor, 4), At(TxFrame.ModeSender, 0, TestItem.AddressB, 8)],
+            true, sponsor, 15);
+
+        // A non-VERIFY approving frame ends the payer walk but must still bound the VERIFY-behind-prefix scan.
+        yield return Walk("ApprovingDefaultFrame_OnlyTheBoundaryWalkFindsIt",
+            [At(TxFrame.ModeDefault, TxFrame.ApprovePayment, sponsor, 1), At(TxFrame.ModeSender, 0, TestItem.AddressB, 2)],
+            true, null, 3);
+        yield return Walk("PayFrameBehindASenderFrame_OnlyTheBoundaryWalkFindsIt",
+            [At(TxFrame.ModeSender, 0, TestItem.AddressB, 1), At(TxFrame.ModeVerify, TxFrame.ApprovePayment, sponsor, 2)],
+            true, null, 3);
+        yield return Walk("ApprovingDefaultBehindADeploy_OnlyTheBoundaryWalkFindsIt",
+            [At(TxFrame.ModeDefault, 0, TestItem.AddressD, 1), At(TxFrame.ModeDefault, TxFrame.ApproveExecutionAndPayment, null, 2),
+             At(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, null, 4)],
+            true, null, 7);
+    }
+
+    /// <summary>The three prefix walks answer different questions and are meant to disagree; a consolidation
+    /// that aligned any two of them would break a case here.</summary>
+    [TestCaseSource(nameof(PrefixWalkCases))]
+    public void PrefixWalks_AnswerTheirOwnQuestionsIndependently(TxFrame[] frames, bool boundaryFound, Address? paymaster, ulong workGas)
+    {
+        Transaction tx = CreateValidFrameTx(t => t.Frames = frames);
+        // A trailing VERIFY frame is rejected only when the boundary walk found somewhere for it to sit behind.
+        Transaction probed = CreateValidFrameTx(t => t.Frames = [.. frames, Frame(mode: TxFrame.ModeVerify, flags: TxFrame.ApproveExecution)]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(FrameTxValidation.IsWellFormed(tx, postTxEnabled: true, out string? error), Is.True, error);
+            Assert.That(FrameTxValidation.HasVerifyFrameAfterPrefix(probed), Is.EqualTo(boundaryFound));
+            Assert.That(FrameTxValidation.GetPrefixPaymaster(tx), Is.EqualTo(paymaster));
+            Assert.That(FrameTxValidation.ValidationWorkGas(tx), Is.EqualTo(workGas));
+        }
+    }
+
     private static TestCaseData Case(string name, Action<Transaction> mutate, string? expectedError) =>
         new TestCaseData(mutate, expectedError).SetName($"IsWellFormed_{name}");
 
@@ -268,8 +337,8 @@ public class FrameTxValidationTests
 
     private static TxFrame DefaultModeFrame() => Frame();
 
-    private static TxFrame ExpiryFrame() =>
-        new(TxFrame.ModeVerify, flags: 0, Eip8141Constants.ExpiryVerifierAddress, gasLimit: 30_000, UInt256.Zero, new byte[Eip8141Constants.ExpiryDataLength]);
+    private static TxFrame ExpiryFrame(ulong gasLimit = 30_000) =>
+        new(TxFrame.ModeVerify, flags: 0, Eip8141Constants.ExpiryVerifierAddress, gasLimit, UInt256.Zero, new byte[Eip8141Constants.ExpiryDataLength]);
 
     private static TxFrame Frame(byte mode = TxFrame.ModeDefault, byte flags = 0, Address? target = null, ulong gasLimit = 50_000, UInt256 value = default, byte[]? data = null) =>
         new(mode, flags, target, gasLimit, value, data ?? Array.Empty<byte>());

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -328,6 +328,8 @@ public static class FrameTxValidation
     /// validated, invalidating the whole transaction. The bound is taken at the first frame permitted to approve
     /// payment, at or before the frame that actually installs the payer, so it errs towards refusing a layout whose
     /// approving frame would not have installed one rather than admitting a frame behind the real prefix.
+    /// Deliberately not restricted to the leading VERIFY run <see cref="GetPrefixPaymaster"/> walks: an approving
+    /// DEFAULT frame, or one behind a SENDER frame, must still bound this scan even though no payer resolves there.
     /// </remarks>
     public static bool HasVerifyFrameAfterPrefix(Transaction transaction)
     {
@@ -398,11 +400,7 @@ public static class FrameTxValidation
             return transaction.PersistedPaymaster;
         }
 
-        int next = 0;
-        if (next < frames.Length && IsExpiryVerifyFrame(frames[next])) next++;
-        if (next < frames.Length && IsDeployFrame(frames[next])) next++;
-
-        for (int i = next; i < frames.Length; i++)
+        for (int i = ApprovalSearchStart(frames); i < frames.Length; i++)
         {
             // A non-VERIFY frame ends the prefix, so nothing past it can install a payer.
             if (frames[i].Mode != TxFrame.ModeVerify) break;
@@ -415,15 +413,25 @@ public static class FrameTxValidation
         return null;
     }
 
+    /// <summary>Where a search for a validation prefix's approving frame starts: past the optional leading
+    /// expiry-verify and deploy frames, neither of which may carry approval scope.</summary>
+    /// <remarks>A lower bound only — the frame at this index need not approve either. Shared by the three walks
+    /// that scan for the approving frame; the prefix simulation asks the same rule positionally and keeps its form.</remarks>
+    public static int ApprovalSearchStart(TxFrame[] frames)
+    {
+        int next = 0;
+        if (next < frames.Length && IsExpiryVerifyFrame(frames[next])) next++;
+        if (next < frames.Length && IsDeployFrame(frames[next])) next++;
+        return next;
+    }
+
     /// <summary>
     /// The number of leading frames forming a validation prefix EIP-8141 recognizes for the public
     /// mempool, or <c>null</c> when the layout matches none of them.
     /// </summary>
     private static int? RecognizedPrefixLength(TxFrame[] frames, Address? sender)
     {
-        int next = 0;
-        if (next < frames.Length && IsExpiryVerifyFrame(frames[next])) next++;
-        if (next < frames.Length && IsDeployFrame(frames[next])) next++;
+        int next = ApprovalSearchStart(frames);
 
         if (next < frames.Length && IsSelfVerifyFrame(frames[next], sender))
         {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -731,7 +731,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     }
 
     /// <summary>Whether frame <paramref name="i"/> is a <c>deploy</c> frame opening the validation prefix.</summary>
-    /// <remarks>Positional, as RecognizedPrefixLength reaches index 1 only past an expiry-verify frame at index 0.</remarks>
+    /// <remarks>Positional, as RecognizedPrefixLength reaches index 1 only past an expiry-verify frame at index 0.
+    /// Spells the same prologue rule as <see cref="FrameTxValidation.ApprovalSearchStart"/>; a grammar change touches both.</remarks>
     private static bool OpensDeployPrefix(TxFrame[] frames, int i) =>
         (i == 0 || (i == 1 && FrameTxValidation.IsExpiryVerifyFrame(frames[0])))
         && i + 1 < frames.Length

--- a/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
+++ b/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
@@ -25,7 +25,7 @@ internal static class FrameTxPayerResolver
         // would wrongly report code on it.
         bool senderHasCode = !senderAccount.IsNull && senderAccount.HasCode;
 
-        int index = PrefixVerifyIndex(frames);
+        int index = FrameTxValidation.ApprovalSearchStart(frames);
 
         // Re-checked here, though FrameTxPayerlessFilter already rejects these, so a direct caller still gets NoPayer.
         if (IsStructurallyPayerless(frames, sender, index))
@@ -74,7 +74,7 @@ internal static class FrameTxPayerResolver
             return false;
         }
 
-        return IsStructurallyPayerless(frames, sender, PrefixVerifyIndex(frames));
+        return IsStructurallyPayerless(frames, sender, FrameTxValidation.ApprovalSearchStart(frames));
     }
 
     /// <summary>Structural NoPayer decision over a prefix whose optional leading expiry and deploy frames are already skipped to <paramref name="index"/>.</summary>
@@ -83,18 +83,6 @@ internal static class FrameTxPayerResolver
         index >= frames.Length
         || (FrameTxValidation.IsOnlyVerifyFrame(frames[index], sender) && index + 1 >= frames.Length);
 
-    /// <summary>The index of the VERIFY frame that names the payer, skipping an optional leading expiry_verify and deploy frame.</summary>
-    /// <remarks>The same prefix grammar <see cref="FrameTxValidation.ValidationWorkGas"/> prices admission against, so the two cannot drift.</remarks>
-    private static int PrefixVerifyIndex(TxFrame[] frames)
-    {
-        int index = FrameTxValidation.IsExpiryVerifyFrame(frames[0]) ? 1 : 0;
-        if (index < frames.Length && FrameTxValidation.IsDeployFrame(frames[index]))
-        {
-            index++;
-        }
-
-        return index;
-    }
 
     /// <summary>Structural check that index-0 is a canonical-hash (empty <c>msg</c>) secp256k1 signature by the sender.</summary>
     /// <remarks>Cryptographic verification is a separate upstream gate.</remarks>


### PR DESCRIPTION
Answers Daniil's design question on #13120 (now merged): should the VERIFY-behind-prefix bound share the payer resolution's leading-run walk, so the two cannot drift apart?

**No — they are meant to disagree.** This PR records why, and makes a future attempt fail loudly rather than quietly succeed. The shared helper it extracts is the small part; the documentation and the regression matrix are the substance.

## The three walks answer different questions

| walk | question | keyed on |
|---|---|---|
| `HasVerifyFrameAfterPrefix` | where is the earliest point a payer *could* be installed? | the approval flag, in any mode, at any position |
| `GetPrefixPaymaster` | which account sponsors this transaction? | first `VERIFY` frame with payment inside the leading run |
| `RecognizedPrefixLength` | does this match a spec-recognized prefix, and how long is it? | exact flag equality against the two named shapes |

Whenever the payer walk reports a frame, it and the boundary walk agree on the index: the prologue frames it skips both carry `flags == 0`, so neither can hold the payment bit. They part company only where the payer walk stops early.

## Why the consolidation is not possible

Three shapes have a genuine payment-approving frame the payer walk never reaches, because it breaks at the first non-`VERIFY` frame:

- `[default(pay, sponsor), user_op]`
- `[user_op, pay(sponsor)]`
- `[deploy, default(pay), self_verify]`

On each, the boundary walk finds the boundary and the payer walk returns null. Giving the filter the leading-run walk would make it report "no boundary" on all three, so a trailing `VERIFY` frame behind them would stop being rejected — reintroducing #13120's hole for the approving-`DEFAULT` and post-`SENDER` cases. Approval scope is valid in any mode, so this is not a hypothetical shape.

## What the PR actually adds

1. **A `<remarks>` on `HasVerifyFrameAfterPrefix`** saying it deliberately does not share the payer walk, and what breaks if it does. This is the part that stops the question being re-asked and answered wrongly.
2. **A nine-case matrix** asserting all three observables per shape, at every point where the walks disagree. Negative-controlled twice: making the boundary walk share the payer walk fails three cases and only the three predicted ones; removing its `prefixEnd < 0` early return fails the two no-approving-frame cases and only those.
3. **`ApprovalSearchStart`**, four lines, extracting the prologue skip that `GetPrefixPaymaster`, `RecognizedPrefixLength` and `FrameTxPayerResolver` spelled identically. Marginal on its own — it is right on the "5+ lines" threshold — and is included because it is the one piece of genuine duplication under the question.

## On `ApprovalSearchStart` being public

AGENTS.md counsels against new public methods, so this is deliberate rather than incidental. `FrameTxPayerResolver` lives in `Nethermind.TxPool`, which is **not** in `Nethermind.Core`'s `InternalsVisibleTo` list (`Nethermind.Core/InternalsVisibility.cs` names Core.Test, Blockchain.Test, Clique.Test, Evm and Trie). Making the helper `internal` would therefore mean adding `Nethermind.TxPool` to that list, exposing *every* internal of `Nethermind.Core` to the pool assembly instead of this one method — a strictly wider grant. It also joins an existing public surface of exactly this kind: `FrameTxPayerResolver` already calls `IsExpiryVerifyFrame`, `IsDeployFrame`, `IsSelfVerifyFrame` and `IsOnlyVerifyFrame` across the same boundary, in the very method changed here.

## The fourth site is named, not folded

`TransactionProcessorBase.OpensDeployPrefix` spells the same prologue rule positionally. It is **not** folded onto the helper: the reformulation would still need its own `IsDeployFrame` guard (a lone leading expiry frame satisfies `i + 1 == ApprovalSearchStart` at `i == 0`), so it comes out no shorter, re-walks the prologue on every frame of the block-execution loop, and rests on the non-obvious mutual exclusion of the two predicates. The `<remarks>` on both sides now cross-reference, so a grammar change finds both.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.Core.Test` 6255 (the 6246 baseline plus nine new cases), `Nethermind.TxPool.Test` green in release and debug (1096), `Nethermind.Evm.Test` frame suites 359, `FrameTxPayerResolverTests` 19. Full release build and the CI lint gate clean. Behaviour preservation was proven by tabulating all three walks over fourteen layouts before and after the extraction: the tables are byte-identical.

The only change to `TransactionProcessorBase.FrameTx.cs` is two lines of XML doc text, so no execution path moves and the frame lanes cannot be affected.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
