### PR TITLE
Clear frame-tx receipt carry-over per transaction

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -20,7 +20,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     private IBlockTracer _otherTracer = NullBlockTracer.Instance;
 
     // EIP-8141: reported by the transaction processor before MarkAsSuccess/MarkAsFailed and
-    // attached to the receipt of the current frame transaction, then cleared.
+    // attached to the current frame transaction's receipt; reset at the start of every tx trace.
     private Address? _frameTxPayer;
     private TxFrameReceipt[]? _frameTxReceipts;
 
@@ -380,8 +380,8 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     public ITxTracer StartNewTxTrace(Transaction? tx)
     {
         CurrentTx = tx;
-        // Cleared per tx so a frame receipt reported for one transaction can never be read for the next:
-        // both fields are consumed unconditionally when building a receipt, but only ever set for a frame tx.
+        // Cleared per tx: BuildFailedReceipt rebuilds a failing tx's log set from _frameTxReceipts
+        // regardless of tx type, so a frame receipt reported for one tx must not survive into the next.
         _frameTxPayer = null;
         _frameTxReceipts = null;
         _currentTxTracer = _otherTracer.StartNewTxTrace(tx);

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -178,9 +178,6 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
                 // successful; the status a caller sees has to be derived from the frames instead.
                 txReceipt.StatusCode = TxFrameReceipt.AggregateStatus(_frameTxReceipts);
             }
-
-            _frameTxPayer = null;
-            _frameTxReceipts = null;
         }
 
         return txReceipt;
@@ -383,6 +380,10 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     public ITxTracer StartNewTxTrace(Transaction? tx)
     {
         CurrentTx = tx;
+        // Cleared per tx so a frame receipt reported for one transaction can never be read for the next:
+        // both fields are consumed unconditionally when building a receipt, but only ever set for a frame tx.
+        _frameTxPayer = null;
+        _frameTxReceipts = null;
         _currentTxTracer = _otherTracer.StartNewTxTrace(tx);
         return _currentTxTracer;
     }


### PR DESCRIPTION
Addresses **M1** from Lukasz's review of #12526.

`_frameTxReceipts`/`_frameTxPayer` are read unconditionally while building any receipt, but only reset inside the `TxType.FrameTx` branch. The pairing holds today only because `ReportFrameTxReceipt` sits after every error return in `ExecuteFrameTx` — an invariant that lives in another assembly. This moves the reset to the start of every tx trace, so a stale frame receipt can never leak into the next transaction's logs/bloom/receipts-root, and drops the now-redundant in-branch reset.