### PR TITLE
fix(precompiles): check BN254 Add/Mul input length in release builds

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
@@ -28,11 +28,8 @@ internal static unsafe class BN254
     /// <summary>Adds two BN254 G1 points and writes the normalized result (EIP-196).</summary>
     /// <remarks>
     /// <paramref name="input"/> must be exactly 128 bytes — two 64-byte big-endian G1 points — and
-    /// <paramref name="output"/> exactly 64 bytes. <see cref="BN254AddPrecompile.Run"/> guarantees both by trimming
-    /// longer call data and zero-padding shorter input as EIP-196 requires, so neither length is
-    /// attacker-controlled. The guard is a runtime check rather than a <c>Debug.Assert</c> because the
-    /// deserialization below reads through a raw pointer: an unchecked mismatch would read past the backing buffer,
-    /// whereas a violation here surfaces as an ordinary precompile failure.
+    /// <paramref name="output"/> exactly 64 bytes; deserialization reads and serialization writes through raw
+    /// pointers with no bounds check, so a mismatched length is rejected up front rather than read past the buffer.
     /// </remarks>
     /// <returns><c>false</c> on a length mismatch, a point that fails to deserialize, or a serialization failure.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -61,19 +58,18 @@ internal static unsafe class BN254
     /// <summary>Multiplies a BN254 G1 point by a scalar and writes the normalized result (EIP-196).</summary>
     /// <remarks>
     /// <paramref name="input"/> must be exactly 96 bytes — a 64-byte big-endian G1 point followed by a 32-byte
-    /// big-endian scalar — and <paramref name="output"/> exactly 64 bytes. <see cref="BN254MulPrecompile.Run"/>
-    /// guarantees both by trimming longer call data and zero-padding shorter input as EIP-196 requires, so neither
-    /// length is attacker-controlled. The guard is a runtime check rather than a <c>Debug.Assert</c> because the
-    /// deserialization below reads through a raw pointer: an unchecked mismatch would read past the backing buffer,
-    /// whereas a violation here surfaces as an ordinary precompile failure.
+    /// big-endian scalar — and <paramref name="output"/> exactly 64 bytes; deserialization reads and serialization
+    /// writes through raw pointers with no bounds check, so a mismatched length is rejected up front rather than
+    /// read past the buffer.
     /// </remarks>
     /// <returns><c>false</c> on a length mismatch, a point or scalar that fails to decode, or a serialization failure.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
     internal static bool Mul(byte[] output, ReadOnlySpan<byte> input)
     {
         const int chunkSize = 64;
+        const int scalarSize = 32;
 
-        if (input.Length != chunkSize + 32 || output.Length != chunkSize)
+        if (input.Length != chunkSize + scalarSize || output.Length != chunkSize)
             return false;
 
         fixed (byte* data = &MemoryMarshal.GetReference(input))
@@ -82,7 +78,7 @@ internal static unsafe class BN254
                 return false;
 
             Unsafe.SkipInit(out mclBnFr y);
-            if (mclBnFr_setBigEndianMod(ref y, (nint)data + chunkSize, 32) == -1 || mclBnFr_isValid(y) == 0)
+            if (mclBnFr_setBigEndianMod(ref y, (nint)data + chunkSize, scalarSize) == -1 || mclBnFr_isValid(y) == 0)
                 return false;
 
             mclBnG1_mul(ref x, x, y);  // x *= y

--- a/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
@@ -27,9 +27,10 @@ internal static unsafe class BN254
 
     /// <summary>Adds two BN254 G1 points and writes the normalized result (EIP-196).</summary>
     /// <remarks>
-    /// <paramref name="input"/> must be exactly 128 bytes — two 64-byte big-endian G1 points — and
-    /// <paramref name="output"/> exactly 64 bytes; deserialization reads and serialization writes through raw
-    /// pointers with no bounds check, so a mismatched length is rejected up front rather than read past the buffer.
+    /// <paramref name="input"/> must be exactly 128 bytes (two 64-byte big-endian G1 points) and
+    /// <paramref name="output"/> at least 64 bytes: both are accessed through raw pointers with no bounds check, so a
+    /// short buffer would read or write past the end. A longer <paramref name="input"/> is rejected to keep the
+    /// contract exact; a longer <paramref name="output"/> is fine — only the first 64 bytes are written.
     /// </remarks>
     /// <returns><c>false</c> on a length mismatch, a point that fails to deserialize, or a serialization failure.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -37,7 +38,7 @@ internal static unsafe class BN254
     {
         const int chunkSize = 64;
 
-        if (input.Length != 2 * chunkSize || output.Length != chunkSize)
+        if (input.Length != 2 * chunkSize || output.Length < chunkSize)
             return false;
 
         fixed (byte* data = &MemoryMarshal.GetReference(input))
@@ -57,10 +58,10 @@ internal static unsafe class BN254
 
     /// <summary>Multiplies a BN254 G1 point by a scalar and writes the normalized result (EIP-196).</summary>
     /// <remarks>
-    /// <paramref name="input"/> must be exactly 96 bytes — a 64-byte big-endian G1 point followed by a 32-byte
-    /// big-endian scalar — and <paramref name="output"/> exactly 64 bytes; deserialization reads and serialization
-    /// writes through raw pointers with no bounds check, so a mismatched length is rejected up front rather than
-    /// read past the buffer.
+    /// <paramref name="input"/> must be exactly 96 bytes (a 64-byte big-endian G1 point followed by a 32-byte
+    /// big-endian scalar) and <paramref name="output"/> at least 64 bytes: both are accessed through raw pointers
+    /// with no bounds check, so a short buffer would read or write past the end. A longer <paramref name="input"/> is
+    /// rejected to keep the contract exact; a longer <paramref name="output"/> is fine — only the first 64 bytes are written.
     /// </remarks>
     /// <returns><c>false</c> on a length mismatch, a point or scalar that fails to decode, or a serialization failure.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -69,7 +70,7 @@ internal static unsafe class BN254
         const int chunkSize = 64;
         const int scalarSize = 32;
 
-        if (input.Length != chunkSize + scalarSize || output.Length != chunkSize)
+        if (input.Length != chunkSize + scalarSize || output.Length < chunkSize)
             return false;
 
         fixed (byte* data = &MemoryMarshal.GetReference(input))

--- a/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/BN254.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Buffers.Binary;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -26,13 +25,23 @@ internal static unsafe class BN254
             throw new InvalidOperationException("MCL initialization failed");
     }
 
+    /// <summary>Adds two BN254 G1 points and writes the normalized result (EIP-196).</summary>
+    /// <remarks>
+    /// <paramref name="input"/> must be exactly 128 bytes — two 64-byte big-endian G1 points — and
+    /// <paramref name="output"/> exactly 64 bytes. <see cref="BN254AddPrecompile.Run"/> guarantees both by trimming
+    /// longer call data and zero-padding shorter input as EIP-196 requires, so neither length is
+    /// attacker-controlled. The guard is a runtime check rather than a <c>Debug.Assert</c> because the
+    /// deserialization below reads through a raw pointer: an unchecked mismatch would read past the backing buffer,
+    /// whereas a violation here surfaces as an ordinary precompile failure.
+    /// </remarks>
+    /// <returns><c>false</c> on a length mismatch, a point that fails to deserialize, or a serialization failure.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
     internal static bool Add(byte[] output, ReadOnlySpan<byte> input)
     {
         const int chunkSize = 64;
 
-        Debug.Assert(input.Length == 128);
-        Debug.Assert(output.Length == 64);
+        if (input.Length != 2 * chunkSize || output.Length != chunkSize)
+            return false;
 
         fixed (byte* data = &MemoryMarshal.GetReference(input))
         {
@@ -49,13 +58,23 @@ internal static unsafe class BN254
         }
     }
 
+    /// <summary>Multiplies a BN254 G1 point by a scalar and writes the normalized result (EIP-196).</summary>
+    /// <remarks>
+    /// <paramref name="input"/> must be exactly 96 bytes — a 64-byte big-endian G1 point followed by a 32-byte
+    /// big-endian scalar — and <paramref name="output"/> exactly 64 bytes. <see cref="BN254MulPrecompile.Run"/>
+    /// guarantees both by trimming longer call data and zero-padding shorter input as EIP-196 requires, so neither
+    /// length is attacker-controlled. The guard is a runtime check rather than a <c>Debug.Assert</c> because the
+    /// deserialization below reads through a raw pointer: an unchecked mismatch would read past the backing buffer,
+    /// whereas a violation here surfaces as an ordinary precompile failure.
+    /// </remarks>
+    /// <returns><c>false</c> on a length mismatch, a point or scalar that fails to decode, or a serialization failure.</returns>
     [MethodImpl(MethodImplOptions.NoInlining)]
     internal static bool Mul(byte[] output, ReadOnlySpan<byte> input)
     {
         const int chunkSize = 64;
 
-        Debug.Assert(input.Length == 96);
-        Debug.Assert(output.Length == 64);
+        if (input.Length != chunkSize + 32 || output.Length != chunkSize)
+            return false;
 
         fixed (byte* data = &MemoryMarshal.GetReference(input))
         {

--- a/src/Nethermind/Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Nethermind.Evm.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Evm\Nethermind.Evm.csproj" />
     <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />

--- a/src/Nethermind/Nethermind.Evm.Test/BN254Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BN254Tests.cs
@@ -23,40 +23,27 @@ public class BN254Tests
     private const string ValidMulInput =
         "089142debb13c461f61523586a60732d8b69c5b38a3380a74da7b2961d867dbf2d5fc7bbc013c16d7945f190b232eacc25da675c0eb093fe6b9f1b4b4e107b36ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-    [TestCase(0)]
-    [TestCase(64)]
-    [TestCase(96)]
-    [TestCase(127)]
-    [TestCase(129)]
-    [TestCase(192)]
-    public void Add_rejects_wrong_input_length(int inputLength) =>
+    [Test]
+    public void Add_rejects_wrong_input_length([Values(0, 64, 96, 127, 129, 192)] int inputLength) =>
         Assert.That(BN254.Add(new byte[64], new byte[inputLength]), Is.False);
 
-    [TestCase(0)]
-    [TestCase(63)]
-    [TestCase(65)]
-    public void Add_rejects_wrong_output_length(int outputLength) =>
+    [Test]
+    public void Add_rejects_short_output([Values(0, 63)] int outputLength) =>
         Assert.That(BN254.Add(new byte[outputLength], new byte[128]), Is.False);
 
     [Test]
-    public void Add_accepts_exact_length_valid_input() =>
-        Assert.That(BN254.Add(new byte[64], Bytes.FromHexString(ValidAddInput)), Is.True);
+    public void Add_accepts_exact_or_oversized_output([Values(64, 128)] int outputLength) =>
+        Assert.That(BN254.Add(new byte[outputLength], Bytes.FromHexString(ValidAddInput)), Is.True);
 
-    [TestCase(0)]
-    [TestCase(64)]
-    [TestCase(95)]
-    [TestCase(97)]
-    [TestCase(128)]
-    public void Mul_rejects_wrong_input_length(int inputLength) =>
+    [Test]
+    public void Mul_rejects_wrong_input_length([Values(0, 64, 95, 97, 128)] int inputLength) =>
         Assert.That(BN254.Mul(new byte[64], new byte[inputLength]), Is.False);
 
-    [TestCase(0)]
-    [TestCase(63)]
-    [TestCase(65)]
-    public void Mul_rejects_wrong_output_length(int outputLength) =>
+    [Test]
+    public void Mul_rejects_short_output([Values(0, 63)] int outputLength) =>
         Assert.That(BN254.Mul(new byte[outputLength], new byte[96]), Is.False);
 
     [Test]
-    public void Mul_accepts_exact_length_valid_input() =>
-        Assert.That(BN254.Mul(new byte[64], Bytes.FromHexString(ValidMulInput)), Is.True);
+    public void Mul_accepts_exact_or_oversized_output([Values(64, 128)] int outputLength) =>
+        Assert.That(BN254.Mul(new byte[outputLength], Bytes.FromHexString(ValidMulInput)), Is.True);
 }

--- a/src/Nethermind/Nethermind.Evm.Test/BN254Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BN254Tests.cs
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Extensions;
+using Nethermind.Evm.Precompiles;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <remarks>
+/// The precompile forwarders (<see cref="BN254AddPrecompile"/>, <see cref="BN254MulPrecompile"/>) always
+/// normalise call data to the exact length before invoking <see cref="BN254"/>, so these length guards are
+/// unreachable through the public surface. They are exercised directly here because a violated length would
+/// otherwise read or write past the backing buffer through the raw pointers inside <c>BN254</c>.
+/// </remarks>
+public class BN254Tests
+{
+    // 128-byte input / 64-byte output vector from BN254AddPrecompileTests.
+    private const string ValidAddInput =
+        "089142debb13c461f61523586a60732d8b69c5b38a3380a74da7b2961d867dbf2d5fc7bbc013c16d7945f190b232eacc25da675c0eb093fe6b9f1b4b4e107b3625f8c89ea3437f44f8fc8b6bfbb6312074dc6f983809a5e809ff4e1d076dd5850b38c7ced6e4daef9c4347f370d6d8b58f4b1d8dc61a3c59d651a0644a2a27cf";
+
+    // 96-byte input / 64-byte output vector from BN254MulPrecompileTests.
+    private const string ValidMulInput =
+        "089142debb13c461f61523586a60732d8b69c5b38a3380a74da7b2961d867dbf2d5fc7bbc013c16d7945f190b232eacc25da675c0eb093fe6b9f1b4b4e107b36ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+    [TestCase(0)]
+    [TestCase(64)]
+    [TestCase(96)]
+    [TestCase(127)]
+    [TestCase(129)]
+    [TestCase(192)]
+    public void Add_rejects_wrong_input_length(int inputLength) =>
+        Assert.That(BN254.Add(new byte[64], new byte[inputLength]), Is.False);
+
+    [TestCase(0)]
+    [TestCase(63)]
+    [TestCase(65)]
+    public void Add_rejects_wrong_output_length(int outputLength) =>
+        Assert.That(BN254.Add(new byte[outputLength], new byte[128]), Is.False);
+
+    [Test]
+    public void Add_accepts_exact_length_valid_input() =>
+        Assert.That(BN254.Add(new byte[64], Bytes.FromHexString(ValidAddInput)), Is.True);
+
+    [TestCase(0)]
+    [TestCase(64)]
+    [TestCase(95)]
+    [TestCase(97)]
+    [TestCase(128)]
+    public void Mul_rejects_wrong_input_length(int inputLength) =>
+        Assert.That(BN254.Mul(new byte[64], new byte[inputLength]), Is.False);
+
+    [TestCase(0)]
+    [TestCase(63)]
+    [TestCase(65)]
+    public void Mul_rejects_wrong_output_length(int outputLength) =>
+        Assert.That(BN254.Mul(new byte[outputLength], new byte[96]), Is.False);
+
+    [Test]
+    public void Mul_accepts_exact_length_valid_input() =>
+        Assert.That(BN254.Mul(new byte[64], Bytes.FromHexString(ValidMulInput)), Is.True);
+}


### PR DESCRIPTION
## Changes

`BN254.Add` and `BN254.Mul` validated their 128- and 96-byte inputs exclusively with `Debug.Assert`, which is compiled out of release builds — how production nodes are built. Both then read those bytes through a raw pointer: `DeserializeG1` walks `data + chunkSize`, and `IsZero64`/`IsZero128`/`CopyReverse32` read fixed 64-, 128- and 32-byte windows with no bounds check. A span of the wrong length would therefore read past the backing buffer instead of failing.

**No behaviour changes and the guard is unreachable from call data today.** Both callers normalise the input first: `BN254AddPrecompile.Run` and `BN254MulPrecompile.Run` trim longer call data and zero-pad shorter input exactly as EIP-196 requires, so neither length is attacker-controlled. `BN254` is also `internal`, so the caller set is closed to the two `std/` forwarders.

- Replace the four `Debug.Assert` calls with real length checks that are active in every build configuration, so the invariant also holds for any future caller that skips that normalisation.
- Check the `output` length as well as the `input` length: `SerializeG1` writes a fixed 64 bytes through `MemoryMarshal.GetArrayDataReference`, so a short output would be an out-of-bounds *write* rather than a read.
- Carry the exact-length contract into XML remarks, since the invariant that makes the pointer arithmetic safe was previously stated only in a debug-only assert.
- Drop the now-unused `using System.Diagnostics;`.

A mismatch returns `false`, which both callers already map to `Errors.Failed`, rather than throwing. These methods already return `bool` for every other "cannot compute" outcome (point not on the curve, deserialization failure), unlike `KeccakHash.ComputeHash` (#13187), which returns `void` and so had to throw `ArgumentOutOfRangeException`.

## Types of changes

- [x] Refactoring
- [x] Bug fix (hardening / defence-in-depth)
- [x] Documentation update
- [x] New tests

## Testing

#### Requires testing

- [x] Yes

#### Notes on testing

`BN254Tests` (new) exercises the guards directly. Because the checks are unreachable through the public precompile surface — `Run` trims or pads before the call — the test project is granted `InternalsVisibleTo(Nethermind.Evm.Test)` and calls `BN254.Add`/`Mul` with mismatched input and output lengths, asserting `false` (pre-fix these read past the buffer in release), plus a valid-length happy path per method. All 110 `BN254*` tests in `Nethermind.Evm.Test` pass in release (91 existing + 19 new), confirming no behaviour change including the existing oversized-input cases in `BN254AddPrecompileTests`.

The CI-equivalent lint build (`EnforceCodeStyleInBuild=true`, `GenerateDocumentationFile=true`) is clean with 0 warnings, and `dotnet format whitespace` reports no changes.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Reported by the audit team as finding F-37 (info / hardening). The finding describes the mechanism accurately, but the invariant is not reachable, so this is defence-in-depth plus documentation rather than a bug fix. The suggested fix was `return false` on the input length alone; the output length is guarded here too, for the reason above.
