### PR TITLE
Count frame-tx block execution gas before the storage refund

### DIFF
--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -40,7 +40,7 @@ on:
       frames_version:
         description: Frame-transaction fixtures release tag (frame lanes only) - pin to an exact tag
         required: false
-        default: tests-frames-devnet@v0.1.0
+        default: tests-frames-devnet@v0.3.0
         type: string
       filter:
         description: Regex filter for test names
@@ -96,7 +96,7 @@ on:
       frames_version:
         description: Frame-transaction fixtures release tag (frame lanes only) - pin to an exact tag
         required: false
-        default: tests-frames-devnet@v0.1.0
+        default: tests-frames-devnet@v0.3.0
         type: string
       filter:
         description: Regex filter for test names (optional)
@@ -136,7 +136,7 @@ env:
   # This archive labels its fork "Bogota" meaning Amsterdam plus EIP-8141, where the FOCIL archive
   # means Amsterdam plus EIP-7805; nothing inside a fixture separates the two, so the lane names the
   # fork it means through the runner's --forkAlias.
-  FRAMES_VERSION: ${{ inputs.frames_version || 'tests-frames-devnet@v0.1.0' }}
+  FRAMES_VERSION: ${{ inputs.frames_version || 'tests-frames-devnet@v0.3.0' }}
   # Minimum cases the pinned release ships across the frame lanes. Asserted so a scope resolving to
   # nothing fails rather than reporting a clean run of no tests.
   FRAME_MIN_CASES: '214'

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxBlockProductionTests.cs
@@ -105,13 +105,13 @@ public class FrameTxBlockProductionTests
     /// <summary>The <see href="https://eips.ethereum.org/EIPS/eip-8037">EIP-8037</see> block totals a
     /// producer carries must charge a frame transaction's state growth to the state dimension and
     /// nowhere else.</summary>
-    /// <remarks>A frame transaction nets its EIP-3529 refund before splitting the charge across the two
-    /// dimensions, so both totals and the receipt sit on one basis; the refunding case pins that, the
-    /// ordinary path instead keeping block gas pre-refund per
-    /// <see href="https://eips.ethereum.org/EIPS/eip-7778">EIP-7778</see>.</remarks>
+    /// <remarks>Per <see href="https://eips.ethereum.org/EIPS/eip-7778">EIP-7778</see> the block's
+    /// execution dimension is accounted before the EIP-3529 refund, so the refund lowers the payer's
+    /// charge and the post-refund receipt total without freeing block capacity; the refunding case pins
+    /// that the block totals stay gross of the refund while the receipt nets it.</remarks>
     [TestCase(StateScenario.None, 0UL, false, TestName = "A frame transaction that grows no state moves no state total")]
     [TestCase(StateScenario.FreshSlot, (ulong)GasCostOf.SSetState, false, TestName = "A fresh slot's growth charge lands in the block state total")]
-    [TestCase(StateScenario.RestoredSlot, 0UL, true, TestName = "A refunding frame transaction keeps the block totals on the receipt's basis")]
+    [TestCase(StateScenario.RestoredSlot, 0UL, true, TestName = "A refunding frame transaction keeps the block totals pre-refund while the receipt nets the refund")]
     public void Produced_block_totals_carry_the_state_dimension_of_a_frame_transaction(
         StateScenario scenario, ulong expectedStateGas, bool expectsRefund)
     {
@@ -136,8 +136,9 @@ public class FrameTxBlockProductionTests
             // the state dimension on top of the execution one instead would bill the block twice.
             ulong grossGas = GrossFrameGas(frameTx, receipt);
             Assert.That(receipt.GasUsedTotal, expectsRefund ? Is.LessThan(grossGas) : Is.EqualTo(grossGas));
-            // Both block totals partition that same charge, so the tracer's two accumulators must sum to it.
-            Assert.That(produced.ExecutionGas + produced.StateGas, Is.EqualTo(receipt.GasUsedTotal));
+            // EIP-7778: the block's execution dimension stays gross of the refund, so the two block
+            // accumulators sum to the pre-refund gross, not the post-refund total the receipt settles on.
+            Assert.That(produced.ExecutionGas + produced.StateGas, Is.EqualTo(grossGas));
             // Both dimensions share the block limit, so the header carries whichever bound is tighter.
             Assert.That(produced.Block.Header.GasUsed, Is.EqualTo(Math.Max(produced.ExecutionGas, produced.StateGas)));
         }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockGasTests.cs
@@ -325,6 +325,29 @@ public class FrameTxBlockGasTests
         }
     }
 
+    [Test]
+    public void Execute_PayloadFrameClearsAStorageSlot_BlockExecutionGasCountsBeforeTheRefund()
+    {
+        Address clearer = TestItem.AddressE;
+        Deploy(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), UInt256.Parse("100000000000000000000"));
+        Deploy(clearer, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        _state.Set(new StorageCell(clearer, (UInt256)0), [1]);
+        _state.Commit(Spec);
+        _state.CommitTree(0);
+
+        TestAllTracerWithOutput tracer = new();
+        Assert.That(Process(FrameTx(nonce: 0, clearer), tracer).TransactionExecuted, Is.True);
+
+        GasConsumed gas = tracer.GasConsumedResult;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_state.Get(new StorageCell(clearer, (UInt256)0)).ToArray(), Is.All.EqualTo((byte)0),
+                "the slot was cleared, so the transaction earned a storage refund");
+            Assert.That(gas.EffectiveBlockGas + gas.BlockStateGas, Is.GreaterThan(gas.SpentGas),
+                "EIP-7778: a storage refund lowers the payer charge but not the gas counted toward the block");
+        }
+    }
+
     private static byte[] ApproveCode(byte scope) =>
         Prepare.EvmCode.PushData(scope).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -478,8 +478,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         System.Diagnostics.Debug.Assert(refundCounter >= 0, $"frame-tx settlement invariant violated: negative refund counter ({refundCounter}).");
         ulong gasAfterRefund = grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)Math.Max(0, refundCounter), spec);
         ulong blockStateGas = (ulong)Math.Max(0, totalFrameStateGasUsed - stateGasCorrection);
-        ulong blockRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockExecutionGas(gasAfterRefund, blockStateGas, floorGas);
-        ulong spentGas = blockRegularGas + blockStateGas;
+        // EIP-7778: the payer pays the post-refund execution dimension, but the block counts it before the refund.
+        ulong payerRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockExecutionGas(gasAfterRefund, blockStateGas, floorGas);
+        ulong blockRegularGas = Eip8037BlockGasInclusionCheck.CalculateBlockExecutionGas(grossGas, blockStateGas, floorGas);
+        ulong spentGas = payerRegularGas + blockStateGas;
         // Set explicitly like the regular path: the BlockGasUsed getter otherwise falls back to tx.GasLimit,
         // which for a frame tx is the frame-gas sum rather than the gas spent that block validation sums.
         tx.BlockGasUsed = blockRegularGas;


### PR DESCRIPTION
## Changes

- Frame-transaction settlement fed the **post-refund** gas into the block execution-gas dimension, so a frame tx carrying an EIP-3529 storage refund under-counted the gas charged to the block by the applied refund (whenever the calldata floor did not bind). EIP-7778, which EIP-8141 `requires`, counts the block execution dimension **before** the refund; the payer is still charged the post-refund amount.
- Split the two in `TransactionProcessorBase.FrameTx.cs` settlement:
  - payer: `max(gas_used_after_refund - tx_state_gas, calldata_floor)` (unchanged),
  - block: `max(gas_used_before_refund - tx_state_gas, calldata_floor)` (was post-refund).
- Every non-frame settlement path (`TransactionProcessor.cs`) already keeps the block dimension pre-refund and the payer charge post-refund; this aligns the frame path with them and with spec §"Block-level gas accounting".
- Added a regression test: a payload frame that clears a storage slot (non-zero refund) now has its block execution gas counted before the refund while the payer charge stays post-refund.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`FrameTxBlockGasTests.Execute_PayloadFrameClearsAStorageSlot_BlockExecutionGasCountsBeforeTheRefund` fails on the base branch (block == payer) and passes with the fix. `FrameTxBlockGasTests`, `FrameTxProcessorTests`, `Eip8037*` all green (434/434); the payer charge is unchanged.

## Documentation

#### Requires documentation update

- [x] No

## Remarks

The equivalent pre-refund change was reverted once (#12942) because, at the time, EIP-8141 computed block execution post-refund and the released EEST fixtures encoded that. The spec has since integrated EIP-7778 (added to `requires:`, block execution restated as `gas_used_before_refund`), and the pinned frame fixtures (`tests-frames-devnet@v0.1.0`, published after that spec change) are regenerated against it. Flagging so the `frameTest` / `frameBlockTest` nethtest lanes are the gate to watch on this PR.
