### PR TITLE
test: wait for the pre-fork revalidation before resubmitting the evicted tx

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -347,13 +347,13 @@ namespace Nethermind.TxPool.Test
             }
 
             await AddEmptyBlock();
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+            AssertRevalidatedForHead();
 
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
 
             _blockTree.BestSuggestedHeader = head.Header;
             await RaiseBlockAddedToMainAndWaitForNewHead(head);
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+            AssertRevalidatedForHead();
 
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
         }
@@ -407,7 +407,7 @@ namespace Nethermind.TxPool.Test
 
             EnsureSenderBalance(TestItem.AddressA, UInt256.Zero);
             await AddEmptyBlock();
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+            AssertRevalidatedForHead();
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             int pendingTransactionsCount = _txPool.GetPendingTransactionsCount();
             AcceptTxResult resubmissionResult = _txPool.SubmitTx(transaction, TxHandlingOptions.None);
@@ -443,7 +443,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+            AssertRevalidatedForHead();
 
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
         }
@@ -509,7 +509,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+            AssertRevalidatedForHead();
 
             using (Assert.EnterMultipleScope())
             {
@@ -543,7 +543,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+            AssertRevalidatedForHead();
 
             using (Assert.EnterMultipleScope())
             {
@@ -585,7 +585,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
 
             await AddEmptyBlock();
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+            AssertRevalidatedForHead();
 
             using (Assert.EnterMultipleScope())
             {
@@ -655,7 +655,7 @@ namespace Nethermind.TxPool.Test
 
             await AddEmptyBlock();
 
-            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
+            AssertRevalidatedForHead();
         }
 
         [Test]
@@ -3538,6 +3538,9 @@ namespace Nethermind.TxPool.Test
                 await semaphoreSlim.WaitAsync(1000);
             }
         }
+
+        private void AssertRevalidatedForHead() =>
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
         private async Task RaiseBlockAddedToMainAndWaitForNewHead(Block block, Block previousBlock = null)
         {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -353,6 +353,7 @@ namespace Nethermind.TxPool.Test
 
             _blockTree.BestSuggestedHeader = head.Header;
             await RaiseBlockAddedToMainAndWaitForNewHead(head);
+            Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));
 
             Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
         }


### PR DESCRIPTION
## Changes

- `should_evict_transactions_that_become_under_gassed_after_fork` waits on `IsRevalidatedFor` after the reorg back to the pre-fork head, before resubmitting the evicted transaction.

The transaction is evicted under the post-fork spec with an intrinsic-gas error, so `RecordValidation` marks it `AllowAfterSpecChange` and its hash is deliberately kept in the long-term hash cache via `RememberForkInvalidatedHash`. Only `ReleaseForkInvalidatedHashesFor` clears it, and that runs inside the revalidation pass triggered by the new head. `RaiseBlockAddedToMainAndWaitForNewHead` only awaits `TxPoolHeadChanged`, which fires before that pass, so the resubmission raced the release and returned `already known` when it lost.

Seen on CI as `should_evict_transactions_that_become_under_gassed_after_fork` â€” expected `Accepted`, got `already known`.

No production change; the wait is the same one every sibling fork-eviction test in the fixture already does after its head change.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: test-only fix for a race between an assertion and the pool's background revalidation

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Instrumenting the resubmit point showed `IsRevalidatedFor` was False on *every* local run â€” the test always submitted before the pass completed and merely happened to land after the hash release, which occurs early in the pass before `_validatedSpec` is published. With the wait: 5 consecutive green runs of the test, and full `Nethermind.TxPool.Test` green (765 passed, 1 skipped, 0 failed).

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Review follow-ups

- **DRY.** The eight verbatim `Assert.That(() => _txPool.IsRevalidatedFor(_blockTree.BestSuggestedHeader), Is.True.After(Timeout, 10));` waits are now a single `AssertRevalidatedForHead()` helper. Waits on an explicit header (a fork or rollback block) are left as they are, since they assert about a header other than the current head.
