### PR TITLE
fix(eip8141): align the frame-tx gas estimate cap with the field validator

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -116,7 +116,7 @@ public class GasEstimator(
             return EstimationResult.Failure(FrameTxGasLimitOverflows);
 
         // EIP-8037: each dimension gets its own block budget, and only execution carries the per-tx cap.
-        return executionReservation > Math.Min(header.GasLimit, spec.GetTxGasLimitCap()) || stateReservation > header.GasLimit
+        return executionReservation > Eip7825Constants.DefaultTxGasLimitCap || stateReservation > header.GasLimit
             ? EstimationResult.Failure(CannotEstimateGasExceeded)
             : EstimationResult.Success(maxGas);
     }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1129,6 +1129,31 @@ public class FrameTxProcessorTests
         }
     }
 
+    /// <remarks>Above the EIP-7825 per-transaction cap the frame validator rejects the transaction, so the
+    /// estimate must report it unestimable rather than hand back a budget that would fail admission; the cap
+    /// binds even where the reservation still fits the block.</remarks>
+    [Test]
+    public void EstimateGas_FrameTxReservingAboveThePerTxCapButUnderTheBlock_ReportsTheBudgetAsUnestimable()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient,
+                executionGasLimit: Eip7825Constants.DefaultTxGasLimitCap, stateGasLimit: 0, UInt256.Zero, default));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(30_000_000).TestObject;
+
+        EstimateGasTracer gasTracer = new();
+        _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, Spec));
+        _transactionProcessor.CallAndRestore(tx, gasTracer);
+
+        GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
+        estimator.Estimate(tx, header, gasTracer, out string? error);
+
+        Assert.That(error, Is.EqualTo(GasEstimator.CannotEstimateGasExceeded));
+    }
+
     /// <summary>Frame counts EIP-8141 never admits: an absent list, an empty one, and an oversized one.</summary>
     private static readonly int?[] FrameCountsOutsideTheAdmittedRange = [null, 0, Eip8141Constants.MaxFrames + 1];
 


### PR DESCRIPTION
## Changes

`eth_estimateGas` on a frame transaction (`GasEstimator.EstimateFrameTx`) capped the budget at `Math.Min(header.GasLimit, spec.GetTxGasLimitCap())`. `GetTxGasLimitCap()` returns `ulong.MaxValue` once EIP-8037 is active (the fork every frame transaction composes onto), so the effective bound was the block gas limit alone.

`FrameTxFieldsTxValidator` caps the execution reservation at the raw `Eip7825Constants.DefaultTxGasLimitCap` (16,777,216). The estimate therefore reported budgets between that cap and the block gas limit that the validator rejects at admission.

The estimate now reuses `TryCalculateBlockGasReservations` and applies the same `DefaultTxGasLimitCap`, so a reported budget is one the transaction can be admitted for.

Surfaced by a review of #12526 (H2).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `EstimateGas_FrameTxReservingAboveThePerTxCapButUnderTheBlock_ReportsTheBudgetAsUnestimable`: a frame transaction reserving execution gas above the per-tx cap but under a 30M block limit is now reported unestimable. Verified it reddens (Expected error, But was null) when the cap clause is removed, and the pre-existing over-the-block test stays green under that same neuter. Full frame estimate suite green (7/7).
