### PR TITLE
Preserve the frame-tx 2D gas breakdown across a receipt round trip

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/ReceiptsForRpcTests.cs
@@ -103,7 +103,13 @@ namespace Nethermind.JsonRpc.Test.Data
 
             TxReceipt? roundTripped = serializer.Deserialize<TxReceipt>(serializer.Serialize(receipt));
 
-            Assert.That(roundTripped!.Logs, Is.Empty);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(roundTripped!.Logs, Is.Empty);
+                Assert.That(roundTripped.BlockGasUsed, Is.EqualTo(10));
+                Assert.That(roundTripped.ExecutionGasUsed, Is.EqualTo(11));
+                Assert.That(roundTripped.StorageGasUsed, Is.EqualTo(12));
+            }
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -449,6 +449,9 @@ public class FrameTransactionForRpcTests
     {
         TxReceipt receipt = BuildFrameTxReceipt();
         receipt.TxHash = Keccak.Zero;
+        receipt.BlockGasUsed = 118_920;
+        receipt.ExecutionGasUsed = 21_000;
+        receipt.StorageGasUsed = 97_920;
         EthereumJsonSerializer serializer = new(new JsonConverter[] { new TxReceiptConverter() });
 
         TxReceipt? roundTripped = serializer.Deserialize<TxReceipt>(serializer.Serialize(receipt));
@@ -456,6 +459,9 @@ public class FrameTransactionForRpcTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(roundTripped!.Payer, Is.EqualTo(TestItem.AddressA));
+            Assert.That(roundTripped.BlockGasUsed, Is.EqualTo(118_920UL));
+            Assert.That(roundTripped.ExecutionGasUsed, Is.EqualTo(21_000UL));
+            Assert.That(roundTripped.StorageGasUsed, Is.EqualTo(97_920UL));
             Assert.That(roundTripped.FrameReceipts, Has.Length.EqualTo(2));
             Assert.That(roundTripped.FrameReceipts![0].ExecutionGasUsed, Is.EqualTo(21_000UL));
             Assert.That(roundTripped.FrameReceipts[0].StateGasUsed, Is.EqualTo(97_920UL));

--- a/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
@@ -25,6 +25,9 @@ namespace Nethermind.JsonRpc.Data
             BlockNumber = receipt.BlockNumber;
             CumulativeGasUsed = receipt.GasUsedTotal;
             GasUsed = receipt.GasUsed;
+            BlockGasUsed = receipt.BlockGasUsed;
+            ExecutionGasUsed = receipt.ExecutionGasUsed;
+            StorageGasUsed = receipt.StorageGasUsed;
             EffectiveGasPrice = gasInfo.EffectiveGasPrice ?? receipt.EffectiveGasPrice;
             BlobGasUsed = gasInfo.BlobGasUsed;
             BlobGasPrice = gasInfo.BlobGasPrice;
@@ -57,6 +60,15 @@ namespace Nethermind.JsonRpc.Data
         public ulong BlockNumber { get; set; }
         public ulong CumulativeGasUsed { get; set; }
         public ulong GasUsed { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public ulong BlockGasUsed { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public ulong ExecutionGasUsed { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public ulong StorageGasUsed { get; set; }
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ulong? BlobGasUsed { get; set; }
@@ -101,6 +113,9 @@ namespace Nethermind.JsonRpc.Data
                 BlockNumber = BlockNumber,
                 ContractAddress = ContractAddress,
                 GasUsed = GasUsed,
+                BlockGasUsed = BlockGasUsed,
+                ExecutionGasUsed = ExecutionGasUsed,
+                StorageGasUsed = StorageGasUsed,
                 StatusCode = Status is not null ? (byte)Status : byte.MinValue,
                 TxHash = TransactionHash,
                 GasUsedTotal = CumulativeGasUsed,

--- a/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
@@ -61,12 +61,17 @@ namespace Nethermind.JsonRpc.Data
         public ulong CumulativeGasUsed { get; set; }
         public ulong GasUsed { get; set; }
 
+        /// <summary>Diagnostic-only EIP-7778 pre-refund gas counted by block-level execution accounting.
+        /// Non-standard (not in execution-apis); zero for non-frame receipts.</summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ulong BlockGasUsed { get; set; }
 
+        /// <summary>Diagnostic-only post-refund execution gas (OperationGas) without the EIP-7976 floor
+        /// adjustment. Not the EIP-8037 execution-dimension block figure — see <see cref="BlockGasUsed"/>.</summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ulong ExecutionGasUsed { get; set; }
 
+        /// <summary>Diagnostic-only EIP-8037 state-dimension gas used by block accounting.</summary>
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
         public ulong StorageGasUsed { get; set; }
 


### PR DESCRIPTION
## Changes

- `TxReceiptConverter.Write` emits a frame-tx receipt's `blockGasUsed`, `executionGasUsed` and `storageGasUsed`, but `ReceiptForRpc` — the model `TxReceiptConverter.Read` binds into — had no properties for them, so `ReceiptForRpc.ToReceipt()` rebuilt a `TxReceipt` with all three at `0`. Any consumer that serialized a receipt with `TxReceiptConverter` and read it back through `ReceiptForRpc` silently lost the EIP-8037 two-dimensional gas breakdown.
- Added `BlockGasUsed`, `ExecutionGasUsed` and `StorageGasUsed` to `ReceiptForRpc` (copied in the constructor, set in `ToReceipt()`). `[JsonIgnore(WhenWritingDefault)]` keeps them off receipts that do not carry them.

## Scope (what this restores, and what it does not)

- Restores the **in-process JSON round trip**: a receipt dumped via `TxReceiptConverter` and re-read in the same process (e.g. `BlockTraceDumper`), and `ReceiptForRpc` deserialization of externally produced receipts (e.g. the Optimism CL derivation pipeline).
- Does **not** make `eth_getTransactionReceipt` report the breakdown. The receipt RLP codecs (`ReceiptStorageDecoder`, `CompactReceiptStorageDecoder`, `ReceiptMessageDecoder`) persist only the per-frame dimensions by design, so anything read back from the receipt store still returns `0` for the top-level trio, and a `debug_insertReceipts` re-ingest is likewise still lossy at the storage layer. Persisting the top-level trio would be a receipt-store DB-format change, out of scope here.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Extended `FrameTransactionForRpcTests.TxReceiptConverter_FrameTx_RoundTripsPayerAndFrameReceipts` to assert the three fields survive a serialize/deserialize round trip (fails without the `ToReceipt` change, reads back `0`), and added the same assertions to the non-frame `ReceiptsForRpcTests.Receipt_with_no_logs_survives_the_converter_round_trip` (the bug drops the breakdown for any tx type, not just frame). `FrameTransactionForRpcTests` and `ReceiptsForRpcTests` green.

## Documentation

#### Requires documentation update

- [x] No
