### PR TITLE
fix(rpc): stop unauthenticated callers flooding the log with -32602

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -14,6 +14,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
+using Nethermind.Core.Test;
 using Nethermind.Logging;
 using Nethermind.JsonRpc.Modules;
 using NSubstitute;
@@ -194,6 +195,24 @@ public class JsonRpcProcessorTests
         yield return new TestCaseData(CreateTransactionCountRequest("67") + CreateTransactionCountBatchRequest(2), true, false).SetName("Single request and batch");
         yield return new TestCaseData(CreateTransactionCountRequest("67") + CreateTransactionCountRequest("68")[..^1], false, true).SetName("Second request not closed");
         yield return new TestCaseData(CreateTransactionCountRequest("67") + "{aaa}", false, true).SetName("Second request invalid");
+    }
+
+    [TestCase(ErrorCodes.InvalidParams, RpcEndpoint.Http, 0)]
+    [TestCase(ErrorCodes.InvalidParams, RpcEndpoint.IPC, 1)]
+    [TestCase(ErrorCodes.InternalError, RpcEndpoint.Http, 1)]
+    public async Task Error_response_warns_unless_bad_params_came_from_an_unauthenticated_caller(int errorCode, RpcEndpoint endpoint, int expectedWarnings)
+    {
+        TestLogger logger = new() { IsInfo = false, IsWarn = true, IsDebug = false, IsTrace = false, IsError = false };
+        IJsonRpcService service = CreateService(request => new JsonRpcErrorResponse
+        {
+            Id = request.Id,
+            Error = new Error { Code = errorCode, Message = "some failure" }
+        });
+        JsonRpcProcessor processor = new(service, new JsonRpcConfig(), Substitute.For<IFileSystem>(), new OneLoggerLogManager(new(logger)), null);
+
+        using CollectedJsonRpcResponses responses = await ProcessAsync(processor, CreateRequest("1", "eth_getBalance"), new JsonRpcContext(endpoint));
+
+        Assert.That(logger.LogList, Has.Count.EqualTo(expectedWarnings), $"only Warn is enabled, so every captured line is one the operator would see for {errorCode}");
     }
 
     private ValueTask<CollectedJsonRpcResponses> ProcessAsync(string request, JsonRpcContext? context = null, JsonRpcConfig? config = null, bool returnErrors = false) =>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -17,6 +17,8 @@ using Nethermind.Config;
 using Nethermind.Core.Test;
 using Nethermind.Logging;
 using Nethermind.JsonRpc.Modules;
+using Nethermind.JsonRpc.Modules.Eth;
+using Nethermind.Serialization.Json;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -63,10 +65,32 @@ public class JsonRpcProcessorTests
     private JsonRpcProcessor CreateFixtureProcessor(IJsonRpcConfig? config = null, bool returnErrors = false) =>
         CreateProcessor(CreateService(request => returnErrors ? new JsonRpcErrorResponse { Id = request.Id } : new JsonRpcSuccessResponse { Id = request.Id }, _errorResponse), config);
 
-    private static JsonRpcProcessor CreateProcessor(IJsonRpcService service, IJsonRpcConfig? config = null, IFileSystem? fileSystem = null, IProcessExitSource? processExitSource = null) =>
-        new(service, config ?? new JsonRpcConfig(), fileSystem ?? Substitute.For<IFileSystem>(), LimboLogs.Instance, processExitSource);
+    private static JsonRpcProcessor CreateProcessor(IJsonRpcService service, IJsonRpcConfig? config = null, IFileSystem? fileSystem = null, IProcessExitSource? processExitSource = null, ILogManager? logManager = null) =>
+        new(service, config ?? new JsonRpcConfig(), fileSystem ?? Substitute.For<IFileSystem>(), logManager ?? LimboLogs.Instance, processExitSource);
 
     private static JsonRpcContext CreateHttpContext() => new(RpcEndpoint.Http);
+
+    private static TestLogger CreateWarnCapturingLogger(bool captureErrors = false) =>
+        new() { IsInfo = false, IsWarn = true, IsDebug = false, IsTrace = false, IsError = captureErrors };
+
+    private static IJsonRpcService CreateRealService(IJsonRpcConfig config, ILogManager logManager)
+    {
+        IRpcModulePool<IEthRpcModule> pool = Substitute.For<IRpcModulePool<IEthRpcModule>>();
+        RpcModuleProvider moduleProvider = new(Substitute.For<IFileSystem>(), config, new EthereumJsonSerializer(), logManager);
+        moduleProvider.Register(pool);
+        return new JsonRpcService(moduleProvider, logManager, config);
+    }
+
+    private static void AssertInvalidParamsAndLogCount(JsonRpcResponse? response, TestLogger logger, int expectedLogCount, string logCountMessage)
+    {
+        Assert.That(response, Is.TypeOf<JsonRpcErrorResponse>());
+        JsonRpcErrorResponse errorResponse = (JsonRpcErrorResponse)response!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(errorResponse.Error!.Code, Is.EqualTo(ErrorCodes.InvalidParams));
+            Assert.That(logger.LogList, Has.Count.EqualTo(expectedLogCount), logCountMessage);
+        }
+    }
 
     [Test]
     public async Task Http_engine_newPayloadV4_keeps_envelope_and_params_on_direct_utf8_path()
@@ -208,11 +232,52 @@ public class JsonRpcProcessorTests
             Id = request.Id,
             Error = new Error { Code = errorCode, Message = "some failure" }
         });
-        JsonRpcProcessor processor = new(service, new JsonRpcConfig(), Substitute.For<IFileSystem>(), new OneLoggerLogManager(new(logger)), null);
+        JsonRpcProcessor processor = CreateProcessor(service, new JsonRpcConfig(), logManager: new OneLoggerLogManager(new(logger)));
 
-        using CollectedJsonRpcResponses responses = await ProcessAsync(processor, CreateRequest("1", "eth_getBalance"), new JsonRpcContext(endpoint));
+        using JsonRpcContext context = new(endpoint);
+        using CollectedJsonRpcResponses responses = await ProcessAsync(processor, CreateRequest("1", "eth_getBalance"), context);
 
         Assert.That(logger.LogList, Has.Count.EqualTo(expectedWarnings), $"only Warn is enabled, so every captured line is one the operator would see for {errorCode}");
+    }
+
+    [TestCase(RpcEndpoint.Http, false, TestName = "Unauthenticated caller over HTTP")]
+    [TestCase(RpcEndpoint.IPC, true, TestName = "Authenticated caller over IPC")]
+    public async Task Real_JsonRpcService_only_warns_on_malformed_params_for_authenticated_callers(RpcEndpoint endpoint, bool expectedAuthenticated)
+    {
+        TestLogger logger = CreateWarnCapturingLogger();
+        OneLoggerLogManager logManager = new(new(logger));
+        IJsonRpcService realService = CreateRealService(new JsonRpcConfig(), logManager);
+
+        using JsonRpcContext context = new(endpoint);
+        Assert.That(context.IsAuthenticated, Is.EqualTo(expectedAuthenticated), "test setup sanity check");
+
+        JsonRpcRequest badParamsRequest = RpcTest.BuildJsonRequest("eth_getBalance", "0x01", "latest");
+        using JsonRpcResponse response = await realService.SendRequestAsync(badParamsRequest, context);
+
+        AssertInvalidParamsAndLogCount(response, logger, expectedAuthenticated ? 1 : 0,
+            "JsonRpcService.PrepareNonEmptyParameters's catch block must gate its own Warn on caller authentication");
+    }
+
+    [TestCase(false, 0, TestName = "Unauthenticated caller over HTTP")]
+    [TestCase(true, 2, TestName = "Authenticated caller over HTTP")]
+    public async Task Composed_processor_and_real_service_are_silent_for_the_issue_13156_repro_unless_authenticated(bool isAuthenticated, int expectedLogCount)
+    {
+        TestLogger logger = CreateWarnCapturingLogger(captureErrors: true);
+        OneLoggerLogManager logManager = new(new(logger));
+        JsonRpcConfig config = new();
+        IJsonRpcService realService = CreateRealService(config, logManager);
+        JsonRpcProcessor processor = CreateProcessor(realService, config, logManager: logManager);
+
+        using JsonRpcContext context = isAuthenticated
+            ? new JsonRpcContext(RpcEndpoint.Http, url: new JsonRpcUrl(string.Empty, string.Empty, 0, RpcEndpoint.Http, true, [ModuleType.Eth]))
+            : CreateHttpContext();
+        Assert.That(context.IsAuthenticated, Is.EqualTo(isAuthenticated), "test setup sanity check");
+
+        using CollectedJsonRpcResponses result = await ProcessAsync(processor, CreateRequest("1", "eth_getBalance", "[\"0x01\",\"latest\"]"), context);
+
+        CollectedJsonRpcResult single = AssertSingleResponse(result);
+        AssertInvalidParamsAndLogCount(single.Response, logger, expectedLogCount,
+            "issue #13156's repro must be silent through the whole composed stack for unauthenticated callers, and log once per warn site once authenticated");
     }
 
     private ValueTask<CollectedJsonRpcResponses> ProcessAsync(string request, JsonRpcContext? context = null, JsonRpcConfig? config = null, bool returnErrors = false) =>

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -906,20 +906,21 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
 
         ValueTask<JsonRpcResponse> responseTask = _jsonRpcService.SendRequestAsync(request, context);
         return responseTask.IsCompletedSuccessfully
-            ? ValueTask.FromResult(CreateSingleRequestEntry(request, responseTask.Result, startTime))
-            : AwaitAndCreateEntryAsync(responseTask, request, startTime);
+            ? ValueTask.FromResult(CreateSingleRequestEntry(request, responseTask.Result, startTime, context))
+            : AwaitAndCreateEntryAsync(responseTask, request, startTime, context);
 
         async ValueTask<JsonRpcResult.Entry> AwaitAndCreateEntryAsync(
             ValueTask<JsonRpcResponse> responseTask,
             JsonRpcRequest request,
-            long startTime)
+            long startTime,
+            JsonRpcContext context)
         {
             JsonRpcResponse response = await responseTask;
-            return CreateSingleRequestEntry(request, response, startTime);
+            return CreateSingleRequestEntry(request, response, startTime, context);
         }
     }
 
-    private JsonRpcResult.Entry CreateSingleRequestEntry(JsonRpcRequest request, JsonRpcResponse response, long startTime)
+    private JsonRpcResult.Entry CreateSingleRequestEntry(JsonRpcRequest request, JsonRpcResponse response, long startTime, JsonRpcContext context)
     {
         bool isError = response.TryGetError(out Error? responseError);
         bool isSuccess = !isError;
@@ -927,7 +928,15 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         {
             if (responseError?.SuppressWarning == false)
             {
-                if (_logger.IsWarn) _logger.Warn($"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {responseError.Code} Message: {responseError.Message}");
+                if (responseError.Code == ErrorCodes.InvalidParams && !context.IsAuthenticated)
+                {
+                    if (_logger.IsDebug) _logger.Debug($"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {responseError.Code} Message: {responseError.Message}");
+                }
+                else if (_logger.IsWarn)
+                {
+                    _logger.Warn($"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {responseError.Code} Message: {responseError.Message}");
+                }
+
                 if (_logger.IsTrace) _logger.Trace($"Error when handling {request} | {SerializeResponseForDiagnostics(response)}");
             }
             Metrics.JsonRpcErrors++;

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -99,6 +99,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             request,
             methodName,
             method,
+            context,
             out object?[]? parameters,
             out int parameterCount,
             out bool returnParametersToPool);
@@ -201,6 +202,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         JsonRpcRequest request,
         string methodName,
         ResolvedMethodInfo method,
+        JsonRpcContext context,
         out object?[]? parameters,
         out int parameterCount,
         out bool returnParametersToPool)
@@ -230,6 +232,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
                 useUtf8Parameters,
                 providedParametersUtf8,
                 providedParameters,
+                context,
                 out parameters,
                 out parameterCount,
                 out returnParametersToPool);
@@ -259,6 +262,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         bool useUtf8Parameters,
         ReadOnlyMemory<byte> providedParametersUtf8,
         JsonElement providedParameters,
+        JsonRpcContext context,
         out object?[]? parameters,
         out int parameterCount,
         out bool returnParametersToPool)
@@ -290,7 +294,15 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         catch (Exception e)
         {
             ReturnParameters(parameters, returnParametersToPool);
-            if (_logger.IsWarn) _logger.Warn($"Incorrect JSON RPC parameters when calling {methodName} with params [{GetParamsForLog(request)}] {e}");
+            if (!context.IsAuthenticated)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Incorrect JSON RPC parameters when calling {methodName} with params [{GetParamsForLog(request)}] {e}");
+            }
+            else if (_logger.IsWarn)
+            {
+                _logger.Warn($"Incorrect JSON RPC parameters when calling {methodName} with params [{GetParamsForLog(request)}] {e}");
+            }
+
             string message = GetSafePublicMessage(e) ?? "Invalid params";
             return GetErrorResponse(methodName, ErrorCodes.InvalidParams, message, null, in request.IdRef);
         }


### PR DESCRIPTION
Fixes #13156

## Changes

- `-32602 Invalid params` responses are now logged at Debug instead of Warn for unauthenticated callers, so a caller sending malformed parameters no longer writes one operator log line per request, at whatever rate it chooses. Authenticated callers (Engine API, IPC) keep Warn, since there malformed params usually mean a consensus-client bug or version mismatch rather than a hostile caller.
- There are two producers of that Warn, and both are gated the same way now:
  - `JsonRpcProcessor.CreateSingleRequestEntry` — the response-classification path every error response passes through. The demotion applies only when `responseError.Code == ErrorCodes.InvalidParams && !context.IsAuthenticated`; every other client-caused code (unknown method `-32601`, an oversized batch, etc.) is untouched and still warns once per request regardless of authentication.
  - `JsonRpcService.PrepareNonEmptyParameters`'s catch block — parameter binding/conversion throws before a response object exists (e.g. `eth_getBalance` with a malformed address string throws in the `Address` converter). This is the path the issue's own repro actually hits; demoting only the processor left it warning once per request. `JsonRpcContext` is threaded through `PrepareParameters`/`PrepareNonEmptyParameters` to gate this site too.
- `Metrics.JsonRpcErrors` and the existing `Trace` line are unchanged, so both the aggregate signal and the full request/response detail are still there.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Three tests in `JsonRpcProcessorTests`, one per layer:

- `Error_response_warns_unless_bad_params_came_from_an_unauthenticated_caller` — `JsonRpcProcessor` alone against a stubbed `IJsonRpcService`, parameterized over `(errorCode, RpcEndpoint, expectedWarnings)`. Pins the `-32602`/`!IsAuthenticated` gate in isolation.
- `Real_JsonRpcService_only_warns_on_malformed_params_for_authenticated_callers` — the real `JsonRpcService` alone, `eth_getBalance` with `["0x01","latest"]`, asserting the catch-block Warn fires only when authenticated.
- `Composed_processor_and_real_service_are_silent_for_the_issue_13156_repro_unless_authenticated` — real processor + real service driven with the issue's exact request, asserting the operator-visible log count is exactly zero for an unauthenticated caller and non-zero once authenticated.

`JsonRpcProcessorTests` passes 84/84.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Rejections with `-32602 Invalid params` on public, unauthenticated JSON-RPC endpoints no longer emit a WARN line, at either the response-classification site or the parameter-parsing site — both now log at Debug. Operators alerting or dashboarding on that line will need to adjust, or can get the detail back without a rebuild via `--Init.LogRules "JsonRpc.JsonRpcProcessor: Debug"` / `"JsonRpc.JsonRpcService: Debug"`. The Engine API and IPC are unaffected — authenticated callers still warn — and the error is still counted in `Metrics.JsonRpcErrors`.

## Remarks

- **Scope is `-32602` only.** The gate in `CreateSingleRequestEntry` is `responseError.Code == ErrorCodes.InvalidParams && !context.IsAuthenticated`. Sibling client-error codes are deliberately untouched: an unauthenticated request with an unknown method still logs one Warn per request (`-32601`), as does an oversized batch. Testing this with a bad *method name* rather than bad *params* will look like it doesn't work — that's expected. Widening to the whole client-error class is a deliberate non-goal here; happy to make it a follow-up if maintainers want the broader change.
- **The `JsonRpcService` catch block is broad.** It catches whatever a parameter converter throws and always reports it as `-32602`, so a genuine Nethermind bug — say a null-reference in a JSON converter — now logs at Debug instead of Warn on a public, unauthenticated endpoint. Adding an error-code condition to the gate wouldn't help distinguish that case, since the block only ever emits `InvalidParams`; the caller receives the same `-32602` either way. Worth flagging as a trade-off of demoting this site.
