### PR TITLE
perf: skip whole RLP items with the cursor in a local

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -1046,6 +1046,34 @@ namespace Nethermind.Core.Test
             }
         }
 
+        [TestCase(-1, 0)]
+        [TestCase(0, 0)]
+        [TestCase(1, 1)]
+        [TestCase(2, 2)]
+        [TestCase(3, 6)]
+        [TestCase(4, 9)]
+        [TestCase(5, 67)]
+        public void SkipItems_advances_the_cursor_like_repeated_SkipItem(int count, int expectedPosition)
+        {
+            // 0x7F | "" | "abc" | [1, 2] | a 56-byte string, so a run crosses every prefix form
+            byte[] rlp = [0x7F, 0x80, 0x83, 0x61, 0x62, 0x63, 0xC2, 0x01, 0x02, 0xB8, 0x38, .. new byte[56]];
+
+            RlpReader batched = new(rlp);
+            batched.SkipItems(count);
+
+            RlpReader oneByOne = new(rlp);
+            for (int i = 0; i < count; i++)
+            {
+                oneByOne.SkipItem();
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(batched.Position, Is.EqualTo(expectedPosition));
+                Assert.That(oneByOne.Position, Is.EqualTo(expectedPosition));
+            }
+        }
+
         private static byte[] BuildLongFormRlp(int prefix, int contentLength)
         {
             int lengthOfLength = prefix < 192 ? prefix - 183 : prefix - 247;

--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -1046,17 +1046,10 @@ namespace Nethermind.Core.Test
             }
         }
 
-        [TestCase(-1, 0)]
-        [TestCase(0, 0)]
-        [TestCase(1, 1)]
-        [TestCase(2, 2)]
-        [TestCase(3, 6)]
-        [TestCase(4, 9)]
-        [TestCase(5, 67)]
-        public void SkipItems_advances_the_cursor_like_repeated_SkipItem(int count, int expectedPosition)
+        [Test]
+        public void SkipItems_advances_the_cursor_like_repeated_SkipItem([Range(-1, MixedItemCount)] int count)
         {
-            // 0x7F | "" | "abc" | [1, 2] | a 56-byte string, so a run crosses every prefix form
-            byte[] rlp = [0x7F, 0x80, 0x83, 0x61, 0x62, 0x63, 0xC2, 0x01, 0x02, 0xB8, 0x38, .. new byte[56]];
+            byte[] rlp = MixedRlpItems();
 
             RlpReader batched = new(rlp);
             batched.SkipItems(count);
@@ -1067,12 +1060,25 @@ namespace Nethermind.Core.Test
                 oneByOne.SkipItem();
             }
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(batched.Position, Is.EqualTo(expectedPosition));
-                Assert.That(oneByOne.Position, Is.EqualTo(expectedPosition));
-            }
+            Assert.That(batched.Position, Is.EqualTo(oneByOne.Position));
         }
+
+        [Test]
+        public void SkipItems_over_every_item_lands_at_the_end()
+        {
+            byte[] rlp = MixedRlpItems();
+            RlpReader reader = new(rlp);
+
+            reader.SkipItems(MixedItemCount);
+
+            Assert.That(reader.Position, Is.EqualTo(rlp.Length));
+        }
+
+        private const int MixedItemCount = 5;
+
+        // 0x7F | "" | "abc" | [1, 2] | a 56-byte string, so a run crosses every prefix form
+        private static byte[] MixedRlpItems() =>
+            [0x7F, 0x80, 0x83, 0x61, 0x62, 0x63, 0xC2, 0x01, 0x02, 0xB8, 0x38, .. new byte[56]];
 
         private static byte[] BuildLongFormRlp(int prefix, int contentLength)
         {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
@@ -25,8 +25,7 @@ namespace Nethermind.Serialization.Rlp
         public (Hash256 CodeHash, Hash256 StorageRoot) DecodeHashesOnly(ref RlpReader context)
         {
             context.SkipLength();
-            context.SkipItem();
-            context.SkipItem();
+            context.SkipItems(2);
 
             Hash256 storageRoot = DecodeStorageRoot(ref context);
             Hash256 codeHash = DecodeCodeHash(ref context);
@@ -37,8 +36,7 @@ namespace Nethermind.Serialization.Rlp
         public Hash256 DecodeStorageRootOnly(ref RlpReader context)
         {
             context.SkipLength();
-            context.SkipItem();
-            context.SkipItem();
+            context.SkipItems(2);
             Hash256 storageRoot = DecodeStorageRoot(ref context);
             return storageRoot;
         }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -746,6 +746,22 @@ public ref struct RlpReader
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SkipItem() => Position += PeekNextRlpLength();
 
+    /// <summary>Advances the cursor past <paramref name="count"/> whole items.</summary>
+    /// <remarks>Keeps the cursor in a local for the walk, so it is read and written once instead of once
+    /// per item. The cursor is a 4-byte field access, which the zkVM charges about eight times an aligned
+    /// 8-byte read and eleven times an 8-byte write.</remarks>
+    public void SkipItems(int count)
+    {
+        ReadOnlySpan<byte> data = Data;
+        int position = Position;
+        for (int i = 0; i < count; i++)
+        {
+            position += RlpHelpers.PeekNextRlpLength(data, position);
+        }
+
+        Position = position;
+    }
+
     public void Reset() => Position = 0;
 
     public bool DecodeBool()

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -749,9 +749,15 @@ public ref struct RlpReader
     /// <summary>Advances the cursor past <paramref name="count"/> whole items.</summary>
     /// <remarks>Keeps the cursor in a local for the walk, so it is read and written once instead of once
     /// per item. The cursor is a 4-byte field access, which the zkVM charges about eight times an aligned
-    /// 8-byte read and eleven times an 8-byte write.</remarks>
+    /// 8-byte read and eleven times an 8-byte write, so a non-positive <paramref name="count"/> returns
+    /// without touching it. A malformed item throws with the cursor still on the first item of the run.</remarks>
     public void SkipItems(int count)
     {
+        if (count <= 0)
+        {
+            return;
+        }
+
         ReadOnlySpan<byte> data = Data;
         int position = Position;
         for (int i = 0; i < count; i++)

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -1411,10 +1411,7 @@ namespace Nethermind.Trie
                 index = 1;
             }
 
-            for (int i = 0; i < index; i++)
-            {
-                rlpReader.SkipItem();
-            }
+            rlpReader.SkipItems(index);
         }
 
         private TrieNode CreateInlineChild(ReadOnlySpan<byte> fullRlp)
@@ -1602,7 +1599,7 @@ namespace Nethermind.Trie
                         if (_currentStreamIndex.HasValue && _currentStreamIndex <= i)
                         {
                             int toSkip = i - _currentStreamIndex.Value;
-                            for (int j = 0; j < toSkip; j++) _rlpReader.SkipItem();
+                            _rlpReader.SkipItems(toSkip);
                             _currentStreamIndex += toSkip;
                         }
                         else
@@ -1617,7 +1614,7 @@ namespace Nethermind.Trie
                             }
                             else
                             {
-                                for (int j = 0; j < i; j++) _rlpReader.SkipItem();
+                                _rlpReader.SkipItems(i);
                             }
 
                             _currentStreamIndex = i;


### PR DESCRIPTION
## Changes

`RlpReader.SkipItem` reads the cursor field, decodes one prefix and writes the cursor back, so a run of
items pays a field read and a field write per item. `SkipItems(count)` walks the whole run through a
local and writes the cursor once. Three loops in `TrieNode` take it: `SeekChildNotNull` and the two
stream-index skips in the child accessor.

On the zkVM guest the cursor is a 4-byte field access, which that cost model charges 122 for a read and
193 for a write, against 16 and 18 for an aligned 8-byte pair — the cursor alone accounts for roughly
2.76M of the guest's 14.2M 4-byte accesses. On the host it is simply one field round-trip instead of
one per item.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

`Nethermind.Trie.Test` 475/0 and `Nethermind.Core.Test` 6045/0 — the trie suites drive
`SeekChildNotNull` and the child accessor on every branch node, and the Core encoding suites cover the
reader. The guest output for block 25532382 is byte-identical.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`ziskemu` steps for mainnet block 25532382, `bflat-riscv64` + `zisk:1.2.0-alpha`, `-Ot`. Measured on top
of the round's other guest changes (#13144, #13145, #13146, #13147), since those land first:

| | steps | Δ |
|---|---:|---:|
| the four together | 435,514,946 | — |
| with this change | 434,992,696 | **−0.12 %** |

This is the cheap half of a larger pot. The alternative — widening the cursor field itself to `nint` —
was measured and rejected: on the host it costs `RlpTrieNodeEncoding.Encode_Branch` **+18 %**
(147.5 → 174.4 ns) and `RlpDecodeBlock` +4…6 %, and on the guest it trades **+0.17 % steps** for
−0.34 % memory cost, because the `int` property then truncates on every read and sign-extends on every
write. Touching the field less often wins on both metrics and needs no per-target split; the remaining
cursor-hot readers (`DecodeRlp`, the `ReadByte` runs, the two branch-RLP passes) can have the same
treatment.
