### PR TITLE
test(eip8141): cover frame transactions through real block production

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionTests.cs
@@ -38,6 +38,7 @@ public class FrameTxBlockProductionTests
     private static readonly Address Sender = TestItem.AddressA;
     private static readonly Address Observer = TestItem.AddressB;
     private static readonly Address SecondObserver = TestItem.AddressC;
+    private static readonly Address NeverApproves = TestItem.AddressD;
 
     private static readonly Hash256 FirstTopic = TestItem.KeccakA;
     private static readonly Hash256 SecondTopic = TestItem.KeccakB;
@@ -48,19 +49,26 @@ public class FrameTxBlockProductionTests
     private static readonly byte[] WriteFreshSlot =
         Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done;
     private static readonly byte[] Inert = Prepare.EvmCode.Op(Instruction.STOP).Done;
+    // Burns the whole verify budget without ever reaching APPROVE, so the transaction can never pay.
+    private static readonly byte[] SpinForever =
+        Prepare.EvmCode.Op(Instruction.JUMPDEST).PushData(0).Op(Instruction.JUMP).Done;
 
-    /// <summary>A frame transaction offered to the producer must reach the produced block, and the
-    /// produced block must re-derive to the same receipts when a validating node replays it.</summary>
+    /// <summary>A frame transaction whose validation prefix never approves is dropped by the producer
+    /// rather than sealed, and the block produced alongside a payable one replays under validation.</summary>
+    /// <remarks>Production skips a failing transaction where validation throws on it, so a producer that
+    /// sealed the unpayable one would emit a block no node could accept.</remarks>
     [Test]
-    public void Produced_block_carrying_a_frame_transaction_revalidates_to_the_same_receipts()
+    public void A_frame_transaction_that_never_approves_is_dropped_and_the_produced_block_still_replays()
     {
-        Transaction frameTx = FrameTx(
+        Transaction frameTx = FrameTx(Sender,
             SelfApprove(),
             new TxFrame(TxFrame.ModeSender, 0, Observer, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default));
+        Transaction unpayable = FrameTx(NeverApproves, SelfApprove());
 
-        Produced produced = Produce(frameTx, (Observer, EmitFirstTopic));
+        Produced produced = Produce([unpayable, frameTx], (Observer, EmitFirstTopic));
 
-        Assert.That(produced.Block.Transactions, Has.Length.EqualTo(1), "the producer skipped the frame transaction");
+        Assert.That(produced.Block.Transactions.Length, Is.EqualTo(1), "the producer sealed the unpayable frame transaction");
+        Assert.That(produced.Block.Transactions[0].Hash, Is.EqualTo(frameTx.Hash));
         Assert.That(produced.Receipts, Has.Length.EqualTo(1));
         TxReceipt producedReceipt = produced.Receipts[0];
 
@@ -81,7 +89,8 @@ public class FrameTxBlockProductionTests
             Assert.That(validatedReceipt.Payer, Is.EqualTo(producedReceipt.Payer));
             Assert.That(validatedReceipt.Logs!.Length, Is.EqualTo(producedReceipt.Logs!.Length));
             Assert.That(ReceiptsRoot(validated), Is.EqualTo(ReceiptsRoot(produced.Receipts)));
-            Assert.That(TxTrie.CalculateRoot(produced.Block.Transactions), Is.EqualTo(produced.Block.Header.TxRoot));
+            // The header must commit to what survived selection, not to what was offered.
+            Assert.That(produced.Block.Header.TxRoot, Is.EqualTo(TxTrie.CalculateRoot(produced.Block.Transactions)));
         }
     }
 
@@ -95,7 +104,7 @@ public class FrameTxBlockProductionTests
             SelfApprove(),
             new TxFrame(TxFrame.ModeSender, 0, Observer, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default));
 
-        Produced produced = Produce(frameTx, (Observer, writesState ? WriteFreshSlot : Inert));
+        Produced produced = Produce([frameTx], (Observer, writesState ? WriteFreshSlot : Inert));
 
         Assert.That(produced.Block.Transactions, Has.Length.EqualTo(1), "the producer skipped the frame transaction");
         using (Assert.EnterMultipleScope())
@@ -117,7 +126,7 @@ public class FrameTxBlockProductionTests
             new TxFrame(TxFrame.ModeSender, 0, Observer, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default),
             new TxFrame(TxFrame.ModeSender, 0, SecondObserver, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default));
 
-        Produced produced = Produce(frameTx, (Observer, EmitFirstTopic), (SecondObserver, EmitSecondTopic));
+        Produced produced = Produce([frameTx], (Observer, EmitFirstTopic), (SecondObserver, EmitSecondTopic));
 
         Assert.That(produced.Block.Transactions, Has.Length.EqualTo(1), "the producer skipped the frame transaction");
         TxReceipt receipt = produced.Receipts[0];
@@ -137,15 +146,15 @@ public class FrameTxBlockProductionTests
 
     private readonly record struct Produced(Block Block, TxReceipt[] Receipts, ulong ExecutionGas, ulong StateGas);
 
-    /// <summary>Offers <paramref name="candidate"/> to the real production executor over a pre-state
+    /// <summary>Offers <paramref name="candidates"/> to the real production executor over a pre-state
     /// carrying <paramref name="contracts"/>, and returns what the producer settled on.</summary>
-    private static Produced Produce(Transaction candidate, params (Address Address, byte[] Code)[] contracts)
+    private static Produced Produce(Transaction[] candidates, params (Address Address, byte[] Code)[] contracts)
     {
         using Chain chain = new(contracts);
 
         BlockToProduce blockToProduce = new(
             Build.A.Block.WithNumber(1).WithBaseFeePerGas(0).WithGasLimit(30_000_000).TestObject.Header,
-            [candidate],
+            candidates,
             []);
 
         BlockProcessor.BlockProductionTransactionsExecutor executor = new(
@@ -209,6 +218,7 @@ public class FrameTxBlockProductionTests
 
             Deploy(Sender, Prepare.EvmCode
                 .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done, 100.Ether);
+            Deploy(NeverApproves, SpinForever, 100.Ether);
             foreach ((Address address, byte[] code) in contracts) Deploy(address, code);
             State.Commit(Spec);
             State.CommitTree(0);
@@ -231,14 +241,16 @@ public class FrameTxBlockProductionTests
     private static TxFrame SelfApprove() =>
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default);
 
-    private static Transaction FrameTx(params TxFrame[] frames)
+    private static Transaction FrameTx(params TxFrame[] frames) => FrameTx(Sender, frames);
+
+    private static Transaction FrameTx(Address sender, params TxFrame[] frames)
     {
         Transaction tx = new()
         {
             Type = TxType.FrameTx,
             ChainId = TestBlockchainIds.ChainId,
             Nonce = 0,
-            SenderAddress = Sender,
+            SenderAddress = sender,
             Frames = frames,
             FrameSignatures = [],
             GasPrice = 1,

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionTests.cs
@@ -48,6 +48,11 @@ public class FrameTxBlockProductionTests
     private static readonly byte[] EmitSecondTopic = LogCode(SecondTopic);
     private static readonly byte[] WriteFreshSlot =
         Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done;
+    // EIP-8038 refunds the write when a slot is restored to its original value, and credits the fresh
+    // slot's state gas back in-frame, so this scenario refunds without moving the state dimension.
+    private static readonly byte[] WriteThenRestoreSlot = Prepare.EvmCode
+        .PushData(1).PushData(0).Op(Instruction.SSTORE)
+        .PushData(0).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done;
     private static readonly byte[] Inert = Prepare.EvmCode.Op(Instruction.STOP).Done;
     // Burns the whole verify budget without ever reaching APPROVE, so the transaction can never pay.
     private static readonly byte[] SpinForever =
@@ -77,7 +82,7 @@ public class FrameTxBlockProductionTests
         Assert.That(producedReceipt.Logs, Has.Length.EqualTo(1), "the SENDER frame's log must reach the produced receipt");
         Assert.That(producedReceipt.FrameReceipts, Has.Length.EqualTo(2));
 
-        TxReceipt[] validated = Validate(produced.Block, (Observer, EmitFirstTopic));
+        (TxReceipt[] validated, BlockHeader replayedHeader) = Validate(produced);
 
         Assert.That(validated, Has.Length.EqualTo(1));
         TxReceipt validatedReceipt = validated[0];
@@ -89,29 +94,50 @@ public class FrameTxBlockProductionTests
             Assert.That(validatedReceipt.Payer, Is.EqualTo(producedReceipt.Payer));
             Assert.That(validatedReceipt.Logs!.Length, Is.EqualTo(producedReceipt.Logs!.Length));
             Assert.That(ReceiptsRoot(validated), Is.EqualTo(ReceiptsRoot(produced.Receipts)));
+            // The header's two-dimensional total is production-specific, so a validating node must
+            // re-derive the same figure from the sealed transactions alone.
+            Assert.That(replayedHeader.GasUsed, Is.EqualTo(produced.Block.Header.GasUsed));
             // The header must commit to what survived selection, not to what was offered.
             Assert.That(produced.Block.Header.TxRoot, Is.EqualTo(TxTrie.CalculateRoot(produced.Block.Transactions)));
         }
     }
 
-    /// <summary>The two-dimensional block totals a producer carries must charge a frame transaction's
-    /// state growth to the state dimension and nowhere else.</summary>
-    [TestCase(false, 0UL, TestName = "A frame transaction that grows no state moves no state total")]
-    [TestCase(true, (ulong)GasCostOf.SSetState, TestName = "A fresh slot's growth charge lands in the block state total")]
-    public void Produced_block_totals_carry_the_state_dimension_of_a_frame_transaction(bool writesState, ulong expectedStateGas)
+    /// <summary>The <see href="https://eips.ethereum.org/EIPS/eip-8037">EIP-8037</see> block totals a
+    /// producer carries must charge a frame transaction's state growth to the state dimension and
+    /// nowhere else.</summary>
+    /// <remarks>A frame transaction nets its EIP-3529 refund before splitting the charge across the two
+    /// dimensions, so both totals and the receipt sit on one basis; the refunding case pins that, the
+    /// ordinary path instead keeping block gas pre-refund per
+    /// <see href="https://eips.ethereum.org/EIPS/eip-7778">EIP-7778</see>.</remarks>
+    [TestCase(StateScenario.None, 0UL, false, TestName = "A frame transaction that grows no state moves no state total")]
+    [TestCase(StateScenario.FreshSlot, (ulong)GasCostOf.SSetState, false, TestName = "A fresh slot's growth charge lands in the block state total")]
+    [TestCase(StateScenario.RestoredSlot, 0UL, true, TestName = "A refunding frame transaction keeps the block totals on the receipt's basis")]
+    public void Produced_block_totals_carry_the_state_dimension_of_a_frame_transaction(
+        StateScenario scenario, ulong expectedStateGas, bool expectsRefund)
     {
         Transaction frameTx = FrameTx(
             SelfApprove(),
             new TxFrame(TxFrame.ModeSender, 0, Observer, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default));
 
-        Produced produced = Produce([frameTx], (Observer, writesState ? WriteFreshSlot : Inert));
+        byte[] observerCode = scenario switch
+        {
+            StateScenario.FreshSlot => WriteFreshSlot,
+            StateScenario.RestoredSlot => WriteThenRestoreSlot,
+            _ => Inert,
+        };
+        Produced produced = Produce([frameTx], (Observer, observerCode));
 
         Assert.That(produced.Block.Transactions, Has.Length.EqualTo(1), "the producer skipped the frame transaction");
+        TxReceipt receipt = produced.Receipts[0];
         using (Assert.EnterMultipleScope())
         {
             Assert.That(produced.StateGas, Is.EqualTo(expectedStateGas));
-            // The state charge leaves the execution dimension; counting it in both bills the block twice.
-            Assert.That(produced.ExecutionGas, Is.EqualTo(produced.Receipts[0].GasUsedTotal - expectedStateGas));
+            // The payer owes what the frames burned, less the one refund the transaction nets; charging
+            // the state dimension on top of the execution one instead would bill the block twice.
+            ulong grossGas = GrossFrameGas(frameTx, receipt);
+            Assert.That(receipt.GasUsedTotal, expectsRefund ? Is.LessThan(grossGas) : Is.EqualTo(grossGas));
+            // Both block totals partition that same charge, so the tracer's two accumulators must sum to it.
+            Assert.That(produced.ExecutionGas + produced.StateGas, Is.EqualTo(receipt.GasUsedTotal));
             // Both dimensions share the block limit, so the header carries whichever bound is tighter.
             Assert.That(produced.Block.Header.GasUsed, Is.EqualTo(Math.Max(produced.ExecutionGas, produced.StateGas)));
         }
@@ -144,7 +170,21 @@ public class FrameTxBlockProductionTests
         }
     }
 
-    private readonly record struct Produced(Block Block, TxReceipt[] Receipts, ulong ExecutionGas, ulong StateGas);
+    /// <summary>The state scenario a test's SENDER frame runs, which fixes both the state gas it moves
+    /// and the execution refund it earns.</summary>
+    public enum StateScenario { None, FreshSlot, RestoredSlot }
+
+    /// <summary>What the producer settled on, carrying the pre-state <see cref="Validate"/> must replay over.</summary>
+    private readonly record struct Produced(
+        Block Block,
+        TxReceipt[] Receipts,
+        ulong ExecutionGas,
+        ulong StateGas,
+        (Address Address, byte[] Code)[] Contracts);
+
+    /// <summary>The header both runs build on, so a replay cannot silently diverge from production.</summary>
+    private static BlockHeader ProductionHeader() =>
+        Build.A.Block.WithNumber(1).WithBaseFeePerGas(0).WithGasLimit(30_000_000).TestObject.Header;
 
     /// <summary>Offers <paramref name="candidates"/> to the real production executor over a pre-state
     /// carrying <paramref name="contracts"/>, and returns what the producer settled on.</summary>
@@ -152,10 +192,7 @@ public class FrameTxBlockProductionTests
     {
         using Chain chain = new(contracts);
 
-        BlockToProduce blockToProduce = new(
-            Build.A.Block.WithNumber(1).WithBaseFeePerGas(0).WithGasLimit(30_000_000).TestObject.Header,
-            candidates,
-            []);
+        BlockToProduce blockToProduce = new(ProductionHeader(), candidates, []);
 
         BlockProcessor.BlockProductionTransactionsExecutor executor = new(
             new BuildUpTransactionProcessorAdapter(chain.Processor),
@@ -173,31 +210,29 @@ public class FrameTxBlockProductionTests
         ulong stateGas = receiptsTracer.BlockStateGasUsed;
         receiptsTracer.EndBlockTrace();
 
-        Block sealed_ = new(blockToProduce.Header, blockToProduce.Transactions.ToArray(), []);
-        return new Produced(sealed_, receipts, executionGas, stateGas);
+        Block producedBlock = new(blockToProduce.Header, blockToProduce.Transactions.ToArray(), []);
+        return new Produced(producedBlock, receipts, executionGas, stateGas, contracts);
     }
 
     /// <summary>Replays <paramref name="produced"/> through the real validation executor over a
     /// freshly-built copy of the same pre-state, as a validating node would.</summary>
-    private static TxReceipt[] Validate(Block produced, params (Address Address, byte[] Code)[] contracts)
+    /// <returns>The replayed receipts and the header the validation tracer re-derived the totals into.</returns>
+    private static (TxReceipt[] Receipts, BlockHeader Header) Validate(Produced produced)
     {
-        using Chain chain = new(contracts);
+        using Chain chain = new(produced.Contracts);
 
         BlockProcessor.BlockValidationTransactionsExecutor executor = new(
             new ExecuteTransactionProcessorAdapter(chain.Processor),
             chain.State);
 
-        Block replayed = new(
-            Build.A.Block.WithNumber(1).WithBaseFeePerGas(0).WithGasLimit(30_000_000).TestObject.Header,
-            produced.Transactions,
-            []);
+        Block replayed = new(ProductionHeader(), produced.Block.Transactions, []);
 
         BlockReceiptsTracer receiptsTracer = new();
         receiptsTracer.StartNewBlockTrace(replayed);
         executor.SetBlockExecutionContext(new BlockExecutionContext(replayed.Header, chain.Spec));
         TxReceipt[] receipts = executor.ProcessTransactions(replayed, ProcessingOptions.None, receiptsTracer, CancellationToken.None);
         receiptsTracer.EndBlockTrace();
-        return receipts;
+        return (receipts, replayed.Header);
     }
 
     /// <summary>Pre-state shared by both runs: a funded sender whose own code approves, plus the
@@ -264,6 +299,19 @@ public class FrameTxBlockProductionTests
 
     private static byte[] LogCode(Hash256 topic) =>
         Prepare.EvmCode.PushData(topic.Bytes.ToArray()).PushData(1).PushData(0).Op(Instruction.LOG1).Op(Instruction.STOP).Done;
+
+    /// <summary>The gas <paramref name="frameTx"/> burned before its transaction-level refund: the
+    /// intrinsic budget the processor prices it against, plus every frame receipt's two dimensions.</summary>
+    private static ulong GrossFrameGas(Transaction frameTx, TxReceipt receipt)
+    {
+        FrameTxValidation.TryCalculateGasBudget(frameTx, Eip8141Prototype.Instance, out ulong grossGas, out _, out _);
+        foreach (TxFrameReceipt frameReceipt in receipt.FrameReceipts!)
+        {
+            grossGas += frameReceipt.ExecutionGasUsed + frameReceipt.StateGasUsed;
+        }
+
+        return grossGas;
+    }
 
     private static Hash256 ReceiptsRoot(TxReceipt[] receipts) =>
         ReceiptTrie.CalculateRoot(Eip8141Prototype.Instance, receipts, new ReceiptMessageDecoder());

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionTests.cs
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Linq;
+using System.Threading;
+using Nethermind.Blockchain.Tracing;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Evm;
+using Nethermind.Evm.State;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.State.Proofs;
+using Nethermind.TxPool;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test;
+
+/// <summary>EIP-8141 frame transactions through the real block-production executor, and the produced
+/// block back through the real validation executor.</summary>
+/// <remarks>The per-transaction properties are pinned elsewhere; what these cover is that production
+/// selects, executes and accounts for a frame transaction the same way validation later re-derives it.</remarks>
+[TestFixture]
+public class FrameTxBlockProductionTests
+{
+    private static readonly Address Sender = TestItem.AddressA;
+    private static readonly Address Observer = TestItem.AddressB;
+    private static readonly Address SecondObserver = TestItem.AddressC;
+
+    private static readonly Hash256 FirstTopic = TestItem.KeccakA;
+    private static readonly Hash256 SecondTopic = TestItem.KeccakB;
+    private static readonly Hash256 UnusedTopic = TestItem.KeccakF;
+
+    private static readonly byte[] EmitFirstTopic = LogCode(FirstTopic);
+    private static readonly byte[] EmitSecondTopic = LogCode(SecondTopic);
+    private static readonly byte[] WriteFreshSlot =
+        Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done;
+    private static readonly byte[] Inert = Prepare.EvmCode.Op(Instruction.STOP).Done;
+
+    /// <summary>A frame transaction offered to the producer must reach the produced block, and the
+    /// produced block must re-derive to the same receipts when a validating node replays it.</summary>
+    [Test]
+    public void Produced_block_carrying_a_frame_transaction_revalidates_to_the_same_receipts()
+    {
+        Transaction frameTx = FrameTx(
+            SelfApprove(),
+            new TxFrame(TxFrame.ModeSender, 0, Observer, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default));
+
+        Produced produced = Produce(frameTx, (Observer, EmitFirstTopic));
+
+        Assert.That(produced.Block.Transactions, Has.Length.EqualTo(1), "the producer skipped the frame transaction");
+        Assert.That(produced.Receipts, Has.Length.EqualTo(1));
+        TxReceipt producedReceipt = produced.Receipts[0];
+
+        // Without these the comparison below could hold over two identically empty runs.
+        Assert.That(producedReceipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+        Assert.That(producedReceipt.Logs, Has.Length.EqualTo(1), "the SENDER frame's log must reach the produced receipt");
+        Assert.That(producedReceipt.FrameReceipts, Has.Length.EqualTo(2));
+
+        TxReceipt[] validated = Validate(produced.Block, (Observer, EmitFirstTopic));
+
+        Assert.That(validated, Has.Length.EqualTo(1));
+        TxReceipt validatedReceipt = validated[0];
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(validatedReceipt.StatusCode, Is.EqualTo(producedReceipt.StatusCode));
+            Assert.That(validatedReceipt.GasUsed, Is.EqualTo(producedReceipt.GasUsed));
+            Assert.That(validatedReceipt.GasUsedTotal, Is.EqualTo(producedReceipt.GasUsedTotal));
+            Assert.That(validatedReceipt.Payer, Is.EqualTo(producedReceipt.Payer));
+            Assert.That(validatedReceipt.Logs!.Length, Is.EqualTo(producedReceipt.Logs!.Length));
+            Assert.That(ReceiptsRoot(validated), Is.EqualTo(ReceiptsRoot(produced.Receipts)));
+            Assert.That(TxTrie.CalculateRoot(produced.Block.Transactions), Is.EqualTo(produced.Block.Header.TxRoot));
+        }
+    }
+
+    /// <summary>The two-dimensional block totals a producer carries must charge a frame transaction's
+    /// state growth to the state dimension and nowhere else.</summary>
+    [TestCase(false, 0UL, TestName = "A frame transaction that grows no state moves no state total")]
+    [TestCase(true, (ulong)GasCostOf.SSetState, TestName = "A fresh slot's growth charge lands in the block state total")]
+    public void Produced_block_totals_carry_the_state_dimension_of_a_frame_transaction(bool writesState, ulong expectedStateGas)
+    {
+        Transaction frameTx = FrameTx(
+            SelfApprove(),
+            new TxFrame(TxFrame.ModeSender, 0, Observer, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default));
+
+        Produced produced = Produce(frameTx, (Observer, writesState ? WriteFreshSlot : Inert));
+
+        Assert.That(produced.Block.Transactions, Has.Length.EqualTo(1), "the producer skipped the frame transaction");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(produced.StateGas, Is.EqualTo(expectedStateGas));
+            // The state charge leaves the execution dimension; counting it in both bills the block twice.
+            Assert.That(produced.ExecutionGas, Is.EqualTo(produced.Receipts[0].GasUsedTotal - expectedStateGas));
+            // Both dimensions share the block limit, so the header carries whichever bound is tighter.
+            Assert.That(produced.Block.Header.GasUsed, Is.EqualTo(Math.Max(produced.ExecutionGas, produced.StateGas)));
+        }
+    }
+
+    /// <summary>A produced frame transaction's receipt blooms over every frame's logs, not just one.</summary>
+    [Test]
+    public void Produced_frame_transaction_receipt_blooms_over_every_frames_logs()
+    {
+        Transaction frameTx = FrameTx(
+            SelfApprove(),
+            new TxFrame(TxFrame.ModeSender, 0, Observer, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeSender, 0, SecondObserver, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default));
+
+        Produced produced = Produce(frameTx, (Observer, EmitFirstTopic), (SecondObserver, EmitSecondTopic));
+
+        Assert.That(produced.Block.Transactions, Has.Length.EqualTo(1), "the producer skipped the frame transaction");
+        TxReceipt receipt = produced.Receipts[0];
+        Assert.That(receipt.FrameReceipts, Has.Length.EqualTo(3));
+
+        Bloom bloom = receipt.CalculateBloom();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.Logs, Has.Length.EqualTo(2), "the receipt logs must be the union across frames");
+            Assert.That(receipt.Logs![0].Topics[0], Is.EqualTo(FirstTopic), "frame order must survive into the union");
+            Assert.That(receipt.Logs[1].Topics[0], Is.EqualTo(SecondTopic));
+            Assert.That(bloom.Matches(FirstTopic), Is.True);
+            Assert.That(bloom.Matches(SecondTopic), Is.True, "a bloom over only the first frame would still pass the check above");
+            Assert.That(bloom.Matches(UnusedTopic), Is.False, "a saturated bloom would match everything");
+        }
+    }
+
+    private readonly record struct Produced(Block Block, TxReceipt[] Receipts, ulong ExecutionGas, ulong StateGas);
+
+    /// <summary>Offers <paramref name="candidate"/> to the real production executor over a pre-state
+    /// carrying <paramref name="contracts"/>, and returns what the producer settled on.</summary>
+    private static Produced Produce(Transaction candidate, params (Address Address, byte[] Code)[] contracts)
+    {
+        using Chain chain = new(contracts);
+
+        BlockToProduce blockToProduce = new(
+            Build.A.Block.WithNumber(1).WithBaseFeePerGas(0).WithGasLimit(30_000_000).TestObject.Header,
+            [candidate],
+            []);
+
+        BlockProcessor.BlockProductionTransactionsExecutor executor = new(
+            new BuildUpTransactionProcessorAdapter(chain.Processor),
+            chain.State,
+            new BlockProcessor.BlockProductionTransactionPicker(chain.SpecProvider),
+            LimboLogs.Instance,
+            NullBlockAccessListManager.Instance,
+            NullTxPool.Instance);
+
+        BlockReceiptsTracer receiptsTracer = new();
+        receiptsTracer.StartNewBlockTrace(blockToProduce);
+        executor.SetBlockExecutionContext(new BlockExecutionContext(blockToProduce.Header, chain.Spec));
+        TxReceipt[] receipts = executor.ProcessTransactions(blockToProduce, ProcessingOptions.ProducingBlock, receiptsTracer, CancellationToken.None);
+        ulong executionGas = receiptsTracer.CumulativeExecutionGasUsed;
+        ulong stateGas = receiptsTracer.BlockStateGasUsed;
+        receiptsTracer.EndBlockTrace();
+
+        Block sealed_ = new(blockToProduce.Header, blockToProduce.Transactions.ToArray(), []);
+        return new Produced(sealed_, receipts, executionGas, stateGas);
+    }
+
+    /// <summary>Replays <paramref name="produced"/> through the real validation executor over a
+    /// freshly-built copy of the same pre-state, as a validating node would.</summary>
+    private static TxReceipt[] Validate(Block produced, params (Address Address, byte[] Code)[] contracts)
+    {
+        using Chain chain = new(contracts);
+
+        BlockProcessor.BlockValidationTransactionsExecutor executor = new(
+            new ExecuteTransactionProcessorAdapter(chain.Processor),
+            chain.State);
+
+        Block replayed = new(
+            Build.A.Block.WithNumber(1).WithBaseFeePerGas(0).WithGasLimit(30_000_000).TestObject.Header,
+            produced.Transactions,
+            []);
+
+        BlockReceiptsTracer receiptsTracer = new();
+        receiptsTracer.StartNewBlockTrace(replayed);
+        executor.SetBlockExecutionContext(new BlockExecutionContext(replayed.Header, chain.Spec));
+        TxReceipt[] receipts = executor.ProcessTransactions(replayed, ProcessingOptions.None, receiptsTracer, CancellationToken.None);
+        receiptsTracer.EndBlockTrace();
+        return receipts;
+    }
+
+    /// <summary>Pre-state shared by both runs: a funded sender whose own code approves, plus the
+    /// contracts a test's SENDER frames target.</summary>
+    private sealed class Chain : IDisposable
+    {
+        private readonly IDisposable _scope;
+
+        public Chain(params (Address Address, byte[] Code)[] contracts)
+        {
+            SpecProvider = new TestSpecProvider(Eip8141Prototype.Instance);
+            State = TestWorldStateFactory.CreateForTest();
+            _scope = State.BeginScope(IWorldState.PreGenesis);
+            EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(SpecProvider), SpecProvider, LimboLogs.Instance);
+            Processor = new EthereumTransactionProcessor(
+                BlobBaseFeeCalculator.Instance, SpecProvider, State, virtualMachine,
+                new EthereumCodeInfoRepository(State), LimboLogs.Instance);
+
+            Deploy(Sender, Prepare.EvmCode
+                .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done, 100.Ether);
+            foreach ((Address address, byte[] code) in contracts) Deploy(address, code);
+            State.Commit(Spec);
+            State.CommitTree(0);
+        }
+
+        public ISpecProvider SpecProvider { get; }
+        public IWorldState State { get; }
+        public ITransactionProcessor Processor { get; }
+        public IReleaseSpec Spec => SpecProvider.GenesisSpec;
+
+        private void Deploy(Address address, byte[] code, UInt256 balance = default)
+        {
+            State.CreateAccount(address, balance);
+            State.InsertCode(address, code, Spec);
+        }
+
+        public void Dispose() => _scope.Dispose();
+    }
+
+    private static TxFrame SelfApprove() =>
+        new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default);
+
+    private static Transaction FrameTx(params TxFrame[] frames)
+    {
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = TestBlockchainIds.ChainId,
+            Nonce = 0,
+            SenderAddress = Sender,
+            Frames = frames,
+            FrameSignatures = [],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 1,
+        };
+        // Only the decoder derives this, and the picker prices the candidate through it.
+        tx.GasLimit = FrameTxValidation.TotalGasLimit(frames);
+        tx.Hash = tx.CalculateHash();
+        return tx;
+    }
+
+    private static byte[] LogCode(Hash256 topic) =>
+        Prepare.EvmCode.PushData(topic.Bytes.ToArray()).PushData(1).PushData(0).Op(Instruction.LOG1).Op(Instruction.STOP).Done;
+
+    private static Hash256 ReceiptsRoot(TxReceipt[] receipts) =>
+        ReceiptTrie.CalculateRoot(Eip8141Prototype.Instance, receipts, new ReceiptMessageDecoder());
+}


### PR DESCRIPTION
## Changes

Adds `Nethermind.Blockchain.Test/FrameTxBlockProductionTests.cs`. Nothing produced a block containing a frame transaction and then replayed it — the existing frame coverage on the producer side stops at `CanAddTransaction` (`FrameTxBlockProductionPickerTests`, `TransactionsExecutorTests`, `BlockGasReservationsFitnessTests`) or runs a single transaction straight through the processor (`FrameTxBlockGasTests`, `FrameTxBlockReceiptsTests`).

Three properties, all through the real `BlockProductionTransactionsExecutor`:

- **An unpayable frame transaction is dropped, and the produced block still replays.** A prefix that never approves is offered alongside a payable one; the producer must skip the first — validation *throws* where production skips, so a producer that sealed it would emit a block no node could accept — and the header's transaction root must commit to what survived selection, not to what was offered. The produced block is then re-run through the real `BlockValidationTransactionsExecutor` over a freshly-built copy of the same pre-state and must yield the same status, gas, payer, logs and receipts root.
- **The two-dimensional block totals carry the state dimension.** A frame transaction writing a fresh slot must move `BlockStateGasUsed` by exactly the growth charge and take that charge *out* of the execution dimension; the header then carries `max` of the two. Parameterised against an inert target that must move neither.
- **The receipt blooms over every frame's logs.** Two SENDER frames emit distinct topics; the receipt's logs must be the union in frame order and the bloom must match both — and not a third, unused topic, so a saturated bloom cannot pass.

No production code changes. Deterministic correctness only — no timing or rate assertions, and no overlap with the measurement harnesses in #13041.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: test coverage

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Each test was shown red under a perturbation of the one mechanism it names, and green with it reverted:

| Test | Injection | Result |
|---|---|---|
| unpayable transaction dropped | production executor adds every non-`Stop` candidate to `includedTx` | `Expected: 1 / But was: 2` |
| state dimension | `UpdateCumulativeGasTracking` stops accumulating `BlockStateGas` | writing case `Expected: 97920 / But was: 0`, inert case stays green |
| bloom over all frames | `Bloom.Add(LogEntry[])` processes only the first entry | `bloom.Matches(SecondTopic)` `Expected: True / But was: False`, everything upstream intact |

The bloom case needed two attempts. Truncating `ConcatLogs` broke the log-count assertion first and aborted the multiple-scope before the bloom assertions ran, so it did not show that the bloom check discriminates on its own; perturbing `Bloom.Add` instead leaves the receipt's two logs in place and isolates the bloom step.

One thing this deliberately does **not** claim: the produce-then-replay receipt comparison is close to tautological on its own. `BuildUp` and `Commit` both carry no `SkipValidation`, so production and validation reach the same validation decisions through the same processor — an injected production-only under-charge of intrinsic gas left the test green. That is why the test offers a transaction the producer must *drop*: the skip-versus-throw asymmetry is the part that is genuinely production-specific.

Full Release build 0 Errors. Suites green: `Nethermind.Blockchain.Test` 1845, `Nethermind.Consensus.Test` 243, `Nethermind.Merge.Plugin.Test` 1843 (`DOTNET_EnableHWIntrinsic=0`), `Nethermind.Evm.Test` 5598, `Nethermind.TxPool.Test` 1096 in Release and Debug. Lint gate in CI's warning-grep form: 0 hits, positive-controlled to 1 with an injected IDE0005.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
