### PR TITLE
perf(zkevm): fold the guest's fork rules and threading out of the image

### DIFF
--- a/.github/workflows/nethermind-tests-single-proc.yml
+++ b/.github/workflows/nethermind-tests-single-proc.yml
@@ -1,0 +1,89 @@
+name: Nethermind tests (Single Proc)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+env:
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
+  TERM: xterm
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-test-artifacts.yml
+    with:
+      matrix: >-
+        {"include":[{"rid":"linux-x64","os":"ubuntu-latest","variant":"release","build_args":""}]}
+
+  # The paths behind RuntimeInformation.IsSingleProcessor run only when the runtime reports one
+  # processor, which the regular matrix never does. These projects hold every such gate, and
+  # Nethermind.Core.Test carries the test that fails the run if the pin stops reaching the runtime.
+  tests:
+    name: Run ${{ matrix.project }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DOTNET_GCConserveMemory: 9
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - Nethermind.Core.Test
+          - Nethermind.Evm.Test
+          - Nethermind.Merge.Plugin.Test
+          - Nethermind.State.Test
+          - Nethermind.Trie.Test
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v5
+
+      - name: Download test binaries
+        uses: ./.github/actions/download-test-artifacts
+        with:
+          variant: release
+
+      - name: ${{ matrix.project }}
+        id: test
+        working-directory: src/Nethermind/${{ matrix.project }}
+        env:
+          # Pins Environment.ProcessorCount, and with it RuntimeInformation.IsSingleProcessor, to 1
+          # for the test host.
+          DOTNET_PROCESSOR_COUNT: 1
+        run: |
+          dotnet restore ${{ matrix.project }}.csproj
+          # A hung test host is killed with a dump of every thread instead of running into the job
+          # timeout, which kills the job without one. The timeout counts inactivity, not runtime, and
+          # a mini dump keeps the write and upload inside whatever job budget the hang leaves.
+          dotnet test --project ${{ matrix.project }}.csproj -c release --no-build --no-restore --hangdump --hangdump-timeout 8m --hangdump-type Mini
+
+      - name: Upload hang dump
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.project }}-hang-dump
+          path: src/Nethermind/${{ matrix.project }}/TestResults/*_hang.*
+          if-no-files-found: ignore
+          retention-days: 3
+
+  tests-summary:
+    name: Tests summary
+    needs: [tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check result
+        run: |
+          [[ "${{ needs.tests.result }}" == "success" ]]

--- a/.github/workflows/nethermind-tests-single-proc.yml
+++ b/.github/workflows/nethermind-tests-single-proc.yml
@@ -25,10 +25,12 @@ jobs:
         {"include":[{"rid":"linux-x64","os":"ubuntu-latest","variant":"release","build_args":""}]}
 
   # The paths behind RuntimeInformation.IsSingleProcessor run only when the runtime reports one
-  # processor, which the regular matrix never does. These projects hold every such gate, and
-  # Nethermind.Core.Test carries the test that fails the run if the pin stops reaching the runtime.
+  # processor, which the regular matrix never does. These projects hold every such gate.
+  # Nethermind.Core.Test runs only its processor-count tests: the guard that fails the run if the pin
+  # stops reaching the runtime, and the ParallelUnbalancedWork suite. Its wall-clock throughput tests
+  # assume more than one worker and starve on one processor.
   tests:
-    name: Run ${{ matrix.project }}
+    name: Run ${{ matrix.project }}${{ matrix.filters && ' (processor-count tests)' || '' }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -38,11 +40,14 @@ jobs:
       fail-fast: false
       matrix:
         project:
-          - Nethermind.Core.Test
           - Nethermind.Evm.Test
           - Nethermind.Merge.Plugin.Test
           - Nethermind.State.Test
           - Nethermind.Trie.Test
+        filters: ['']
+        include:
+          - project: Nethermind.Core.Test
+            filters: FullyQualifiedName~RuntimeInformationTests FullyQualifiedName~ParallelUnbalancedWorkTests
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -67,7 +72,15 @@ jobs:
           # A hung test host is killed with a dump of every thread instead of running into the job
           # timeout, which kills the job without one. The timeout counts inactivity, not runtime, and
           # a mini dump keeps the write and upload inside whatever job budget the hang leaves.
-          dotnet test --project ${{ matrix.project }}.csproj -c release --no-build --no-restore --hangdump --hangdump-timeout 8m --hangdump-type Mini
+          test_args=(--no-build --no-restore --hangdump --hangdump-timeout 8m --hangdump-type Mini)
+          if [ -z "${{ matrix.filters }}" ]; then
+            dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}"
+          else
+            # One filter per invocation: the test platform does not combine them reliably.
+            for filter in ${{ matrix.filters }}; do
+              dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" --filter "$filter"
+            done
+          fi
 
       - name: Upload hang dump
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/nethermind-tests-single-proc.yml
+++ b/.github/workflows/nethermind-tests-single-proc.yml
@@ -26,11 +26,10 @@ jobs:
 
   # The paths behind RuntimeInformation.IsSingleProcessor run only when the runtime reports one
   # processor, which the regular matrix never does. These projects hold every such gate.
-  # Nethermind.Core.Test runs only its processor-count tests: the guard that fails the run if the pin
-  # stops reaching the runtime, and the ParallelUnbalancedWork suite. Its wall-clock throughput tests
-  # assume more than one worker and starve on one processor.
+  # Nethermind.Core.Test carries the guard that fails the run if the pin stops reaching the runtime;
+  # it runs without the fixtures known to need more than one worker, listed in its filter.
   tests:
-    name: Run ${{ matrix.project }}${{ matrix.filters && ' (processor-count tests)' || '' }}
+    name: Run ${{ matrix.project }}
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -44,10 +43,11 @@ jobs:
           - Nethermind.Merge.Plugin.Test
           - Nethermind.State.Test
           - Nethermind.Trie.Test
-        filters: ['']
+        filter: ['']
         include:
+          # The rate limiter's wall-clock throughput cases starve on one processor.
           - project: Nethermind.Core.Test
-            filters: FullyQualifiedName~RuntimeInformationTests FullyQualifiedName~ParallelUnbalancedWorkTests
+            filter: FullyQualifiedName!~RateLimiterTests
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -73,14 +73,8 @@ jobs:
           # timeout, which kills the job without one. The timeout counts inactivity, not runtime, and
           # a mini dump keeps the write and upload inside whatever job budget the hang leaves.
           test_args=(--no-build --no-restore --hangdump --hangdump-timeout 8m --hangdump-type Mini)
-          if [ -z "${{ matrix.filters }}" ]; then
-            dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}"
-          else
-            # One filter per invocation: the test platform does not combine them reliably.
-            for filter in ${{ matrix.filters }}; do
-              dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" --filter "$filter"
-            done
-          fi
+          if [ -n "${{ matrix.filter }}" ]; then test_args+=(--filter "${{ matrix.filter }}"); fi
+          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}"
 
       - name: Upload hang dump
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -151,6 +151,7 @@ jobs:
           - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
           - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
           # Single-processor legs: the paths behind RuntimeInformation.IsSingleProcessor run only there.
+          - { runner: ubuntu-latest, project: Nethermind.Core.Test, chunk: '', processors: 1 }
           - { runner: ubuntu-latest, project: Nethermind.Evm.Test, chunk: '', processors: 1 }
           - { runner: ubuntu-latest, project: Nethermind.Merge.Plugin.Test, chunk: '', processors: 1 }
           - { runner: ubuntu-latest, project: Nethermind.State.Test, chunk: '', processors: 1 }

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -37,7 +37,7 @@ jobs:
       matrix: '{"include":[{"rid":"linux-x64","os":"ubuntu-latest","variant":"release","build_args":""},{"rid":"linux-arm64","os":"ubuntu-24.04-arm","variant":"release","build_args":""}]}'
 
   tests:
-    name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}${{ matrix.processors && format(' [{0} cpu]', matrix.processors) || '' }} (${{ matrix.runner }})
+    name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }} (${{ matrix.runner }})
     needs: build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
@@ -150,12 +150,6 @@ jobs:
           - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
           - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
           - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
-          # Single-processor legs: the paths behind RuntimeInformation.IsSingleProcessor run only there.
-          - { runner: ubuntu-latest, project: Nethermind.Core.Test, chunk: '', processors: 1 }
-          - { runner: ubuntu-latest, project: Nethermind.Evm.Test, chunk: '', processors: 1 }
-          - { runner: ubuntu-latest, project: Nethermind.Merge.Plugin.Test, chunk: '', processors: 1 }
-          - { runner: ubuntu-latest, project: Nethermind.State.Test, chunk: '', processors: 1 }
-          - { runner: ubuntu-latest, project: Nethermind.Trie.Test, chunk: '', processors: 1 }
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -169,13 +163,13 @@ jobs:
         with:
           variant: release
 
-      - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}${{ matrix.processors && format(' [{0} cpu]', matrix.processors) || '' }}
+      - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
         id: test
         working-directory: src/Nethermind/${{ matrix.project }}
         env:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
-          flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && !matrix.processors && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
+          flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
           if [ "$RUNNER_OS" = "Linux" ]; then
             dotnet restore ${{ matrix.project }}.csproj          # binaries from the shared Linux artifact
           else
@@ -185,8 +179,6 @@ jobs:
           # A hung test host is killed with a dump of every thread instead of running into the job
           # timeout, which kills the job without one. The timeout counts inactivity, not runtime, and
           # a mini dump keeps the write and upload inside whatever job budget the hang leaves.
-          # The single-processor leg takes the paths behind RuntimeInformation.IsSingleProcessor.
-          if [ -n "${{ matrix.processors }}" ]; then export DOTNET_PROCESSOR_COUNT=${{ matrix.processors }}; fi
           test_args=(--no-build --no-restore --hangdump --hangdump-timeout 8m --hangdump-type Mini)
 
           set +e
@@ -209,13 +201,13 @@ jobs:
         if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}${{ matrix.processors && format('-{0}cpu', matrix.processors) || '' }}-${{ matrix.runner }}-hang-dump
+          name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}-${{ matrix.runner }}-hang-dump
           path: src/Nethermind/${{ matrix.project }}/TestResults/*_hang.*
           if-no-files-found: ignore
           retention-days: 3
 
       - name: Upload coverage report
-        if: matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && !matrix.processors
+        if: matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}-coverage

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -37,7 +37,7 @@ jobs:
       matrix: '{"include":[{"rid":"linux-x64","os":"ubuntu-latest","variant":"release","build_args":""},{"rid":"linux-arm64","os":"ubuntu-24.04-arm","variant":"release","build_args":""}]}'
 
   tests:
-    name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }} (${{ matrix.runner }})
+    name: Run ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}${{ matrix.processors && format(' [{0} cpu]', matrix.processors) || '' }} (${{ matrix.runner }})
     needs: build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
@@ -150,6 +150,11 @@ jobs:
           - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 2of4 }
           - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 3of4 }
           - { runner: windows-latest, project: Nethermind.Synchronization.Test, chunk: 4of4 }
+          # Single-processor legs: the paths behind RuntimeInformation.IsSingleProcessor run only there.
+          - { runner: ubuntu-latest, project: Nethermind.Evm.Test, chunk: '', processors: 1 }
+          - { runner: ubuntu-latest, project: Nethermind.Merge.Plugin.Test, chunk: '', processors: 1 }
+          - { runner: ubuntu-latest, project: Nethermind.State.Test, chunk: '', processors: 1 }
+          - { runner: ubuntu-latest, project: Nethermind.Trie.Test, chunk: '', processors: 1 }
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -163,13 +168,13 @@ jobs:
         with:
           variant: release
 
-      - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}
+      - name: ${{ matrix.project }}${{ matrix.chunk && format(' ({0})', matrix.chunk) || '' }}${{ matrix.processors && format(' [{0} cpu]', matrix.processors) || '' }}
         id: test
         working-directory: src/Nethermind/${{ matrix.project }}
         env:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
-          flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
+          flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && !matrix.processors && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
           if [ "$RUNNER_OS" = "Linux" ]; then
             dotnet restore ${{ matrix.project }}.csproj          # binaries from the shared Linux artifact
           else
@@ -179,6 +184,8 @@ jobs:
           # A hung test host is killed with a dump of every thread instead of running into the job
           # timeout, which kills the job without one. The timeout counts inactivity, not runtime, and
           # a mini dump keeps the write and upload inside whatever job budget the hang leaves.
+          # The single-processor leg takes the paths behind RuntimeInformation.IsSingleProcessor.
+          if [ -n "${{ matrix.processors }}" ]; then export DOTNET_PROCESSOR_COUNT=${{ matrix.processors }}; fi
           test_args=(--no-build --no-restore --hangdump --hangdump-timeout 8m --hangdump-type Mini)
 
           set +e
@@ -201,13 +208,13 @@ jobs:
         if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}-${{ matrix.runner }}-hang-dump
+          name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}${{ matrix.processors && format('-{0}cpu', matrix.processors) || '' }}-${{ matrix.runner }}-hang-dump
           path: src/Nethermind/${{ matrix.project }}/TestResults/*_hang.*
           if-no-files-found: ignore
           retention-days: 3
 
       - name: Upload coverage report
-        if: matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true'
+        if: matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && !matrix.processors
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}-coverage

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
@@ -370,8 +370,11 @@ public partial class BlockAccessListManager
             BalTxProcessorFactory txProcessorFactory)
         {
             IWorldState worldState = stateProvider;
-            if (ExecutionFlags.ParallelExecution && parallel)
+            if (parallel)
             {
+                // A build without the capability never constructs the parallel pool; failing here
+                // keeps a mis-wired processor from producing a wrong BAL.
+                if (!ExecutionFlags.ParallelExecution) ThrowParallelExecutionUnavailable();
                 _balWorldState = new BlockAccessListBasedWorldState(stateProvider, logManager);
                 worldState = _balWorldState;
             }
@@ -402,6 +405,10 @@ public partial class BlockAccessListManager
             _parentReader?.Dispose();
             _parentReader = null;
         }
+
+        [DoesNotReturn]
+        private static void ThrowParallelExecutionUnavailable()
+            => throw new NotSupportedException("Parallel execution is not available in this build.");
 
         [DoesNotReturn]
         private static void ThrowParentReaderStillAttached()

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.TxProcessorPool.cs
@@ -370,7 +370,7 @@ public partial class BlockAccessListManager
             BalTxProcessorFactory txProcessorFactory)
         {
             IWorldState worldState = stateProvider;
-            if (parallel)
+            if (ExecutionFlags.ParallelExecution && parallel)
             {
                 _balWorldState = new BlockAccessListBasedWorldState(stateProvider, logManager);
                 worldState = _balWorldState;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockAccessListManager.cs
@@ -54,8 +54,10 @@ public partial class BlockAccessListManager(
     private BlockExecutionContext? _blockExecutionContext;
     private ITxProcessorWithWorldStateManager? _txProcessorWithWorldStateManager;
     private Task? _balWarmupTask;
-    private readonly Lazy<ParallelTxProcessorWithWorldStateManager> _parallelTxProcessorWithWorldStateManager =
-        new(() => new(stateProvider, logManager, prewarmerEnvFactory, preBlockCaches, readOnlyTxProcessingEnvFactory, txProcessorFactory));
+    // Null in a build that folds parallel execution out, so nothing behind the pool is compiled.
+    private readonly Lazy<ParallelTxProcessorWithWorldStateManager>? _parallelTxProcessorWithWorldStateManager = ExecutionFlags.ParallelExecution
+        ? new Lazy<ParallelTxProcessorWithWorldStateManager>(() => new(stateProvider, logManager, prewarmerEnvFactory, preBlockCaches, readOnlyTxProcessingEnvFactory, txProcessorFactory))
+        : null;
     private readonly Lazy<SequentialTxProcessorWithWorldStateManager> _sequentialTxProcessorWithWorldStateManager =
         new(() => new(stateProvider, logManager, txProcessorFactory));
     private const int GasValidationChunkSize = 8;
@@ -127,7 +129,8 @@ public partial class BlockAccessListManager(
         Enabled = _blockAccessListsEnabled && !suggestedBlock.IsGenesis;
         _isBuilding = options.ContainsFlag(ProcessingOptions.ProducingBlock);
 
-        ParallelExecutionEnabled = Enabled
+        ParallelExecutionEnabled = ExecutionFlags.ParallelExecution
+            && Enabled
             && blocksConfig.ParallelExecution
             && !options.ContainsFlag(ProcessingOptions.ForceSequentialBlockAccessList)
             && !_isBuilding
@@ -170,7 +173,7 @@ public partial class BlockAccessListManager(
     // Only the parallel executor drains the hint; sequential execution contends with the warming reads.
     private Task? StartBalReadWarmup(Block suggestedBlock)
     {
-        if (!BatchReadEnabled || !ParallelExecutionEnabled || suggestedBlock.BlockAccessList is null)
+        if (!ExecutionFlags.ParallelExecution || !BatchReadEnabled || !ParallelExecutionEnabled || suggestedBlock.BlockAccessList is null)
             return null;
 
         try
@@ -186,6 +189,9 @@ public partial class BlockAccessListManager(
 
     public void WaitForBalWarmup()
     {
+        // Only the parallel path starts warming, so a build without it has nothing to wait for.
+        if (!ExecutionFlags.ParallelExecution) return;
+
         Task? task = _balWarmupTask;
         if (task is null) return;
         _balWarmupTask = null;
@@ -210,7 +216,9 @@ public partial class BlockAccessListManager(
     {
         if (Enabled)
         {
-            _txProcessorWithWorldStateManager = ParallelExecutionEnabled ? _parallelTxProcessorWithWorldStateManager.Value : _sequentialTxProcessorWithWorldStateManager.Value;
+            _txProcessorWithWorldStateManager = ExecutionFlags.ParallelExecution && ParallelExecutionEnabled
+                ? _parallelTxProcessorWithWorldStateManager!.Value
+                : _sequentialTxProcessorWithWorldStateManager.Value;
             CheckInitialized();
             _txProcessorWithWorldStateManager.Setup(block, _blockExecutionContext.Value, _parentStateRoot);
         }
@@ -252,19 +260,19 @@ public partial class BlockAccessListManager(
 
     public void ReturnTxProcessor(uint balIndex)
     {
-        if (Enabled && ParallelExecutionEnabled)
+        if (ExecutionFlags.ParallelExecution && Enabled && ParallelExecutionEnabled)
         {
             // Eagerly detach the worker's generated BAL into a per-tx slot and recycle the
             // pool slot. Workers therefore never block on the validator — but the validator
             // still merges per-tx slots into the target in order, preserving incremental
             // validation semantics.
-            _parallelTxProcessorWithWorldStateManager.Value.Return(balIndex);
+            _parallelTxProcessorWithWorldStateManager!.Value.Return(balIndex);
         }
     }
 
     public void Dispose()
     {
-        if (_parallelTxProcessorWithWorldStateManager.IsValueCreated)
+        if (ExecutionFlags.ParallelExecution && _parallelTxProcessorWithWorldStateManager!.IsValueCreated)
         {
             _parallelTxProcessorWithWorldStateManager.Value.Dispose();
         }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -32,7 +32,7 @@ public partial class BlockProcessor
         : IBlockProcessor.IBlockTransactionsExecutor
     {
         private readonly ILogger _logger = logManager.GetClassLogger<ParallelBlockValidationTransactionsExecutor>();
-        private readonly IncrementalValidationWorkItem _incrementalValidationWorkItem = new();
+        private IncrementalValidationWorkItem? _incrementalValidationWorkItem;
         private BlockReceiptsTracer[] _receiptsTracerPool = [];
         private GasValidationResultSlot[] _gasResultPool = [];
         private int[] _txExecutionOrder = [];
@@ -54,7 +54,7 @@ public partial class BlockProcessor
             Metrics.ResetBlockStats();
             inner.SetupTxTimingMetrics(block);
 
-            TxReceipt[] receipts = !block.IsGenesis && balManager.ParallelExecutionEnabled
+            TxReceipt[] receipts = ExecutionFlags.ParallelExecution && !block.IsGenesis && balManager.ParallelExecutionEnabled
                 ? ProcessTransactionsParallel(block, processingOptions, receiptsTracer, token)
                 : ProcessTransactionsSequential(block, processingOptions, receiptsTracer, token);
 
@@ -128,7 +128,7 @@ public partial class BlockProcessor
                 gasResults[i].Reset();
             }
 
-            IncrementalValidationWorkItem incrementalValidation = _incrementalValidationWorkItem;
+            IncrementalValidationWorkItem incrementalValidation = _incrementalValidationWorkItem ??= new();
             incrementalValidation.Schedule(balManager, block, gasResults, receiptsTracers, transactionProcessedEventHandler, token);
             BuildTxExecutionOrder(block.Transactions, _txExecutionOrder, _txExecutionSortKeys, GetCanonicalExecutionLead(len));
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/ExecutionFlags.std.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ExecutionFlags.std.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Consensus.Processing;
+
+/// <summary>
+/// The block-execution capabilities a build compiles in.
+/// </summary>
+/// <remarks>
+/// Readers test a flag before the run-time decision it guards, so a constant <c>true</c> folds
+/// away and this build pays nothing. It exists so the zkEVM build can answer <c>false</c>: an
+/// ahead-of-time compiler emits every reachable path, and a guest that runs single-threaded would
+/// otherwise carry the parallel executor, its worker pool and the thread-pool machinery behind
+/// them. See <c>ExecutionFlags.zkevm.cs</c>.
+/// </remarks>
+internal static partial class ExecutionFlags
+{
+    /// <summary>Whether this build can execute a block's transactions in parallel.</summary>
+    public static bool ParallelExecution => true;
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/ExecutionFlags.zkevm.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/ExecutionFlags.zkevm.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.Consensus.Processing;
+
+/// <inheritdoc cref="ExecutionFlags"/>
+internal static partial class ExecutionFlags
+{
+    /// <summary>The guest runs single-threaded, so readers fold the parallel paths out of the image.</summary>
+    public static bool ParallelExecution => false;
+}

--- a/src/Nethermind/Nethermind.Core.Test/Cpu/RuntimeInformationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Cpu/RuntimeInformationTests.cs
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core.Cpu;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Cpu;
+
+public class RuntimeInformationTests
+{
+    /// <summary>
+    /// The CI matrix pins the runtime to one processor with <c>DOTNET_PROCESSOR_COUNT</c> so the
+    /// paths behind <see cref="RuntimeInformation.IsSingleProcessor"/> run. That leg is only worth
+    /// its minutes if the pin reaches the runtime, so it fails here if the runtime ignores it.
+    /// </summary>
+    [Test]
+    public void Processor_count_follows_the_runtime_pin()
+    {
+        string? pinned = Environment.GetEnvironmentVariable("DOTNET_PROCESSOR_COUNT");
+        Assume.That(pinned, Is.Not.Null, "meaningful only when DOTNET_PROCESSOR_COUNT pins the runtime");
+
+        int expected = int.Parse(pinned!);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Environment.ProcessorCount, Is.EqualTo(expected));
+            Assert.That(RuntimeInformation.ProcessorCount, Is.EqualTo(expected));
+            Assert.That(RuntimeInformation.IsSingleProcessor, Is.EqualTo(expected == 1));
+        }
+    }
+
+    [Test]
+    public void Single_processor_flag_follows_the_count()
+        => Assert.That(RuntimeInformation.IsSingleProcessor, Is.EqualTo(RuntimeInformation.ProcessorCount <= 1));
+}

--- a/src/Nethermind/Nethermind.Core.Test/Cpu/RuntimeInformationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Cpu/RuntimeInformationTests.cs
@@ -10,9 +10,11 @@ namespace Nethermind.Core.Test.Cpu;
 public class RuntimeInformationTests
 {
     /// <summary>
-    /// The CI matrix pins the runtime to one processor with <c>DOTNET_PROCESSOR_COUNT</c> so the
-    /// paths behind <see cref="RuntimeInformation.IsSingleProcessor"/> run. That leg is only worth
-    /// its minutes if the pin reaches the runtime, so it fails here if the runtime ignores it.
+    /// The <c>Nethermind tests (Single Proc)</c> workflow
+    /// (<c>.github/workflows/nethermind-tests-single-proc.yml</c>) pins the runtime to one processor
+    /// with <c>DOTNET_PROCESSOR_COUNT</c> so the paths behind
+    /// <see cref="RuntimeInformation.IsSingleProcessor"/> run. That run is only worth its minutes if
+    /// the pin reaches the runtime, so it fails here if the runtime ignores it.
     /// </summary>
     [Test]
     public void Processor_count_follows_the_runtime_pin()

--- a/src/Nethermind/Nethermind.Core.ZkEvm.Test/Nethermind.Core.ZkEvm.Test.csproj
+++ b/src/Nethermind/Nethermind.Core.ZkEvm.Test/Nethermind.Core.ZkEvm.Test.csproj
@@ -10,6 +10,10 @@
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Nethermind.Core.Test\Threading\ParallelUnbalancedWorkTests.cs" Link="Threading\ParallelUnbalancedWorkTests.cs" />
+  </ItemGroup>
+
   <Target Name="RequireZkEvm" BeforeTargets="PrepareForBuild" Condition="'$(EnableZkEvm)' != 'true'">
     <Error Text="Build this project with EnableZkEvm=true." />
   </Target>

--- a/src/Nethermind/Nethermind.Core/Cpu/RuntimeInformation.cs
+++ b/src/Nethermind/Nethermind.Core/Cpu/RuntimeInformation.cs
@@ -33,7 +33,23 @@ public static class RuntimeInformation
         return null;
     }
 
+    /// <summary>The logical processors available to the process, at least one.</summary>
+    /// <remarks>
+    /// The zkEVM guest runs single-threaded and is compiled ahead of time, so it takes a constant and
+    /// every path that fans out on the count compiles away.
+    /// </remarks>
+#if ZK_EVM
+    public const int ProcessorCount = 1;
+#else
     public static readonly int ProcessorCount = Math.Max(1, Environment.ProcessorCount);
+#endif
+    /// <summary>Whether the process has a single logical processor.</summary>
+    /// <remarks>
+    /// Fan-out gates test this rather than the count: nothing gains from fanning out on one processor,
+    /// and a property is not a constant expression, so a guard on it raises no unreachable-code
+    /// diagnostic where the count is a constant.
+    /// </remarks>
+    public static bool IsSingleProcessor => ProcessorCount <= 1;
     public static int PhysicalCoreCount { get; } = GetCpuInfo()?.PhysicalCoreCount ?? ProcessorCount;
     public static ParallelOptions ParallelOptionsLogicalCores { get; } = new() { MaxDegreeOfParallelism = ProcessorCount };
     public static ParallelOptions ParallelOptionsPhysicalCoresUpTo16 { get; } = new() { MaxDegreeOfParallelism = Math.Min(ProcessorCount, 16) };

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Runtime.ExceptionServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nethermind.Core.Threading;
@@ -11,10 +9,15 @@ namespace Nethermind.Core.Threading;
 /// <summary>
 /// Provides methods to execute parallel loops efficiently for unbalanced workloads.
 /// </summary>
-public class ParallelUnbalancedWork : IThreadPoolWorkItem
+/// <remarks>
+/// The loop bodies live in <c>ParallelUnbalancedWork.std.cs</c>, which spreads the range over
+/// thread-pool workers, and in <c>ParallelUnbalancedWork.zkevm.cs</c>, which runs it on the calling
+/// thread: the zkEVM guest has no threads, and an ahead-of-time build would otherwise carry the
+/// thread pool for loops that never fan out.
+/// </remarks>
+public partial class ParallelUnbalancedWork
 {
     public static readonly ParallelOptions DefaultOptions = new() { MaxDegreeOfParallelism = Cpu.RuntimeInformation.ProcessorCount };
-    private readonly Data _data;
 
     /// <summary>
     /// Executes a parallel for loop over a range of integers.
@@ -33,30 +36,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
     /// <param name="parallelOptions">An object that configures the behavior of this operation.</param>
     /// <param name="action">The delegate that is invoked once per iteration.</param>
     public static void For(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int> action)
-    {
-        int threads = GetWorkerCount(fromInclusive, toExclusive, parallelOptions);
-        if (threads == 0) return;
-
-        Data data = new(threads, fromInclusive, toExclusive, action, parallelOptions.CancellationToken);
-
-        for (int i = 0; i < threads - 1; i++)
-        {
-            ThreadPool.UnsafeQueueUserWorkItem(new ParallelUnbalancedWork(data), preferLocal: false);
-        }
-
-        new ParallelUnbalancedWork(data).Execute();
-
-        // If there are still active threads, wait for them to complete
-        if (data.ActiveThreads > 0)
-        {
-            data.Event.Wait();
-        }
-
-        // Rethrow the first captured worker exception, if any, on the calling thread
-        data.ThrowIfFaulted();
-
-        parallelOptions.CancellationToken.ThrowIfCancellationRequested();
-    }
+        => ForCore(fromInclusive, toExclusive, parallelOptions, action);
 
     /// <summary>
     /// Executes a parallel for loop over a range of integers, with thread-local data, initialization, and finalization functions.
@@ -75,7 +55,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         Func<TLocal> init,
         Func<int, TLocal, TLocal> action,
         Action<TLocal> @finally)
-        => InitProcessor<TLocal>.For(fromInclusive, toExclusive, parallelOptions, init, default, action, @finally);
+        => ForCore(fromInclusive, toExclusive, parallelOptions, init, default, action, @finally);
 
     /// <summary>
     /// Executes a parallel for loop over a range of integers, with thread-local data, initialization, and finalization functions.
@@ -94,7 +74,7 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         TLocal value,
         Func<int, TLocal, TLocal> action,
         Action<TLocal> @finally)
-        => InitProcessor<TLocal>.For(fromInclusive, toExclusive, parallelOptions, null, value, action, @finally);
+        => ForCore(fromInclusive, toExclusive, parallelOptions, null, value, action, @finally);
 
     /// <summary>
     /// Executes a parallel for loop over a range of integers, with thread-local data.
@@ -122,293 +102,16 @@ public class ParallelUnbalancedWork : IThreadPoolWorkItem
         ParallelOptions parallelOptions,
         TLocal state,
         Func<int, TLocal, TLocal> action)
-        => InitProcessor<TLocal>.For(fromInclusive, toExclusive, parallelOptions, null, state, action);
+        => ForCore(fromInclusive, toExclusive, parallelOptions, null, state, action, null);
 
-    private static int GetWorkerCount(int fromInclusive, int toExclusive, ParallelOptions parallelOptions)
-    {
-        parallelOptions.CancellationToken.ThrowIfCancellationRequested();
+    private static partial void ForCore(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int> action);
 
-        long rangeLength = (long)toExclusive - fromInclusive;
-        if (rangeLength <= 0) return 0;
-
-        int maxWorkers = parallelOptions.MaxDegreeOfParallelism > 0
-            ? parallelOptions.MaxDegreeOfParallelism
-            : Environment.ProcessorCount;
-
-        return (int)Math.Min(rangeLength, maxWorkers);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ParallelUnbalancedWork"/> class.
-    /// </summary>
-    /// <param name="data">The shared data for the parallel work.</param>
-    private ParallelUnbalancedWork(Data data) => _data = data;
-
-    /// <summary>
-    /// Executes the parallel work item.
-    /// </summary>
-    public void Execute()
-    {
-        try
-        {
-            try
-            {
-                int i = _data.Index.GetNext();
-                while (i < _data.ToExclusive)
-                {
-                    // Stop pulling work once cancelled or another worker has faulted.
-                    if (_data.CancellationToken.IsCancellationRequested || _data.IsFaulted) return;
-                    _data.Action(i);
-                    i = _data.Index.GetNext();
-                }
-            }
-            catch (Exception ex)
-            {
-                // Capture so the exception is rethrown on the calling thread instead of escaping
-                // a thread-pool worker (which would otherwise be unobserved/fatal).
-                _data.CaptureException(ex);
-            }
-        }
-        finally
-        {
-            // Signal that this thread has completed its work
-            _data.MarkThreadCompleted();
-        }
-    }
-
-    /// <summary>
-    /// Provides a thread-safe counter for sharing indices among threads.
-    /// </summary>
-    private class SharedCounter(int fromInclusive)
-    {
-        private CacheLinePaddedLong _index = new(fromInclusive);
-
-        /// <summary>
-        /// Gets the next index in a thread-safe manner.
-        /// </summary>
-        /// <returns>The next index.</returns>
-        public int GetNext() => (int)(Interlocked.Increment(ref _index.Value) - 1);
-    }
-
-    /// <summary>
-    /// Represents the base data shared among threads during parallel execution.
-    /// </summary>
-    private class BaseData(int threads, int fromInclusive, int toExclusive, CancellationToken token)
-    {
-        /// <summary>
-        /// Gets the shared counter for indices.
-        /// </summary>
-        public SharedCounter Index { get; } = new SharedCounter(fromInclusive);
-
-        public ManualResetEventSlim Event { get; } = new(initialState: false);
-        private int _activeThreads = threads;
-        private int _faulted;
-        private ExceptionDispatchInfo? _exception;
-        public CancellationToken CancellationToken { get; } = token;
-
-        /// <summary>
-        /// Gets the exclusive upper bound of the range.
-        /// </summary>
-        public int ToExclusive => toExclusive;
-
-        /// <summary>
-        /// Gets the number of active threads.
-        /// </summary>
-        public int ActiveThreads => Volatile.Read(ref _activeThreads);
-
-        /// <summary>
-        /// Whether any worker has captured an exception. Used by workers to short-circuit
-        /// fetching new indices once the operation is already faulted.
-        /// </summary>
-        public bool IsFaulted => Volatile.Read(ref _faulted) != 0;
-
-        /// <summary>
-        /// Captures the first exception observed by any worker so it can be rethrown on the
-        /// calling thread. Subsequent exceptions are dropped.
-        /// </summary>
-        public void CaptureException(Exception exception)
-        {
-            // Publish the fault flag before the (non-trivial) ExceptionDispatchInfo.Capture so
-            // other workers can short-circuit during the capture window.
-            if (Interlocked.CompareExchange(ref _faulted, 1, 0) != 0) return;
-            Volatile.Write(ref _exception, ExceptionDispatchInfo.Capture(exception));
-        }
-
-        /// <summary>
-        /// Rethrows the first captured exception (preserving its original stack trace), if any.
-        /// </summary>
-        public void ThrowIfFaulted() => Volatile.Read(ref _exception)?.Throw();
-
-        /// <summary>
-        /// Marks a thread as completed.
-        /// </summary>
-        /// <returns>The number of remaining active threads.</returns>
-        public int MarkThreadCompleted()
-        {
-            int remaining = Interlocked.Decrement(ref _activeThreads);
-
-            if (remaining == 0)
-            {
-                Event.Set();
-            }
-
-            return remaining;
-        }
-    }
-
-    /// <summary>
-    /// Represents the data shared among threads for the parallel action.
-    /// </summary>
-    private class Data(int threads, int fromInclusive, int toExclusive, Action<int> action, CancellationToken token) :
-        BaseData(threads, fromInclusive, toExclusive, token)
-    {
-        /// <summary>
-        /// Gets the action to be executed for each iteration.
-        /// </summary>
-        public Action<int> Action => action;
-    }
-
-    /// <summary>
-    /// Provides methods to execute parallel loops with thread-local data initialization and finalization.
-    /// </summary>
-    /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>
-    private class InitProcessor<TLocal> : IThreadPoolWorkItem
-    {
-        private readonly Data<TLocal> _data;
-
-        /// <summary>
-        /// Executes a parallel for loop over a range of integers, with thread-local data initialization and finalization.
-        /// </summary>
-        /// <param name="fromInclusive">The inclusive lower bound of the range.</param>
-        /// <param name="toExclusive">The exclusive upper bound of the range.</param>
-        /// <param name="parallelOptions">An object that configures the behavior of this operation.</param>
-        /// <param name="init">The function to initialize the local data for each thread.</param>
-        /// <param name="initValue">The initial value of the local data.</param>
-        /// <param name="action">The delegate that is invoked once per iteration.</param>
-        /// <param name="finally">The function to finalize the local data for each thread.</param>
-        public static void For(
-            int fromInclusive,
-            int toExclusive,
-            ParallelOptions parallelOptions,
-            Func<TLocal>? init,
-            TLocal? initValue,
-            Func<int, TLocal, TLocal> action,
-            Action<TLocal>? @finally = null)
-        {
-            int threads = GetWorkerCount(fromInclusive, toExclusive, parallelOptions);
-            if (threads == 0) return;
-
-            // Create shared data with thread-local initializers and finalizers
-            Data<TLocal> data = new(threads, fromInclusive, toExclusive, action, init, initValue, @finally, parallelOptions.CancellationToken);
-
-            // Queue work items to the thread pool for all threads except the current one
-            for (int i = 0; i < threads - 1; i++)
-            {
-                ThreadPool.UnsafeQueueUserWorkItem(new InitProcessor<TLocal>(data), preferLocal: false);
-            }
-
-            // Execute work on the current thread
-            new InitProcessor<TLocal>(data).Execute();
-
-            // If there are still active threads, wait for them to complete
-            if (data.ActiveThreads > 0)
-            {
-                data.Event.Wait();
-            }
-
-            // Rethrow the first captured worker exception, if any, on the calling thread
-            data.ThrowIfFaulted();
-
-            parallelOptions.CancellationToken.ThrowIfCancellationRequested();
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InitProcessor{TLocal}"/> class.
-        /// </summary>
-        /// <param name="data">The shared data for the parallel work.</param>
-        private InitProcessor(Data<TLocal> data) => _data = data;
-
-        /// <summary>
-        /// Executes the parallel work item with thread-local data.
-        /// </summary>
-        public void Execute()
-        {
-            TLocal? value = default;
-            // Track Init success so a throwing Init does not leak into Finally with default(TLocal)
-            // — matches BCL Parallel.For<TLocal>, which only invokes localFinally when localInit ran.
-            bool initSucceeded = false;
-            try
-            {
-                int i = _data.Index.GetNext();
-                if (i >= _data.ToExclusive || _data.CancellationToken.IsCancellationRequested || _data.IsFaulted)
-                {
-                    return;
-                }
-
-                value = _data.Init();
-                initSucceeded = true;
-                while (i < _data.ToExclusive)
-                {
-                    // Stop pulling work once cancelled or another worker has faulted.
-                    if (_data.CancellationToken.IsCancellationRequested || _data.IsFaulted) return;
-                    value = _data.Action(i, value);
-                    i = _data.Index.GetNext();
-                }
-            }
-            catch (Exception ex)
-            {
-                // Capture so the exception is rethrown on the calling thread instead of escaping
-                // a thread-pool worker (which would otherwise be unobserved/fatal).
-                _data.CaptureException(ex);
-            }
-            finally
-            {
-                if (initSucceeded)
-                {
-                    // A throwing Finally must not skip MarkThreadCompleted, or the calling thread
-                    // hangs on the semaphore. Capture and continue.
-                    try
-                    {
-                        _data.Finally(value!);
-                    }
-                    catch (Exception ex)
-                    {
-                        _data.CaptureException(ex);
-                    }
-                }
-                _data.MarkThreadCompleted();
-            }
-        }
-
-        /// <summary>
-        /// Represents the data shared among threads for the parallel action with thread-local data.
-        /// </summary>
-        /// <typeparam name="TValue">The type of the thread-local data.</typeparam>
-        private class Data<TValue>(int threads,
-            int fromInclusive,
-            int toExclusive,
-            Func<int, TLocal, TLocal> action,
-            Func<TValue>? init,
-            TValue? initValue,
-            Action<TValue>? @finally,
-            CancellationToken token) : BaseData(threads, fromInclusive, toExclusive, token)
-        {
-            /// <summary>
-            /// Gets the action to be executed for each iteration.
-            /// </summary>
-            public Func<int, TLocal, TLocal> Action => action;
-
-            /// <summary>
-            /// Initializes the thread-local data.
-            /// </summary>
-            /// <returns>The initialized thread-local data.</returns>
-            public TValue Init() => init is not null ? init.Invoke() : initValue!;
-
-            /// <summary>
-            /// Finalizes the thread-local data.
-            /// </summary>
-            /// <param name="value">The thread-local data to finalize.</param>
-            public void Finally(TValue value) => @finally?.Invoke(value);
-        }
-    }
+    private static partial void ForCore<TLocal>(
+        int fromInclusive,
+        int toExclusive,
+        ParallelOptions parallelOptions,
+        Func<TLocal>? init,
+        TLocal? initValue,
+        Func<int, TLocal, TLocal> action,
+        Action<TLocal>? @finally);
 }

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.std.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.std.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.std.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.std.cs
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Core.Threading;
+
+public partial class ParallelUnbalancedWork : IThreadPoolWorkItem
+{
+    private readonly Data _data;
+
+    private static partial void ForCore(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int> action)
+    {
+        int threads = GetWorkerCount(fromInclusive, toExclusive, parallelOptions);
+        if (threads == 0) return;
+
+        Data data = new(threads, fromInclusive, toExclusive, action, parallelOptions.CancellationToken);
+
+        for (int i = 0; i < threads - 1; i++)
+        {
+            ThreadPool.UnsafeQueueUserWorkItem(new ParallelUnbalancedWork(data), preferLocal: false);
+        }
+
+        new ParallelUnbalancedWork(data).Execute();
+
+        // If there are still active threads, wait for them to complete
+        if (data.ActiveThreads > 0)
+        {
+            data.Event.Wait();
+        }
+
+        // Rethrow the first captured worker exception, if any, on the calling thread
+        data.ThrowIfFaulted();
+
+        parallelOptions.CancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private static partial void ForCore<TLocal>(
+        int fromInclusive,
+        int toExclusive,
+        ParallelOptions parallelOptions,
+        Func<TLocal>? init,
+        TLocal? initValue,
+        Func<int, TLocal, TLocal> action,
+        Action<TLocal>? @finally)
+        => InitProcessor<TLocal>.For(fromInclusive, toExclusive, parallelOptions, init, initValue, action, @finally);
+
+    private static int GetWorkerCount(int fromInclusive, int toExclusive, ParallelOptions parallelOptions)
+    {
+        parallelOptions.CancellationToken.ThrowIfCancellationRequested();
+
+        long rangeLength = (long)toExclusive - fromInclusive;
+        if (rangeLength <= 0) return 0;
+
+        int maxWorkers = parallelOptions.MaxDegreeOfParallelism > 0
+            ? parallelOptions.MaxDegreeOfParallelism
+            : Environment.ProcessorCount;
+
+        return (int)Math.Min(rangeLength, maxWorkers);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ParallelUnbalancedWork"/> class.
+    /// </summary>
+    /// <param name="data">The shared data for the parallel work.</param>
+    private ParallelUnbalancedWork(Data data) => _data = data;
+
+    /// <summary>
+    /// Executes the parallel work item.
+    /// </summary>
+    public void Execute()
+    {
+        try
+        {
+            try
+            {
+                int i = _data.Index.GetNext();
+                while (i < _data.ToExclusive)
+                {
+                    // Stop pulling work once cancelled or another worker has faulted.
+                    if (_data.CancellationToken.IsCancellationRequested || _data.IsFaulted) return;
+                    _data.Action(i);
+                    i = _data.Index.GetNext();
+                }
+            }
+            catch (Exception ex)
+            {
+                // Capture so the exception is rethrown on the calling thread instead of escaping
+                // a thread-pool worker (which would otherwise be unobserved/fatal).
+                _data.CaptureException(ex);
+            }
+        }
+        finally
+        {
+            // Signal that this thread has completed its work
+            _data.MarkThreadCompleted();
+        }
+    }
+
+    /// <summary>
+    /// Provides a thread-safe counter for sharing indices among threads.
+    /// </summary>
+    private class SharedCounter(int fromInclusive)
+    {
+        private CacheLinePaddedLong _index = new(fromInclusive);
+
+        /// <summary>
+        /// Gets the next index in a thread-safe manner.
+        /// </summary>
+        /// <returns>The next index.</returns>
+        public int GetNext() => (int)(Interlocked.Increment(ref _index.Value) - 1);
+    }
+
+    /// <summary>
+    /// Represents the base data shared among threads during parallel execution.
+    /// </summary>
+    private class BaseData(int threads, int fromInclusive, int toExclusive, CancellationToken token)
+    {
+        /// <summary>
+        /// Gets the shared counter for indices.
+        /// </summary>
+        public SharedCounter Index { get; } = new SharedCounter(fromInclusive);
+
+        public ManualResetEventSlim Event { get; } = new(initialState: false);
+        private int _activeThreads = threads;
+        private int _faulted;
+        private ExceptionDispatchInfo? _exception;
+        public CancellationToken CancellationToken { get; } = token;
+
+        /// <summary>
+        /// Gets the exclusive upper bound of the range.
+        /// </summary>
+        public int ToExclusive => toExclusive;
+
+        /// <summary>
+        /// Gets the number of active threads.
+        /// </summary>
+        public int ActiveThreads => Volatile.Read(ref _activeThreads);
+
+        /// <summary>
+        /// Whether any worker has captured an exception. Used by workers to short-circuit
+        /// fetching new indices once the operation is already faulted.
+        /// </summary>
+        public bool IsFaulted => Volatile.Read(ref _faulted) != 0;
+
+        /// <summary>
+        /// Captures the first exception observed by any worker so it can be rethrown on the
+        /// calling thread. Subsequent exceptions are dropped.
+        /// </summary>
+        public void CaptureException(Exception exception)
+        {
+            // Publish the fault flag before the (non-trivial) ExceptionDispatchInfo.Capture so
+            // other workers can short-circuit during the capture window.
+            if (Interlocked.CompareExchange(ref _faulted, 1, 0) != 0) return;
+            Volatile.Write(ref _exception, ExceptionDispatchInfo.Capture(exception));
+        }
+
+        /// <summary>
+        /// Rethrows the first captured exception (preserving its original stack trace), if any.
+        /// </summary>
+        public void ThrowIfFaulted() => Volatile.Read(ref _exception)?.Throw();
+
+        /// <summary>
+        /// Marks a thread as completed.
+        /// </summary>
+        /// <returns>The number of remaining active threads.</returns>
+        public int MarkThreadCompleted()
+        {
+            int remaining = Interlocked.Decrement(ref _activeThreads);
+
+            if (remaining == 0)
+            {
+                Event.Set();
+            }
+
+            return remaining;
+        }
+    }
+
+    /// <summary>
+    /// Represents the data shared among threads for the parallel action.
+    /// </summary>
+    private class Data(int threads, int fromInclusive, int toExclusive, Action<int> action, CancellationToken token) :
+        BaseData(threads, fromInclusive, toExclusive, token)
+    {
+        /// <summary>
+        /// Gets the action to be executed for each iteration.
+        /// </summary>
+        public Action<int> Action => action;
+    }
+
+    /// <summary>
+    /// Provides methods to execute parallel loops with thread-local data initialization and finalization.
+    /// </summary>
+    /// <typeparam name="TLocal">The type of the thread-local data.</typeparam>
+    private class InitProcessor<TLocal> : IThreadPoolWorkItem
+    {
+        private readonly Data<TLocal> _data;
+
+        /// <summary>
+        /// Executes a parallel for loop over a range of integers, with thread-local data initialization and finalization.
+        /// </summary>
+        /// <param name="fromInclusive">The inclusive lower bound of the range.</param>
+        /// <param name="toExclusive">The exclusive upper bound of the range.</param>
+        /// <param name="parallelOptions">An object that configures the behavior of this operation.</param>
+        /// <param name="init">The function to initialize the local data for each thread.</param>
+        /// <param name="initValue">The initial value of the local data.</param>
+        /// <param name="action">The delegate that is invoked once per iteration.</param>
+        /// <param name="finally">The function to finalize the local data for each thread.</param>
+        public static void For(
+            int fromInclusive,
+            int toExclusive,
+            ParallelOptions parallelOptions,
+            Func<TLocal>? init,
+            TLocal? initValue,
+            Func<int, TLocal, TLocal> action,
+            Action<TLocal>? @finally = null)
+        {
+            int threads = GetWorkerCount(fromInclusive, toExclusive, parallelOptions);
+            if (threads == 0) return;
+
+            // Create shared data with thread-local initializers and finalizers
+            Data<TLocal> data = new(threads, fromInclusive, toExclusive, action, init, initValue, @finally, parallelOptions.CancellationToken);
+
+            // Queue work items to the thread pool for all threads except the current one
+            for (int i = 0; i < threads - 1; i++)
+            {
+                ThreadPool.UnsafeQueueUserWorkItem(new InitProcessor<TLocal>(data), preferLocal: false);
+            }
+
+            // Execute work on the current thread
+            new InitProcessor<TLocal>(data).Execute();
+
+            // If there are still active threads, wait for them to complete
+            if (data.ActiveThreads > 0)
+            {
+                data.Event.Wait();
+            }
+
+            // Rethrow the first captured worker exception, if any, on the calling thread
+            data.ThrowIfFaulted();
+
+            parallelOptions.CancellationToken.ThrowIfCancellationRequested();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InitProcessor{TLocal}"/> class.
+        /// </summary>
+        /// <param name="data">The shared data for the parallel work.</param>
+        private InitProcessor(Data<TLocal> data) => _data = data;
+
+        /// <summary>
+        /// Executes the parallel work item with thread-local data.
+        /// </summary>
+        public void Execute()
+        {
+            TLocal? value = default;
+            // Track Init success so a throwing Init does not leak into Finally with default(TLocal)
+            // — matches BCL Parallel.For<TLocal>, which only invokes localFinally when localInit ran.
+            bool initSucceeded = false;
+            try
+            {
+                int i = _data.Index.GetNext();
+                if (i >= _data.ToExclusive || _data.CancellationToken.IsCancellationRequested || _data.IsFaulted)
+                {
+                    return;
+                }
+
+                value = _data.Init();
+                initSucceeded = true;
+                while (i < _data.ToExclusive)
+                {
+                    // Stop pulling work once cancelled or another worker has faulted.
+                    if (_data.CancellationToken.IsCancellationRequested || _data.IsFaulted) return;
+                    value = _data.Action(i, value);
+                    i = _data.Index.GetNext();
+                }
+            }
+            catch (Exception ex)
+            {
+                // Capture so the exception is rethrown on the calling thread instead of escaping
+                // a thread-pool worker (which would otherwise be unobserved/fatal).
+                _data.CaptureException(ex);
+            }
+            finally
+            {
+                if (initSucceeded)
+                {
+                    // A throwing Finally must not skip MarkThreadCompleted, or the calling thread
+                    // hangs on the semaphore. Capture and continue.
+                    try
+                    {
+                        _data.Finally(value!);
+                    }
+                    catch (Exception ex)
+                    {
+                        _data.CaptureException(ex);
+                    }
+                }
+                _data.MarkThreadCompleted();
+            }
+        }
+
+        /// <summary>
+        /// Represents the data shared among threads for the parallel action with thread-local data.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the thread-local data.</typeparam>
+        private class Data<TValue>(int threads,
+            int fromInclusive,
+            int toExclusive,
+            Func<int, TLocal, TLocal> action,
+            Func<TValue>? init,
+            TValue? initValue,
+            Action<TValue>? @finally,
+            CancellationToken token) : BaseData(threads, fromInclusive, toExclusive, token)
+        {
+            /// <summary>
+            /// Gets the action to be executed for each iteration.
+            /// </summary>
+            public Func<int, TLocal, TLocal> Action => action;
+
+            /// <summary>
+            /// Initializes the thread-local data.
+            /// </summary>
+            /// <returns>The initialized thread-local data.</returns>
+            public TValue Init() => init is not null ? init.Invoke() : initValue!;
+
+            /// <summary>
+            /// Finalizes the thread-local data.
+            /// </summary>
+            /// <param name="value">The thread-local data to finalize.</param>
+            public void Finally(TValue value) => @finally?.Invoke(value);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Threading/ParallelUnbalancedWork.zkevm.cs
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nethermind.Core.Threading;
+
+/// <inheritdoc cref="ParallelUnbalancedWork"/>
+public partial class ParallelUnbalancedWork
+{
+    // One worker, the calling thread. The order of checks mirrors the threaded worker: cancellation
+    // stops the loop before the next action, a failure is reported before cancellation is, and the
+    // finalizer runs whenever initialization did.
+    private static partial void ForCore(int fromInclusive, int toExclusive, ParallelOptions parallelOptions, Action<int> action)
+    {
+        CancellationToken token = parallelOptions.CancellationToken;
+        token.ThrowIfCancellationRequested();
+
+        for (int i = fromInclusive; i < toExclusive && !token.IsCancellationRequested; i++)
+        {
+            action(i);
+        }
+
+        token.ThrowIfCancellationRequested();
+    }
+
+    private static partial void ForCore<TLocal>(
+        int fromInclusive,
+        int toExclusive,
+        ParallelOptions parallelOptions,
+        Func<TLocal>? init,
+        TLocal? initValue,
+        Func<int, TLocal, TLocal> action,
+        Action<TLocal>? @finally)
+    {
+        CancellationToken token = parallelOptions.CancellationToken;
+        token.ThrowIfCancellationRequested();
+        if (toExclusive <= fromInclusive) return;
+
+        TLocal value = init is not null ? init() : initValue!;
+        Exception? fault = null;
+        try
+        {
+            for (int i = fromInclusive; i < toExclusive && !token.IsCancellationRequested; i++)
+            {
+                value = action(i, value);
+            }
+        }
+        catch (Exception ex)
+        {
+            fault = ex;
+        }
+
+        try
+        {
+            @finally?.Invoke(value);
+        }
+        catch (Exception ex)
+        {
+            fault ??= ex;
+        }
+
+        if (fault is not null) ExceptionDispatchInfo.Throw(fault);
+        token.ThrowIfCancellationRequested();
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -240,10 +240,10 @@ public class EthereumGasPolicyTests
         spec.ClearReceivedCalls();
         bool actual = (eip3860, eip8038) switch
         {
-            (true, true) => ChargeCreate<EvmInstructions.CreateSpec<OffFlag, OffFlag, OnFlag, OnFlag>>(ref specializedGas, spec, eip8037, create2, words),
-            (true, false) => ChargeCreate<EvmInstructions.CreateSpec<OffFlag, OffFlag, OnFlag, OffFlag>>(ref specializedGas, spec, eip8037, create2, words),
-            (false, true) => ChargeCreate<EvmInstructions.CreateSpec<OffFlag, OffFlag, OffFlag, OnFlag>>(ref specializedGas, spec, eip8037, create2, words),
-            (false, false) => ChargeCreate<EvmInstructions.CreateSpec<OffFlag, OffFlag, OffFlag, OffFlag>>(ref specializedGas, spec, eip8037, create2, words),
+            (true, true) => ChargeCreate<EvmInstructions.CreateSpec<OffFlag, OffFlag, OnFlag, Eip8038On>>(ref specializedGas, spec, eip8037, create2, words),
+            (true, false) => ChargeCreate<EvmInstructions.CreateSpec<OffFlag, OffFlag, OnFlag, Eip8038Off>>(ref specializedGas, spec, eip8037, create2, words),
+            (false, true) => ChargeCreate<EvmInstructions.CreateSpec<OffFlag, OffFlag, OffFlag, Eip8038On>>(ref specializedGas, spec, eip8037, create2, words),
+            (false, false) => ChargeCreate<EvmInstructions.CreateSpec<OffFlag, OffFlag, OffFlag, Eip8038Off>>(ref specializedGas, spec, eip8037, create2, words),
         };
 
         using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -236,7 +236,7 @@ public class EthereumGasPolicyTests
         spec.IsEip8038Enabled.Returns(eip8038);
         EthereumGasPolicy dynamicGas = EthereumGasPolicy.FromULong(availableGas);
         EthereumGasPolicy specializedGas = dynamicGas;
-        bool expected = ChargeCreate<EvmInstructions.DynamicCreateSpec>(ref dynamicGas, spec, eip8037, create2, words);
+        bool expected = ChargeCreateDynamic(ref dynamicGas, spec, eip8037, create2, words);
         spec.ClearReceivedCalls();
         bool actual = (eip3860, eip8038) switch
         {
@@ -263,6 +263,17 @@ public class EthereumGasPolicyTests
             (true, false) => TSpec.ConsumeCreateGas<EthereumGasPolicy, OnFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
             (false, true) => TSpec.ConsumeCreateGas<EthereumGasPolicy, OffFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
             (false, false) => TSpec.ConsumeCreateGas<EthereumGasPolicy, OffFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
+        };
+
+    /// <summary>The policy's own spec-reading create charge, the oracle the specialized specs must match.</summary>
+    private static bool ChargeCreateDynamic<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec, bool eip8037, bool create2, ulong words)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
+        (eip8037, create2) switch
+        {
+            (true, true) => TGasPolicy.ConsumeCreateGas<OnFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
+            (true, false) => TGasPolicy.ConsumeCreateGas<OnFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
+            (false, true) => TGasPolicy.ConsumeCreateGas<OffFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
+            (false, false) => TGasPolicy.ConsumeCreateGas<OffFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
         };
 
     // Locks the ConsumeDataCopyGas contract: the policy computes base access cost + per-word copy

--- a/src/Nethermind/Nethermind.Evm.Test/SpecFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/SpecFlagsTests.cs
@@ -20,30 +20,40 @@ namespace Nethermind.Evm.Test;
 /// The zkEVM guest is compiled ahead of time, so every reachable handler specialization is emitted
 /// while one runs. A fork rule that holds a single value across the range of forks the guest serves
 /// can be a constant, which folds the branch reading it and drops the specialization behind the
-/// untaken side. This test recomputes which rules qualify and fails when the checked-in file
+/// untaken side. Rules that vary but take the same value on every fork in the range move together,
+/// so one reads the spec and the others follow its flag, which drops the pairings the range never
+/// produces. This test recomputes which rules qualify for each and fails when the checked-in file
 /// disagrees - which is what happens when a fork is added, or when the range below is moved.
 /// </remarks>
 public class SpecFlagsTests
 {
-    /// <summary>Oldest fork the guest serves. Raise it to drop older forks and fold more rules.</summary>
     private const string ResourceName = "SpecFlags.zkevm.cs";
 
+    /// <summary>Oldest fork the guest serves. Raise it to drop older forks and fold more rules.</summary>
     private const string Floor = nameof(Osaka);
 
     /// <summary>Newest fork the guest serves, or null to serve every fork descended from the floor.</summary>
     private static readonly string? Max = nameof(Amsterdam);
 
-    /// <summary>Each rule the opcode table branches on, and how it reads from a spec.</summary>
-    private static readonly (string Rule, Func<IReleaseSpec, bool> Read)[] Rules =
+    /// <summary>
+    /// Each rule the opcode table branches on: the spec property the generated file must read it
+    /// from, and the same read as a delegate for evaluating it on a fork.
+    /// </summary>
+    /// <remarks>Extension properties are spelled out because <c>nameof</c> rejects extension members (CS9316).</remarks>
+    private static readonly (string Rule, string Property, Func<IReleaseSpec, bool> Read)[] Rules =
     [
-        ("Eip150", static s => s.Use63Over64Rule),
-        ("Eip158", static s => s.ClearEmptyAccountWhenTouched),
-        ("Eip2780", static s => s.IsEip2780Enabled),
-        ("Eip2929", static s => s.UseHotAndColdStorage),
-        ("Eip3860", static s => s.IsEip3860Enabled),
-        ("Eip7708", static s => s.IsEip7708Enabled),
-        ("Eip8037", static s => s.IsEip8037Enabled),
-        ("Eip8038", static s => s.IsEip8038Enabled),
+        ("Eip150", "Use63Over64Rule", static s => s.Use63Over64Rule),
+        ("Eip158", "ClearEmptyAccountWhenTouched", static s => s.ClearEmptyAccountWhenTouched),
+        ("Eip2200", "UseNetGasMeteringWithAStipendFix", static s => s.UseNetGasMeteringWithAStipendFix),
+        ("Eip2780", nameof(IReleaseSpec.IsEip2780Enabled), static s => s.IsEip2780Enabled),
+        ("Eip2929", "UseHotAndColdStorage", static s => s.UseHotAndColdStorage),
+        ("Eip3860", nameof(IReleaseSpec.IsEip3860Enabled), static s => s.IsEip3860Enabled),
+        ("Eip6780", "SelfdestructOnlyOnSameTransaction", static s => s.SelfdestructOnlyOnSameTransaction),
+        ("Eip7708", nameof(IReleaseSpec.IsEip7708Enabled), static s => s.IsEip7708Enabled),
+        ("Eip8037", nameof(IReleaseSpec.IsEip8037Enabled), static s => s.IsEip8037Enabled),
+        ("Eip8038", nameof(IReleaseSpec.IsEip8038Enabled), static s => s.IsEip8038Enabled),
+        ("Eip8246", "RemoveSelfdestructBurn", static s => s.RemoveSelfdestructBurn),
+        ("NetGasMetering", "UseNetGasMetering", static s => s.UseNetGasMetering),
     ];
 
     [Test]
@@ -68,24 +78,43 @@ public class SpecFlagsTests
         List<NamedReleaseSpec> range = ForkRange();
         string source = GeneratedSource();
 
+        HashSet<string> declared = Regex
+            .Matches(source, @"public static bool (?<rule>\w+)(?:<T\w+>)?\(IReleaseSpec spec\)")
+            .Select(static m => m.Groups["rule"].Value).ToHashSet();
         Dictionary<string, bool> constants = Regex
-            .Matches(source, @"public const bool Const(?<rule>Eip\w+) = (?<value>true|false);")
+            .Matches(source, @"public const bool Const(?<rule>\w+) = (?<value>true|false);")
             .ToDictionary(static m => m.Groups["rule"].Value, static m => m.Groups["value"].Value == "true");
         HashSet<string> folded = Regex
-            .Matches(source, @"public static bool (?<rule>Eip\w+)\(IReleaseSpec spec\) => Const\k<rule>;")
+            .Matches(source, @"public static bool (?<rule>\w+)(?:<T\w+>)?\(IReleaseSpec spec\)(?: where T\w+ : struct, IFlag)? => Const\k<rule>;")
             .Select(static m => m.Groups["rule"].Value).ToHashSet();
-        HashSet<string> validated = Regex
-            .Matches(source, @"Check\(spec\.\w+, Const(?<rule>Eip\w+),")
-            .Select(static m => m.Groups["rule"].Value).ToHashSet();
+        Dictionary<string, string> reads = Regex
+            .Matches(source, @"public static bool (?<rule>\w+)(?:<T\w+>)?\(IReleaseSpec spec\)(?: where T\w+ : struct, IFlag)? => spec\.(?<property>\w+);")
+            .ToDictionary(static m => m.Groups["rule"].Value, static m => m.Groups["property"].Value);
+        Dictionary<string, string> derived = Regex
+            .Matches(source, @"public static bool (?<rule>\w+)<T(?<anchor>\w+)>\(IReleaseSpec spec\) where T\k<anchor> : struct, IFlag => T\k<anchor>\.IsActive;")
+            .ToDictionary(static m => m.Groups["rule"].Value, static m => m.Groups["anchor"].Value);
+        Dictionary<string, string> checkedProperties = Regex
+            .Matches(source, @"Check\(spec\.(?<property>\w+), Const(?<rule>\w+),")
+            .ToDictionary(static m => m.Groups["rule"].Value, static m => m.Groups["property"].Value);
+        Dictionary<string, (string Property, string AnchorProperty, string Anchor)> followed = Regex
+            .Matches(source, @"Follows\(spec\.(?<property>\w+), spec\.(?<anchorProperty>\w+), ""(?<rule>[^""]+)"", ""(?<anchor>[^""]+)""\)")
+            .ToDictionary(
+                static m => m.Groups["rule"].Value,
+                static m => (m.Groups["property"].Value, m.Groups["anchorProperty"].Value, m.Groups["anchor"].Value));
 
         StringBuilder wrong = new();
 
-        // Everything below walks Rules, so a constant with no entry there would go unexamined - the
-        // one way the generated file could drift while this test still passed.
-        Assert.That(constants.Keys.Except(Rules.Select(static r => r.Rule)), Is.Empty,
-            "A folded constant with no entry in Rules is never checked against the fork graph.");
+        // Everything below walks Rules, so a rule the file declares, or names as an anchor, but Rules
+        // lacks would go unexamined.
+        Assert.That(declared.Concat(constants.Keys).Concat(derived.Values).Except(Rules.Select(static r => r.Rule)), Is.Empty,
+            "A rule in the generated file with no entry in Rules is never checked against the fork graph.");
 
-        foreach ((string rule, Func<IReleaseSpec, bool> read) in Rules)
+        Dictionary<string, string> properties = Rules.ToDictionary(static r => r.Rule, static r => r.Property);
+        Dictionary<string, string> values = Rules.ToDictionary(
+            static r => r.Rule,
+            r => string.Concat(range.Select(f => r.Read(f) ? '1' : '0')));
+
+        foreach ((string rule, string property, Func<IReleaseSpec, bool> read) in Rules)
         {
             bool value = read(range[0]);
             bool invariant = range.TrueForAll(f => read(f) == value);
@@ -98,18 +127,56 @@ public class SpecFlagsTests
                 continue;
             }
 
-            if (!invariant) continue;
+            if (invariant)
+            {
+                if (constants[rule] != value)
+                    wrong.AppendLine($"{rule} is declared {constants[rule]} but is {value} across {Describe(range)}.");
+                if (!folded.Contains(rule))
+                    wrong.AppendLine($"{rule} declares a constant but its body does not return it, so nothing folds.");
+                if (!checkedProperties.TryGetValue(rule, out string? checkedProperty))
+                    wrong.AppendLine($"{rule} is folded but Validate skips it, so an out-of-range block runs against a rule that does not describe it.");
+                else if (checkedProperty != property)
+                    wrong.AppendLine($"Validate checks {rule} against spec.{checkedProperty}, but the rule reads spec.{property}.");
+                continue;
+            }
 
-            if (constants[rule] != value)
-                wrong.AppendLine($"{rule} is declared {constants[rule]} but is {value} across {Describe(range)}.");
-            if (!folded.Contains(rule))
-                wrong.AppendLine($"{rule} declares a constant but its body does not return it, so nothing folds.");
-            if (!validated.Contains(rule))
-                wrong.AppendLine($"{rule} is folded but Validate skips it, so an out-of-range block runs against a rule that does not describe it.");
+            List<string> peers = Rules
+                .Select(static r => r.Rule)
+                .Where(r => r != rule && values[r] == values[rule])
+                .ToList();
+
+            if (derived.TryGetValue(rule, out string? anchor))
+            {
+                if (!peers.Contains(anchor))
+                    wrong.AppendLine($"{rule} follows {anchor} but does not move with it across {Describe(range)}; read it from the spec.");
+                else if (derived.ContainsKey(anchor))
+                    wrong.AppendLine($"{rule} follows {anchor}, which follows another rule itself; follow the one that reads the spec.");
+                if (!followed.TryGetValue(Display(rule), out (string Property, string AnchorProperty, string Anchor) pairing))
+                    wrong.AppendLine($"{rule} follows {anchor} but Validate does not check that they agree, so an out-of-range block runs against a pairing that was never compiled.");
+                else if (pairing.Anchor != Display(anchor) || pairing.Property != property || pairing.AnchorProperty != properties[anchor])
+                    wrong.AppendLine($"Validate checks {rule} as spec.{pairing.Property} following {pairing.Anchor} as spec.{pairing.AnchorProperty}; the rule reads spec.{property} and follows {anchor}, spec.{properties[anchor]}.");
+                continue;
+            }
+
+            if (!reads.TryGetValue(rule, out string? readProperty))
+                wrong.AppendLine($"{rule} varies across {Describe(range)} but neither reads the spec nor follows another rule.");
+            else if (readProperty != property)
+                wrong.AppendLine($"{rule} reads spec.{readProperty}; the opcode table's rule is spec.{property}.");
+
+            // This rule reads the spec, so a peer that also reads it compiles pairings the range never produces.
+            foreach (string peer in peers)
+            {
+                if (!derived.ContainsKey(peer) && string.CompareOrdinal(rule, peer) < 0)
+                    wrong.AppendLine($"{rule} and {peer} move together across {Describe(range)}; make one follow the other.");
+            }
         }
 
         Assert.That(wrong.ToString(), Is.Empty, "SpecFlags.zkevm.cs disagrees with the fork graph; move it and Floor/Max together.");
     }
+
+    /// <summary>The name Validate reports a rule under: <c>EIP-150</c> for <c>Eip150</c>.</summary>
+    private static string Display(string rule) =>
+        rule.StartsWith("Eip", StringComparison.Ordinal) ? $"EIP-{rule.AsSpan(3)}" : rule;
 
     /// <summary>Forks at or descended from <see cref="Floor"/>, capped at <see cref="Max"/>.</summary>
     /// <remarks>

--- a/src/Nethermind/Nethermind.Evm.Test/SpecFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/SpecFlagsTests.cs
@@ -227,7 +227,8 @@ public class SpecFlagsTests
 
     /// <summary>
     /// A follower rule is anchored on the EIP-8038 setting through its type-parameter constraint, so
-    /// the marker interface has to stay exclusive to the two EIP-8038 flags.
+    /// the marker interface has to stay exclusive to the two EIP-8038 flags. The interface is internal,
+    /// so this assembly is the only place an implementation can live and the scan is exhaustive.
     /// </summary>
     [Test]
     public void Anchor_interface_is_implemented_only_by_the_two_Eip8038_flags()

--- a/src/Nethermind/Nethermind.Evm.Test/SpecFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/SpecFlagsTests.cs
@@ -85,13 +85,13 @@ public class SpecFlagsTests
             .Matches(source, @"public const bool Const(?<rule>\w+) = (?<value>true|false);")
             .ToDictionary(static m => m.Groups["rule"].Value, static m => m.Groups["value"].Value == "true");
         HashSet<string> folded = Regex
-            .Matches(source, @"public static bool (?<rule>\w+)(?:<T\w+>)?\(IReleaseSpec spec\)(?: where T\w+ : struct, IFlag)? => Const\k<rule>;")
+            .Matches(source, @"public static bool (?<rule>\w+)(?:<T\w+>)?\(IReleaseSpec spec\)(?: where T\w+ : struct, I\w+)? => Const\k<rule>;")
             .Select(static m => m.Groups["rule"].Value).ToHashSet();
         Dictionary<string, string> reads = Regex
-            .Matches(source, @"public static bool (?<rule>\w+)(?:<T\w+>)?\(IReleaseSpec spec\)(?: where T\w+ : struct, IFlag)? => spec\.(?<property>\w+);")
+            .Matches(source, @"public static bool (?<rule>\w+)(?:<T\w+>)?\(IReleaseSpec spec\)(?: where T\w+ : struct, I\w+)? => spec\.(?<property>\w+);")
             .ToDictionary(static m => m.Groups["rule"].Value, static m => m.Groups["property"].Value);
         Dictionary<string, string> derived = Regex
-            .Matches(source, @"public static bool (?<rule>\w+)<T(?<anchor>\w+)>\(IReleaseSpec spec\) where T\k<anchor> : struct, IFlag => T\k<anchor>\.IsActive;")
+            .Matches(source, @"public static bool (?<rule>\w+)<T(?<anchor>\w+)>\(IReleaseSpec spec\) where T\k<anchor> : struct, I\k<anchor>Flag => T\k<anchor>\.IsActive;")
             .ToDictionary(static m => m.Groups["rule"].Value, static m => m.Groups["anchor"].Value);
         Dictionary<string, string> checkedProperties = Regex
             .Matches(source, @"Check\(spec\.(?<property>\w+), Const(?<rule>\w+),")
@@ -223,6 +223,22 @@ public class SpecFlagsTests
             if (f.GetType() == fork.GetType()) return true;
         }
         return false;
+    }
+
+    /// <summary>
+    /// A follower rule is anchored on the EIP-8038 setting through its type-parameter constraint, so
+    /// the marker interface has to stay exclusive to the two EIP-8038 flags.
+    /// </summary>
+    [Test]
+    public void Anchor_interface_is_implemented_only_by_the_two_Eip8038_flags()
+    {
+        string[] implementers = typeof(IEip8038Flag).Assembly.GetTypes()
+            .Where(static t => t.IsValueType && typeof(IEip8038Flag).IsAssignableFrom(t))
+            .Select(static t => t.Name)
+            .Order()
+            .ToArray();
+
+        Assert.That(implementers, Is.EqualTo(new[] { nameof(Eip8038Off), nameof(Eip8038On) }));
     }
 
     private static string Describe(List<NamedReleaseSpec> range) =>

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Nethermind.Core.Cpu;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm.Precompiles;
@@ -73,10 +74,11 @@ public sealed class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
 
     public void AnalyzeInBackgroundIfRequired()
     {
-#if !ZK_EVM
+        // Analysis only runs ahead of execution on another processor; the guest folds the queue away.
+        if (RuntimeInformation.IsSingleProcessor) return;
+
         if (!ReferenceEquals(_analyzer, _emptyAnalyzer) && (_analyzer?.RequiresAnalysis ?? false))
             ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
-#endif
     }
 
     public override bool Equals(object? obj)

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -51,11 +51,10 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
     [MethodImpl(MethodImplOptions.NoInlining)]
     private long[] CreateOrWaitForJumpDestinationBitmap()
     {
-#if ZK_EVM
-        // Nothing analyzes in the background on the single-threaded guest, so there is no completion
-        // event to allocate, signal or wait on.
-        return CreateJumpDestinationBitmap();
-#else
+        // A single processor never queues the background analysis, so there is no completion event
+        // to allocate, signal or wait on; the guest folds the rest of the method away.
+        if (Core.Cpu.RuntimeInformation.IsSingleProcessor) return CreateJumpDestinationBitmap();
+
         object? previous = Volatile.Read(ref _analysisComplete);
         if (previous is null)
         {
@@ -71,7 +70,6 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
 
         // Must be the bitmap, and lost check->create benign data race
         return (long[])previous;
-#endif
     }
 
     private static void WaitForAnalysisToComplete(ManualResetEventSlim resetEvent)

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -51,6 +51,13 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
     [MethodImpl(MethodImplOptions.NoInlining)]
     private long[] CreateOrWaitForJumpDestinationBitmap()
     {
+#if ZK_EVM
+        // Nothing analyzes in the background on the single-threaded guest, so there is no completion
+        // event to allocate, signal or wait on.
+        long[] bitmap = CreateJumpDestinationBitmap();
+        Volatile.Write(ref _analysisComplete, bitmap);
+        return bitmap;
+#else
         object? previous = Volatile.Read(ref _analysisComplete);
         if (previous is null)
         {
@@ -66,6 +73,7 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
 
         // Must be the bitmap, and lost check->create benign data race
         return (long[])previous;
+#endif
     }
 
     private static void WaitForAnalysisToComplete(ManualResetEventSlim resetEvent)

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -54,9 +54,7 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
 #if ZK_EVM
         // Nothing analyzes in the background on the single-threaded guest, so there is no completion
         // event to allocate, signal or wait on.
-        long[] bitmap = CreateJumpDestinationBitmap();
-        Volatile.Write(ref _analysisComplete, bitmap);
-        return bitmap;
+        return CreateJumpDestinationBitmap();
 #else
         object? previous = Volatile.Read(ref _analysisComplete);
         if (previous is null)

--- a/src/Nethermind/Nethermind.Evm/Eip8038Flag.cs
+++ b/src/Nethermind/Nethermind.Evm/Eip8038Flag.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+
+namespace Nethermind.Evm;
+
+/// <summary>
+/// The EIP-8038 setting the opcode table has chosen for a handler.
+/// </summary>
+/// <remarks>
+/// The rules that switch together with EIP-8038 take this setting as their type parameter. Only
+/// <see cref="Eip8038On"/> and <see cref="Eip8038Off"/> implement the interface, so anchoring one of
+/// those rules on any other flag does not compile.
+/// </remarks>
+public interface IEip8038Flag : IFlag;
+
+/// <summary>EIP-8038 is active.</summary>
+public readonly struct Eip8038On : IEip8038Flag
+{
+    /// <inheritdoc />
+    public static bool IsActive => true;
+}
+
+/// <summary>EIP-8038 is inactive.</summary>
+public readonly struct Eip8038Off : IEip8038Flag
+{
+    /// <inheritdoc />
+    public static bool IsActive => false;
+}

--- a/src/Nethermind/Nethermind.Evm/Eip8038Flag.cs
+++ b/src/Nethermind/Nethermind.Evm/Eip8038Flag.cs
@@ -13,17 +13,17 @@ namespace Nethermind.Evm;
 /// <see cref="Eip8038On"/> and <see cref="Eip8038Off"/> implement the interface, so anchoring one of
 /// those rules on any other flag does not compile.
 /// </remarks>
-public interface IEip8038Flag : IFlag;
+internal interface IEip8038Flag : IFlag;
 
 /// <summary>EIP-8038 is active.</summary>
-public readonly struct Eip8038On : IEip8038Flag
+internal readonly struct Eip8038On : IEip8038Flag
 {
     /// <inheritdoc />
     public static bool IsActive => true;
 }
 
 /// <summary>EIP-8038 is inactive.</summary>
-public readonly struct Eip8038Off : IEip8038Flag
+internal readonly struct Eip8038Off : IEip8038Flag
 {
     /// <inheritdoc />
     public static bool IsActive => false;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -74,22 +74,13 @@ public static partial class EvmInstructions
     /// <typeparam name="TTracingInst">
     /// A type implementing <see cref="IFlag"/> that indicates whether instruction tracing is active.
     /// </typeparam>
+    /// <typeparam name="TSpec">The fork rules the opcode table specialized this handler on.</typeparam>
     /// <param name="vm">The current virtual machine instance containing execution state.</param>
     /// <param name="stack">The EVM stack for retrieving call parameters and pushing results.</param>
     /// <param name="gas">The gas which is updated by the operation's cost.</param>
     /// <returns>
     /// An <see cref="EvmExceptionType"/> value indicating success or the type of error encountered.
     /// </returns>
-    [SkipLocalsInit]
-    public static EvmExceptionType InstructionCall<TGasPolicy, TOpCall, TTracingInst, TEip8037, TEip7708>(
-        ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-        where TOpCall : struct, IOpCall
-        where TTracingInst : struct, IFlag
-        where TEip8037 : struct, IFlag
-        where TEip7708 : struct, IFlag =>
-        InstructionCall<TGasPolicy, TOpCall, TTracingInst, TEip8037, TEip7708, DynamicCallSpec>(ref stack, ref gas, vm);
-
     [SkipLocalsInit]
     internal static EvmExceptionType InstructionCall<TGasPolicy, TOpCall, TTracingInst, TEip8037, TEip7708, TSpec>(
         ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
@@ -153,7 +144,7 @@ public static partial class EvmInstructions
         {
             // EIP-2780 charges a flat value-move cost with no state read: the spec performs the
             // static gas check before any target access, so an OOG here must not touch the BAL.
-            bool valueOutOfGas = TSpec.IsEip2780Enabled(spec)
+            bool valueOutOfGas = TSpec.IsEip2780Enabled
                 ? !TGasPolicy.ConsumeCallValueTransferEip2780(ref gas)
                 : !TGasPolicy.ConsumeCallValueTransfer(ref gas);
             if (valueOutOfGas) goto OutOfGas;
@@ -171,7 +162,7 @@ public static partial class EvmInstructions
 
         CodeInfo codeInfo = vm.CodeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation: false, vmSpec: spec, delegationAddress: out Address? delegated);
 
-        if (TSpec.UseHotAndColdStorage(spec) &&
+        if (TSpec.UseHotAndColdStorage &&
             delegated is not null &&
             !TSpec.ConsumeAccountAccessGas<TGasPolicy>(ref gas, vm.Spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, delegated))
             goto OutOfGas;
@@ -179,9 +170,9 @@ public static partial class EvmInstructions
         // Charge additional gas if the target account is new or considered empty.
         // EIP-8038 charges a value transfer to a dead recipient the NEW_ACCOUNT state cost, separate
         // from the flat CALL_VALUE above; standalone EIP-2780 adds nothing extra here.
-        bool chargesNewAccount = TSpec.IsEip8038Enabled(spec)
+        bool chargesNewAccount = TSpec.IsEip8038Enabled
             ? hasValueTransfer && state.IsDeadAccount(target)
-            : !TSpec.IsEip2780Enabled(spec) && (TSpec.ClearEmptyAccountWhenTouched(spec) switch
+            : !TSpec.IsEip2780Enabled && (TSpec.ClearEmptyAccountWhenTouched switch
             {
                 false => !state.AccountExists(target),
                 true => hasValueTransfer && state.IsDeadAccount(target),

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -235,13 +235,6 @@ public static partial class EvmInstructions
     /// and marks the executing account for destruction.
     /// </summary>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionSelfDestruct<TGasPolicy, TEip8037, TEip7708>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-        where TEip8037 : struct, IFlag
-        where TEip7708 : struct, IFlag =>
-        InstructionSelfDestruct<TGasPolicy, TEip8037, TEip7708, DynamicSelfDestructSpec>(ref stack, ref gas, vm);
-
-    [SkipLocalsInit]
     internal static EvmExceptionType InstructionSelfDestruct<TGasPolicy, TEip8037, TEip7708, TSpec>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TEip8037 : struct, IFlag
@@ -259,7 +252,7 @@ public static partial class EvmInstructions
             goto StaticCallViolation;
 
         // If Shanghai DDoS protection is active, charge the appropriate gas cost.
-        if (TSpec.UseShanghaiDDosProtection(spec))
+        if (TSpec.UseShanghaiDDosProtection)
         {
             if (!TGasPolicy.ConsumeSelfDestructGas(ref gas))
                 goto OutOfGas;
@@ -276,7 +269,7 @@ public static partial class EvmInstructions
 
         Address executingAccount = vmState.Env.ExecutingAccount;
         bool createInSameTx = vmState.AccessTracker.CreateList.Contains(executingAccount);
-        bool selfdestructOnlyOnSameTx = TSpec.SelfdestructOnlyOnSameTransaction(spec);
+        bool selfdestructOnlyOnSameTx = TSpec.SelfdestructOnlyOnSameTransaction;
         // Mark the executing account for destruction if allowed.
         if (!selfdestructOnlyOnSameTx || createInSameTx)
             vmState.AccessTracker.ToBeDestroyed(executingAccount);
@@ -289,16 +282,16 @@ public static partial class EvmInstructions
 
         // Charge gas if transferring to a dead or non-existent account.
         bool inheritorAccountExists = state.AccountExists(inheritor);
-        bool chargesNewAccount = TSpec.ClearEmptyAccountWhenTouched(spec) switch
+        bool chargesNewAccount = TSpec.ClearEmptyAccountWhenTouched switch
         {
             true => !result.IsZero && state.IsDeadAccount(inheritor),
-            false => !inheritorAccountExists && TSpec.UseShanghaiDDosProtection(spec),
+            false => !inheritorAccountExists && TSpec.UseShanghaiDDosProtection,
         };
 
         // EIP-8038 adds an ACCOUNT_WRITE execution charge on top of the NEW_ACCOUNT state gas;
         // charge execution first so an execution-gas OOG does not spill state gas.
         bool outOfGas = chargesNewAccount &&
-            !((!TSpec.IsEip8038Enabled(spec) || TGasPolicy.UpdateGas(ref gas, Eip8038Constants.AccountWrite))
+            !((!TSpec.IsEip8038Enabled || TGasPolicy.UpdateGas(ref gas, Eip8038Constants.AccountWrite))
               && TGasPolicy.ConsumeNewAccountCreation<TEip8037>(ref gas));
 
         if (outOfGas) goto OutOfGas;
@@ -315,7 +308,7 @@ public static partial class EvmInstructions
 
         // Self-targeting SELFDESTRUCT moves no ETH and emits no log: a pure no-op for the EIP-6780
         // case (not in the destroy list), while EIP-8246 still finalizes but preserves the balance.
-        if (inheritor.Equals(executingAccount) && (TSpec.RemoveSelfdestructBurn(spec) || (selfdestructOnlyOnSameTx && !createInSameTx)))
+        if (inheritor.Equals(executingAccount) && (TSpec.RemoveSelfdestructBurn || (selfdestructOnlyOnSameTx && !createInSameTx)))
             goto Stop;
 
         vm.AddSelfDestructLog<TEip8037, TEip7708>(executingAccount, inheritor, result);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
@@ -61,19 +61,11 @@ public static partial class EvmInstructions
     /// <typeparam name="TGasPolicy">The gas policy implementation.</typeparam>
     /// <typeparam name="TOpCreate">The type of create operation (either <see cref="OpCreate"/> or <see cref="OpCreate2"/>).</typeparam>
     /// <typeparam name="TTracingInst">Tracing instructions type used for instrumentation if active.</typeparam>
+    /// <typeparam name="TSpec">The fork rules the opcode table specialized this handler on.</typeparam>
     /// <param name="vm">The current virtual machine instance.</param>
     /// <param name="stack">Reference to the EVM stack.</param>
     /// <param name="gas">Reference to the gas state.</param>
     /// <returns>An <see cref="EvmExceptionType"/> indicating success or the type of exception encountered.</returns>
-    [SkipLocalsInit]
-    public static EvmExceptionType InstructionCreate<TGasPolicy, TOpCreate, TTracingInst, TEip8037>(
-        ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-        where TOpCreate : struct, IOpCreate
-        where TTracingInst : struct, IFlag
-        where TEip8037 : struct, IFlag =>
-        InstructionCreate<TGasPolicy, TOpCreate, TTracingInst, TEip8037, DynamicCreateSpec>(ref stack, ref gas, vm);
-
     [SkipLocalsInit]
     internal static EvmExceptionType InstructionCreate<TGasPolicy, TOpCreate, TTracingInst, TEip8037, TSpec>(
         ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
@@ -111,7 +103,7 @@ public static partial class EvmInstructions
         }
 
         // EIP-3860: Limit the maximum size of the initialization code.
-        bool isEip3860 = TSpec.IsEip3860Enabled(spec);
+        bool isEip3860 = TSpec.IsEip3860Enabled;
         if (isEip3860)
         {
             if (initCodeLength > spec.MaxInitCodeSize)
@@ -168,7 +160,7 @@ public static partial class EvmInstructions
             : ContractAddress.From(env.ExecutingAccount, salt, initCode.Span);
 
         // For EIP-2929 support, pre-warm the contract address in the access tracker to account for hot/cold storage costs.
-        if (TSpec.UseHotAndColdStorage(spec))
+        if (TSpec.UseHotAndColdStorage)
         {
             vm.VmState.AccessTracker.WarmUp(contractAddress);
         }
@@ -201,7 +193,7 @@ public static partial class EvmInstructions
         CodeInfo? codeInfo = CodeInfoFactory.CreateCodeInfo(initCode);
 
         // EIP-684: if the account already exists with code or a non-zero nonce, the creation fails.
-        // Collision behaves as an immediate exceptional halt — burned callGas counts as block_execution.
+        // Collision behaves as an immediate exceptional halt - burned callGas counts as block_execution.
         if (isNonZeroAccount)
         {
             if (chargeCreateStateGas)

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -540,13 +540,6 @@ public static partial class EvmInstructions
     /// </returns>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EvmExceptionType InstructionBalance<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-        where TTracingInst : struct, IFlag =>
-        InstructionBalance<TGasPolicy, TTracingInst, DynamicAccessSpec>(ref stack, ref gas, vm);
-
-    [SkipLocalsInit]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static EvmExceptionType InstructionBalance<TGasPolicy, TTracingInst, TSpec>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -612,13 +605,6 @@ public static partial class EvmInstructions
     /// <see cref="EvmExceptionType.OutOfGas"/> if the gas becomes negative
     /// or <see cref="EvmExceptionType.StackUnderflow"/> if not enough items on stack.
     /// </returns>
-    [SkipLocalsInit]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EvmExceptionType InstructionExtCodeHash<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-        where TTracingInst : struct, IFlag =>
-        InstructionExtCodeHash<TGasPolicy, TTracingInst, DynamicAccessSpec>(ref stack, ref gas, vm);
-
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static EvmExceptionType InstructionExtCodeHash<TGasPolicy, TTracingInst, TSpec>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Spec.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Spec.cs
@@ -18,15 +18,6 @@ public static partial class EvmInstructions
             where TGasPolicy : struct, IGasPolicy<TGasPolicy>;
     }
 
-    internal readonly struct DynamicAccessSpec : IAccessSpec
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
-            ref readonly StackAccessTracker tracker, bool tracing, Address address, AccountAccessKind kind = AccountAccessKind.Default)
-            where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
-            TGasPolicy.ConsumeAccountAccessGas(ref gas, spec, in tracker, tracing, address, kind);
-    }
-
     internal readonly struct AccessSpec<Eip2929, Eip8038> : IAccessSpec
         where Eip2929 : struct, IFlag
         where Eip8038 : struct, IFlag
@@ -40,33 +31,12 @@ public static partial class EvmInstructions
 
     internal interface ICallSpec : IAccessSpec
     {
-        static abstract bool UseHotAndColdStorage(IReleaseSpec spec);
-        static abstract bool ClearEmptyAccountWhenTouched(IReleaseSpec spec);
-        static abstract bool IsEip2780Enabled(IReleaseSpec spec);
-        static abstract bool IsEip8038Enabled(IReleaseSpec spec);
+        static abstract bool UseHotAndColdStorage { get; }
+        static abstract bool ClearEmptyAccountWhenTouched { get; }
+        static abstract bool IsEip2780Enabled { get; }
+        static abstract bool IsEip8038Enabled { get; }
         static abstract bool TryReserveChildGas<TGasPolicy>(ref TGasPolicy gas, in UInt256 requestedGas, IReleaseSpec spec, out ulong childGas)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy>;
-    }
-
-    internal readonly struct DynamicCallSpec : ICallSpec
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool UseHotAndColdStorage(IReleaseSpec spec) => spec.UseHotAndColdStorage;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ClearEmptyAccountWhenTouched(IReleaseSpec spec) => spec.ClearEmptyAccountWhenTouched;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsEip2780Enabled(IReleaseSpec spec) => spec.IsEip2780Enabled;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsEip8038Enabled(IReleaseSpec spec) => spec.IsEip8038Enabled;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReserveChildGas<TGasPolicy>(ref TGasPolicy gas, in UInt256 requestedGas, IReleaseSpec spec, out ulong childGas)
-            where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
-            TGasPolicy.TryReserveChildGas(ref gas, in requestedGas, spec, out childGas);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
-            ref readonly StackAccessTracker tracker, bool tracing, Address address, AccountAccessKind kind = AccountAccessKind.Default)
-            where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
-            TGasPolicy.ConsumeAccountAccessGas(ref gas, spec, in tracker, tracing, address, kind);
     }
 
     internal readonly struct CallSpec<Eip2929, Eip150, Eip158, Eip2780, Eip8038> : ICallSpec
@@ -76,14 +46,10 @@ public static partial class EvmInstructions
         where Eip2780 : struct, IFlag
         where Eip8038 : struct, IFlag
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool UseHotAndColdStorage(IReleaseSpec spec) => Eip2929.IsActive;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ClearEmptyAccountWhenTouched(IReleaseSpec spec) => Eip158.IsActive;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsEip2780Enabled(IReleaseSpec spec) => Eip2780.IsActive;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsEip8038Enabled(IReleaseSpec spec) => Eip8038.IsActive;
+        public static bool UseHotAndColdStorage => Eip2929.IsActive;
+        public static bool ClearEmptyAccountWhenTouched => Eip158.IsActive;
+        public static bool IsEip2780Enabled => Eip2780.IsActive;
+        public static bool IsEip8038Enabled => Eip8038.IsActive;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReserveChildGas<TGasPolicy>(ref TGasPolicy gas, in UInt256 requestedGas, IReleaseSpec spec, out ulong childGas)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
@@ -97,8 +63,8 @@ public static partial class EvmInstructions
 
     internal interface ICreateSpec
     {
-        static abstract bool UseHotAndColdStorage(IReleaseSpec spec);
-        static abstract bool IsEip3860Enabled(IReleaseSpec spec);
+        static abstract bool UseHotAndColdStorage { get; }
+        static abstract bool IsEip3860Enabled { get; }
         static abstract bool TryReserveChildGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec, out ulong childGas)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy>;
         static abstract bool ConsumeCreateGas<TGasPolicy, Eip8037, TOpCreate>(ref TGasPolicy gas, IReleaseSpec spec, ulong words)
@@ -107,34 +73,14 @@ public static partial class EvmInstructions
             where TOpCreate : struct, IOpCreate;
     }
 
-    internal readonly struct DynamicCreateSpec : ICreateSpec
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool UseHotAndColdStorage(IReleaseSpec spec) => spec.UseHotAndColdStorage;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsEip3860Enabled(IReleaseSpec spec) => spec.IsEip3860Enabled;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReserveChildGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec, out ulong childGas)
-            where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
-            TGasPolicy.TryReserveChildGas(ref gas, spec, out childGas);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ConsumeCreateGas<TGasPolicy, Eip8037, TOpCreate>(ref TGasPolicy gas, IReleaseSpec spec, ulong words)
-            where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-            where Eip8037 : struct, IFlag
-            where TOpCreate : struct, IOpCreate =>
-            TGasPolicy.ConsumeCreateGas<Eip8037, TOpCreate>(ref gas, spec, words);
-    }
-
     internal readonly struct CreateSpec<Eip2929, Eip150, Eip3860, Eip8038> : ICreateSpec
         where Eip2929 : struct, IFlag
         where Eip150 : struct, IFlag
         where Eip3860 : struct, IFlag
         where Eip8038 : struct, IFlag
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool UseHotAndColdStorage(IReleaseSpec spec) => Eip2929.IsActive;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsEip3860Enabled(IReleaseSpec spec) => Eip3860.IsActive;
+        public static bool UseHotAndColdStorage => Eip2929.IsActive;
+        public static bool IsEip3860Enabled => Eip3860.IsActive;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReserveChildGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec, out ulong childGas)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
@@ -149,30 +95,11 @@ public static partial class EvmInstructions
 
     internal interface ISelfDestructSpec : IAccessSpec
     {
-        static abstract bool UseShanghaiDDosProtection(IReleaseSpec spec);
-        static abstract bool ClearEmptyAccountWhenTouched(IReleaseSpec spec);
-        static abstract bool SelfdestructOnlyOnSameTransaction(IReleaseSpec spec);
-        static abstract bool RemoveSelfdestructBurn(IReleaseSpec spec);
-        static abstract bool IsEip8038Enabled(IReleaseSpec spec);
-    }
-
-    internal readonly struct DynamicSelfDestructSpec : ISelfDestructSpec
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool UseShanghaiDDosProtection(IReleaseSpec spec) => spec.UseShanghaiDDosProtection;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ClearEmptyAccountWhenTouched(IReleaseSpec spec) => spec.ClearEmptyAccountWhenTouched;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool SelfdestructOnlyOnSameTransaction(IReleaseSpec spec) => spec.SelfdestructOnlyOnSameTransaction;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool RemoveSelfdestructBurn(IReleaseSpec spec) => spec.RemoveSelfdestructBurn;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsEip8038Enabled(IReleaseSpec spec) => spec.IsEip8038Enabled;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
-            ref readonly StackAccessTracker tracker, bool tracing, Address address, AccountAccessKind kind = AccountAccessKind.Default)
-            where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
-            DynamicAccessSpec.ConsumeAccountAccessGas(ref gas, spec, in tracker, tracing, address, kind);
+        static abstract bool UseShanghaiDDosProtection { get; }
+        static abstract bool ClearEmptyAccountWhenTouched { get; }
+        static abstract bool SelfdestructOnlyOnSameTransaction { get; }
+        static abstract bool RemoveSelfdestructBurn { get; }
+        static abstract bool IsEip8038Enabled { get; }
     }
 
     internal readonly struct SelfDestructSpec<TAccess, Eip150, Eip158, Eip6780, Eip8246, Eip8038> : ISelfDestructSpec
@@ -183,16 +110,11 @@ public static partial class EvmInstructions
         where Eip8246 : struct, IFlag
         where Eip8038 : struct, IFlag
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool UseShanghaiDDosProtection(IReleaseSpec spec) => Eip150.IsActive;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ClearEmptyAccountWhenTouched(IReleaseSpec spec) => Eip158.IsActive;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool SelfdestructOnlyOnSameTransaction(IReleaseSpec spec) => Eip6780.IsActive;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool RemoveSelfdestructBurn(IReleaseSpec spec) => Eip8246.IsActive;
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsEip8038Enabled(IReleaseSpec spec) => Eip8038.IsActive;
+        public static bool UseShanghaiDDosProtection => Eip150.IsActive;
+        public static bool ClearEmptyAccountWhenTouched => Eip158.IsActive;
+        public static bool SelfdestructOnlyOnSameTransaction => Eip6780.IsActive;
+        public static bool RemoveSelfdestructBurn => Eip8246.IsActive;
+        public static bool IsEip8038Enabled => Eip8038.IsActive;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
             ref readonly StackAccessTracker tracker, bool tracing, Address address, AccountAccessKind kind = AccountAccessKind.Default)

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Spec.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Spec.cs
@@ -46,10 +46,10 @@ public static partial class EvmInstructions
         where Eip2780 : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
     {
-        public static bool UseHotAndColdStorage => Eip2929.IsActive;
-        public static bool ClearEmptyAccountWhenTouched => Eip158.IsActive;
-        public static bool IsEip2780Enabled => Eip2780.IsActive;
-        public static bool IsEip8038Enabled => Eip8038.IsActive;
+        public static bool UseHotAndColdStorage { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip2929.IsActive; }
+        public static bool ClearEmptyAccountWhenTouched { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip158.IsActive; }
+        public static bool IsEip2780Enabled { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip2780.IsActive; }
+        public static bool IsEip8038Enabled { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip8038.IsActive; }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReserveChildGas<TGasPolicy>(ref TGasPolicy gas, in UInt256 requestedGas, IReleaseSpec spec, out ulong childGas)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
@@ -79,8 +79,8 @@ public static partial class EvmInstructions
         where Eip3860 : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
     {
-        public static bool UseHotAndColdStorage => Eip2929.IsActive;
-        public static bool IsEip3860Enabled => Eip3860.IsActive;
+        public static bool UseHotAndColdStorage { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip2929.IsActive; }
+        public static bool IsEip3860Enabled { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip3860.IsActive; }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryReserveChildGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec, out ulong childGas)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
@@ -110,11 +110,11 @@ public static partial class EvmInstructions
         where Eip8246 : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
     {
-        public static bool UseShanghaiDDosProtection => Eip150.IsActive;
-        public static bool ClearEmptyAccountWhenTouched => Eip158.IsActive;
-        public static bool SelfdestructOnlyOnSameTransaction => Eip6780.IsActive;
-        public static bool RemoveSelfdestructBurn => Eip8246.IsActive;
-        public static bool IsEip8038Enabled => Eip8038.IsActive;
+        public static bool UseShanghaiDDosProtection { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip150.IsActive; }
+        public static bool ClearEmptyAccountWhenTouched { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip158.IsActive; }
+        public static bool SelfdestructOnlyOnSameTransaction { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip6780.IsActive; }
+        public static bool RemoveSelfdestructBurn { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip8246.IsActive; }
+        public static bool IsEip8038Enabled { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip8038.IsActive; }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
             ref readonly StackAccessTracker tracker, bool tracing, Address address, AccountAccessKind kind = AccountAccessKind.Default)

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Spec.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Spec.cs
@@ -20,7 +20,7 @@ public static partial class EvmInstructions
 
     internal readonly struct AccessSpec<Eip2929, Eip8038> : IAccessSpec
         where Eip2929 : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
@@ -44,7 +44,7 @@ public static partial class EvmInstructions
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag
         where Eip2780 : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
     {
         public static bool UseHotAndColdStorage => Eip2929.IsActive;
         public static bool ClearEmptyAccountWhenTouched => Eip158.IsActive;
@@ -77,7 +77,7 @@ public static partial class EvmInstructions
         where Eip2929 : struct, IFlag
         where Eip150 : struct, IFlag
         where Eip3860 : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
     {
         public static bool UseHotAndColdStorage => Eip2929.IsActive;
         public static bool IsEip3860Enabled => Eip3860.IsActive;
@@ -108,7 +108,7 @@ public static partial class EvmInstructions
         where Eip158 : struct, IFlag
         where Eip6780 : struct, IFlag
         where Eip8246 : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
     {
         public static bool UseShanghaiDDosProtection => Eip150.IsActive;
         public static bool ClearEmptyAccountWhenTouched => Eip158.IsActive;

--- a/src/Nethermind/Nethermind.Evm/SpecFlags.std.cs
+++ b/src/Nethermind/Nethermind.Evm/SpecFlags.std.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Core;
 using Nethermind.Core.Specs;
 
 namespace Nethermind.Evm;

--- a/src/Nethermind/Nethermind.Evm/SpecFlags.std.cs
+++ b/src/Nethermind/Nethermind.Evm/SpecFlags.std.cs
@@ -39,13 +39,13 @@ internal static partial class SpecFlags
 
     // The type parameter is the EIP-8038 flag the table has already chosen. A build whose fork range
     // switches these rules together with it derives them from the flag; this build reads the spec.
-    public static bool Eip2780<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => spec.IsEip2780Enabled;
+    public static bool Eip2780<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IEip8038Flag => spec.IsEip2780Enabled;
 
-    public static bool Eip7708<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => spec.IsEip7708Enabled;
+    public static bool Eip7708<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IEip8038Flag => spec.IsEip7708Enabled;
 
-    public static bool Eip8037<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => spec.IsEip8037Enabled;
+    public static bool Eip8037<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IEip8038Flag => spec.IsEip8037Enabled;
 
-    public static bool Eip8246<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => spec.RemoveSelfdestructBurn;
+    public static bool Eip8246<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IEip8038Flag => spec.RemoveSelfdestructBurn;
 
     /// <summary>Rejects a spec the build cannot serve.</summary>
     /// <remarks>Every rule is read from <paramref name="spec"/> here, so every spec is servable.</remarks>

--- a/src/Nethermind/Nethermind.Evm/SpecFlags.std.cs
+++ b/src/Nethermind/Nethermind.Evm/SpecFlags.std.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core;
 using Nethermind.Core.Specs;
 
 namespace Nethermind.Evm;
@@ -12,8 +13,11 @@ namespace Nethermind.Evm;
 /// Each rule is read once per table build rather than per execution, so routing them through this
 /// type costs nothing at run time. It exists so the zkEVM build can answer a rule with a constant:
 /// an ahead-of-time compiler emits every reachable instantiation, and a rule that cannot vary over
-/// the range of forks the guest is built for removes half of them. See <c>SpecFlags.zkevm.cs</c>,
-/// which is generated from the fork graph and verified by <c>SpecFlagsTests</c>.
+/// the range of forks the guest is built for removes half of them. A rule that varies but always
+/// moves together with another takes that rule's flag as a type parameter, so the zkEVM build can
+/// derive it from the flag and skip the pairings the range never produces. See
+/// <c>SpecFlags.zkevm.cs</c>, which is generated from the fork graph and verified by
+/// <c>SpecFlagsTests</c>.
 /// </remarks>
 internal static partial class SpecFlags
 {
@@ -21,17 +25,27 @@ internal static partial class SpecFlags
 
     public static bool Eip158(IReleaseSpec spec) => spec.ClearEmptyAccountWhenTouched;
 
-    public static bool Eip2780(IReleaseSpec spec) => spec.IsEip2780Enabled;
+    public static bool Eip2200(IReleaseSpec spec) => spec.UseNetGasMeteringWithAStipendFix;
 
     public static bool Eip2929(IReleaseSpec spec) => spec.UseHotAndColdStorage;
 
     public static bool Eip3860(IReleaseSpec spec) => spec.IsEip3860Enabled;
 
-    public static bool Eip7708(IReleaseSpec spec) => spec.IsEip7708Enabled;
-
-    public static bool Eip8037(IReleaseSpec spec) => spec.IsEip8037Enabled;
+    public static bool Eip6780(IReleaseSpec spec) => spec.SelfdestructOnlyOnSameTransaction;
 
     public static bool Eip8038(IReleaseSpec spec) => spec.IsEip8038Enabled;
+
+    public static bool NetGasMetering(IReleaseSpec spec) => spec.UseNetGasMetering;
+
+    // The type parameter is the EIP-8038 flag the table has already chosen. A build whose fork range
+    // switches these rules together with it derives them from the flag; this build reads the spec.
+    public static bool Eip2780<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => spec.IsEip2780Enabled;
+
+    public static bool Eip7708<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => spec.IsEip7708Enabled;
+
+    public static bool Eip8037<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => spec.IsEip8037Enabled;
+
+    public static bool Eip8246<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => spec.RemoveSelfdestructBurn;
 
     /// <summary>Rejects a spec the build cannot serve.</summary>
     /// <remarks>Every rule is read from <paramref name="spec"/> here, so every spec is servable.</remarks>

--- a/src/Nethermind/Nethermind.Evm/SpecFlags.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/SpecFlags.zkevm.cs
@@ -60,13 +60,13 @@ internal static partial class SpecFlags
     // EIP-2780, EIP-7708, EIP-8037 and EIP-8246 also activate at Amsterdam and at no other fork in the
     // range, so they follow the EIP-8038 flag the table has already chosen. Reading the spec here
     // would compile every pairing of the five where the range produces two.
-    public static bool Eip2780<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => TEip8038.IsActive;
+    public static bool Eip2780<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IEip8038Flag => TEip8038.IsActive;
 
-    public static bool Eip7708<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => TEip8038.IsActive;
+    public static bool Eip7708<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IEip8038Flag => TEip8038.IsActive;
 
-    public static bool Eip8037<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => TEip8038.IsActive;
+    public static bool Eip8037<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IEip8038Flag => TEip8038.IsActive;
 
-    public static bool Eip8246<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => TEip8038.IsActive;
+    public static bool Eip8246<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IEip8038Flag => TEip8038.IsActive;
 
     private static IReleaseSpec? _validated;
 

--- a/src/Nethermind/Nethermind.Evm/SpecFlags.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/SpecFlags.zkevm.cs
@@ -6,6 +6,7 @@
 // To change the range, move the Floor and Max constants in SpecFlagsTests and rerun it.
 
 using System;
+using Nethermind.Core;
 using Nethermind.Core.Specs;
 
 namespace Nethermind.Evm;
@@ -24,28 +25,48 @@ internal static partial class SpecFlags
     public const bool ConstEip158 = true;
 
     /// <inheritdoc cref="ConstEip150"/>
+    public const bool ConstEip2200 = true;
+
+    /// <inheritdoc cref="ConstEip150"/>
     public const bool ConstEip2929 = true;
 
     /// <inheritdoc cref="ConstEip150"/>
     public const bool ConstEip3860 = true;
 
+    /// <inheritdoc cref="ConstEip150"/>
+    public const bool ConstEip6780 = true;
+
+    /// <inheritdoc cref="ConstEip150"/>
+    public const bool ConstNetGasMetering = true;
+
     public static bool Eip150(IReleaseSpec spec) => ConstEip150;
 
     public static bool Eip158(IReleaseSpec spec) => ConstEip158;
+
+    public static bool Eip2200(IReleaseSpec spec) => ConstEip2200;
 
     public static bool Eip2929(IReleaseSpec spec) => ConstEip2929;
 
     public static bool Eip3860(IReleaseSpec spec) => ConstEip3860;
 
-    // EIP-2780, EIP-7708, EIP-8037 and EIP-8038 activate at Amsterdam, which is inside the range, so
-    // they stay dynamic and the handlers behind both settings are compiled.
-    public static bool Eip2780(IReleaseSpec spec) => spec.IsEip2780Enabled;
+    public static bool Eip6780(IReleaseSpec spec) => ConstEip6780;
 
-    public static bool Eip7708(IReleaseSpec spec) => spec.IsEip7708Enabled;
+    public static bool NetGasMetering(IReleaseSpec spec) => ConstNetGasMetering;
 
-    public static bool Eip8037(IReleaseSpec spec) => spec.IsEip8037Enabled;
-
+    // EIP-8038 activates at Amsterdam, which is inside the range, so it stays dynamic and the handlers
+    // behind both settings are compiled.
     public static bool Eip8038(IReleaseSpec spec) => spec.IsEip8038Enabled;
+
+    // EIP-2780, EIP-7708, EIP-8037 and EIP-8246 also activate at Amsterdam and at no other fork in the
+    // range, so they follow the EIP-8038 flag the table has already chosen. Reading the spec here
+    // would compile every pairing of the five where the range produces two.
+    public static bool Eip2780<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => TEip8038.IsActive;
+
+    public static bool Eip7708<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => TEip8038.IsActive;
+
+    public static bool Eip8037<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => TEip8038.IsActive;
+
+    public static bool Eip8246<TEip8038>(IReleaseSpec spec) where TEip8038 : struct, IFlag => TEip8038.IsActive;
 
     private static IReleaseSpec? _validated;
 
@@ -62,8 +83,15 @@ internal static partial class SpecFlags
 
         Check(spec.Use63Over64Rule, ConstEip150, "EIP-150");
         Check(spec.ClearEmptyAccountWhenTouched, ConstEip158, "EIP-158");
+        Check(spec.UseNetGasMeteringWithAStipendFix, ConstEip2200, "EIP-2200");
         Check(spec.UseHotAndColdStorage, ConstEip2929, "EIP-2929");
         Check(spec.IsEip3860Enabled, ConstEip3860, "EIP-3860");
+        Check(spec.SelfdestructOnlyOnSameTransaction, ConstEip6780, "EIP-6780");
+        Check(spec.UseNetGasMetering, ConstNetGasMetering, "NetGasMetering");
+        Follows(spec.IsEip2780Enabled, spec.IsEip8038Enabled, "EIP-2780", "EIP-8038");
+        Follows(spec.IsEip7708Enabled, spec.IsEip8038Enabled, "EIP-7708", "EIP-8038");
+        Follows(spec.IsEip8037Enabled, spec.IsEip8038Enabled, "EIP-8037", "EIP-8038");
+        Follows(spec.RemoveSelfdestructBurn, spec.IsEip8038Enabled, "EIP-8246", "EIP-8038");
         _validated = spec;
 
         static void Check(bool actual, bool compiled, string eip)
@@ -71,6 +99,13 @@ internal static partial class SpecFlags
             if (actual != compiled)
                 throw new InvalidOperationException(
                     $"{eip} is {actual} for this block but the guest was built for the fork range Osaka..Amsterdam, where it is always {compiled}. Rebuild with a range that covers the block.");
+        }
+
+        static void Follows(bool actual, bool anchor, string eip, string anchorEip)
+        {
+            if (actual != anchor)
+                throw new InvalidOperationException(
+                    $"{eip} is {actual} for this block but {anchorEip} is {anchor}; the guest was built for the fork range Osaka..Amsterdam, where they move together. Rebuild with a range that covers the block.");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm/SpecFlags.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/SpecFlags.zkevm.cs
@@ -6,7 +6,6 @@
 // To change the range, move the Floor and Max constants in SpecFlagsTests and rerun it.
 
 using System;
-using Nethermind.Core;
 using Nethermind.Core.Specs;
 
 namespace Nethermind.Evm;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
@@ -299,8 +299,8 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag =>
         SpecFlags.Eip8038(spec)
-            ? GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, OnFlag>(spec)
-            : GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, OffFlag>(spec);
+            ? GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip8038On>(spec)
+            : GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip8038Off>(spec);
 
     private static delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>
         GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip8038>(IReleaseSpec spec)
@@ -310,7 +310,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip2929 : struct, IFlag
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag
-        where Eip8038 : struct, IFlag =>
+        where Eip8038 : struct, IEip8038Flag =>
         SpecFlags.Eip2780<Eip8038>(spec)
             ? GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip8038, OnFlag>(spec)
             : GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip8038, OffFlag>(spec);
@@ -323,7 +323,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip2929 : struct, IFlag
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip2780 : struct, IFlag =>
         (SpecFlags.Eip8037<Eip8038>(spec), SpecFlags.Eip7708<Eip8038>(spec)) switch
         {
@@ -372,8 +372,8 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip150 : struct, IFlag
         where Eip3860 : struct, IFlag =>
         SpecFlags.Eip8038(spec)
-            ? GetCreateHandler<TOpCreate, TTracingInst, TCancelable, Eip2929, Eip150, Eip3860, OnFlag>(spec)
-            : GetCreateHandler<TOpCreate, TTracingInst, TCancelable, Eip2929, Eip150, Eip3860, OffFlag>(spec);
+            ? GetCreateHandler<TOpCreate, TTracingInst, TCancelable, Eip2929, Eip150, Eip3860, Eip8038On>(spec)
+            : GetCreateHandler<TOpCreate, TTracingInst, TCancelable, Eip2929, Eip150, Eip3860, Eip8038Off>(spec);
 
     private static delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>
         GetCreateHandler<TOpCreate, TTracingInst, TCancelable, Eip2929, Eip150, Eip3860, Eip8038>(IReleaseSpec spec)
@@ -383,7 +383,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip2929 : struct, IFlag
         where Eip150 : struct, IFlag
         where Eip3860 : struct, IFlag
-        where Eip8038 : struct, IFlag =>
+        where Eip8038 : struct, IEip8038Flag =>
         SpecFlags.Eip8037<Eip8038>(spec)
             ? OpcodeHandler<CreateOpcode<TOpCreate, TTracingInst, OnFlag, EvmInstructions.CreateSpec<Eip2929, Eip150, Eip3860, Eip8038>>, TTracingInst, TCancelable>()
             : OpcodeHandler<CreateOpcode<TOpCreate, TTracingInst, OffFlag, EvmInstructions.CreateSpec<Eip2929, Eip150, Eip3860, Eip8038>>, TTracingInst, TCancelable>();
@@ -394,16 +394,16 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip2929 : struct, IFlag
     {
         if (SpecFlags.Eip8038(spec))
-            ConfigureAccessOpcodes<TTracingInst, TCancelable, Eip2929, OnFlag>(lookup, spec);
+            ConfigureAccessOpcodes<TTracingInst, TCancelable, Eip2929, Eip8038On>(lookup, spec);
         else
-            ConfigureAccessOpcodes<TTracingInst, TCancelable, Eip2929, OffFlag>(lookup, spec);
+            ConfigureAccessOpcodes<TTracingInst, TCancelable, Eip2929, Eip8038Off>(lookup, spec);
     }
 
     private static void ConfigureAccessOpcodes<TTracingInst, TCancelable, Eip2929, Eip8038>(delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[] lookup, IReleaseSpec spec)
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
         where Eip2929 : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
     {
         lookup[(int)Instruction.BALANCE] = OpcodeHandler<BalanceOpcode<TTracingInst, EvmInstructions.AccessSpec<Eip2929, Eip8038>>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.EXTCODESIZE] = OpcodeHandler<ExtCodeSizeOpcode<TTracingInst, Eip8038, Eip2929>, TTracingInst, TCancelable>();
@@ -421,7 +421,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
         where TAccess : struct, EvmInstructions.IAccessSpec
-        where Eip8038 : struct, IFlag =>
+        where Eip8038 : struct, IEip8038Flag =>
         SpecFlags.Eip150(spec)
             ? GetSelfDestructHandler<TTracingInst, TCancelable, TAccess, Eip8038, OnFlag>(spec)
             : GetSelfDestructHandler<TTracingInst, TCancelable, TAccess, Eip8038, OffFlag>(spec);
@@ -431,7 +431,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
         where TAccess : struct, EvmInstructions.IAccessSpec
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip150 : struct, IFlag =>
         SpecFlags.Eip158(spec)
             ? GetSelfDestructHandler<TTracingInst, TCancelable, TAccess, Eip8038, Eip150, OnFlag>(spec)
@@ -442,7 +442,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
         where TAccess : struct, EvmInstructions.IAccessSpec
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag =>
         SpecFlags.Eip6780(spec)
@@ -454,7 +454,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
         where TAccess : struct, EvmInstructions.IAccessSpec
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag
         where Eip6780 : struct, IFlag =>
@@ -467,7 +467,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
         where TAccess : struct, EvmInstructions.IAccessSpec
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag
         where Eip6780 : struct, IFlag
@@ -661,7 +661,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct ExtCodeSizeOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip2929 : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
@@ -674,7 +674,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct ExtCodeCopyOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip2929 : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
@@ -764,7 +764,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         SStoreOpcodeHandler<TTracingInst, TCancelable, Eip8038, Eip2929>(IReleaseSpec spec)
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip2929 : struct, IFlag =>
         SpecFlags.NetGasMetering(spec)
             ? SpecFlags.Eip2200(spec)
@@ -778,7 +778,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct SLoadOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip2929 : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
@@ -789,7 +789,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TTracingInst : struct, IFlag
         where TStipendFix : struct, IFlag
         where TEip8037 : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip2929 : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
@@ -798,7 +798,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct SStoreUnmeteredOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
-        where Eip8038 : struct, IFlag
+        where Eip8038 : struct, IEip8038Flag
         where Eip2929 : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
@@ -298,34 +298,34 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip2929 : struct, IFlag
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag =>
-        SpecFlags.Eip2780(spec)
+        SpecFlags.Eip8038(spec)
             ? GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, OnFlag>(spec)
             : GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, OffFlag>(spec);
 
     private static delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>
-        GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip2780>(IReleaseSpec spec)
+        GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip8038>(IReleaseSpec spec)
         where TOpCall : struct, EvmInstructions.IOpCall
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
         where Eip2929 : struct, IFlag
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag
-        where Eip2780 : struct, IFlag =>
-        SpecFlags.Eip8038(spec)
-            ? GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip2780, OnFlag>(spec)
-            : GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip2780, OffFlag>(spec);
+        where Eip8038 : struct, IFlag =>
+        SpecFlags.Eip2780<Eip8038>(spec)
+            ? GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip8038, OnFlag>(spec)
+            : GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip8038, OffFlag>(spec);
 
     private static delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>
-        GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip2780, Eip8038>(IReleaseSpec spec)
+        GetCallHandler<TOpCall, TTracingInst, TCancelable, Eip2929, Eip150, Eip158, Eip8038, Eip2780>(IReleaseSpec spec)
         where TOpCall : struct, EvmInstructions.IOpCall
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
         where Eip2929 : struct, IFlag
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag
-        where Eip2780 : struct, IFlag
-        where Eip8038 : struct, IFlag =>
-        (SpecFlags.Eip8037(spec), SpecFlags.Eip7708(spec)) switch
+        where Eip8038 : struct, IFlag
+        where Eip2780 : struct, IFlag =>
+        (SpecFlags.Eip8037<Eip8038>(spec), SpecFlags.Eip7708<Eip8038>(spec)) switch
         {
             (true, true) => OpcodeHandler<CallOpcode<TOpCall, TTracingInst, OnFlag, OnFlag, EvmInstructions.CallSpec<Eip2929, Eip150, Eip158, Eip2780, Eip8038>>, TTracingInst, TCancelable>(),
             (true, false) => OpcodeHandler<CallOpcode<TOpCall, TTracingInst, OnFlag, OffFlag, EvmInstructions.CallSpec<Eip2929, Eip150, Eip158, Eip2780, Eip8038>>, TTracingInst, TCancelable>(),
@@ -384,7 +384,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip150 : struct, IFlag
         where Eip3860 : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        SpecFlags.Eip8037(spec)
+        SpecFlags.Eip8037<Eip8038>(spec)
             ? OpcodeHandler<CreateOpcode<TOpCreate, TTracingInst, OnFlag, EvmInstructions.CreateSpec<Eip2929, Eip150, Eip3860, Eip8038>>, TTracingInst, TCancelable>()
             : OpcodeHandler<CreateOpcode<TOpCreate, TTracingInst, OffFlag, EvmInstructions.CreateSpec<Eip2929, Eip150, Eip3860, Eip8038>>, TTracingInst, TCancelable>();
 
@@ -422,7 +422,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TCancelable : struct, IFlag
         where TAccess : struct, EvmInstructions.IAccessSpec
         where Eip8038 : struct, IFlag =>
-        spec.UseShanghaiDDosProtection
+        SpecFlags.Eip150(spec)
             ? GetSelfDestructHandler<TTracingInst, TCancelable, TAccess, Eip8038, OnFlag>(spec)
             : GetSelfDestructHandler<TTracingInst, TCancelable, TAccess, Eip8038, OffFlag>(spec);
 
@@ -445,7 +445,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip8038 : struct, IFlag
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag =>
-        spec.SelfdestructOnlyOnSameTransaction
+        SpecFlags.Eip6780(spec)
             ? GetSelfDestructHandler<TTracingInst, TCancelable, TAccess, Eip8038, Eip150, Eip158, OnFlag>(spec)
             : GetSelfDestructHandler<TTracingInst, TCancelable, TAccess, Eip8038, Eip150, Eip158, OffFlag>(spec);
 
@@ -458,7 +458,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip150 : struct, IFlag
         where Eip158 : struct, IFlag
         where Eip6780 : struct, IFlag =>
-        spec.RemoveSelfdestructBurn
+        SpecFlags.Eip8246<Eip8038>(spec)
             ? GetSelfDestructHandler<TTracingInst, TCancelable, TAccess, Eip8038, Eip150, Eip158, Eip6780, OnFlag>(spec)
             : GetSelfDestructHandler<TTracingInst, TCancelable, TAccess, Eip8038, Eip150, Eip158, Eip6780, OffFlag>(spec);
 
@@ -472,7 +472,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where Eip158 : struct, IFlag
         where Eip6780 : struct, IFlag
         where Eip8246 : struct, IFlag =>
-        (SpecFlags.Eip8037(spec), SpecFlags.Eip7708(spec)) switch
+        (SpecFlags.Eip8037<Eip8038>(spec), SpecFlags.Eip7708<Eip8038>(spec)) switch
         {
             (true, true) => TerminatingOpcodeHandler<SelfDestructOpcode<OnFlag, OnFlag, EvmInstructions.SelfDestructSpec<TAccess, Eip150, Eip158, Eip6780, Eip8246, Eip8038>>, TTracingInst, TCancelable>(),
             (true, false) => TerminatingOpcodeHandler<SelfDestructOpcode<OnFlag, OffFlag, EvmInstructions.SelfDestructSpec<TAccess, Eip150, Eip158, Eip6780, Eip8246, Eip8038>>, TTracingInst, TCancelable>(),
@@ -766,12 +766,12 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TCancelable : struct, IFlag
         where Eip8038 : struct, IFlag
         where Eip2929 : struct, IFlag =>
-        spec.UseNetGasMetering
-            ? spec.UseNetGasMeteringWithAStipendFix
-                ? SpecFlags.Eip8037(spec)
+        SpecFlags.NetGasMetering(spec)
+            ? SpecFlags.Eip2200(spec)
+                ? SpecFlags.Eip8037<Eip8038>(spec)
                     ? OpcodeHandler<SStoreMeteredOpcode<TTracingInst, OnFlag, OnFlag, Eip8038, Eip2929>, TTracingInst, TCancelable>()
                     : OpcodeHandler<SStoreMeteredOpcode<TTracingInst, OnFlag, OffFlag, Eip8038, Eip2929>, TTracingInst, TCancelable>()
-                : SpecFlags.Eip8037(spec)
+                : SpecFlags.Eip8037<Eip8038>(spec)
                     ? OpcodeHandler<SStoreMeteredOpcode<TTracingInst, OffFlag, OnFlag, Eip8038, Eip2929>, TTracingInst, TCancelable>()
                     : OpcodeHandler<SStoreMeteredOpcode<TTracingInst, OffFlag, OffFlag, Eip8038, Eip2929>, TTracingInst, TCancelable>()
             : OpcodeHandler<SStoreUnmeteredOpcode<TTracingInst, Eip8038, Eip2929>, TTracingInst, TCancelable>();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Nethermind.Core.Cpu;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
@@ -94,7 +95,8 @@ public class ExecutionPayloadTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(rootTask, Is.Not.Null);
+            // A single processor computes the root inline instead of starting the task.
+            Assert.That(rootTask, RuntimeInformation.IsSingleProcessor ? Is.Null : Is.Not.Null);
             Assert.That(block.Data!.Header.TxRoot, Is.EqualTo(TxTrie.CalculateRoot(rlps)));
         }
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -164,7 +164,8 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
     public virtual Result<Block> TryGetBlock(UInt256? totalDifficulty = null)
     {
         byte[][] encodedTransactions = Transactions;
-        // Folded to null where the count is a constant, so the guest carries no task machinery for it.
+        // Repeats the check inside StartTxRootComputation so the guest build never reaches the call
+        // and carries no task machinery for it.
         Task<Hash256>? txRootTask = RuntimeInformation.IsSingleProcessor ? null : StartTxRootComputation();
 
         Result<Transaction[]> transactions = TryGetTransactions();

--- a/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Data/ExecutionPayload.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.Cpu;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Int256;
@@ -163,7 +164,8 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
     public virtual Result<Block> TryGetBlock(UInt256? totalDifficulty = null)
     {
         byte[][] encodedTransactions = Transactions;
-        Task<Hash256>? txRootTask = StartTxRootComputation();
+        // Folded to null where the count is a constant, so the guest carries no task machinery for it.
+        Task<Hash256>? txRootTask = RuntimeInformation.IsSingleProcessor ? null : StartTxRootComputation();
 
         Result<Transaction[]> transactions = TryGetTransactions();
         if (transactions.IsError)
@@ -226,7 +228,7 @@ public class ExecutionPayload : IForkValidator, IExecutionPayloadParams, IExecut
     internal Task<Hash256>? StartTxRootComputation()
     {
         byte[][] encodedTransactions = _encodedTransactions;
-        return _txRootTask ??= encodedTransactions.Length >= MinTxsForParallelDecoding && Environment.ProcessorCount > 1
+        return _txRootTask ??= encodedTransactions.Length >= MinTxsForParallelDecoding && !RuntimeInformation.IsSingleProcessor
             ? Task.Run(() => TxTrie.CalculateRoot(encodedTransactions))
             : null;
     }

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -554,7 +554,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         {
             if (isTracing) TraceNoChanges();
 
-            codeFlushTask.GetAwaiter().GetResult();
+            AwaitCodeFlush(codeFlushTask);
             return;
         }
 
@@ -583,7 +583,16 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         _nullAccountReads.ClearAndTrim();
         _intraTxCache.ClearAndTrim();
 
-        codeFlushTask.GetAwaiter().GetResult();
+        AwaitCodeFlush(codeFlushTask);
+
+        // The guest persists the batch inline, so its task is always the completed one and there is
+        // nothing to await; leaving the awaiter out keeps the task machinery out of the image.
+        static void AwaitCodeFlush(Task codeFlushTask)
+        {
+#if !ZK_EVM
+            codeFlushTask.GetAwaiter().GetResult();
+#endif
+        }
 
         Task CommitCodeAsync(IWorldStateScopeProvider.ICodeDb codeDb)
         {

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -585,13 +585,11 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
         AwaitCodeFlush(codeFlushTask);
 
-        // The guest persists the batch inline, so its task is always the completed one and there is
-        // nothing to await; leaving the awaiter out keeps the task machinery out of the image.
+        // A single processor persists the batch inline, so its task is always the completed one and
+        // there is nothing to await; skipping the awaiter keeps the task machinery out of the guest.
         static void AwaitCodeFlush(Task codeFlushTask)
         {
-#if !ZK_EVM
-            codeFlushTask.GetAwaiter().GetResult();
-#endif
+            if (!Core.Cpu.RuntimeInformation.IsSingleProcessor) codeFlushTask.GetAwaiter().GetResult();
         }
 
         Task CommitCodeAsync(IWorldStateScopeProvider.ICodeDb codeDb)
@@ -627,12 +625,14 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                 if (Interlocked.CompareExchange(ref _codeBatch, dict, null) is null)
                     _codeBatchAlternate = _codeBatch.GetAlternateLookup<ValueHash256>();
             }
-#if ZK_EVM
-            PersistCodeBatch();
-            return Task.CompletedTask;
-#else
+            // A single processor gains nothing from the hop to the pool, and the guest folds it away.
+            if (Core.Cpu.RuntimeInformation.IsSingleProcessor)
+            {
+                PersistCodeBatch();
+                return Task.CompletedTask;
+            }
+
             return Task.Run(PersistCodeBatch);
-#endif
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -589,7 +589,13 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         // there is nothing to await; skipping the awaiter keeps the task machinery out of the guest.
         static void AwaitCodeFlush(Task codeFlushTask)
         {
-            if (!Core.Cpu.RuntimeInformation.IsSingleProcessor) codeFlushTask.GetAwaiter().GetResult();
+            if (Core.Cpu.RuntimeInformation.IsSingleProcessor)
+            {
+                Debug.Assert(codeFlushTask.IsCompletedSuccessfully, "A single processor persists the code batch inline.");
+                return;
+            }
+
+            codeFlushTask.GetAwaiter().GetResult();
         }
 
         Task CommitCodeAsync(IWorldStateScopeProvider.ICodeDb codeDb)

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -109,11 +109,23 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
             CancelHintBal();
 
             // Legacy trie-store path: no trie warmer, so HintBal only does work when a sink is given.
-            // Warming reads on the one processor that will run the block only contends with it.
-            if (sink is null || Core.Cpu.RuntimeInformation.IsSingleProcessor) return Task.CompletedTask;
+            if (sink is null) return Task.CompletedTask;
 
             int accountCount = bal.AccountChanges.Count;
             if (accountCount == 0) return Task.CompletedTask;
+
+            // The one processor that will run the block would only contend with a warm-up task, so
+            // feed the sink inline; the guest folds the threaded path away.
+            if (Core.Cpu.RuntimeInformation.IsSingleProcessor)
+            {
+                ReadOnlySpan<ReadOnlyAccountChanges> accounts = bal.AccountChanges.AsSpan();
+                for (int i = 0; i < accounts.Length; i++)
+                {
+                    WarmAccount(sink, in accounts[i]);
+                }
+
+                return Task.CompletedTask;
+            }
 
             // Copy the span into a pooled array so the Parallel.For body can capture it.
             ArrayPoolList<ReadOnlyAccountChanges> accountChanges = new(bal.AccountChanges.AsSpan());
@@ -133,65 +145,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                     {
                         if (token.IsCancellationRequested) return;
                         ReadOnlyAccountChanges ac = accountChanges[i];
-                        Address address = ac.Address;
-
-                        // Swallow MissingTrieNodeException so a partially-synced trie can't blow up
-                        // the background warmup task; it'll fault the main read path normally instead.
-                        try
-                        {
-                            StateTree privateStateTree = _scopeProvider.CreateStateTree();
-                            privateStateTree.RootHash = _backingStateTree.RootHash;
-
-                            Account? account;
-                            if (sink.StillNeeded(address, out Account? cached))
-                            {
-                                account = privateStateTree.Get(address);
-                                sink.OnAccountRead(address, account);
-                            }
-                            else
-                            {
-                                account = cached;
-                            }
-
-                            if (account is null) return;
-                            Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
-                            if (storageRoot == Keccak.EmptyTreeHash) return;
-
-                            ReadOnlySpan<UInt256> changed = ac.ChangedSlots;
-                            ReadOnlySpan<UInt256> reads = ac.StorageReads;
-                            if (changed.Length + reads.Length == 0) return;
-
-                            // Sorted-merge walk over (ChangedSlots, StorageReads) — both arrays are
-                            // ascending and disjoint, so one merged pass keeps adjacent trie paths
-                            // hot across consecutive Get calls.
-                            StorageTree storageTree = _scopeProvider.CreateStorageTree(address, storageRoot);
-                            int slotIndex = 0;
-                            int readIndex = 0;
-                            while (slotIndex < changed.Length || readIndex < reads.Length)
-                            {
-                                UInt256 slot;
-                                if (readIndex >= reads.Length)
-                                {
-                                    slot = changed[slotIndex++];
-                                }
-                                else
-                                {
-                                    slot = reads[readIndex];
-                                    if (slotIndex < changed.Length && changed[slotIndex].CompareTo(in slot) <= 0)
-                                    {
-                                        slot = changed[slotIndex++];
-                                    }
-                                    else
-                                    {
-                                        readIndex++;
-                                    }
-                                }
-                                StorageCell cell = new(address, in slot);
-                                if (!sink.StillNeeded(in cell)) continue;
-                                sink.OnStorageRead(in cell, storageTree.Get(in slot));
-                            }
-                        }
-                        catch (MissingTrieNodeException) { }
+                        WarmAccount(sink, in ac);
                     });
                 }
                 catch (OperationCanceledException) { }
@@ -200,6 +154,69 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                     accountChanges.Dispose();
                 }
             });
+        }
+
+        private void WarmAccount(IWorldStateScopeProvider.IAsyncBalReaderSink sink, in ReadOnlyAccountChanges ac)
+        {
+            Address address = ac.Address;
+
+            // Swallow MissingTrieNodeException so a partially-synced trie can't blow up
+            // the background warmup task; it'll fault the main read path normally instead.
+            try
+            {
+                StateTree privateStateTree = _scopeProvider.CreateStateTree();
+                privateStateTree.RootHash = _backingStateTree.RootHash;
+
+                Account? account;
+                if (sink.StillNeeded(address, out Account? cached))
+                {
+                    account = privateStateTree.Get(address);
+                    sink.OnAccountRead(address, account);
+                }
+                else
+                {
+                    account = cached;
+                }
+
+                if (account is null) return;
+                Hash256 storageRoot = account.StorageRoot ?? Keccak.EmptyTreeHash;
+                if (storageRoot == Keccak.EmptyTreeHash) return;
+
+                ReadOnlySpan<UInt256> changed = ac.ChangedSlots;
+                ReadOnlySpan<UInt256> reads = ac.StorageReads;
+                if (changed.Length + reads.Length == 0) return;
+
+                // Sorted-merge walk over (ChangedSlots, StorageReads) — both arrays are
+                // ascending and disjoint, so one merged pass keeps adjacent trie paths
+                // hot across consecutive Get calls.
+                StorageTree storageTree = _scopeProvider.CreateStorageTree(address, storageRoot);
+                int slotIndex = 0;
+                int readIndex = 0;
+                while (slotIndex < changed.Length || readIndex < reads.Length)
+                {
+                    UInt256 slot;
+                    if (readIndex >= reads.Length)
+                    {
+                        slot = changed[slotIndex++];
+                    }
+                    else
+                    {
+                        slot = reads[readIndex];
+                        if (slotIndex < changed.Length && changed[slotIndex].CompareTo(in slot) <= 0)
+                        {
+                            slot = changed[slotIndex++];
+                        }
+                        else
+                        {
+                            readIndex++;
+                        }
+                    }
+                    StorageCell cell = new(address, in slot);
+                    if (!sink.StillNeeded(in cell)) continue;
+                    sink.OnStorageRead(in cell, storageTree.Get(in slot));
+                }
+            }
+            catch (MissingTrieNodeException) { }
         }
 
         public IWorldStateScopeProvider.ICodeDb CodeDb => _codeDb1;

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -71,6 +71,9 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
 
         private void CancelHintBal()
         {
+            // A single processor never starts the warm-up task, so there is nothing to drain.
+            if (Core.Cpu.RuntimeInformation.IsSingleProcessor) return;
+
             _hintBalCts?.Cancel();
             try { _hintBalTask?.GetAwaiter().GetResult(); }
             catch (OperationCanceledException) { }
@@ -105,7 +108,8 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
             CancelHintBal();
 
             // Legacy trie-store path: no trie warmer, so HintBal only does work when a sink is given.
-            if (sink is null) return Task.CompletedTask;
+            // Warming reads on the one processor that will run the block only contends with it.
+            if (sink is null || Core.Cpu.RuntimeInformation.IsSingleProcessor) return Task.CompletedTask;
 
             int accountCount = bal.AccountChanges.Count;
             if (accountCount == 0) return Task.CompletedTask;
@@ -217,6 +221,12 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
         {
             using IBlockCommitter blockCommitter = _scopeProvider._trieStore.BeginBlockCommit(blockNumber);
 
+#if ZK_EVM
+            foreach (KeyValuePair<AddressAsKey, StorageTree> storage in _storages)
+            {
+                storage.Value.Commit();
+            }
+#else
             // Note: These all runs in about 0.4ms. So the little overhead like attempting to sort the tasks
             // may make it worst. Always check on mainnet.
             using ArrayPoolListRef<Task> commitTask = new(_storages.Count);
@@ -238,6 +248,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
             }
 
             Task.WaitAll(commitTask.AsSpan());
+#endif
             _backingStateTree.Commit();
             _storages.Clear();
         }

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -71,7 +71,8 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
 
         private void CancelHintBal()
         {
-            // A single processor never starts the warm-up task, so there is nothing to drain.
+            // HintBal never starts the warm-up task on a single processor, so both fields are null.
+            // Returning early keeps the task awaiter out of the guest image.
             if (Core.Cpu.RuntimeInformation.IsSingleProcessor) return;
 
             _hintBalCts?.Cancel();

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -222,34 +222,38 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
         {
             using IBlockCommitter blockCommitter = _scopeProvider._trieStore.BeginBlockCommit(blockNumber);
 
-#if ZK_EVM
-            foreach (KeyValuePair<AddressAsKey, StorageTree> storage in _storages)
+            if (Core.Cpu.RuntimeInformation.IsSingleProcessor)
             {
-                storage.Value.Commit();
-            }
-#else
-            // Note: These all runs in about 0.4ms. So the little overhead like attempting to sort the tasks
-            // may make it worst. Always check on mainnet.
-            using ArrayPoolListRef<Task> commitTask = new(_storages.Count);
-            foreach (KeyValuePair<AddressAsKey, StorageTree> storage in _storages)
-            {
-                if (blockCommitter.TryRequestConcurrencyQuota())
-                {
-                    commitTask.Add(Task.Factory.StartNew((ctx) =>
-                    {
-                        StorageTree st = (StorageTree)ctx;
-                        st.Commit();
-                        blockCommitter.ReturnConcurrencyQuota();
-                    }, storage.Value, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default));
-                }
-                else
+                foreach (KeyValuePair<AddressAsKey, StorageTree> storage in _storages)
                 {
                     storage.Value.Commit();
                 }
             }
+            else
+            {
+                // Note: These all runs in about 0.4ms. So the little overhead like attempting to sort the tasks
+                // may make it worst. Always check on mainnet.
+                using ArrayPoolListRef<Task> commitTask = new(_storages.Count);
+                foreach (KeyValuePair<AddressAsKey, StorageTree> storage in _storages)
+                {
+                    if (blockCommitter.TryRequestConcurrencyQuota())
+                    {
+                        commitTask.Add(Task.Factory.StartNew((ctx) =>
+                        {
+                            StorageTree st = (StorageTree)ctx;
+                            st.Commit();
+                            blockCommitter.ReturnConcurrencyQuota();
+                        }, storage.Value, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default));
+                    }
+                    else
+                    {
+                        storage.Value.Commit();
+                    }
+                }
 
-            Task.WaitAll(commitTask.AsSpan());
-#endif
+                Task.WaitAll(commitTask.AsSpan());
+            }
+
             _backingStateTree.Commit();
             _storages.Clear();
         }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.BulkSet.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.BulkSet.cs
@@ -199,7 +199,7 @@ public partial class PatriciaTree
         bool hasRemove = false;
         int nonNullChildCount = 0;
 
-        if (entries.Length >= MinEntriesToParallelizeThreshold && nibMask == FullBranch && !flags.HasFlag(Flags.DoNotParallelize))
+        if (!Core.Cpu.RuntimeInformation.IsSingleProcessor && entries.Length >= MinEntriesToParallelizeThreshold && nibMask == FullBranch && !flags.HasFlag(Flags.DoNotParallelize))
         {
             using ArrayPoolList<(
                 int startIdx,

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -160,7 +160,7 @@ namespace Nethermind.Trie
 
                 static bool UseParallel(bool canBeParallel, TrieNode item)
                 {
-                    if (Environment.ProcessorCount <= 1 || !canBeParallel)
+                    if (RuntimeInformation.IsSingleProcessor || !canBeParallel)
                     {
                         return false;
                     }


### PR DESCRIPTION
## Changes

Five commits, each folding a run-time decision the zkEVM guest can never take the other side of into a build-time constant, so ILC stops emitting the code behind it. Every fold is measured on the ILC map and on fixture block 25532382 under ziskemu; the state root is unchanged throughout.

**1. Compile the Amsterdam rules as one setting, not every pairing.** The opcode table asks `SpecFlags` one fork rule at a time, so the ahead-of-time build compiled a handler for every combination of the rules that vary over its fork range. Over Osaka..Amsterdam five rules vary (EIP-2780, 7708, 8037, 8038, 8246) and all of them switch at Amsterdam, yet the guest carried every pairing: `InstructionCall` 64 times, `InstructionSelfDestruct` 64 times. EIP-8038 is now the flag each selection chain chooses first, and the other four take it as a type parameter constrained to `IEip8038Flag`, which only the two EIP-8038 flag types implement, so a follower anchored on any other flag does not compile; the spec structs' EIP-8038 slot carries the same constraint. `SpecFlags.std.cs` ignores the parameter and reads the spec exactly as before, so the standard build selects the same handler for every spec, mixed-flag specs such as `Amsterdam.NoEip8037Instance` included; `SpecFlags.zkevm.cs` returns the flag (`TEip8038.IsActive`), which the JIT folds, so only the Osaka and Amsterdam settings are reachable. The SELFDESTRUCT and SSTORE chains read EIP-150, EIP-6780, EIP-2200 and net gas metering straight from the spec, which kept those constants from folding; they go through `SpecFlags` now. `SpecFlagsTests` groups the varying rules by their values over the range, requires one rule per group to read the spec and the rest to follow it, and checks that `Validate` tests every constant and every pairing against the property the rule reads; five mutations of the generated file each fail it with a message naming the fix. A further test keeps the anchor interface exclusive to the two EIP-8038 flags.

| | before | after | change |
|---|---|---|---|
| `InstructionCall` instantiations | 64 (452,736 B) | 8 (57,204 B) | -56 (-395,532 B) |
| `InstructionSelfDestruct` instantiations | 64 (108,768 B) | 2 (3,476 B) | -62 (-105,292 B) |
| `InstructionCreate` instantiations | 8 | 4 | -4 |
| `InstructionSStore*` instantiations | 10 | 2 | -8 |
| managed code | 3,612,492 B | 3,022,684 B | -589,808 B (-16.3%) |
| `.text` | 4,218,016 B | 3,626,624 B | -591,392 B (-14.0%) |
| ROM usage | 26.59% | 23.03% | -3.56 points |

**2. Drop the spec-reading handler specs nothing selects.** The `DynamicCallSpec`, `DynamicCreateSpec`, `DynamicSelfDestructSpec` and `DynamicAccessSpec` structs and the five forwarding overloads that were their only users had no caller in the repository and no instantiation in the guest map. With them gone the fork-rule queries on `ICallSpec`, `ICreateSpec` and `ISelfDestructSpec` drop the spec argument every implementation ignored and become static properties like `IFlag.IsActive`. The create-charge test compares the specialized specs against the gas policy's own spec-reading charge, which is what the removed struct forwarded to. The guest is byte-for-byte unchanged by this commit.

**3. Fold parallel block execution out of the guest.** The stateless environment already configures `ParallelExecution = false`, but the value is read at run time through `IBlocksConfig`, so the guest still compiled the parallel transactions executor, its worker pool, `BlockAccessListBasedWorldState`, the BAL read warm-up task and the thread-pool machinery behind them. `ExecutionFlags.ParallelExecution` names the capability per build, in the mould of `DispatchFlags`: `true` in the standard build, where every reader combines it with the run-time decision and the JIT folds it away, and `false` in the guest. The parallel pool's `Lazy` is null in a build without the capability, the incremental-validation work item is created by the parallel path instead of a field initializer, and the shared tx-processor constructor throws when asked for the BAL world state in a build without the capability, so a mis-wired processor fails fast instead of producing a wrong BAL and the guest compiles nothing past the throw. None of the removals depend on what the JIT happens to inline. Reflection code in the guest halved as a side effect (119 KB to 56 KB): the parallel path was what rooted it.

| | before | after | change |
|---|---|---|---|
| managed code | 7,509 methods, 3,613,616 B | 6,990 methods, 3,436,984 B | -519 methods, -176,632 B (-4.9%) |
| constructed types | 4,629 | 4,268 | -361 |
| `.text` | 4,219,136 B | 4,038,496 B | -180,640 B (-4.3%) |
| ROM usage | 26.60% | 25.42% | -1.18 points |
| steps, decode-failure input (startup) | 415,467 | 394,331 | -21,136 (-5.1%) |

**4. Run `ParallelUnbalancedWork` loops inline in the guest.** The class is split the way `VirtualMachine` is: the shared file keeps `DefaultOptions` and the public overloads, `ParallelUnbalancedWork.std.cs` keeps the threaded implementation behind two private partial methods, and `ParallelUnbalancedWork.zkevm.cs` runs the range in order on the calling thread, mirroring the threaded worker's control flow for cancellation, init/finally and exception precedence. Call sites do not change.

**5. Make the guest's processor count a constant.** `RuntimeInformation.ProcessorCount` becomes `const 1` under `ZK_EVM`, read through a new `IsSingleProcessor` property so the C# compiler sees no constant condition (the repository treats CS0162 as an error) while the JIT still folds it. Every remaining root of the thread pool was found by walking ILC's dependency graph back from the pool code to guest code and gating it on that property: the Trie's branch-RLP predicate, the bulk-set fan-out, the payload's transactions-root task, the scope's BAL warm-up fan-out and its drain, the storage-tree commit tasks, the code batch's persist task and the await on it, and the background jump-destination analysis with its completion event. The two `#if ZK_EVM` blocks that had kept the code flush inline and the analysis unqueued in the guest are replaced by the same check, so no method body in the branch carries a preprocessor branch; the constant itself is the one `#if`. Thread pool, portable pool and completion-event code: zero methods left. `Task` keeps four: its static constructor, that constructor's lambda, and the `Dispose` and `InnerInvoke` slots of its constructed type.

The per-commit tables above were measured against the master each commit was built on (`90dbfaf611` for the first two, `35e16a6336` for the rest). The whole branch at `3d169aa7dc` against its base `13a8178aff`, built with the Makefile's own flags (`--ldflags=--strip-all` included, so the file row is the shipped `bin/nethermind`), same fixture:

| | master `13a8178aff` | this branch | change |
|---|---|---|---|
| managed code (ILC `MethodCode`) | 7,525 methods, 3,582,748 B | 6,381 methods, 2,710,184 B | -1,144 methods, -872,564 B (-24.4%) |
| constructed types | 4,648 (454,528 B) | 4,003 (388,224 B) | -645 (-66,304 B) |
| `.text` | 4,188,624 B | 3,306,272 B | -882,352 B (-21.1%) |
| read-only segment | 832,765 B | 718,885 B | -113,880 B (-13.7%) |
| read-write segment | 763,808 B | 654,472 B | -109,336 B (-14.3%) |
| guest file (`bin/nethermind`) | 5,790,624 B | 4,685,960 B | -1,104,664 B (-19.1%) |
| ziskemu `ROM USAGE` | 26.42% (1,107,980 units) | 20.95% (878,699 units) | -5.47 points (-229,281 units) |
| steps, full block | 428,281,976 | 427,746,771 | -535,205 (-0.12%) |
| steps, decode-failure input (startup) | 415,879 | 376,117 | -39,762 (-9.6%) |
| `ThreadPool`, `ManualResetEventSlim` and `Parallel` methods | 31 | 0 | -31 |
| reflection code | 415 methods, 119,504 B | 189 methods, 56,248 B | -226 methods, -63,256 B |
| state root, success flag | same | same | - |

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [x] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`SpecFlagsTests` was extended (commit 1) and verified against five mutations of the generated file, each failing with a message naming the fix: a follower reading the spec instead of its anchor, a missing `Follows` check, `Follows` comparing the anchor with itself, the anchor returning a constant instead of reading the spec, and `Validate` checking a constant through the wrong property. The standard build reduces every gated expression to what it was, so the existing suites cover the rest: `Nethermind.Evm.Test`, `Nethermind.Core.Test`, `Nethermind.Trie.Test`, `Nethermind.State.Test`, `Nethermind.Consensus.Test` and `Nethermind.Blockchain.Test` pass in full on the combined branch, plus the Merge plugin's `ExecutionPayload` tests. The guest was built with the Makefile's bflat invocation at the base and at the head and run on the fixture block; the ILC map confirms which methods left. The guest-side test projects `Nethermind.Core.ZkEvm.Test`, `Nethermind.Trie.ZkEvm.Test` and `Nethermind.Evm.ZkEvm.Test` build with `EnableZkEvm=true`; the Core one now links the thirteen `ParallelUnbalancedWorkTests` from `Nethermind.Core.Test`, so the inline guest loops are held to the threaded contract, and all three pass locally under `EnableZkEvm=true`. The single-processor paths of the standard build were swept with `DOTNET_PROCESSOR_COUNT=1` over `Nethermind.State.Test`, `Nethermind.Trie.Test`, `Nethermind.Blockchain.Test`, the payload tests and the code-analysis tests, and a new workflow, `Nethermind tests (Single Proc)` (`nethermind-tests-single-proc.yml`, in the mould of the Flat DB one), runs `Nethermind.Evm.Test`, `Nethermind.Merge.Plugin.Test`, `Nethermind.State.Test` and `Nethermind.Trie.Test` with that setting on every pull request, so those paths stay covered, plus `Nethermind.Core.Test` without its rate-limiter fixture, whose wall-clock throughput cases assume more than one worker; Core carries the guard that fails the run if the pin ever stops reaching the runtime. The payload test that asserted the early transactions-root task now states the contract on both kinds of host. `stateless-tests.yml` runs those projects and the fixture matrix on the built guest.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Four deliberate changes reach the standard build on single-core hosts only: the bulk-set fan-out and the background jump-destination analysis no longer run there, the trie scope's BAL read warm-up feeds its sink inline instead of on the pool (the flat scope's warm-up is unchanged), and the code batch persists inline instead of through the pool. Each only removes a hop or a contention with the one core the block runs on. The transactions-root task already skipped single-core hosts. The `-0.26%` step change from commit 1 is in execution, not startup, and its cause is not attributed; the state root is identical.
