### PR TITLE
fix(rlp): classify a truncated frame transaction as a truncation

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -29,6 +29,8 @@ public class FrameTxDecoderTests
     private const int BlobVersionedHashesDecodeCap = ShardBlobNetworkWrapperRlp.BlobCountLimit;
     private const int SignaturesDecodeCap = 1024;
     private const int FrameDataDecodeCap = 30 * 1024 * 1024;
+    // The largest RLP sequence prefix still carrying its content length inline (0xc0 + 55).
+    private const int ShortSequencePrefixMax = 0xf7;
 
     private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
 
@@ -522,6 +524,33 @@ public class FrameTxDecoderTests
         }
     }
 
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(3)]
+    [TestCase(4)]
+    public void Decode_DeclaredLengthOverrunsTheBuffer_ReportsTruncatedReferences(int overrun)
+    {
+        // Inflating the declared payload length without adding bytes leaves the end-of-payload checkpoint
+        // past the last real field, so the decoder enters the trailing recent-root-reference list and reads
+        // off the end of the buffer. That must surface as an RLP error naming the list, not as a bare
+        // IndexOutOfRangeException and not as a truncated signature — a frame transaction has no envelope
+        // signature to truncate.
+        byte[] payload = EncodeConsensusPayload(CreateFrameTx());
+        // Byte 0 is the transaction type, byte 1 the payload sequence prefix.
+        Assert.That(payload[1] + overrun, Is.LessThanOrEqualTo(ShortSequencePrefixMax),
+            "the overrun must keep the short-form prefix, or it declares a length of length instead");
+        payload[1] += (byte)overrun;
+
+        void Decode()
+        {
+            RlpReader reader = new(payload);
+            _txDecoder.DecodeGuardNotNull(ref reader, RlpBehaviors.SkipTypedWrapping);
+        }
+
+        Assert.That(Decode, Throws.InstanceOf<RlpException>()
+            .With.Message.Contains("RLP data is truncated").And.Message.Contains("recent root reference"));
+    }
+
     private static Transaction EncodeDecode(Transaction tx, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         byte[] bytes = new byte[_txDecoder.GetLength(tx, rlpBehaviors)];
@@ -531,13 +560,15 @@ public class FrameTxDecoderTests
         return _txDecoder.Decode(ref reader, rlpBehaviors)!;
     }
 
-    private static Hash256 ConsensusHash(Transaction tx)
+    // The consensus form ignores any network wrapper: keccak(type || rlp(tx_payload_body)).
+    private static Hash256 ConsensusHash(Transaction tx) => Keccak.Compute(EncodeConsensusPayload(tx));
+
+    private static byte[] EncodeConsensusPayload(Transaction tx)
     {
-        // The consensus form ignores any network wrapper: keccak(type || rlp(tx_payload_body)).
         byte[] bytes = new byte[_txDecoder.GetLength(tx, RlpBehaviors.SkipTypedWrapping)];
         RlpWriter writer = new(bytes);
         _txDecoder.Encode(ref writer, tx, RlpBehaviors.SkipTypedWrapping);
-        return Keccak.Compute(bytes);
+        return bytes;
     }
 
     private static Transaction CreateBlobCarryingFrameTx(ProofVersion version, int blobCount)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -101,15 +101,27 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         return new Hash256(hash.GenerateValueHash());
     }
 
+    /// <inheritdoc/>
+    /// <remarks>A frame transaction carries no envelope signature, so its trailing element is EIP-8272's
+    /// recent-root-reference list. An overlong declared payload length leaves the end-of-payload checkpoint
+    /// past the last real field, so the list is read off the end of the buffer; that is reported as a
+    /// truncation naming the list rather than as a bare index-out-of-range.</remarks>
     protected override void DecodeTrailing(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors)
     {
-        if (!decoderContext.IsSequenceNext())
+        try
         {
-            ThrowTrailingSignature();
-        }
+            if (!decoderContext.IsSequenceNext())
+            {
+                ThrowTrailingSignature();
+            }
 
-        transaction.RecentRootReferences = decoderContext.DecodeNonNullArray(RecentRootReferenceDecoder.Instance, limit: ReferencesCountLimit);
-        transaction.ReferenceCalldataStats = RecentRootReferenceDecoder.Instance.Measure(transaction.RecentRootReferences);
+            transaction.RecentRootReferences = decoderContext.DecodeNonNullArray(RecentRootReferenceDecoder.Instance, limit: ReferencesCountLimit);
+            transaction.ReferenceCalldataStats = RecentRootReferenceDecoder.Instance.Measure(transaction.RecentRootReferences);
+        }
+        catch (Exception e) when (e is IndexOutOfRangeException or ArgumentOutOfRangeException)
+        {
+            ThrowTruncatedReferences(e);
+        }
     }
 
     protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,
@@ -281,6 +293,10 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
     [DoesNotReturn, StackTraceHidden]
     private static void ThrowTrailingSignature() => throw new RlpException("frame transaction must not carry a trailing signature");
+
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowTruncatedReferences(Exception inner) =>
+        throw new RlpException("RLP data is truncated: frame transaction recent root reference list is incomplete.", inner);
 }
 
 /// <summary>

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -116,12 +116,14 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
             }
 
             transaction.RecentRootReferences = decoderContext.DecodeNonNullArray(RecentRootReferenceDecoder.Instance, limit: ReferencesCountLimit);
-            transaction.ReferenceCalldataStats = RecentRootReferenceDecoder.Instance.Measure(transaction.RecentRootReferences);
         }
         catch (Exception e) when (e is IndexOutOfRangeException or ArgumentOutOfRangeException)
         {
             ThrowTruncatedReferences(e);
         }
+
+        transaction.ReferenceCalldataStats = RecentRootReferenceDecoder.Instance.Measure(transaction.RecentRootReferences);
+    }
     }
 
     protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,


### PR DESCRIPTION
## Changes

- `FrameTxDecoder.DecodeTrailing` now catches `IndexOutOfRangeException`/`ArgumentOutOfRangeException` and reports `RLP data is truncated: frame transaction recent root reference list is incomplete.`, instead of letting a bare `IndexOutOfRangeException` escape.
- Regression test covering a type-6 payload whose declared envelope length overruns the buffer.
- Test-only: extracted `EncodeConsensusPayload` out of the existing `ConsensusHash` helper, now shared by both.

A type-6 payload whose declared envelope length overruns the buffer reaches `DecodeTrailing`, where `IsSequenceNext()` reads `Data[Position]` at `Position == Data.Length`.

This is **not** a P2P misclassification bug. `RlpDecoder<T>.Decode` already catches that exception pair and rethrows `RlpException("Cannot decode stream of Transaction", inner)`, so `ProtocolHandlerBase.DeserializeMessage`'s `catch (RlpException)` fires correctly today. The change is diagnostic: the message named neither the truncation nor the section that ran off the end.

#### On the message wording

Two deliberate choices:

- **It keeps the `RLP data is truncated` prefix**, matching `RlpHelpers.ThrowRlpDataTruncated`. That substring appears in none of `FrameExceptionFragments`' `Format`/`Signature`/`Execution`/`Decode` sets, so it cannot break their pairwise-disjointness invariant, and it will match the EEST `RLP_ERROR_EOF` label for free once that mapping lands.
- **It is not the envelope-signature wording.** A frame transaction has no envelope signature; its trailing element is EIP-8272's recent-root-reference list.

No `FrameExceptionFragments` entry was added — no fixture in the frames suite exercises this path, so an entry would be a dead mapping.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Decode_DeclaredLengthOverrunsTheBuffer_ReportsTruncatedReferences` was confirmed red before the fix (`But was: "Cannot decode stream of Transaction"`) and green after.

The overrun range is 1–4, not wider: with `SkipTypedWrapping` the payload is `06 f3 01 2a 94…`, so byte 0 is the type byte and byte 1 the sequence prefix `0xf3`. Adding 5 lands on `0xf8` and flips the prefix to the long form, which fails on address decoding rather than on the trailing section. The test asserts that short-form ceiling as a precondition so it fails loudly, rather than silently exercising the wrong path, if the fixture transaction grows.

One behavioural side effect: the new `RlpException` is not in `RlpDecoder<T>.Decode`'s catch pair, so it propagates unwrapped and the frames message now reaches `TransactionTestBase` in place of `"Cannot decode stream of Transaction"`. The `txTest` lane was measured on both sides to confirm this changes no verdict.

Fixtures at `eest-frames-v010`, run via `nethtest` with `--forkAlias Bogota=Eip8141Prototype`:

| Lane | Before | After |
|---|---|---|
| frame `blockTest` | — | 214 / 214 |
| frame `engineTest` | — | 214 / 214 |
| full `blockchain_tests` | — | 122824 / 122824 |
| `transaction_tests` | 290 / 314 | 290 / 314 |

The 24 `txTest` failures are pre-existing signature/fee cases, identical on both sides — no test newly fails or newly passes.

Unit tests: `FrameTxDecoderTests` 46/46, all `Nethermind.Core.Test` `Encoding` 495/495, `Ethereum.Transaction.Test` 20/20. Lint-enforced build clean on both touched projects (gate positive-controlled with an injected unused `using`, which did produce IDE0005); `dotnet format whitespace --verify-no-changes` clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
