### PR TITLE
test: drive request-sizer latency from a ManualTimeProvider

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyAndMessageSizeBasedRequestSizerTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyAndMessageSizeBasedRequestSizerTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Nethermind.Core.RequestSizer;
+using Nethermind.Core.Test.Threading;
 
 namespace Nethermind.Core.Test.RequestSizer;
 
@@ -14,26 +15,34 @@ public class LatencyAndMessageSizeBasedRequestSizerTests
 {
     private static readonly int[] _sampleRequest = Enumerable.Range(0, 10).ToArray();
 
+    /// <remarks>
+    /// The sizer compares measured latency against its watermarks, so the request latency is advanced on a
+    /// <see cref="ManualTimeProvider"/> rather than awaited. Sleeping for it made the outcome depend on how
+    /// loaded the machine was: a <c>Task.Delay(50)</c> that overshot the 200ms upper watermark shrank the
+    /// request instead of keeping it, and one that undershot the 20ms lower watermark grew it.
+    /// </remarks>
     [TestCase(0, 0, 2, 3)]
     [TestCase(0, 10000, 2, 1)]
     [TestCase(50, 0, 2, 2)]
     [TestCase(50, 10000, 2, 1)]
     [TestCase(500, 0, 2, 1)]
     [TestCase(50, 0, 1, 1)]
-    public async Task TestChangeInRequestSize(int waitTimeMs, long responseSize, int responseCount, int afterRequestSize)
+    public async Task TestChangeInRequestSize(int latencyMs, long responseSize, int responseCount, int afterRequestSize)
     {
+        ManualTimeProvider timeProvider = new();
         LatencyAndMessageSizeBasedRequestSizer sizer = new(
             1, 4,
             TimeSpan.FromMilliseconds(20),
             TimeSpan.FromMilliseconds(200),
             1000,
-            2
+            2,
+            timeProvider: timeProvider
         );
 
-        await sizer.Run<int[], int, int>(_sampleRequest, async adjustedSize =>
+        await sizer.Run<int[], int, int>(_sampleRequest, adjustedSize =>
         {
-            await Task.Delay(waitTimeMs);
-            return (new int[responseCount], responseSize);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(latencyMs));
+            return Task.FromResult((new int[responseCount], responseSize));
         });
 
         IReadOnlyList<int> modifiedRequestSize = await sizer.Run<IReadOnlyList<int>, int, int>(

--- a/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyAndMessageSizeBasedRequestSizerTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyAndMessageSizeBasedRequestSizerTests.cs
@@ -16,10 +16,8 @@ public class LatencyAndMessageSizeBasedRequestSizerTests
     private static readonly int[] _sampleRequest = Enumerable.Range(0, 10).ToArray();
 
     /// <remarks>
-    /// The sizer compares measured latency against its watermarks, so the request latency is advanced on a
-    /// <see cref="ManualTimeProvider"/> rather than awaited. Sleeping for it made the outcome depend on how
-    /// loaded the machine was: a <c>Task.Delay(50)</c> that overshot the 200ms upper watermark shrank the
-    /// request instead of keeping it, and one that undershot the 20ms lower watermark grew it.
+    /// Latency is advanced on a <see cref="ManualTimeProvider"/> so the case lands on a known side of the
+    /// 20ms/200ms watermarks regardless of machine load.
     /// </remarks>
     [TestCase(0, 0, 2, 3)]
     [TestCase(0, 10000, 2, 1)]

--- a/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyBasedRequestSizerTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyBasedRequestSizerTests.cs
@@ -5,27 +5,35 @@ using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Nethermind.Core.RequestSizer;
+using Nethermind.Core.Test.Threading;
 
 namespace Nethermind.Core.Test.RequestSizer;
 
 public class LatencyBasedRequestSizerTests
 {
+    /// <remarks>
+    /// Latency is advanced on a <see cref="ManualTimeProvider"/> rather than awaited: sleeping for it made
+    /// the outcome depend on machine load, since a <c>Task.Delay(50)</c> that overshot the 200ms upper
+    /// watermark shrank the request instead of keeping it.
+    /// </remarks>
     [TestCase(0, 3)]
     [TestCase(50, 2)]
     [TestCase(500, 1)]
-    public async Task TestWait(int waitTimeMs, int afterRequestSize)
+    public async Task TestWait(int latencyMs, int afterRequestSize)
     {
+        ManualTimeProvider timeProvider = new();
         LatencyBasedRequestSizer sizer = new(
             1, 4,
             TimeSpan.FromMilliseconds(20),
-            TimeSpan.FromMilliseconds(200));
+            TimeSpan.FromMilliseconds(200),
+            timeProvider: timeProvider);
 
         await sizer.MeasureLatency((_ => Task.FromResult(0)));
-        await sizer.MeasureLatency((async _ =>
+        await sizer.MeasureLatency(_ =>
         {
-            await Task.Delay(waitTimeMs);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(latencyMs));
             return Task.FromResult(0);
-        }));
+        });
 
         int modifiedRequestSize = await sizer.MeasureLatency((Task.FromResult));
 

--- a/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyBasedRequestSizerTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyBasedRequestSizerTests.cs
@@ -12,14 +12,13 @@ namespace Nethermind.Core.Test.RequestSizer;
 public class LatencyBasedRequestSizerTests
 {
     /// <remarks>
-    /// Latency is advanced on a <see cref="ManualTimeProvider"/> rather than awaited: sleeping for it made
-    /// the outcome depend on machine load, since a <c>Task.Delay(50)</c> that overshot the 200ms upper
-    /// watermark shrank the request instead of keeping it.
+    /// Latency is advanced on a <see cref="ManualTimeProvider"/> so the case lands on a known side of the
+    /// 20ms/200ms watermarks regardless of machine load.
     /// </remarks>
     [TestCase(0, 3)]
     [TestCase(50, 2)]
     [TestCase(500, 1)]
-    public async Task TestWait(int latencyMs, int afterRequestSize)
+    public async Task TestChangeInRequestSize(int latencyMs, int afterRequestSize)
     {
         ManualTimeProvider timeProvider = new();
         LatencyBasedRequestSizer sizer = new(


### PR DESCRIPTION
## Changes

- `LatencyAndMessageSizeBasedRequestSizerTests` and `LatencyBasedRequestSizerTests` advance a `ManualTimeProvider` by the latency under test instead of sleeping for it.

Both tests slept for the latency they wanted to measure and then asserted which side of the sizer's 20ms/200ms watermarks it landed on, which makes the result a function of machine load rather than of the code under test. On a busy runner a `Task.Delay(50)` overshoots the 200ms upper watermark, so the sizer shrinks the request instead of keeping it and the case expecting "stay" fails. The same `Task.Delay(0)` case can overshoot the 20ms lower watermark and skip the expected grow.

Seen on CI as `TestChangeInRequestSize(50,0,2,2)` — expected 2, got 1.

No production change: both sizers already take a `TimeProvider` for exactly this, and `ManualTimeProvider` already exists in `Nethermind.Core.Test`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: test-only fix for a wall-clock-dependent flake

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

All 9 cases across the two fixtures pass on 3 consecutive runs; full `Nethermind.Core.Test` is green (6096 passed, 108 skipped, 0 failed). The runs no longer depend on wall-clock timing at all.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
