### PR TITLE
Cover the keyed-nonce AVX-512 batch and scalar tail seam

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/KeyedNonceManagerTests.cs
@@ -50,6 +50,9 @@ public class KeyedNonceManagerTests
     }
 
     [TestCase(8)]
+    [TestCase(9)]
+    [TestCase(12)]
+    [TestCase(15)]
     [TestCase(Eip8250Constants.MaxNonceKeys)]
     public void Batched_storage_indices_match_individual_slots(int count)
     {
@@ -64,10 +67,11 @@ public class KeyedNonceManagerTests
         }
     }
 
-    [Test]
-    public void Batched_nonce_set_is_consumed_and_validated()
+    [TestCase(12)]
+    [TestCase(Eip8250Constants.MaxNonceKeys)]
+    public void Batched_nonce_set_is_consumed_and_validated(int count)
     {
-        UInt256[] keys = StrictlyIncreasing(Eip8250Constants.MaxNonceKeys);
+        UInt256[] keys = StrictlyIncreasing(count);
 
         KeyedNonceManager.ConsumeNonceSet(_state, TestItem.AddressA, keys, nonceSeq: 41);
 


### PR DESCRIPTION
## Changes

- `KeyedNonceManager` derives NONCE_MANAGER storage indices, consumes a nonce set, and validates one with an AVX-512 batch of 8 followed by a scalar tail (`StorageIndices`, `ConsumeNonceSet`, `IsNonceSetValid`). The existing tests only exercised key counts 8 and 16 — both exact multiples of the batch width — so the scalar tail after one batch ran zero iterations and the batch+tail seam was never covered.
- Added key counts 9, 12 and 15 to `Batched_storage_indices_match_individual_slots`, and parameterised `Batched_nonce_set_is_consumed_and_validated` to also run at 12. On AVX-512 hardware these exercise one batch plus a 1–7 element scalar tail; on other hardware they cover the scalar path for those counts.

## Types of changes

- [x] Other: test coverage

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`KeyedNonceManagerTests` 37/37 green. No production change.

## Documentation

#### Requires documentation update

- [x] No
