### PR TITLE
fix(rlp): break the Rlp/TxDecoder type initializer cycle

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/RlpDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/RlpDecoderTests.cs
@@ -14,6 +14,10 @@ namespace Nethermind.Core.Test.Encoding;
 public class RlpDecoderTests
 {
     [Test]
+    public void Transaction_decoder_is_registered() =>
+        Assert.That(Rlp.GetDecoder<Transaction>(), Is.SameAs(TxDecoder.Instance));
+
+    [Test]
     public void Decode_complete_not_null_decodes_item()
     {
         WithdrawalDecoder decoder = new();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -56,9 +56,6 @@ namespace Nethermind.Serialization.Rlp
         static Rlp()
         {
             RegisterDecoders(typeof(Rlp).Assembly);
-            // Registered from here rather than from TxDecoder's own initializer: the scan already builds
-            // decoders that read TxDecoder.Instance, and a registration running the other way round makes
-            // the two type initializers wait on each other whenever separate threads enter them at once.
             RegisterDecoder(typeof(Transaction), TxDecoder.Instance);
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -56,8 +56,6 @@ namespace Nethermind.Serialization.Rlp
         static Rlp()
         {
             RegisterDecoders(typeof(Rlp).Assembly);
-            // Not registered from TxDecoder's own initializer: the scan above already reads Instance,
-            // so the reverse direction makes the two initializers wait on each other.
             RegisterDecoder(typeof(Transaction), TxDecoder.Instance);
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -56,6 +56,8 @@ namespace Nethermind.Serialization.Rlp
         static Rlp()
         {
             RegisterDecoders(typeof(Rlp).Assembly);
+            // Not registered from TxDecoder's own initializer: the scan above already reads Instance,
+            // so the reverse direction makes the two initializers wait on each other.
             RegisterDecoder(typeof(Transaction), TxDecoder.Instance);
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -53,7 +53,14 @@ namespace Nethermind.Serialization.Rlp
         internal static readonly Rlp OfEmptyStringHash = Encode(Keccak.OfAnEmptyString.Bytes); // use bytes to avoid stack overflow
 
         internal static readonly Rlp EmptyBloom = Encode(Bloom.Empty.Bytes);
-        static Rlp() => RegisterDecoders(typeof(Rlp).Assembly);
+        static Rlp()
+        {
+            RegisterDecoders(typeof(Rlp).Assembly);
+            // Registered from here rather than from TxDecoder's own initializer: the scan already builds
+            // decoders that read TxDecoder.Instance, and a registration running the other way round makes
+            // the two type initializers wait on each other whenever separate threads enter them at once.
+            RegisterDecoder(typeof(Transaction), TxDecoder.Instance);
+        }
 
         /// <summary>
         /// This is not encoding - just a creation of an RLP object, e.g. passing 192 would mean an RLP of an empty sequence.

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -18,8 +18,6 @@ public sealed class TxDecoder : TxDecoder<Transaction>
 
     private TxDecoder(Func<Transaction> transactionFactory) : base(transactionFactory) { }
 
-    // Nothing here may touch Rlp: Rlp's own initializer builds decoders that read Instance, so a call back
-    // into Rlp deadlocks the two initializers against each other. Rlp registers this decoder itself.
     static TxDecoder()
     {
         TxObjectPool = new DefaultObjectPool<Transaction>(new Transaction.PoolPolicy(), Environment.ProcessorCount * 4);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -18,11 +18,12 @@ public sealed class TxDecoder : TxDecoder<Transaction>
 
     private TxDecoder(Func<Transaction> transactionFactory) : base(transactionFactory) { }
 
+    // Nothing here may touch Rlp: Rlp's own initializer builds decoders that read Instance, so a call back
+    // into Rlp deadlocks the two initializers against each other. Rlp registers this decoder itself.
     static TxDecoder()
     {
         TxObjectPool = new DefaultObjectPool<Transaction>(new Transaction.PoolPolicy(), Environment.ProcessorCount * 4);
         Instance = new TxDecoder(static () => TxObjectPool.Get());
-        Rlp.RegisterDecoder(typeof(Transaction), Instance);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -142,10 +142,6 @@ internal class Program
         string input = parseResult.GetValue(Options.Input);
         if (parseResult.GetValue(Options.Stdin)) input = Console.ReadLine();
 
-        // Rlp's and the decoders' static initializers reach into each other via RegisterDecoders;
-        // racing the first RLP use across parse workers can deadlock class init. Warm it up here.
-        System.Runtime.CompilerServices.RuntimeHelpers.RunClassConstructor(typeof(Nethermind.Serialization.Rlp.Rlp).TypeHandle);
-
         ulong chainId = parseResult.GetValue(Options.GnosisTest) ? GnosisSpecProvider.Instance.ChainId : MainnetSpecProvider.Instance.ChainId;
         bool jsonOutput = parseResult.GetValue(Options.JsonOutput);
         int workers = Math.Max(1, parseResult.GetValue(Options.Workers));


### PR DESCRIPTION
## Changes

`Rlp`'s static constructor scans its own assembly and builds every decoder, and `BlockBodyDecoder` reads `TxDecoder.Instance` as it is constructed. `TxDecoder`'s static constructor registered itself back into `Rlp`. Each initializer therefore needed the other — harmless on a single thread, where the CLR allows the re-entry, and a deadlock across two.

Captured in CI from `Nethermind.Optimism.Test` with the hang dump added in #13149:

```
thread 0x976   Rlp..cctor()                                  <- holds the Rlp initializer
               +- RegisterDecoders(assembly)
                  +- Activator.CreateInstance -> BlockBodyDecoder..ctor
                     +- InitClassSlow ...                     <- waits for TxDecoder's initializer

thread 0x978   TxDecoder..cctor()                             <- holds the TxDecoder initializer
               ^  reached from EthereumEcdsaExtensions..cctor (a static TxDecoder.Instance field)
               +- Rlp.RegisterDecoder(typeof(Transaction), Instance)
                  +- InitClassSlow ...                        <- waits for Rlp's initializer
```

Three further test threads sat behind the `Rlp` initializer (`Build.A.Block…TestObject` → `CalculateHash` → `Rlp.LengthOf`), which is why four tests are named as still running and why nothing in the suite finished. The job then ran to its 15-minute timeout.

This is the cause of the CI hangs seen 13 times in the 41 hours before the instrumentation landed, across `checked`, `no-intrinsics` and `release`, on x64 and arm64, mostly in `Nethermind.Optimism.Test` and once in `Nethermind.Trie.Test`.

- `TxDecoder`'s initializer no longer touches `Rlp`.
- `Rlp` registers the transaction decoder itself, where `ResetDecoders()` already registers it, so the dependency only runs one way.
- `Nethermind.Test.Runner` no longer warms up `Rlp`'s initializer by hand. That call was added in 96ed40dcd4 to stop the parse workers racing this very cycle; with the cycle gone it is dead weight, and its comment asserted the mutual dependency that no longer exists.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New `RlpDecoderTests.Transaction_decoder_is_registered` guards the moved registration. `Nethermind.Core.Test` (6157) and `Nethermind.Optimism.Test` (724) pass. `Nethermind.Test.Runner` builds clean after the warm-up removal; the EEST suites in CI are what exercise it.

The deadlock itself needs a thread race between two type initializers that each run once per process, so it cannot be reproduced deterministically from a test — it never reproduced locally in any of the runs attempted here. What is checkable is that the back-edge is gone: the decompiled IL of `TxDecoder`'s static constructor no longer references `Rlp`. A regression would resurface in CI as a hang, which #13149 now dumps and names.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Depends on nothing, but pairs with #13149: that PR is what captured this. Worth landing both.


