### PR TITLE
build(zkevm): drop the stack-trace table and symbol tables from the guest

### DIFF
--- a/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
+++ b/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
@@ -11,9 +11,8 @@ ZISK_IMAGE ?= nethermindeth/zisk:1.2.0-alpha@sha256:7b3ea05815cf902f0bceb17458d9
 # ziskemu ROMs the whole .text, so even unreachable F/D/C/A instructions reject
 # the guest - fail at build time instead.
 ISA_GATES ?= --error-on-float --error-on-float-binary --error-on-compressed --error-on-atomic
-# Nothing in the guest reads a stack trace (the throw hook prints type and message), so the
-# method-name table is 0.2 MB of dead read-only data; the symbol tables are 8 MB the loader never
-# maps. Build with TRIM_FLAGS= to keep the symbols for objdump size attribution.
+# The guest never reads the stack-trace name table or the symbol tables.
+# TRIM_FLAGS=--no-stacktrace-data keeps the symbols without changing the loaded layout.
 TRIM_FLAGS ?= --no-stacktrace-data --ldflags=--strip-all
 # The guest has no instruction cache, so the code-size cost of inlining buys nothing back
 # and favouring speed is close to free. Must land together with the TrieNode seqlock

--- a/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
+++ b/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
@@ -12,8 +12,9 @@ ZISK_IMAGE ?= nethermindeth/zisk:1.2.0-alpha@sha256:7b3ea05815cf902f0bceb17458d9
 # the guest - fail at build time instead.
 ISA_GATES ?= --error-on-float --error-on-float-binary --error-on-compressed --error-on-atomic
 # Nothing in the guest reads a stack trace (the throw hook prints type and message), so the
-# method-name table is 0.2 MB of dead read-only data.
-TRIM_FLAGS ?= --no-stacktrace-data
+# method-name table is 0.2 MB of dead read-only data; the symbol tables are 8 MB the loader never
+# maps. Build with TRIM_FLAGS= to keep the symbols for objdump size attribution.
+TRIM_FLAGS ?= --no-stacktrace-data --ldflags=--strip-all
 # The guest has no instruction cache, so the code-size cost of inlining buys nothing back
 # and favouring speed is close to free. Must land together with the TrieNode seqlock
 # collapse: -Ot over the seqlock builds a guest whose output success flag is 0. The

--- a/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
+++ b/src/Nethermind/Nethermind.Stateless.ZiskGuest/Makefile
@@ -11,6 +11,9 @@ ZISK_IMAGE ?= nethermindeth/zisk:1.2.0-alpha@sha256:7b3ea05815cf902f0bceb17458d9
 # ziskemu ROMs the whole .text, so even unreachable F/D/C/A instructions reject
 # the guest - fail at build time instead.
 ISA_GATES ?= --error-on-float --error-on-float-binary --error-on-compressed --error-on-atomic
+# Nothing in the guest reads a stack trace (the throw hook prints type and message), so the
+# method-name table is 0.2 MB of dead read-only data.
+TRIM_FLAGS ?= --no-stacktrace-data
 # The guest has no instruction cache, so the code-size cost of inlining buys nothing back
 # and favouring speed is close to free. Must land together with the TrieNode seqlock
 # collapse: -Ot over the seqlock builds a guest whose output success flag is 0. The
@@ -64,6 +67,7 @@ build: dotnet-build
 		$(BFLAT_IMAGE) \
 		bflat build --arch riscv64 --os linux --stdlib dotnet --libc zisk \
 		$(OPT_FLAGS) \
+		$(TRIM_FLAGS) \
 		--no-pie \
 		--no-pthread \
 		--no-globalization \


### PR DESCRIPTION
## Changes

- The guest Makefile gains a `TRIM_FLAGS` variable, passed to bflat next to `OPT_FLAGS`, holding two flags that remove data nothing in the guest uses:
  - `--no-stacktrace-data`: ILC emits no stack-trace method-name table. `Exception.StackTrace` becomes `null`; nothing in the guest closure reads it (the `ZkvmThrow` hook prints type and message, and the creation-site traces in the pooled collections are `DEBUG`-only).
  - `--ldflags=--strip-all`: the linker drops `.symtab` and `.strtab`, 8 MB the loader never maps, so they only inflated the CI artifact and the release package. bflat's own `--separate-symbols` is not usable in the pinned image: its `llvm-objcopy` cannot load `libicuuc.so.74` and the binary is left untouched.
- `make build TRIM_FLAGS=--no-stacktrace-data` keeps the symbols for `objdump -t` size attribution while leaving the loaded layout identical to the shipped binary; `TRIM_FLAGS=` restores both.

Measured on this branch's base (`3a0a311702`, which already has the chainspec removal from #13181), fixture block 25532382:

| | before | after | diff |
|---|---|---|---|
| file size (`Program.patched`) | 14,817,904 B | 5,821,536 B | -8,996,368 B (-60.7%) |
| `.symtab` + `.strtab` | 8,041,187 B | 0 B | -8,041,187 B |
| loaded code (E segment) | 4,245,408 B | 4,218,016 B | -27,392 B |
| loaded read-only data (R segment) | 1,019,550 B | 835,781 B | -183,769 B |
| loaded data (RW segment) | 767,928 B | 761,952 B | -5,976 B |
| ziskemu `ROM USAGE` | 26.90% (1,128,147 units) | 26.59% (1,115,297 units) | -12,850 units (-0.31 points) |
| steps | 454,906,880 | 454,924,733 | +17,853 (+0.004%) |
| state root, success flag | same | same | - |

Each flag was also measured alone: the strip leaves the loaded segments, steps, ROM usage and root byte-for-byte unchanged; the stack-trace flag accounts for the whole segment and ROM change and for the step delta. That delta is hashtable re-bucketing, not work: `Type.GetHashCode()` is address-based in the guest runtime and `Rlp.Decoders` hashes its `Type` key, so moving the MethodTables changes the probe-chain lengths of the tens of thousands of decoder lookups a block makes. It moved between +0.004% and +0.027% across bases, and on a decode-failure input, which is almost all startup, the build without the table runs 940 steps faster.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The guest was built with the Makefile's bflat invocation before and after and run on the same fixture under ziskemu (table above); the resource gate from #13181 still reports an empty resource blob. `make -n build` shows the flags expanding into the bflat command and `TRIM_FLAGS=` removing them. CI's `stateless-tests.yml` runs `make build` and the fixture matrix, so the stripped binary is exercised there.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Of the other bflat size switches, none pays: `--no-exception-messages` and `--no-debug-info` change nothing here, `--remove-eh` drops the section headers without shrinking the loaded segment and changes throw semantics, and `-Os` saves 3.4 ROM points for 11.7% more steps. The remaining large items are code: the EVM fork-flag cross-product (`InstructionCall` compiled 64 times, about 470 KB recoverable), the reflection runtime pinned by `Rlp`'s static constructor and `RlpLimit.For<T>`, and the parallel executor compiled for a single-threaded guest.

