### PR TITLE
fix(crypto): reject Keccak output sizes the sponge cannot serve

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -294,7 +294,26 @@ namespace Nethermind.Core.Test
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(() => KeccakHash.ComputeHash(input, output), Throws.InstanceOf<ArgumentOutOfRangeException>());
-                Assert.That(() => KeccakHash.Create(outputLength), Throws.InstanceOf<ArgumentException>());
+                Assert.That(() => KeccakHash.Create(outputLength), Throws.InstanceOf<ArgumentOutOfRangeException>());
+            }
+        }
+
+        // UpdateFinalTo squeezes from that same single block, so it is bounded by the sponge's rate
+        // rather than by MAX_HASH_SIZE. 66 is the widest hash and so carries the narrowest rate, 68.
+        [Test]
+        public void Incremental_output_wider_than_the_rate_is_rejected()
+        {
+            byte[] input = new byte[300];
+
+            KeccakHash atRate = KeccakHash.Create(66);
+            atRate.Update(input);
+            KeccakHash overRate = KeccakHash.Create(66);
+            overRate.Update(input);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(() => atRate.UpdateFinalTo(new byte[68]), Throws.Nothing);
+                Assert.That(() => overRate.UpdateFinalTo(new byte[69]), Throws.InstanceOf<ArgumentOutOfRangeException>());
             }
         }
 

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -278,6 +278,47 @@ namespace Nethermind.Core.Test
             Assert.That(output.ToHexString(), Is.EqualTo(expected));
         }
 
+        // The sponge squeezes a single block, so it can only serve an output that fits the rate,
+        // STATE_SIZE - 2 * size. Larger sizes used to be accepted: at 100 the rate is zero and the absorb
+        // loop never advanced, and above that it is negative and the state was indexed backwards.
+        [TestCase(0)]
+        [TestCase(67)]
+        [TestCase(100)]
+        [TestCase(137)]
+        [TestCase(201)]
+        public void Unsupported_output_sizes_are_rejected(int outputLength)
+        {
+            byte[] input = new byte[200];
+            byte[] output = new byte[outputLength];
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(() => KeccakHash.ComputeHash(input, output), Throws.InstanceOf<ArgumentOutOfRangeException>());
+                Assert.That(() => KeccakHash.Create(outputLength), Throws.InstanceOf<ArgumentException>());
+            }
+        }
+
+        [TestCase(1)]
+        [TestCase(32)]
+        [TestCase(64)]
+        [TestCase(66)]
+        public void Supported_output_sizes_agree_across_the_one_shot_and_incremental_paths(int outputLength)
+        {
+            byte[] input = new byte[300];
+            for (int i = 0; i < input.Length; i++)
+            {
+                input[i] = (byte)(i * 37 + 11);
+            }
+
+            byte[] oneShot = new byte[outputLength];
+            KeccakHash.ComputeHash(input, oneShot);
+
+            KeccakHash incremental = KeccakHash.Create(outputLength);
+            incremental.Update(input);
+
+            Assert.That(incremental.Hash, Is.EqualTo(oneShot));
+        }
+
         [TestCase("0x", "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")]
         public void Sanity_check(string hexString, string expected)
         {

--- a/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakTests.cs
@@ -266,12 +266,8 @@ namespace Nethermind.Core.Test
         [TestCase(64, "52c1f4616862f9d5011ed6a2a77d89a2102e51ee7db2db045bb5fb267fba98d1")]
         public void Common_input_lengths_match_known_hash(int inputLength, string expected)
         {
-            byte[] input = new byte[inputLength];
+            byte[] input = FilledInput(inputLength);
             byte[] output = new byte[32];
-            for (int i = 0; i < input.Length; i++)
-            {
-                input[i] = (byte)(i * 37 + 11);
-            }
 
             KeccakHash.ComputeHash(input, output);
 
@@ -317,17 +313,15 @@ namespace Nethermind.Core.Test
             }
         }
 
-        [TestCase(1)]
-        [TestCase(32)]
-        [TestCase(64)]
-        [TestCase(66)]
-        public void Supported_output_sizes_agree_across_the_one_shot_and_incremental_paths(int outputLength)
+        // The 20- and 32-byte inputs take ComputeHash's sub-rate fast paths, which write the terminator at
+        // stateBytes[input.Length] without comparing it against the rate. That is only safe because the rate
+        // is at least 68, which the widest output, 66, exercises at its tightest.
+        [Test]
+        public void Supported_output_sizes_agree_across_the_one_shot_and_incremental_paths(
+            [Values(20, 32, 300)] int inputLength,
+            [Values(1, 32, 64, 66)] int outputLength)
         {
-            byte[] input = new byte[300];
-            for (int i = 0; i < input.Length; i++)
-            {
-                input[i] = (byte)(i * 37 + 11);
-            }
+            byte[] input = FilledInput(inputLength);
 
             byte[] oneShot = new byte[outputLength];
             KeccakHash.ComputeHash(input, oneShot);
@@ -1475,6 +1469,17 @@ namespace Nethermind.Core.Test
         {
             public Memory<byte> Memory => data;
             public void Dispose() { }
+        }
+
+        private static byte[] FilledInput(int length)
+        {
+            byte[] input = new byte[length];
+            for (int i = 0; i < input.Length; i++)
+            {
+                input[i] = (byte)(i * 37 + 11);
+            }
+
+            return input;
         }
 
         private static FieldInfo GetRemainderCacheField()

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -318,7 +318,7 @@ public sealed partial class KeccakHash
             ThrowHashingComplete();
 
         if (output.Length > _roundSize)
-            ThrowOutputWiderThanRate(output.Length, _roundSize);
+            ThrowOutputWiderThanRate($"{nameof(output)}.{nameof(output.Length)}", output.Length, _roundSize);
 
         ulong[] state = _state;
 
@@ -564,8 +564,8 @@ public sealed partial class KeccakHash
         paramName, size, $"Keccak hash size must be between 1 and {MAX_HASH_SIZE}.");
 
     [DoesNotReturn]
-    private static void ThrowOutputWiderThanRate(int length, int roundSize) => throw new ArgumentOutOfRangeException(
-        "output.Length", length, $"A single squeeze cannot serve more than the {roundSize}-byte rate.");
+    private static void ThrowOutputWiderThanRate(string paramName, int length, int roundSize) => throw new ArgumentOutOfRangeException(
+        paramName, length, $"A single squeeze cannot serve more than the {roundSize}-byte rate.");
 
     [InlineArray(STATE_LANES)]
     private struct KeccakState

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -128,7 +128,7 @@ public sealed partial class KeccakHash
     public static void ComputeHash(ReadOnlySpan<byte> input, Span<byte> output)
     {
         if ((uint)(output.Length - 1) >= MAX_HASH_SIZE)
-            ThrowInvalidHashSize(nameof(output), output.Length);
+            ThrowInvalidHashSize($"{nameof(output)}.{nameof(output.Length)}", output.Length);
 
         int inputLength = input.Length;
         // One-block fast path for the dominant EVM input sizes: address (20), word or hash (32), two words (64).
@@ -317,6 +317,9 @@ public sealed partial class KeccakHash
         if (_hash is not null)
             ThrowHashingComplete();
 
+        if (output.Length > _roundSize)
+            ThrowOutputWiderThanRate(output.Length, _roundSize);
+
         ulong[] state = _state;
 
         if (state.Length == 0)
@@ -407,7 +410,9 @@ public sealed partial class KeccakHash
 
     private static partial void KeccakF(Span<ulong> st);
 
-    // Callers bound hashSize to [1, MAX_HASH_SIZE], so the rate is always at least hashSize bytes.
+    // Callers bound hashSize to [1, MAX_HASH_SIZE], so the rate is always at least hashSize bytes, and
+    // never below 68 — which is what lets ComputeHash write its 20- and 32-byte inputs, and their
+    // terminator, without comparing against it.
     private static int GetRoundSize(int hashSize) => STATE_SIZE - 2 * hashSize;
 
     private byte[] GenerateHash()
@@ -557,6 +562,10 @@ public sealed partial class KeccakHash
     [DoesNotReturn]
     private static void ThrowInvalidHashSize(string paramName, int size) => throw new ArgumentOutOfRangeException(
         paramName, size, $"Keccak hash size must be between 1 and {MAX_HASH_SIZE}.");
+
+    [DoesNotReturn]
+    private static void ThrowOutputWiderThanRate(int length, int roundSize) => throw new ArgumentOutOfRangeException(
+        "output.Length", length, $"A single squeeze cannot serve more than the {roundSize}-byte rate.");
 
     [InlineArray(STATE_LANES)]
     private struct KeccakState

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -72,6 +72,10 @@ public sealed partial class KeccakHash
         HashSize = size;
     }
 
+    /// <summary>Creates an incremental hasher whose digest is <paramref name="size"/> bytes wide.</summary>
+    /// <param name="size">The digest size in bytes, from 1 to 66.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="size"/> is outside [1, 66], the widths
+    /// whose digest still fits the sponge's rate.</exception>
     public static KeccakHash Create(int size = HASH_SIZE) => new(size);
 
     /// <summary>
@@ -124,6 +128,10 @@ public sealed partial class KeccakHash
         }
     }
 
+    /// <summary>Computes the Keccak digest of <paramref name="input"/> in one shot.</summary>
+    /// <param name="output">Receives the digest; its length picks the Keccak width and must be from 1 to 66.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="output"/> is empty or wider than 66 bytes,
+    /// the widths whose digest still fits the sponge's rate.</exception>
     [SkipLocalsInit]
     public static void ComputeHash(ReadOnlySpan<byte> input, Span<byte> output)
     {
@@ -311,6 +319,13 @@ public sealed partial class KeccakHash
         }
     }
 
+    /// <summary>Squeezes the sponge into <paramref name="output"/>, completing the hash.</summary>
+    /// <param name="output">Receives the digest. It may be narrower than <see cref="HashSize"/>, but not wider
+    /// than the sponge's rate, <c>200 - 2 * HashSize</c>.</param>
+    /// <remarks>The sponge squeezes a single block, so the rate rather than <see cref="HashSize"/> bounds the
+    /// output here.</remarks>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="output"/> is wider than the rate.</exception>
+    /// <exception cref="CryptographicException">The hash is already complete.</exception>
     [SkipLocalsInit]
     public void UpdateFinalTo(Span<byte> output)
     {

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakHash.cs
@@ -18,6 +18,9 @@ public sealed partial class KeccakHash
     private const int STATE_SIZE = 200;
     private const int STATE_LANES = STATE_SIZE / sizeof(ulong);
     private const int HASH_DATA_AREA = 136;
+    // The sponge squeezes once, so the output has to fit the rate: size <= GetRoundSize(size), i.e.
+    // size <= STATE_SIZE / 3. Covers every standard Keccak width; 512 bits is the widest at 64 bytes.
+    private const int MAX_HASH_SIZE = STATE_SIZE / 3;
     private const int ROUNDS = 24;
 
     private static readonly ulong[] RoundConstants =
@@ -59,13 +62,12 @@ public sealed partial class KeccakHash
 
     private KeccakHash(int size)
     {
-        // Verify the size
-        if (size <= 0 || size > STATE_SIZE)
+        if ((uint)(size - 1) >= MAX_HASH_SIZE)
         {
-            throw new ArgumentException($"Invalid Keccak hash size. Must be between 0 and {STATE_SIZE}.");
+            ThrowInvalidHashSize(nameof(size), size);
         }
 
-        _roundSize = STATE_SIZE == size ? HASH_DATA_AREA : checked(STATE_SIZE - (2 * size));
+        _roundSize = GetRoundSize(size);
         _remainderLength = 0;
         HashSize = size;
     }
@@ -125,8 +127,8 @@ public sealed partial class KeccakHash
     [SkipLocalsInit]
     public static void ComputeHash(ReadOnlySpan<byte> input, Span<byte> output)
     {
-        if ((uint)(output.Length - 1) >= STATE_SIZE)
-            ThrowInvalidOutputSize(output.Length);
+        if ((uint)(output.Length - 1) >= MAX_HASH_SIZE)
+            ThrowInvalidHashSize(nameof(output), output.Length);
 
         int inputLength = input.Length;
         // One-block fast path for the dominant EVM input sizes: address (20), word or hash (32), two words (64).
@@ -405,7 +407,7 @@ public sealed partial class KeccakHash
 
     private static partial void KeccakF(Span<ulong> st);
 
-    // Callers bound hashSize to [1, STATE_SIZE], so the arithmetic cannot overflow.
+    // Callers bound hashSize to [1, MAX_HASH_SIZE], so the rate is always at least hashSize bytes.
     private static int GetRoundSize(int hashSize) => STATE_SIZE - 2 * hashSize;
 
     private byte[] GenerateHash()
@@ -553,8 +555,8 @@ public sealed partial class KeccakHash
     private static void ThrowHashingComplete() => throw new CryptographicException("Keccak hash is complete.");
 
     [DoesNotReturn]
-    private static void ThrowInvalidOutputSize(int length) => throw new ArgumentOutOfRangeException(
-        nameof(length), length, $"Must be between 1 and {STATE_SIZE}.");
+    private static void ThrowInvalidHashSize(string paramName, int size) => throw new ArgumentOutOfRangeException(
+        paramName, size, $"Keccak hash size must be between 1 and {MAX_HASH_SIZE}.");
 
     [InlineArray(STATE_LANES)]
     private struct KeccakState


### PR DESCRIPTION
## Changes

Both entry points admitted output sizes up to `STATE_SIZE`:

- `ComputeHash` — `(uint)(output.Length - 1) >= STATE_SIZE`
- `KeccakHash.Create` — `size <= 0 || size > STATE_SIZE`

But the rate is `GetRoundSize(size) = STATE_SIZE - 2 * size`, and this implementation squeezes exactly
one block, so it can only serve `size <= GetRoundSize(size)`, i.e. **`size <= 66`**. Above that the
sizes were not merely unsupported, they were unsafe:

| size | rate | what happened |
|---|---:|---|
| 67–99 | 66–2 | digest silently read past the rate into the capacity — a non-Keccak value, no error |
| 100 | 0 | `AbsorbFullBlocks` and `Update` never advance the offset — **spins forever** on any input |
| 101–200 | negative | `input[..roundSize]` / `input.Slice(offset, roundSize)` throw, or `stateBytes[roundSize - 1]` indexes backwards |

`UpdateFinalTo` is a third exit with the same defect: it copies `output.Length` bytes out of the state
with no check at all, so an output wider than the rate read the capacity there too. Nothing in tree is
affected — every caller sizes off `HashSize` — but two thirds of a fix is not one.

All three guards now bound the output: the two size guards to `[1, MAX_HASH_SIZE]`, and the incremental
squeeze to the sponge's own rate. The
`size == STATE_SIZE ? HASH_DATA_AREA` special case in the constructor goes with them — it was the only
thing that produced a rate unrelated to the output size, and its 200-byte digest read the capacity as
well. Nothing constructs one: every caller in the tree uses 32 (`Keccak`, the RLPx handshake MACs) or
64 (`Keccak512`), both comfortably inside the bound, as is every standard Keccak width.

Found by the Claude review on #13170, which flagged it as pre-existing rather than a regression there.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Unsupported_output_sizes_are_rejected` covers 0, 67, 100, 137 and 201 against both entry points.
Against master it reports one pass (0), one failure (67, where both paths accepted the size), and then
hangs on 100 — I killed the run at four minutes. Post-fix the whole `KeccakTests` class finishes in
1.8 s.

`Supported_output_sizes_agree_across_the_one_shot_and_incremental_paths` pins the one-shot and
incremental paths to each other at 1, 32, 64 and 66, so the new upper bound is exercised rather than
just asserted.

`Incremental_output_wider_than_the_rate_is_rejected` covers `UpdateFinalTo` at the boundary of the
narrowest rate: `Create(66)` has a rate of 68, so 68 bytes out is accepted and 69 is not.

`Nethermind.Core.Test` 6193/0 (includes `Keccak512Tests`), `Nethermind.Network.Test` handshake and
frame-MAC filter 121/0, `dotnet format whitespace --verify-no-changes` clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The bound is 66 (`STATE_SIZE / 3`) rather than just "not zero or negative", so 67–99 now throw where
they previously returned a wrong-but-quiet digest. That is the one behaviour change beyond the hang;
no caller is anywhere near it.

