### PR TITLE
perf: encode a branch node in one pass

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -720,6 +720,32 @@ public class TrieNodeTests
     }
 
     [Test]
+    public void Can_encode_branch_with_every_child_a_hash()
+    {
+        TrieNode node = new(NodeType.Branch);
+        for (int i = 0; i < TrieNode.BranchesCount; i++)
+        {
+            node.SetChild(i, new TrieNode(NodeType.Unknown, Keccak.Compute([(byte)i])));
+        }
+
+        TreePath emptyPath = TreePath.Empty;
+        CappedArray<byte> rlp = node.RlpEncode(NullTrieNodeResolver.Instance, ref emptyPath);
+
+        TrieNode restoredNode = new(NodeType.Unknown, rlp);
+        restoredNode.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // The widest a branch encodes to: sixteen 33-byte hash items plus the value and the header.
+            Assert.That(rlp.Length, Is.EqualTo(532), "RLP length");
+            for (int i = 0; i < TrieNode.BranchesCount; i++)
+            {
+                Assert.That(restoredNode.GetChildHash(i), Is.EqualTo(Keccak.Compute([(byte)i])), $"child {i}");
+            }
+        }
+    }
+
+    [Test]
     public void Size_of_a_heavy_leaf_is_correct()
     {
         Context ctx = new();

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -142,19 +142,62 @@ namespace Nethermind.Trie
             [DoesNotReturn, StackTraceHidden]
             private static void ThrowNullKey(TrieNode node) => throw new TrieException($"Hex prefix of a leaf node is null at node {node.Keccak}");
 
+            /// <summary>Scratch for one branch's children, before the sequence header is known.</summary>
+            /// <remarks>Sixteen children at most, each either a 33-byte hash item or a node small enough
+            /// to be embedded, which the trie only does below 32 bytes. A struct local rather than a
+            /// stackalloc, for the reason given on <c>KeccakHash</c>'s state buffer: localloc would pin
+            /// the method at Tier0-FullOpts and add stack-probe overhead per call. Writes go through a
+            /// span, so an over-long branch throws rather than running off the buffer.</remarks>
+            [InlineArray(BranchesCount * Rlp.LengthOfKeccakRlp)]
+            private struct BranchScratch
+            {
+                private byte _element0;
+            }
+
             public static CappedArray<byte> RlpEncodeBranch(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? pool, bool canBeParallel)
             {
                 Metrics.IncrementTreeNodeRlpEncodings();
 
                 const int valueRlpLength = 1;
-                int contentLength = valueRlpLength + (UseParallel(canBeParallel, item) ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel) : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));
-                int sequenceLength = Rlp.LengthOfSequence(contentLength);
-                CappedArray<byte> result = pool.SafeRent(sequenceLength);
-                Span<byte> resultSpan = result.AsSpan();
-                int position = Rlp.StartSequence(resultSpan, 0, contentLength);
-                WriteChildrenRlpBranch(tree, ref path, item, resultSpan.Slice(position, contentLength - valueRlpLength), pool, canBeParallel);
-                position = sequenceLength - valueRlpLength;
-                resultSpan[position] = 128;
+                int contentLength;
+                int sequenceLength;
+                CappedArray<byte> result;
+                Span<byte> resultSpan;
+                int position;
+
+                // The children have to be measured before they can be written, because the sequence
+                // header carries their length and CappedArray has no offset to write it backwards into.
+                // Measuring means walking all sixteen children twice - resolving each one, decoding the
+                // old RLP to find the next - which is the whole of GetChildrenRlpLengthForBranch. Where
+                // there is nothing else to gain from the walk, write the children into a scratch buffer
+                // instead and copy them in behind the header: one bounded copy for a whole pass. On a
+                // host with AVX-512 the measuring pass also collects full branches for batched hashing,
+                // which is worth more than the walk costs, so that target keeps it.
+                if (Avx512F.VL.IsSupported || UseParallel(canBeParallel, item))
+                {
+                    contentLength = valueRlpLength + (UseParallel(canBeParallel, item)
+                        ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel)
+                        : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));
+                    sequenceLength = Rlp.LengthOfSequence(contentLength);
+                    result = pool.SafeRent(sequenceLength);
+                    resultSpan = result.AsSpan();
+                    position = Rlp.StartSequence(resultSpan, 0, contentLength);
+                    WriteChildrenRlpBranch(tree, ref path, item, resultSpan.Slice(position, contentLength - valueRlpLength), pool, canBeParallel);
+                    resultSpan[sequenceLength - valueRlpLength] = 128;
+
+                    return result;
+                }
+
+                Unsafe.SkipInit(out BranchScratch scratch);
+                Span<byte> children = scratch;
+                int childrenLength = WriteChildrenRlpBranch(tree, ref path, item, children, pool, canBeParallel);
+                contentLength = valueRlpLength + childrenLength;
+                sequenceLength = Rlp.LengthOfSequence(contentLength);
+                result = pool.SafeRent(sequenceLength);
+                resultSpan = result.AsSpan();
+                position = Rlp.StartSequence(resultSpan, 0, contentLength);
+                children[..childrenLength].CopyTo(resultSpan[position..]);
+                resultSpan[sequenceLength - valueRlpLength] = 128;
 
                 return result;
 
@@ -444,20 +487,15 @@ namespace Nethermind.Trie
                 return totalLength;
             }
 
-            private static void WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
-            {
+            /// <returns>The number of bytes written.</returns>
+            private static int WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel) =>
                 // Tail call optimized.
-                if (item.HasRlp)
-                {
-                    WriteChildrenRlpBranchRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
-                }
-                else
-                {
-                    WriteChildrenRlpBranchNonRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
-                }
-            }
+                item.HasRlp
+                    ? WriteChildrenRlpBranchRlp(tree, ref path, item, destination, bufferPool, canBeParallel)
+                    : WriteChildrenRlpBranchNonRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
 
-            private static void WriteChildrenRlpBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
+            /// <inheritdoc cref="WriteChildrenRlpBranch" />
+            private static int WriteChildrenRlpBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int position = 0;
                 for (int i = 0; i < BranchesCount; i++)
@@ -492,9 +530,12 @@ namespace Nethermind.Trie
                         }
                     }
                 }
+
+                return position;
             }
 
-            private static void WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
+            /// <inheritdoc cref="WriteChildrenRlpBranch" />
+            private static int WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 RlpReader rlpReader = item.RlpReader;
                 item.SeekChild(ref rlpReader, 0);
@@ -562,7 +603,10 @@ namespace Nethermind.Trie
                 if (runStart >= 0)
                 {
                     rlpReader.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
+                    position += runLength;
                 }
+
+                return position;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -154,6 +154,7 @@ namespace Nethermind.Trie
                 private byte _element0;
             }
 
+            [SkipLocalsInit]
             public static CappedArray<byte> RlpEncodeBranch(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? pool, bool canBeParallel)
             {
                 Metrics.IncrementTreeNodeRlpEncodings();
@@ -165,17 +166,15 @@ namespace Nethermind.Trie
                 Span<byte> resultSpan;
                 int position;
 
-                // The children have to be measured before they can be written, because the sequence
-                // header carries their length and CappedArray has no offset to write it backwards into.
-                // Measuring means walking all sixteen children twice - resolving each one, decoding the
-                // old RLP to find the next - which is the whole of GetChildrenRlpLengthForBranch. Where
-                // there is nothing else to gain from the walk, write the children into a scratch buffer
-                // instead and copy them in behind the header: one bounded copy for a whole pass. On a
-                // host with AVX-512 the measuring pass also collects full branches for batched hashing,
-                // which is worth more than the walk costs, so that target keeps it.
-                if (Avx512F.VL.IsSupported || UseParallel(canBeParallel, item))
+                // The sequence header carries the children's length and CappedArray has no offset to write
+                // it backwards into, so the length has to be known before the children can go in. Writing
+                // them into a scratch buffer and copying them in behind the header trades the measuring
+                // walk for one bounded copy. On a host with AVX-512 that walk also collects full branches
+                // for batched hashing (HashPreparedBranches), which is worth more than the walk costs.
+                bool useParallel = UseParallel(canBeParallel, item);
+                if (Avx512F.VL.IsSupported || useParallel)
                 {
-                    contentLength = valueRlpLength + (UseParallel(canBeParallel, item)
+                    contentLength = valueRlpLength + (useParallel
                         ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel)
                         : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));
                     sequenceLength = Rlp.LengthOfSequence(contentLength);

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -507,6 +507,8 @@ namespace Nethermind.Trie
                 return totalLength;
             }
 
+            /// <summary>Writes a branch's sixteen children into <paramref name="destination" />, each as a hash
+            /// item or an embedded node.</summary>
             /// <returns>The number of bytes written.</returns>
             private static int WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel) =>
                 // Tail call optimized.

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -169,10 +169,10 @@ namespace Nethermind.Trie
                 // The sequence header carries the children's length and CappedArray has no offset to write
                 // it backwards into, so the length has to be known before the children can go in. Writing
                 // them into a scratch buffer and copying them in behind the header trades the measuring
-                // walk for one bounded copy. On a host with AVX-512 that walk also collects full branches
-                // for batched hashing (HashPreparedBranches), which is worth more than the walk costs.
+                // walk for one bounded copy. The walk is kept where it does something else as well:
+                // spreading the children over cores, or collecting branch pairs for batched hashing.
                 bool useParallel = UseParallel(canBeParallel, item);
-                if (Avx512F.VL.IsSupported || useParallel)
+                if (useParallel || (Avx512F.VL.IsSupported && HasBatchableChildPair(item)))
                 {
                     contentLength = valueRlpLength + (useParallel
                         ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel)
@@ -220,6 +220,25 @@ namespace Nethermind.Trie
 
                     return false;
                 }
+            }
+
+            /// <summary>Whether the measuring walk could pair up child hashes for <see cref="HashPreparedBranches" />.</summary>
+            /// <remarks>Only a dirty branch child is a candidate, and a lone candidate is hashed on its own, so
+            /// a branch without two of them gains nothing from the walk. The walk narrows the set further — a
+            /// candidate whose RLP is not a full branch drops out — so an upper bound is all this needs to be.</remarks>
+            private static bool HasBatchableChildPair(TrieNode item)
+            {
+                const int MinChildrenForBatchedHashing = 2;
+                int candidates = 0;
+                for (int i = 0; i < BranchesCount; i++)
+                {
+                    if (item._nodeData[i] is TrieNode { IsBranch: true, Keccak: null } && ++candidates >= MinChildrenForBatchedHashing)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
 
             private static void HashPreparedBranches(TrieNode item, ushort candidateMask)

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -230,9 +230,11 @@ namespace Nethermind.Trie
             {
                 const int MinChildrenForBatchedHashing = 2;
                 int candidates = 0;
+                Debug.Assert(item._nodeData is BranchData, "Data is not BranchData");
+                BranchData branchData = Unsafe.As<BranchData>(item._nodeData!);
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    if (item._nodeData[i] is TrieNode { IsBranch: true, Keccak: null } && ++candidates >= MinChildrenForBatchedHashing)
+                    if (branchData[i] is TrieNode { IsBranch: true, Keccak: null } && ++candidates >= MinChildrenForBatchedHashing)
                     {
                         return true;
                     }


### PR DESCRIPTION
## Changes

Encoding a branch node walked its sixteen children **twice**. The second walk writes them; the first
exists only to measure, because an RLP sequence header carries the content length and `CappedArray` has
no offset that would let the header be written backwards into the buffer afterwards. Measuring is not
cheap: `GetChildrenRlpLengthForBranch` resolves every child and decodes the old RLP to find where the
next one starts — in the zkVM guest that pass is **2.53 % of all steps**, against 2.73 % for the pass
that does the work.

Where nothing else depends on the measuring walk, the children are now written into a bounded stack
scratch first, and copied in behind the header once their length is known: one copy of at most 528
bytes in place of an entire pass. The scratch is an `[InlineArray]` struct local rather than a
`stackalloc`, for the reason `KeccakHash`'s state buffer documents — localloc would pin the method at
Tier0-FullOpts and add stack-probe overhead per call — and everything is written through a `Span`, so a
branch that somehow exceeded the buffer throws rather than running past it.

The measuring walk is kept where it earns its cost. The parallel path keeps it. On a host with AVX-512
it is kept for a branch with at least two dirty branch children, because those are the only children
`HashPreparedBranches` can pair up for batched hashing — a branch without such a pair gains nothing
from a second walk, so the whole bottom layer of any dirty subtree takes the single pass on AVX-512
too. That gate is an upper bound on what the walk would collect (a candidate whose RLP is not a full
branch drops out during the walk itself), so no batching opportunity is lost either way.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Can_encode_branch_with_every_child_a_hash` pins the 528-byte scratch bound against the widest branch
there is, and round-trips it back through the decoder. Beyond that the existing suites cover this
encoder densely — `Nethermind.Trie.Test` 537/0, `Nethermind.State.Test` 1283/0,
`Nethermind.Blockchain.Test` 1772/0 — and `nethermind-tests-checked.yml` runs all three in the
`no-intrinsics` variant, so the single-pass path is exercised on every PR whatever the runner's CPU
happens to be. The guest output for mainnet block 25532382 is byte-identical, which exercises the new
path on every branch commit in a real block.

Caveat: the AVX-512 arm of the gate cannot be exercised locally — this box is AVX2 — so it rests on
review plus whichever CI runners happen to have AVX-512. Both arms encode identically, so a wrong gate
would cost throughput, not correctness.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`ziskemu` steps for mainnet block 25532382, `bflat-riscv64` + `zisk:1.2.0-alpha`, `-Ot`:

| | steps | Δ |
|---|---:|---:|
| master `3bb4807754` | 474,276,697 | — |
| #13164 + #13165 + #13166 | 470,801,450 | −0.73 % |
| with this change | **462,376,717** | **−2.51 %** total, **−1.79 %** for this commit |

The trie is 21.6 % of guest steps and node re-encoding is 6.45 % of it, so this takes roughly a quarter
of the encoder. The guest has no AVX-512, so it takes the single pass unconditionally.

The batching gate was measured separately against the tip of this branch (same emulator, `-Ot`, output
byte-identical): 418,197,507 steps against 418,197,455, i.e. +52. `Avx512F.VL.IsSupported` folds to
false on riscv64, so the candidate scan is eliminated in the guest and the gate is a host-only change.

For the record, tidying `RlpEncodeBranch`'s duplicated tail was tried and dropped: splitting it into
`RlpEncodeBranchTwoPass`/`RlpEncodeBranchSinglePass` costs **+0.73 %** guest steps (421,244,816), a
shared rent-header helper the same, and `AggressiveInlining` on all of them does not recover it
(421,327,494) - ILC already inlines them. Folding the two tails into one branch inside the single
method costs the same +0.73 %. The duplication stays because every alternative measured worse.

### Host side

`RlpTrieNodeEncodingBenchmark`, BenchmarkDotNet ShortRun, quiet machine, run base → branch → base so
drift is visible (this box is AVX2, so it takes the single-pass path):

| | base | branch | base again |
|---|---:|---:|---:|
| `Encode_Branch` | 161.59 ns | **94.99 ns** | 176.82 ns |
| `Encode_Extension` | 36.07 ns | 40.55 ns | 35.46 ns |
| `Encode_Leaf` | 25.30 ns | 25.64 ns | 26.89 ns |

Branch encoding is about 44 % faster, bracketed by both baseline runs.

On the extension reading above: re-measuring it five arms interleaved (base -> branch -> base ->
branch -> base) shows the box drifting monotonically, `Encode_Leaf` included - untouched by any commit
here and still spreading 33 % (29.20 -> 33.17 -> 30.18 -> 23.57 -> 22.17 ns). Normalised against that
control there is no extension signal in either direction, so the ~4.5 ns is drift, not the scratch.
