### PR TITLE
perf(zkevm): convert stack slots with the shared-mask swap

### DIFF
--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -48,8 +48,42 @@ public ref partial struct EvmStack
     private readonly ITxTracer _tracer;
     private readonly ref byte _stack;
     internal readonly ref byte Code;
+#if ZK_EVM
+    // Both are read on nearly every opcode and Head is written too, and the guest charges 122 for a
+    // four-byte field read and 193 for a write against 16 and 18 for a native-width one - a cost the
+    // step count does not show at all. Storing them wide keeps the int-typed surface below unchanged.
+    private nint _head;
+
+    internal readonly nint CodeLength;
+
+    /// <inheritdoc cref="Head" />
+    public int Head
+    {
+        readonly get => (int)_head;
+        set => _head = value;
+    }
+#else
     public int Head;
     internal readonly int CodeLength;
+#endif
+
+    /// <summary>The stack pointer, at native width, for this type's own hot paths.</summary>
+    /// <remarks>
+    /// Reading through <see cref="Head"/> would undo half of storing it wide: the narrowing to <c>int</c>
+    /// lets the compiler fold the load back to a four-byte one, which is equivalent on a little-endian
+    /// target and costs the guest 122 against 16. Keeping the offset native-width to the point of use also
+    /// drops the widening each slot address needed.
+    /// </remarks>
+    private nuint HeadOffset
+    {
+#if ZK_EVM
+        readonly get => (nuint)_head;
+        set => _head = (nint)value;
+#else
+        readonly get => (uint)Head;
+        set => Head = (int)value;
+#endif
+    }
 
     /// <summary>
     /// Reserves the next stack slot and returns a ref to it. On overflow returns <see cref="Unsafe.NullRef{T}"/>;
@@ -59,14 +93,14 @@ public ref partial struct EvmStack
     public ref byte PushBytesRef()
     {
         // Workhorse method
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return ref Unsafe.NullRef<byte>();
         }
 
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
         return ref Unsafe.Add(ref _stack, (nint)(headOffset * WordSize));
     }
 
@@ -208,13 +242,13 @@ public ref partial struct EvmStack
     public EvmExceptionType PushRightPaddedBytes<TTracingInst>(ref byte src, uint length)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         ref byte dst = ref Unsafe.Add(ref _stack, (nint)(headOffset * WordSize));
 
@@ -378,13 +412,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push10Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -407,13 +441,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push11Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -436,13 +470,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push12Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -464,13 +498,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push13Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -492,13 +526,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push14Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -520,13 +554,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push15Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -548,13 +582,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push16Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -582,13 +616,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push17Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -611,13 +645,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push18Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -640,13 +674,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push19Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -669,13 +703,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push20Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -698,13 +732,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push21Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -727,13 +761,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push22Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -756,13 +790,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push23Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -785,13 +819,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push24Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -814,13 +848,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push25Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -843,13 +877,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push26Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -872,13 +906,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push27Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -901,13 +935,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push28Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -930,13 +964,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push29Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -959,13 +993,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push2Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -985,13 +1019,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push30Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1014,13 +1048,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push31Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1043,13 +1077,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push32Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1066,13 +1100,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push3Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1092,13 +1126,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push4Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1116,13 +1150,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push5Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1142,13 +1176,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push6Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1168,13 +1202,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push7Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1195,13 +1229,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push8Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1219,13 +1253,13 @@ public ref partial struct EvmStack
     public EvmExceptionType Push9Bytes<TTracingInst>(ref byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1247,13 +1281,13 @@ public ref partial struct EvmStack
     public EvmExceptionType PushByte<TTracingInst>(byte value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
         {
@@ -1292,13 +1326,13 @@ public ref partial struct EvmStack
     public EvmExceptionType PushBothPaddedBytes<TTracingInst>(ref byte start, int used, int pushSize)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
             ReportStackPush(ref start, used);
@@ -1389,13 +1423,13 @@ public ref partial struct EvmStack
     public EvmExceptionType PushOne<TTracingInst>()
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
             _tracer.ReportStackPush(Bytes.OneByteSpan);
@@ -1422,13 +1456,13 @@ public ref partial struct EvmStack
     public EvmExceptionType PushZero<TTracingInst>()
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (TTracingInst.IsActive)
             _tracer.ReportStackPush(Bytes.ZeroByteSpan);
@@ -1453,14 +1487,14 @@ public ref partial struct EvmStack
     public EvmExceptionType PushUInt32<TTracingInst>(uint value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
         ref EvmWord head = ref Unsafe.As<byte, EvmWord>(ref Unsafe.Add(ref _stack, (nint)(headOffset * WordSize)));
-        if (newOffset >= MaxStackSize)
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         value = BinaryPrimitives.ReverseEndianness(value);
         // uint size
@@ -1485,14 +1519,14 @@ public ref partial struct EvmStack
     public EvmExceptionType PushUInt64<TTracingInst>(ulong value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
         ref EvmWord head = ref Unsafe.As<byte, EvmWord>(ref Unsafe.Add(ref _stack, (nint)(headOffset * WordSize)));
-        if (newOffset >= MaxStackSize)
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         value = Bytes.Bswap64(value);
         // ulong size
@@ -1523,14 +1557,14 @@ public ref partial struct EvmStack
     public EvmExceptionType PushUInt256<TTracingInst>(in UInt256 value)
         where TTracingInst : struct, IFlag
     {
-        uint headOffset = (uint)Head;
-        uint newOffset = headOffset + 1;
+        nuint headOffset = HeadOffset;
+        nuint newOffset = headOffset + 1;
         ref EvmWord head = ref Unsafe.As<byte, EvmWord>(ref Unsafe.Add(ref _stack, (nint)(headOffset * WordSize)));
-        if (newOffset >= MaxStackSize)
+        if (newOffset >= (nuint)MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
-        Head = (int)newOffset;
+        HeadOffset = newOffset;
 
         if (Avx2.IsSupported)
         {

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -345,9 +345,16 @@ public ref partial struct EvmStack
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ReadUInt256FromSlot(ref byte slot, out UInt256 value)
     {
+#if ZK_EVM
+        // The same conversion PushUInt256 and PopUInt256 already use: it shares the swap masks across
+        // the four lanes rather than rematerialising them per lane, and skips three of the four swaps
+        // outright for a word whose high limbs are zero - which is most of what arithmetic operates on.
+        value = ReadBeWord(ref slot);
+#else
         Unsafe.SkipInit(out value);
         EvmWord beBytes = Unsafe.ReadUnaligned<EvmWord>(ref slot);
         Unsafe.As<UInt256, EvmWord>(ref value) = beBytes.ByteSwap();
+#endif
     }
 
     /// <summary>
@@ -358,8 +365,13 @@ public ref partial struct EvmStack
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void WriteUInt256ToSlot(ref byte slot, in UInt256 value)
     {
+#if ZK_EVM
+        // Mirrors ReadUInt256FromSlot: shared masks, and the high limbs skipped when they are zero.
+        WriteBeWord(ref Unsafe.As<byte, EvmWord>(ref slot), in value);
+#else
         EvmWord leBytes = Unsafe.As<UInt256, EvmWord>(ref Unsafe.AsRef(in value));
         Unsafe.As<byte, EvmWord>(ref slot) = leBytes.ByteSwap();
+#endif
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
@@ -72,7 +72,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
         => DataCopy<TGasPolicy, TTracingInst>(vm, ref stack, ref gas,
-            MemoryMarshal.CreateReadOnlySpan(ref stack.Code, stack.CodeLength));
+            MemoryMarshal.CreateReadOnlySpan(ref stack.Code, (int)stack.CodeLength));
 
     /// <summary>
     /// CALLDATACOPY - copies a portion of the transaction's calldata into memory.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -998,7 +998,7 @@ public static partial class EvmInstructions
 
     // EIP-8024 specifies that a missing immediate beyond end of code evaluates to zero.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static byte ReadEip8024ImmediateOrZero(ref byte code, int codeLength, nint programCounter)
+    private static byte ReadEip8024ImmediateOrZero(ref byte code, nint codeLength, nint programCounter)
         => programCounter < codeLength ? Unsafe.Add(ref code, programCounter) : (byte)0;
 
     /// <summary>


### PR DESCRIPTION
## Changes

Stacked on #13172.

`Math2ParamCore` runs `ReadUInt256FromSlot` twice and `WriteUInt256ToSlot` once for every arithmetic
opcode. Both went through `EvmWord.ByteSwap`, which on the guest rematerialises the swap masks for each
of the four lanes and swaps all four whatever the value holds.

`PushUInt256` and `PopUInt256` already had better. The guest's `ReadBeWord`/`WriteBeWord` load the swap
masks once and share them across the lanes, and when a word's high limbs are zero they swap a single lane
instead of four. Arithmetic operands are offsets, counters, lengths and amounts, so that shortcut is the
common case rather than the exception — which is why this is worth more than its size suggests.

The two slot helpers now use that pair on the guest. The host keeps its own form verbatim: it reads each
lane with `movbe`, deliberately, and is not touched.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

No new tests: this swaps one existing conversion for another that the stack's push and pop paths have
been using all along, and every arithmetic opcode in the guest run goes through it — the output for
mainnet block 25532382 is byte-identical. `Nethermind.Evm.Test` 5178/0, `Nethermind.Core.Test` 6045/0,
and the guest suites `Nethermind.Evm.ZkEvm.Test` 200/0 and `Nethermind.Core.ZkEvm.Test` 15/0.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`ziskemu` steps for mainnet block 25532382, `bflat-riscv64` + `zisk:1.2.0-alpha`, `-Ot`:

| | steps | Δ |
|---|---:|---:|
| #13172 | 451,548,683 | — |
| with this change | **437,561,208** | **−3.10 %** |

That is **−7.74 %** against master `3bb4807754` for the stack.

### Host side

Everything new is inside `#if ZK_EVM`, so the host build is byte-identical and no benchmark applies.
