### PR TITLE
perf: OR and XOR byte spans a word at a time in the scalar fallback

### DIFF
--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.Vector.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.Vector.cs
@@ -96,6 +96,7 @@ public static unsafe partial class Bytes
         else
         {
             // Whole words, then a byte tail: the widest access the target has without SIMD.
+            // Correct at any base; the win needs a word-aligned start, which Bloom's byte[256] has.
             int i = 0;
             for (; i <= thisSpan.Length - sizeof(ulong); i += sizeof(ulong))
             {
@@ -163,9 +164,18 @@ public static unsafe partial class Bytes
             if (i == thisSpan.Length) return;
         }
 
+        // Whole words, then a byte tail, as in Or above.
+        for (; i <= thisSpan.Length - sizeof(ulong); i += sizeof(ulong))
+        {
+            ref byte destination = ref Unsafe.Add(ref thisRef, i);
+            Unsafe.WriteUnaligned(ref destination,
+                Unsafe.ReadUnaligned<ulong>(ref destination) ^ Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref valueRef, i)));
+        }
+
         for (; i < thisSpan.Length; i++)
         {
-            Unsafe.Add(ref thisRef, i) ^= Unsafe.Add(ref valueRef, i);
+            ref byte destination = ref Unsafe.Add(ref thisRef, i);
+            destination = (byte)(destination ^ Unsafe.Add(ref valueRef, i));
         }
     }
 

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.Vector.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.Vector.cs
@@ -95,10 +95,19 @@ public static unsafe partial class Bytes
         }
         else
         {
-            // scalar fallback
-            for (int i = 0; i < thisSpan.Length; i++)
+            // Whole words, then a byte tail: the widest access the target has without SIMD.
+            int i = 0;
+            for (; i <= thisSpan.Length - sizeof(ulong); i += sizeof(ulong))
             {
-                Unsafe.Add(ref thisRef, i) |= Unsafe.Add(ref valueRef, i);
+                ref byte destination = ref Unsafe.Add(ref thisRef, i);
+                Unsafe.WriteUnaligned(ref destination,
+                    Unsafe.ReadUnaligned<ulong>(ref destination) | Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref valueRef, i)));
+            }
+
+            for (; i < thisSpan.Length; i++)
+            {
+                ref byte destination = ref Unsafe.Add(ref thisRef, i);
+                destination = (byte)(destination | Unsafe.Add(ref valueRef, i));
             }
         }
     }


### PR DESCRIPTION
## Changes

`Bytes.Or`'s scalar fallback merged a byte at a time. It is the branch a span takes when no vector width
applies — which on the zkVM guest is every span, where bloom accumulation alone was 946k byte reads and
473k byte read-modify-writes per block. A byte-wide dirty write is the priciest access in that cost
model, about eleven times an aligned 8-byte write. The loop now merges whole words and keeps a byte
tail.

The compound assignment was a second, smaller problem: `Unsafe.Add(ref thisRef, i) |= …` captures the
element address in a temporary (lvalue-once semantics), which stops the RISC-V backend from folding
base+offset into both the load and the store — the same pattern #13091 documented for the keccak
absorb lanes.

`Xor`'s scalar tail carried both problems verbatim, so it gets the same treatment. It is not on a
guest hot path today — `Bytes32` and `HandshakeService` reach the array-returning overload — but on
the guest that tail is the whole span, and on x64 it is the 8-15 byte remainder after the
`Vector128` loop, which was previously all byte ops.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

`Nethermind.Core.Test` 6045/0, which covers both the `Bloom` accumulation path and the `Bytes` span
helpers. `BytesTests.BitwiseTests` generates lengths 0, 1, 7, 8, 9 and 15, so the scalar word loop,
its pure-tail cases and the empty span are all exercised for `Or` and `Xor` alike, against expected
values computed independently via `Zip`. The guest output for block 25532382 is byte-identical.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`ziskemu` steps for mainnet block 25532382, `bflat-riscv64` + `zisk:1.2.0-alpha`, `-Ot`, measured
against master `3bb4807754`:

| | steps | Δ |
|---|---:|---:|
| master `3bb4807754` | 474,276,697 | — |
| this branch | 471,590,112 | **−0.57 %** |

### Host side

x64 has `Vector128` accelerated, so a span of 16 bytes or more takes a vector path and never reaches
`Or`'s scalar branch — `Bloom`'s span is 256 bytes. For spans shorter than a vector, and for `Xor`'s
sub-vector tail, the new form is strictly fewer operations than the byte loop it replaces.

