### PR TITLE
Reject a chainspec enabling EIP-8141 without EIP-8037

### DIFF
--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecHardforkLabelTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecHardforkLabelTests.cs
@@ -75,7 +75,10 @@ public class ChainSpecHardforkLabelTests
     [TestCaseSource(nameof(AllLabels))]
     public void Label_expands_to_all_constituent_transition_fields(IHardforkLabel label)
     {
-        ChainSpec spec = Load($"\"{ToCamelCase(label.LabelName)}\": \"0x{ActivationValue:x}\"");
+        bool needsEip8037Companion = label.EipPropertyNames.Contains(nameof(ChainParameters.Eip8141TransitionTimestamp))
+            && !label.EipPropertyNames.Contains(nameof(ChainParameters.Eip8037TransitionTimestamp));
+        string companion = needsEip8037Companion ? $"\"eip8037TransitionTimestamp\": \"0x{ActivationValue:x}\", " : "";
+        ChainSpec spec = Load($"{companion}\"{ToCamelCase(label.LabelName)}\": \"0x{ActivationValue:x}\"");
 
         foreach (string propName in label.EipPropertyNames)
         {

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecLoaderTests.cs
@@ -201,6 +201,55 @@ public class ChainSpecLoaderTests
         }
     }
 
+    [TestCase(null, 100UL, TestName = "Eip8141 without Eip8037 is rejected at load")]
+    [TestCase(200UL, 100UL, TestName = "Eip8037 activating after Eip8141 is rejected at load")]
+    public void Frame_transactions_require_Eip8037_no_later_than_their_activation(ulong? eip8037, ulong eip8141)
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(FrameChainSpecJson(eip8037, eip8141)));
+        ChainSpecLoader loader = new(new EthereumJsonSerializer(), LimboLogs.Instance);
+
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(() => loader.Load(stream))!;
+        Assert.That(exception.InnerException, Is.TypeOf<InvalidOperationException>());
+        Assert.That(exception.InnerException!.Message, Does.Contain("Eip8037TransitionTimestamp"));
+    }
+
+    [TestCase(100UL, TestName = "Eip8037 activating before Eip8141 loads")]
+    [TestCase(200UL, TestName = "Eip8037 activating with Eip8141 in the same block loads")]
+    public void Frame_transactions_load_when_Eip8037_activates_no_later(ulong eip8037)
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(FrameChainSpecJson(eip8037, eip8141: 200UL)));
+        ChainSpecLoader loader = new(new EthereumJsonSerializer(), LimboLogs.Instance);
+
+        ChainSpec chainSpec = loader.Load(stream);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(chainSpec.Parameters.Eip8037TransitionTimestamp, Is.EqualTo(eip8037));
+            Assert.That(chainSpec.Parameters.Eip8141TransitionTimestamp, Is.EqualTo(200UL));
+        }
+    }
+
+    private static string FrameChainSpecJson(ulong? eip8037, ulong eip8141)
+    {
+        string eip8037Line = eip8037 is null ? "" : $"\"eip8037TransitionTimestamp\": \"0x{eip8037.Value:x}\",";
+        return $$"""
+            {
+                "name": "Test",
+                "engine": { "NethDev": {} },
+                "params": {
+                    {{eip8037Line}}
+                    "eip8141TransitionTimestamp": "0x{{eip8141:x}}"
+                },
+                "genesis": {
+                    "seal": { "ethereum": { "nonce": "0x0", "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000" } },
+                    "difficulty": "0x1",
+                    "gasLimit": "0x1000000",
+                    "timestamp": "0x0"
+                }
+            }
+            """;
+    }
+
     private static object? CreateTestValue(Type type)
     {
         Type underlyingType = Nullable.GetUnderlyingType(type) ?? type;

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -329,10 +329,11 @@ public class GethGenesisLoaderTests
     [Test]
     public void Can_load_genesis_with_eip8141_prototype_time()
     {
-        ChainSpec chainSpec = LoadStandardGethGenesis(configExtra: "\"eip8141PrototypeTime\": 15");
+        ChainSpec chainSpec = LoadStandardGethGenesis(configExtra: "\"amsterdamTime\": 10, \"eip8141PrototypeTime\": 15");
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(chainSpec.Parameters.Eip8037TransitionTimestamp, Is.EqualTo(10));
             Assert.That(chainSpec.Parameters.Eip8141TransitionTimestamp, Is.EqualTo(15));
             Assert.That(chainSpec.Parameters.Eip7805TransitionTimestamp, Is.Null);
         }
@@ -342,8 +343,18 @@ public class GethGenesisLoaderTests
         {
             Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(14)).IsEip8141Enabled, Is.False);
             Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(15)).IsEip8141Enabled, Is.True);
+            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(15)).IsEip8037Enabled, Is.True);
             Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(15)).IsEip7805Enabled, Is.False);
         }
+    }
+
+    [Test]
+    public void Rejects_a_geth_genesis_enabling_eip8141_without_eip8037()
+    {
+        InvalidDataException exception = Assert.Throws<InvalidDataException>(
+            () => LoadStandardGethGenesis(configExtra: "\"eip8141PrototypeTime\": 15"))!;
+        Assert.That(exception.InnerException, Is.TypeOf<InvalidOperationException>());
+        Assert.That(exception.InnerException!.Message, Does.Contain("Eip8037TransitionTimestamp"));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/ChainSpecLoader.cs
@@ -264,7 +264,7 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
                 : value
             : default;
 
-    private static void ValidateParams(ChainParameters parameters)
+    internal static void ValidateParams(ChainParameters parameters)
     {
         if (parameters.Eip1283ReenableTransition != parameters.Eip1706Transition
             && parameters.Eip1283DisableTransition.HasValue)
@@ -276,6 +276,13 @@ public class ChainSpecLoader(IJsonSerializer serializer, ILogManager logManager)
             && parameters.Eip2200Transition.HasValue)
         {
             throw new InvalidOperationException("Both 'Eip2200Transition' and 'Eip1706Transition' are provided. Please provide either 'Eip2200Transition' or pair of 'Eip1283ReenableTransition' and 'Eip1706Transition' as they have same meaning.");
+        }
+
+        if (parameters.Eip8141TransitionTimestamp.HasValue
+            && (parameters.Eip8037TransitionTimestamp is null
+                || parameters.Eip8037TransitionTimestamp > parameters.Eip8141TransitionTimestamp))
+        {
+            throw new InvalidOperationException("'Eip8141TransitionTimestamp' requires 'Eip8037TransitionTimestamp' to be set no later than it: EIP-8141 frame transactions compose only onto specs carrying EIP-8037.");
         }
     }
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/GethGenesisLoader.cs
@@ -168,6 +168,8 @@ public class GethGenesisLoader(IJsonSerializer serializer) : IChainSpecLoader
         // Fan out Shanghai/Cancun/Prague/Osaka/Amsterdam timestamps via the shared HardforkLabels
         // table — same source of truth as the Parity loader, driven by Forks/*.cs.
         HardforkLabels.ExpandAll(chainSpec.Parameters, config);
+
+        ChainSpecLoader.ValidateParams(chainSpec.Parameters);
     }
 
     private readonly record struct BlobScheduleFork(int Order);

--- a/src/Nethermind/Nethermind.Specs/Forks/Eip8141Prototype.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/Eip8141Prototype.cs
@@ -5,8 +5,11 @@ namespace Nethermind.Specs.Forks;
 
 /// <summary>
 /// Prototype fork for EIP-8141 frame transactions. Not scheduled on any network; exists so a devnet
-/// can activate frame transactions on their own, through <c>eip8141TransitionTimestamp</c>, this
-/// label, or the Geth-genesis <c>eip8141PrototypeTime</c>, without joining a fork that means more.
+/// can activate frame transactions through <c>eip8141TransitionTimestamp</c>, this label, or the
+/// Geth-genesis <c>eip8141PrototypeTime</c>, without joining a fork that means more. EIP-8141 composes
+/// onto EIP-8037's gas dimension, so a chainspec must co-activate EIP-8037 (<c>amsterdamTime</c> on the
+/// Geth side) no later than the prototype; <see cref="ChainSpecStyle.ChainSpecLoader"/> rejects any spec
+/// that does not.
 /// </summary>
 public class Eip8141Prototype() : NamedReleaseSpec<Eip8141Prototype>(Amsterdam.Instance)
 {


### PR DESCRIPTION
Addresses **M6** from Lukasz's review of #12526.

The four frame-tx transition timestamps are read independently. A hand-written chainspec setting `eip8141TransitionTimestamp` without `eip8037TransitionTimestamp` (or with EIP-8037 activating *after* EIP-8141) was accepted silently, then ran the frame gas schedule with the EIP-8037 state-gas branch quietly off. This adds a `ValidateParams` guard that turns that silent divergence into a startup error, plus a regression test (both bad orderings rejected, the valid ordering still loads).

No bundled chainspec sets EIP-8141 without EIP-8037, so nothing existing changes.