### PR TITLE
perf: stop copying code out of the code db

### DIFF
--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -403,7 +403,9 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
         private readonly AssociativeKeyCache<ValueHash256>? _persistedHint
             = isPersistent ? new AssociativeKeyCache<ValueHash256>(1_024) : null;
 
-        public byte[]? GetCode(in ValueHash256 codeHash) => codeDb[codeHash.Bytes]?.ToArray();
+        // The indexer already hands back an array of the store's own, and code is never mutated in
+        // place, so copying it only allocated a second one.
+        public byte[]? GetCode(in ValueHash256 codeHash) => codeDb[codeHash.Bytes];
 
         public IWorldStateScopeProvider.ICodeSetter BeginCodeWrite() => new CodeSetter(codeDb.StartWriteBatch());
 

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -403,8 +403,6 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
         private readonly AssociativeKeyCache<ValueHash256>? _persistedHint
             = isPersistent ? new AssociativeKeyCache<ValueHash256>(1_024) : null;
 
-        // The indexer already hands back an array of the store's own, and code is never mutated in
-        // place, so copying it only allocated a second one.
         public byte[]? GetCode(in ValueHash256 codeHash) => codeDb[codeHash.Bytes];
 
         public IWorldStateScopeProvider.ICodeSetter BeginCodeWrite() => new CodeSetter(codeDb.StartWriteBatch());


### PR DESCRIPTION
## Changes

`KeyValueWithBatchingBackedCodeDb.GetCode` was `codeDb[codeHash.Bytes]?.ToArray()`. The indexer returns
`byte[]`, and `ToArray()` on an array binds to `Enumerable.ToArray` — so every code lookup allocated a
second copy of the contract's entire code and memcpy'd into it. The store's array is already the
caller's to hold and code is never mutated in place, so the copy bought nothing.

Found while chasing guest allocations: it was the `System.Linq.Enumerable.ICollectionToArray<Byte>` in
the allocation profile, i.e. the reason LINQ was running in the zkVM guest at all.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

`Nethermind.State.Test` and `Nethermind.Core.Test`; the guest output for mainnet block 25532382 is
byte-identical.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Worth −0.09 % of zkVM guest steps (817 code lookups in the measured block, each losing an allocation
plus a copy of the whole code), and it removes the same allocation and copy from every code lookup on
the client. Not benchmarked on the host: the two `Nethermind.Benchmark/State` benchmarks that touch
`GetCode` use stub code dbs that return `null`.
