### PR TITLE
perf: compare storage slots through UInt256's own equality

### DIFF
--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -773,9 +773,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
             private Comparer() { }
 
-            // Through UInt256's own equality rather than a vector compare written here: it carries the
-            // per-target form, and on a target without SIMD a Vector256 comparison expands to a
-            // byte-at-a-time element loop over each lane.
             public bool Equals(UInt256 x, UInt256 y) => x.Equals(in y);
 
             public int GetHashCode([DisallowNull] UInt256 obj)

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Collections;

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -773,8 +773,10 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
             private Comparer() { }
 
-            public bool Equals(UInt256 x, UInt256 y)
-                => Unsafe.As<UInt256, Vector256<byte>>(ref x) == Unsafe.As<UInt256, Vector256<byte>>(ref y);
+            // Through UInt256's own equality rather than a vector compare written here: it carries the
+            // per-target form, and on a target without SIMD a Vector256 comparison expands to a
+            // byte-at-a-time element loop over each lane.
+            public bool Equals(UInt256 x, UInt256 y) => x.Equals(in y);
 
             public int GetHashCode([DisallowNull] UInt256 obj)
                 => MemoryMarshal.AsBytes(MemoryMarshal.CreateReadOnlySpan(in obj, 1)).FastHash();


### PR DESCRIPTION
## Changes

The comparer behind the storage-slot dictionaries spelled out a `Vector256<byte>` comparison of the two
`UInt256` keys. A target without SIMD has nothing behind that: ILC expands a vector comparison into a
byte-at-a-time element loop over each 8-byte lane, so every probe cost about 320 steps of byte loads —
these dictionaries were the last place in the zkVM guest still paying it after #13144.

`UInt256.Equals` already carries the per-target form (`Nethermind.Numerics.Int256` ships std and zkEVM
flavours: the vector compare on hosts, a four-limb XOR-OR on the guest), so the comparer just calls it.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

`Nethermind.State.Test` 1283/0 and `Nethermind.Core.Test` 6045/0. The guest output for mainnet block
25532382 is byte-identical.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`ziskemu` steps for mainnet block 25532382, `bflat-riscv64` + `zisk:1.2.0-alpha`, `-Ot`, against master
`3bb4807754`:

| | steps | Δ |
|---|---:|---:|
| master `3bb4807754` | 474,276,697 | — |
| this branch | 472,343,986 | **−0.41 %** |

### Host side

On a host, `UInt256.Equals(in UInt256)` is the same `Vector256` comparison this comparer was writing by
hand — `Vector256.IsHardwareAccelerated ? EqualsVector : four-limb XOR-OR` — and it is marked
`AggressiveInlining`, so the host codegen is what it was.
