### PR TITLE
perf(zkevm): byte-swap a word without going through a vector

### DIFF
--- a/src/Nethermind/Nethermind.Core.ZkEvm.Test/Extensions/GuestMixerTests.cs
+++ b/src/Nethermind/Nethermind.Core.ZkEvm.Test/Extensions/GuestMixerTests.cs
@@ -26,6 +26,12 @@ public class GuestMixerTests
 {
     private const int SampleCount = 4096;
 
+    /// <remarks>The guest installs its hash seed at start-up rather than in a static initializer, which
+    /// is what keeps a class-initialisation check off every mixer call; a test process reaches these
+    /// mixers without going through <c>StatelessExecutor.Execute</c>, so it has to do the same.</remarks>
+    [OneTimeSetUp]
+    public void SeedHashes() => SpanExtensions.SeedHashes(SpanExtensions.DefaultHashSeed);
+
     public static IEnumerable<TestCaseData> CounterOffsets()
     {
         foreach (int length in new[] { 20, 32 })

--- a/src/Nethermind/Nethermind.Core/Extensions/EvmWordExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/EvmWordExtensions.cs
@@ -8,7 +8,7 @@ using System.Runtime.Intrinsics.X86;
 
 namespace Nethermind.Core.Extensions;
 
-public static class EvmWordExtensions
+public static partial class EvmWordExtensions
 {
     extension(EvmWord word)
     {
@@ -39,14 +39,19 @@ public static class EvmWordExtensions
                 return Vector256.Create(lower, upper).AsByte();
             }
 
-            Vector256<ulong> u = word.AsUInt64();
-            ulong out0 = Bytes.Bswap64(u.GetElement(3));
-            ulong out1 = Bytes.Bswap64(u.GetElement(2));
-            ulong out2 = Bytes.Bswap64(u.GetElement(1));
-            ulong out3 = Bytes.Bswap64(u.GetElement(0));
-            return Vector256.Create(out0, out1, out2, out3).AsByte();
+            return ByteSwapScalar(word);
         }
     }
+
+    /// <summary>Byte-reverses a 32-byte word without SIMD.</summary>
+    /// <param name="word">The word to reverse.</param>
+    /// <returns><paramref name="word"/> with its bytes in the opposite order.</returns>
+    /// <remarks>Split per target. Both arms reverse the same four lanes and swap their order; they differ
+    /// only in how they get at them. A host reaches this at all only without AVX2 or AdvSimd, so it keeps
+    /// the vector spelling; the guest has no vectors, where <c>GetElement</c> and <c>Vector256.Create</c>
+    /// become a stack round-trip per lane around a byte swap that is already only a few instructions.
+    /// See <c>EvmWordExtensions.std.cs</c> and <c>.zkevm.cs</c>.</remarks>
+    private static partial EvmWord ByteSwapScalar(EvmWord word);
 
     // PSHUFB / PermuteVar32x8 mask that byte-reverses a 256-bit word.
     // Property form so the JIT folds it to a PC-relative rodata load at every call site.

--- a/src/Nethermind/Nethermind.Core/Extensions/EvmWordExtensions.std.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/EvmWordExtensions.std.cs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace Nethermind.Core.Extensions;
+
+public static partial class EvmWordExtensions
+{
+    /// <inheritdoc cref="EvmWordExtensions.ByteSwapScalar" />
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static partial EvmWord ByteSwapScalar(EvmWord word)
+    {
+        Vector256<ulong> u = word.AsUInt64();
+        ulong out0 = Bytes.Bswap64(u.GetElement(3));
+        ulong out1 = Bytes.Bswap64(u.GetElement(2));
+        ulong out2 = Bytes.Bswap64(u.GetElement(1));
+        ulong out3 = Bytes.Bswap64(u.GetElement(0));
+        return Vector256.Create(out0, out1, out2, out3).AsByte();
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Extensions/EvmWordExtensions.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/EvmWordExtensions.zkevm.cs
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+
+namespace Nethermind.Core.Extensions;
+
+public static partial class EvmWordExtensions
+{
+    /// <inheritdoc cref="EvmWordExtensions.ByteSwapScalar" />
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static partial EvmWord ByteSwapScalar(EvmWord word)
+    {
+        // Straight over the four lanes: the parameter is already this frame's copy, and the result is
+        // written lane by lane, so neither side needs the staging buffer a Vector256 would go through.
+        ref ulong src = ref Unsafe.As<EvmWord, ulong>(ref word);
+        Unsafe.SkipInit(out EvmWord result);
+        ref ulong dst = ref Unsafe.As<EvmWord, ulong>(ref result);
+
+        dst = Bytes.Bswap64(Unsafe.Add(ref src, 3));
+        Unsafe.Add(ref dst, 1) = Bytes.Bswap64(Unsafe.Add(ref src, 2));
+        Unsafe.Add(ref dst, 2) = Bytes.Bswap64(Unsafe.Add(ref src, 1));
+        Unsafe.Add(ref dst, 3) = Bytes.Bswap64(src);
+
+        return result;
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -20,6 +20,20 @@ namespace Nethermind.Core.Extensions
     {
         private const ulong ShortInputDomain = 0xD6E8FEB86659FD93UL;
 
+        /// <summary>The hash seed a stateless run installs when the payload does not carry one.</summary>
+        public const uint DefaultHashSeed = 2098026241U;
+
+        /// <summary>Installs the seed the hash mixers derive their lane multipliers from.</summary>
+        /// <param name="instanceRandom">The per-run seed.</param>
+        /// <remarks>
+        /// A no-op on the host, which randomises its seed per process at start-up. The guest installs it
+        /// here rather than in a static initializer for two reasons: the seed comes from the payload, and
+        /// any static initializer gives the type a class constructor, after which every mixer call - the
+        /// hottest leaf in the guest - pays a class-initialisation check, a fence and a two-level static
+        /// load. Call once, before anything hashes a key.
+        /// </remarks>
+        public static partial void SeedHashes(uint instanceRandom);
+
         internal static uint ComputeSeed(int len) => InstanceRandom + (uint)len;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.std.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.std.cs
@@ -14,6 +14,11 @@ namespace Nethermind.Core.Extensions
     {
         // Ensure that hashes are different for every run of the node and every node, so if there are any hash collisions
         // on one node, they will not be the same on another node or across a restart and cannot degrade the network as a whole.
+        /// <inheritdoc cref="SpanExtensions.SeedHashes" />
+        /// <remarks>The host randomises its own seed per process; the argument is the guest's.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static partial void SeedHashes(uint instanceRandom) { }
+
         public static readonly uint InstanceRandom =
             (uint)System.Security.Cryptography.RandomNumberGenerator.GetInt32(int.MinValue, int.MaxValue);
 

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.zkevm.cs
@@ -20,8 +20,10 @@ namespace Nethermind.Core.Extensions
         private const ulong AesHashFinalSeed0 = 0x3C6EF372FE94F82BUL;
         private const ulong AesHashFinalSeed1 = 0xA54FF53A5F1D36F1UL;
 
-        // Guest execution requires stable hashes across runs.
-        public static readonly uint InstanceRandom = 2098026241U;
+        // Assigned by SeedHashes, never initialised inline: a static initializer anywhere in this type
+        // gives it a class constructor, and then every mixer call pays a class-initialisation check, a
+        // fence and a two-level static load. The consts below carry no storage and cost nothing.
+        public static uint InstanceRandom;
 
         // Distinct odd multipliers so a lane's contribution depends on its position: a plain XOR fold
         // would collide for inputs that differ only by swapping two lanes.
@@ -57,11 +59,20 @@ namespace Nethermind.Core.Extensions
         // Frozen-array loads rather than literals: the riscv64 backend materializes each 64-bit
         // constant with a five-instruction sequence at every use, and an array element - unlike a
         // static readonly primitive - cannot be folded back into one.
-        private static readonly ulong[] AddrLanes =
-            [SeededLane(Lane0, Address.Size), SeededLane(Lane1, Address.Size), SeededLane(Lane2, Address.Size)];
+        // Nullable rather than initialised: any initializer here, even `null!`, gives the type a class
+        // constructor. Null until SeedHashes runs, which StatelessExecutor does before it decodes.
+        private static ulong[]? AddrLanes;
 
-        private static readonly ulong[] WordLanes =
-            [SeededLane(Lane0, WordWidth), SeededLane(Lane1, WordWidth), SeededLane(Lane2, WordWidth), SeededLane(Lane3, WordWidth)];
+        private static ulong[]? WordLanes;
+
+        /// <inheritdoc cref="SpanExtensions.SeedHashes" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static partial void SeedHashes(uint instanceRandom)
+        {
+            InstanceRandom = instanceRandom;
+            AddrLanes = [SeededLane(Lane0, Address.Size), SeededLane(Lane1, Address.Size), SeededLane(Lane2, Address.Size)];
+            WordLanes = [SeededLane(Lane0, WordWidth), SeededLane(Lane1, WordWidth), SeededLane(Lane2, WordWidth), SeededLane(Lane3, WordWidth)];
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int FastHashFallback(ReadOnlySpan<byte> input)
@@ -88,7 +99,7 @@ namespace Nethermind.Core.Extensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong MixAddress(ref byte b)
         {
-            ref ulong lanes = ref MemoryMarshal.GetArrayDataReference(AddrLanes);
+            ref ulong lanes = ref MemoryMarshal.GetArrayDataReference(AddrLanes!);
             return Finish(
                 Unsafe.ReadUnaligned<ulong>(ref b) * lanes ^
                 Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref b, 8)) * Unsafe.Add(ref lanes, 1) ^
@@ -104,7 +115,7 @@ namespace Nethermind.Core.Extensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong Mix32(ref byte b)
         {
-            ref ulong lanes = ref MemoryMarshal.GetArrayDataReference(WordLanes);
+            ref ulong lanes = ref MemoryMarshal.GetArrayDataReference(WordLanes!);
             return Finish(
                 Unsafe.ReadUnaligned<ulong>(ref b) * lanes ^
                 Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref b, 8)) * Unsafe.Add(ref lanes, 1) ^

--- a/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
@@ -9,6 +9,7 @@ using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Logging;
@@ -20,6 +21,11 @@ public static class StatelessExecutor
 {
     public static byte[] Execute(ReadOnlySpan<byte> data)
     {
+        // Before anything hashes a key: the guest derives its mixers' lane multipliers from this seed,
+        // and installing it here rather than in a static initializer keeps a class-initialisation check
+        // off every mixer call. A no-op on the host, which seeds itself per process.
+        SpanExtensions.SeedHashes(SpanExtensions.DefaultHashSeed);
+
         byte[] output = StatelessValidationResult.Encode(_defaultFailureResult);
         FailureOutput = output;
         StatelessPayload payload;

--- a/src/Nethermind/Nethermind.Trie.ZkEvm.Test/GuestNibblesTests.cs
+++ b/src/Nethermind/Nethermind.Trie.ZkEvm.Test/GuestNibblesTests.cs
@@ -162,5 +162,108 @@ public class GuestNibblesTests
         return nibbles;
     }
 
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(3)]
+    [TestCase(4)]
+    [TestCase(5)]
+    [TestCase(6)]
+    [TestCase(7)]
+    [TestCase(8)]
+    [TestCase(9)]
+    [TestCase(15)]
+    [TestCase(16)]
+    [TestCase(17)]
+    [TestCase(31)]
+    [TestCase(32)]
+    [TestCase(33)]
+    public void Pack_nibbles_matches_the_scalar_reference(int count)
+    {
+        byte[] nibbles = Nibble(count * 2, seed: 3);
+        byte[] expected = PackReference(nibbles);
+        byte[] actual = new byte[count];
+
+        Nibbles.PackNibbles(ref Ref(nibbles), ref Ref(actual), count);
+
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    /// <remarks>
+    /// The SWAR body writes four bytes per word read, so <c>count % 4</c> selects which scalar tail
+    /// runs. Every high nibble is 0x0 and every low nibble 0xF, which catches a swapped pair that a
+    /// symmetric value would hide - the failure a naive lane order produces.
+    /// </remarks>
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(3)]
+    [TestCase(4)]
+    [TestCase(5)]
+    [TestCase(7)]
+    [TestCase(8)]
+    [TestCase(9)]
+    public void Pack_nibbles_keeps_the_high_nibble_first(int count)
+    {
+        byte[] nibbles = new byte[count * 2];
+        for (int i = 0; i < nibbles.Length; i++) nibbles[i] = (byte)(i % 2 == 0 ? 0x0 : 0xF);
+        byte[] actual = new byte[count];
+
+        Nibbles.PackNibbles(ref Ref(nibbles), ref Ref(actual), count);
+
+        Assert.That(actual, Is.EqualTo(PackReference(nibbles)));
+        Assert.That(actual, Is.All.EqualTo((byte)0x0F));
+    }
+
+    /// <summary>Packing is the exact inverse of expanding, for every length either tail can take.</summary>
+    [TestCase(1)]
+    [TestCase(3)]
+    [TestCase(4)]
+    [TestCase(5)]
+    [TestCase(8)]
+    [TestCase(16)]
+    [TestCase(17)]
+    [TestCase(33)]
+    public void Pack_undoes_expand(int count)
+    {
+        byte[] bytes = Fill(count, seed: 11);
+        byte[] nibbles = new byte[count * 2];
+        Nibbles.ExpandNibbles(ref Ref(bytes), ref Ref(nibbles), count);
+        byte[] roundTripped = new byte[count];
+
+        Nibbles.PackNibbles(ref Ref(nibbles), ref Ref(roundTripped), count);
+
+        Assert.That(roundTripped, Is.EqualTo(bytes));
+    }
+
+    [Test]
+    public void Pack_nibbles_writes_no_further_than_count()
+    {
+        byte[] nibbles = Nibble(16, seed: 5);
+        byte[] actual = new byte[9];
+        actual[8] = 0xAA;
+
+        Nibbles.PackNibbles(ref Ref(nibbles), ref Ref(actual), 8);
+
+        Assert.That(actual[8], Is.EqualTo((byte)0xAA));
+    }
+
+    private static byte[] Nibble(int length, int seed)
+    {
+        byte[] nibbles = new byte[length];
+        for (int i = 0; i < length; i++) nibbles[i] = (byte)((i * 7 + seed) & 15);
+        return nibbles;
+    }
+
+    private static byte[] PackReference(byte[] nibbles)
+    {
+        byte[] bytes = new byte[nibbles.Length / 2];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            bytes[i] = (byte)((nibbles[i * 2] << 4) | nibbles[(i * 2) + 1]);
+        }
+
+        return bytes;
+    }
+
     private static ref byte Ref(byte[] bytes) => ref MemoryMarshal.GetArrayDataReference(bytes);
 }

--- a/src/Nethermind/Nethermind.Trie/HexPrefix.cs
+++ b/src/Nethermind/Nethermind.Trie/HexPrefix.cs
@@ -29,10 +29,10 @@ public static class HexPrefix
             pathIndex = 1;
         }
 
-        for (int outputIndex = 1; pathIndex < pathLength; outputIndex++, pathIndex += 2)
-        {
-            output[outputIndex] = (byte)(16 * path[pathIndex] + path[pathIndex + 1]);
-        }
+        Nibbles.PackNibbles(
+            ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(path), pathIndex),
+            ref Unsafe.Add(ref MemoryMarshal.GetReference(output), 1),
+            (pathLength - pathIndex) / 2);
     }
 
     public static byte[] ToBytes(byte[] path, bool isLeaf)

--- a/src/Nethermind/Nethermind.Trie/Nibbles.cs
+++ b/src/Nethermind/Nethermind.Trie/Nibbles.cs
@@ -14,6 +14,14 @@ namespace Nethermind.Trie
     [DebuggerStepThrough]
     public static partial class Nibbles
     {
+        /// <summary>Packs <c>2 * count</c> nibble bytes into <paramref name="count"/> whole bytes.</summary>
+        /// <param name="nibbles">The nibbles, high nibble first, each byte holding one nibble.</param>
+        /// <param name="bytes">Destination for the packed bytes.</param>
+        /// <param name="count">Number of bytes to write.</param>
+        /// <remarks>Split per target; see <c>Nibbles.std.cs</c> and <c>Nibbles.zkevm.cs</c>.
+        /// Caller guarantees <paramref name="nibbles"/> holds <c>2 * count</c> bytes and
+        /// <paramref name="bytes"/> has room for <paramref name="count"/>.</remarks>
+
         private const int StackAllocLengthLimit = 255;
 
         public static Nibble[] FromBytes(params byte[] bytes) => FromBytes(bytes.AsSpan());

--- a/src/Nethermind/Nethermind.Trie/Nibbles.std.cs
+++ b/src/Nethermind/Nethermind.Trie/Nibbles.std.cs
@@ -23,6 +23,19 @@ namespace Nethermind.Trie
             }
         }
 
+        /// <inheritdoc cref="Nibbles.PackNibbles" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void PackNibbles(ref byte nibbles, ref byte bytes, int count)
+        {
+            // Raw refs rather than spans, as in ExpandNibbles: the doubled source index defeats the
+            // JIT's bounds-check elimination.
+            for (int i = 0; i < count; i++)
+            {
+                Unsafe.Add(ref bytes, i) =
+                    (byte)((Unsafe.Add(ref nibbles, i * 2) << 4) | Unsafe.Add(ref nibbles, i * 2 + 1));
+            }
+        }
+
         /// <summary>Length of the common prefix of two nibble keys.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int CommonPrefixLength(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)

--- a/src/Nethermind/Nethermind.Trie/Nibbles.zkevm.cs
+++ b/src/Nethermind/Nethermind.Trie/Nibbles.zkevm.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Trie
 {
     public static partial class Nibbles
     {
-        private static readonly ulong[] ExpandMasks = [0x0000FFFF0000FFFFUL, 0x00FF00FF00FF00FFUL, 0x000F000F000F000FUL];
+        private static readonly ulong[] ExpandMasks = [0x0000FFFF0000FFFFUL, 0x00FF00FF00FF00FFUL, 0x000F000F000F000FUL, 0x00000000FFFFFFFFUL];
 
         /// <summary>Expands <paramref name="count"/> bytes into high/low nibble pairs.</summary>
         /// <remarks>
@@ -31,14 +31,23 @@ namespace Nethermind.Trie
             ulong m16 = masks;
             ulong m8 = Unsafe.Add(ref masks, 1);
             ulong mNibble = Unsafe.Add(ref masks, 2);
+            ulong mLow = Unsafe.Add(ref masks, 3);
             int i = 0;
+            // Eight source bytes per read, expanded as two halves: one load, one loop test and one
+            // address computation instead of two, and the four-byte load the zkVM charges roughly eight
+            // times an aligned word read becomes a word read. The low half must be masked first - the
+            // spread's own mask keeps bits 32..47, which in a whole word hold source bytes four and five.
+            for (; i + sizeof(ulong) <= count; i += sizeof(ulong))
+            {
+                ulong src = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref bytes, i));
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref nibbles, i * 2), Spread(src & mLow, m16, m8, mNibble));
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref nibbles, (i * 2) + sizeof(ulong)), Spread(src >> 32, m16, m8, mNibble));
+            }
+
             for (; i + sizeof(uint) <= count; i += sizeof(uint))
             {
-                ulong v = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref bytes, i));
-                v = (v | (v << 16)) & m16;
-                v = (v | (v << 8)) & m8;
-                ulong expanded = ((v >> 4) & mNibble) | ((v & mNibble) << 8);
-                Unsafe.WriteUnaligned(ref Unsafe.Add(ref nibbles, i * 2), expanded);
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref nibbles, i * 2),
+                    Spread(Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref bytes, i)), m16, m8, mNibble));
             }
 
             for (; i < count; i++)
@@ -82,6 +91,17 @@ namespace Nethermind.Trie
                 Unsafe.Add(ref bytes, i) =
                     (byte)((Unsafe.Add(ref nibbles, i * 2) << 4) | Unsafe.Add(ref nibbles, i * 2 + 1));
             }
+        }
+
+        /// <summary>Spreads the low four bytes of <paramref name="value"/> into eight nibble bytes.</summary>
+        /// <remarks>Bits above those four bytes must already be clear: the first mask keeps bits 32..47,
+        /// so anything left there would be folded into the third and fourth nibble pair.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong Spread(ulong value, ulong m16, ulong m8, ulong mNibble)
+        {
+            ulong v = (value | (value << 16)) & m16;
+            v = (v | (v << 8)) & m8;
+            return ((v >> 4) & mNibble) | ((v & mNibble) << 8);
         }
 
         /// <summary>Length of the common prefix of two nibble keys.</summary>

--- a/src/Nethermind/Nethermind.Trie/Nibbles.zkevm.cs
+++ b/src/Nethermind/Nethermind.Trie/Nibbles.zkevm.cs
@@ -49,6 +49,41 @@ namespace Nethermind.Trie
             }
         }
 
+        /// <inheritdoc cref="Nibbles.PackNibbles" />
+        /// <remarks>
+        /// SWAR, the inverse of <see cref="ExpandNibbles"/>: eight nibble bytes come in as one word, the
+        /// high/low pair of each output byte is folded into the low byte of its 16-bit lane, and the four
+        /// lane bytes are gathered into a single 32-bit write. The indexed form it replaces spent more of
+        /// its instructions widening indices and checking bounds than on the nibbles themselves.
+        /// Little-endian only, for the reason given at <see cref="ExpandNibbles"/>; the host keeps the
+        /// plain loop in <c>Nibbles.std.cs</c>.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void PackNibbles(ref byte nibbles, ref byte bytes, int count)
+        {
+            ref ulong masks = ref MemoryMarshal.GetArrayDataReference(ExpandMasks);
+            ulong m16 = masks;
+            ulong m8 = Unsafe.Add(ref masks, 1);
+            int i = 0;
+            for (; i + sizeof(uint) <= count; i += sizeof(uint))
+            {
+                ulong v = Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref nibbles, i * 2));
+                // Each 16-bit lane ends up holding one output byte: its high nibble shifted up, its low
+                // nibble brought down from the next source byte.
+                ulong packed = ((v & m8) << 4) | ((v >> 8) & m8);
+                // Gather lanes 0..3 into the low four bytes.
+                packed = (packed | (packed >> 8)) & m16;
+                packed |= packed >> 16;
+                Unsafe.WriteUnaligned(ref Unsafe.Add(ref bytes, i), (uint)packed);
+            }
+
+            for (; i < count; i++)
+            {
+                Unsafe.Add(ref bytes, i) =
+                    (byte)((Unsafe.Add(ref nibbles, i * 2) << 4) | Unsafe.Add(ref nibbles, i * 2 + 1));
+            }
+        }
+
         /// <summary>Length of the common prefix of two nibble keys.</summary>
         /// <remarks>Word-at-a-time: the BCL scalar fallback compares byte by byte, and no vector
         /// path is available on riscv64. The mismatch position falls out of the XOR's low set bit,

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -142,19 +142,62 @@ namespace Nethermind.Trie
             [DoesNotReturn, StackTraceHidden]
             private static void ThrowNullKey(TrieNode node) => throw new TrieException($"Hex prefix of a leaf node is null at node {node.Keccak}");
 
+            /// <summary>Scratch for one branch's children, before the sequence header is known.</summary>
+            /// <remarks>Sixteen children at most, each either a 33-byte hash item or a node small enough
+            /// to be embedded, which the trie only does below 32 bytes. A struct local rather than a
+            /// stackalloc, for the reason given on <c>KeccakHash</c>'s state buffer: localloc would pin
+            /// the method at Tier0-FullOpts and add stack-probe overhead per call. Writes go through a
+            /// span, so an over-long branch throws rather than running off the buffer.</remarks>
+            [InlineArray(BranchesCount * Rlp.LengthOfKeccakRlp)]
+            private struct BranchScratch
+            {
+                private byte _element0;
+            }
+
             public static CappedArray<byte> RlpEncodeBranch(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? pool, bool canBeParallel)
             {
                 Metrics.IncrementTreeNodeRlpEncodings();
 
                 const int valueRlpLength = 1;
-                int contentLength = valueRlpLength + (UseParallel(canBeParallel, item) ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel) : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));
-                int sequenceLength = Rlp.LengthOfSequence(contentLength);
-                CappedArray<byte> result = pool.SafeRent(sequenceLength);
-                Span<byte> resultSpan = result.AsSpan();
-                int position = Rlp.StartSequence(resultSpan, 0, contentLength);
-                WriteChildrenRlpBranch(tree, ref path, item, resultSpan.Slice(position, contentLength - valueRlpLength), pool, canBeParallel);
-                position = sequenceLength - valueRlpLength;
-                resultSpan[position] = 128;
+                int contentLength;
+                int sequenceLength;
+                CappedArray<byte> result;
+                Span<byte> resultSpan;
+                int position;
+
+                // The children have to be measured before they can be written, because the sequence
+                // header carries their length and CappedArray has no offset to write it backwards into.
+                // Measuring means walking all sixteen children twice - resolving each one, decoding the
+                // old RLP to find the next - which is the whole of GetChildrenRlpLengthForBranch. Where
+                // there is nothing else to gain from the walk, write the children into a scratch buffer
+                // instead and copy them in behind the header: one bounded copy for a whole pass. On a
+                // host with AVX-512 the measuring pass also collects full branches for batched hashing,
+                // which is worth more than the walk costs, so that target keeps it.
+                if (Avx512F.VL.IsSupported || UseParallel(canBeParallel, item))
+                {
+                    contentLength = valueRlpLength + (UseParallel(canBeParallel, item)
+                        ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel)
+                        : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));
+                    sequenceLength = Rlp.LengthOfSequence(contentLength);
+                    result = pool.SafeRent(sequenceLength);
+                    resultSpan = result.AsSpan();
+                    position = Rlp.StartSequence(resultSpan, 0, contentLength);
+                    WriteChildrenRlpBranch(tree, ref path, item, resultSpan.Slice(position, contentLength - valueRlpLength), pool, canBeParallel);
+                    resultSpan[sequenceLength - valueRlpLength] = 128;
+
+                    return result;
+                }
+
+                Unsafe.SkipInit(out BranchScratch scratch);
+                Span<byte> children = scratch;
+                int childrenLength = WriteChildrenRlpBranch(tree, ref path, item, children, pool, canBeParallel);
+                contentLength = valueRlpLength + childrenLength;
+                sequenceLength = Rlp.LengthOfSequence(contentLength);
+                result = pool.SafeRent(sequenceLength);
+                resultSpan = result.AsSpan();
+                position = Rlp.StartSequence(resultSpan, 0, contentLength);
+                children[..childrenLength].CopyTo(resultSpan[position..]);
+                resultSpan[sequenceLength - valueRlpLength] = 128;
 
                 return result;
 
@@ -444,20 +487,15 @@ namespace Nethermind.Trie
                 return totalLength;
             }
 
-            private static void WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
-            {
+            /// <returns>The number of bytes written.</returns>
+            private static int WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel) =>
                 // Tail call optimized.
-                if (item.HasRlp)
-                {
-                    WriteChildrenRlpBranchRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
-                }
-                else
-                {
-                    WriteChildrenRlpBranchNonRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
-                }
-            }
+                item.HasRlp
+                    ? WriteChildrenRlpBranchRlp(tree, ref path, item, destination, bufferPool, canBeParallel)
+                    : WriteChildrenRlpBranchNonRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
 
-            private static void WriteChildrenRlpBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
+            /// <inheritdoc cref="WriteChildrenRlpBranch" />
+            private static int WriteChildrenRlpBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int position = 0;
                 for (int i = 0; i < BranchesCount; i++)
@@ -492,9 +530,12 @@ namespace Nethermind.Trie
                         }
                     }
                 }
+
+                return position;
             }
 
-            private static void WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
+            /// <inheritdoc cref="WriteChildrenRlpBranch" />
+            private static int WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 RlpReader rlpReader = item.RlpReader;
                 item.SeekChild(ref rlpReader, 0);
@@ -562,7 +603,10 @@ namespace Nethermind.Trie
                 if (runStart >= 0)
                 {
                     rlpReader.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
+                    position += runLength;
                 }
+
+                return position;
             }
         }
     }


### PR DESCRIPTION
## Changes

Stacked on #13167.

`EvmWord.ByteSwap` picks a SIMD path per host — AVX-512 VBMI, AVX2, AdvSimd — and falls back to reading
its four lanes with `GetElement` and reassembling them with `Vector256.Create`. On a host that fallback
is nearly unreachable. The guest has no vectors at all, so it is the only path there, and ILC gives each
`GetElement` and the `Create` a stack round-trip — around a byte swap that `ZkEvmBitOperations.Bswap64`
already does in a handful of instructions.

That is not a rare path in the guest: `Math2ParamCore` swaps three words per arithmetic opcode — pop `a`,
read `b`, write the result — because the stack holds words big-endian and `UInt256` is little-endian
limbs. The dead store-and-reload-the-same-register pairs this produces are 0.68% of the whole guest run,
and roughly 0.6 of that sits in `VirtualMachine` and the `InstructionMath2Param` instantiations.

The fallback moves behind a `ByteSwapScalar` partial pair. The host arm is the old body verbatim; the
guest arm walks the four lanes through `Unsafe.Add` and writes the result lane by lane, so neither side
goes through a vector.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

No new tests: both arms compute the same permutation as the SIMD paths, which the existing suites already
pin — `Nethermind.Core.Test` 6045/0 and `Nethermind.Evm.Test` 5178/0. Every arithmetic opcode in the
guest run passes through this function, and the guest output for mainnet block 25532382 is byte-identical.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`ziskemu` steps for mainnet block 25532382, `bflat-riscv64` + `zisk:1.2.0-alpha`, `-Ot`:

| | steps | Δ |
|---|---:|---:|
| #13167 | 462,376,717 | — |
| with this change | **459,131,557** | **−0.70 %** |

That is −3.19 % against master `3bb4807754` for the stack so far.

### Host side

The host arm is the previous body, moved without edit, and it is reached only on a machine with neither
AVX2 nor AdvSimd — every path an actual host takes is chosen above it and is untouched. No benchmark run:
there is no host codegen change to measure.
