### PR TITLE
perf(zkevm): leave the embedded chainspecs out of the guest build

### DIFF
--- a/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
+++ b/src/Nethermind/Nethermind.Config/Nethermind.Config.csproj
@@ -13,7 +13,8 @@
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Network.Enr\Nethermind.Network.Enr.csproj" />
   </ItemGroup>
-  <ItemGroup>
+  <!-- The zkEVM guest never reads a chainspec; embedding them would add 6.9 MB, a third of the guest image. -->
+  <ItemGroup Condition="'$(EnableZkEvm)' != 'true'">
     <EmbeddedResource Include="..\Chains\**\*.*">
       <Link>chainspec\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </EmbeddedResource>

--- a/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
+++ b/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
@@ -52,6 +52,8 @@ BFLAT_REFS := \
 dotnet-build:
 	dotnet build -c release -p:EnableZkEvm=true $(GUEST_DIR)/Nethermind.Stateless.ZiskGuest.csproj
 
+# ILC embeds every manifest resource of every input assembly and the guest reads none, so resource
+# bytes in the image are dead weight (6.9 MB of chainspecs once rode along) - fail the build instead.
 build: dotnet-build
 	docker run --platform linux/amd64 --rm \
 		-e DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 \
@@ -67,10 +69,16 @@ build: dotnet-build
 		--no-globalization \
 		--nostdlibrefs \
 		--substitution $(SRC_DIR)/substitutions.xml \
+		--map $(SRC_DIR)/Program.map.xml \
 		$(BFLAT_REFS) \
 		--extlib $(BIN_DIR)/runtimes/linux-riscv64/native/libziskos.bflat.manifest \
 		$(ISA_GATES) \
 		$(SRC_DIR)/Program.cs
+	@len=$$(sed -n 's/.*Name="__embedded_resourcedata" Length="\([0-9]*\)".*/\1/p' $(GUEST_DIR)/Program.map.xml); \
+	rm -f $(GUEST_DIR)/Program.map.xml; \
+	if [ -z "$$len" ]; then echo "error: could not read __embedded_resourcedata from the ILC map" >&2; exit 1; fi; \
+	if [ "$$len" != "0" ]; then echo "error: the guest image embeds $$len bytes of manifest resources; the guest reads none, find the assembly that added them" >&2; exit 1; fi; \
+	echo "Resource verification: OK - no manifest resources in the guest image"
 	mkdir -p $(GUEST_DIR)/bin && \
 		mv -f $(GUEST_DIR)/Program.patched $(GUEST_DIR)/bin/nethermind && \
 		rm -f $(GUEST_DIR)/Program
@@ -88,7 +96,8 @@ clean:
 		$(GUEST_DIR)/bin/** \
 		$(GUEST_DIR)/Program \
 		$(GUEST_DIR)/Program.o \
-		$(GUEST_DIR)/Program.patched
+		$(GUEST_DIR)/Program.patched \
+		$(GUEST_DIR)/Program.map.xml
 	dotnet clean -c release $(MAKEFILE_DIR)/../Stateless.slnx
 
 .PHONY: \


### PR DESCRIPTION
## Changes

- `Nethermind.Config` no longer embeds the `Chains/**` chainspec files when built with `EnableZkEvm=true`. The ZisK guest builds every project with that property, and nothing in the guest's compiled closure opens a chainspec (no `ChainSpecFileLoader` or `GetManifestResourceStream` caller survives ILC's dependency analysis), yet ILC embeds every manifest resource of every input assembly, so the 71 files rode along into the guest image.

Measured on this branch's base (`75b18b762b`) with the pinned bflat and zisk images, fixture block 25532382:

| | before | after | diff |
|---|---|---|---|
| zk-built `Nethermind.Config.dll` | 6,928,896 B | 52,736 B | -6,876,160 B (-6.88 MB) |
| guest image (`Program.patched`) | 21,698,688 B | 14,817,408 B | -6,881,280 B (-6.88 MB, -31.7%) |
| `__embedded_resourcedata` in the ILC map | 6,870,938 B | 0 B | -6,870,938 B |
| ziskemu `ROM USAGE` | 32.02% (1,343,102 units) | 26.90% (1,128,090 units) | -215,012 units (-5.12 points) |
| steps | 458,365,590 | 458,365,590 | 0 |
| state root, success flag | same | same | - |

The normal build is unchanged: `ChainSpecLoaderTests` (7 tests) still load the embedded files.

- The guest Makefile now fails the build if the image embeds any manifest resource: bflat writes an object map (`--map`) and the recipe checks that `__embedded_resourcedata` is empty, so a resource creeping back in from any input assembly is caught at build time instead of silently inflating the image or surfacing as a missing-resource fault inside the zkVM.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The guest was built with the Makefile's bflat invocation before and after the change and run on the same fixture under ziskemu (table above). The standard build ran `Nethermind.Specs.Test` with `--filter FullyQualifiedName~ChainSpecLoaderTests`. The Makefile gate was exercised under GNU make with dash as `/bin/sh` and `docker` stubbed to drop in prebuilt bflat outputs: the empty blob passes and the binary lands in `bin/nethermind`; the 6,870,938-byte blob fails with the error message and a non-zero exit. CI's `stateless-tests.yml` runs `make build`, so the gate runs there.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

ziskemu's `ROM USAGE` gauge counts read-only data as well as code, which is why a data-only change moves it by five points. The reflection runtime that `--no-reflection` would drop is worth under one further point; the guest cannot take that flag yet because `Rlp`'s static constructor evaluates `typeof(Rlp).Assembly` and `RlpLimit.For<T>` stores `typeof(T).Name` eagerly.


