### PR TITLE
test(state): pin that a contract destroyed in its creation block leaves no storage behind

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/FlatSameBlockDestroyTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/FlatSameBlockDestroyTests.cs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using Autofac;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+using Nethermind.State.Flat;
+using NUnit.Framework;
+
+namespace Nethermind.Store.Test;
+
+[TestFixture]
+public class FlatSameBlockDestroyTests
+{
+    [TestCase(true, true)]
+    [TestCase(true, false)]
+    [TestCase(false, true)]
+    [TestCase(false, false)]
+    public void Storage_of_a_contract_destroyed_in_its_creation_block_is_gone_before_and_after_persistence(bool touchedAgain, bool commitPath)
+    {
+        (IWorldState worldState, IStateReader reader, IContainer container) = TestWorldStateFactory.CreateFlatForTestWithStateReader();
+        using IContainer _ = container;
+        Address contract = TestItem.AddressA;
+        StorageCell slot = new(contract, 0);
+        BlockHeader header;
+        using (worldState.BeginScope(IWorldState.PreGenesis))
+        {
+            worldState.CreateAccount(contract, 1);
+            worldState.Set(slot, [0x01]);
+            worldState.Set(new StorageCell(contract, 1), [0x02]);
+            worldState.Commit(Frontier.Instance);
+
+            worldState.GetNonce(contract);
+            if (commitPath) worldState.MarkStorageDestroyed(contract);
+            else worldState.ClearStorage(contract);
+            worldState.DeleteAccount(contract);
+            worldState.Commit(Frontier.Instance);
+
+            if (touchedAgain)
+            {
+                worldState.CreateAccount(contract, 0);
+                worldState.Commit(Frontier.Instance);
+            }
+
+            worldState.CommitTree(0);
+            header = Build.A.BlockHeader.WithNumber(0).WithStateRoot(worldState.StateRoot).TestObject;
+        }
+
+        byte[] beforeFlush = reader.GetStorage(header, contract, 0).ToArray();
+        container.Resolve<IFlatDbManager>().FlushCache(CancellationToken.None);
+        byte[] afterFlush = reader.GetStorage(header, contract, 0).ToArray();
+        byte[] afterFlushSlot1 = reader.GetStorage(header, contract, 1).ToArray();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(beforeFlush.IsZero(), Is.True, "read through the snapshot bundle");
+            Assert.That(afterFlush.IsZero(), Is.True, "read from the persisted flat column: a contract destroyed in the block it was created in ends the block with no storage");
+            Assert.That(afterFlushSlot1.IsZero(), Is.True);
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State.Test/FlatSameBlockDestroyTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/FlatSameBlockDestroyTests.cs
@@ -8,7 +8,6 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
-using Nethermind.Int256;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
 using Nethermind.State.Flat;
@@ -23,7 +22,7 @@ public class FlatSameBlockDestroyTests
     [TestCase(true, false)]
     [TestCase(false, true)]
     [TestCase(false, false)]
-    public void Storage_of_a_contract_destroyed_in_its_creation_block_is_gone_before_and_after_persistence(bool touchedAgain, bool commitPath)
+    public void Storage_of_a_contract_destroyed_in_its_creation_block_is_gone_before_and_after_persistence(bool recreatedInSameBlock, bool markDestroyed)
     {
         (IWorldState worldState, IStateReader reader, IContainer container) = TestWorldStateFactory.CreateFlatForTestWithStateReader();
         using IContainer _ = container;
@@ -37,13 +36,13 @@ public class FlatSameBlockDestroyTests
             worldState.Set(new StorageCell(contract, 1), [0x02]);
             worldState.Commit(Frontier.Instance);
 
-            worldState.GetNonce(contract);
-            if (commitPath) worldState.MarkStorageDestroyed(contract);
+            worldState.GetBalance(contract);
+            if (markDestroyed) worldState.MarkStorageDestroyed(contract);
             else worldState.ClearStorage(contract);
             worldState.DeleteAccount(contract);
             worldState.Commit(Frontier.Instance);
 
-            if (touchedAgain)
+            if (recreatedInSameBlock)
             {
                 worldState.CreateAccount(contract, 0);
                 worldState.Commit(Frontier.Instance);
@@ -57,12 +56,15 @@ public class FlatSameBlockDestroyTests
         container.Resolve<IFlatDbManager>().FlushCache(CancellationToken.None);
         byte[] afterFlush = reader.GetStorage(header, contract, 0).ToArray();
         byte[] afterFlushSlot1 = reader.GetStorage(header, contract, 1).ToArray();
+        bool accountExists = reader.TryGetAccount(header, contract, out AccountStruct account);
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(beforeFlush.IsZero(), Is.True, "read through the snapshot bundle");
             Assert.That(afterFlush.IsZero(), Is.True, "read from the persisted flat column: a contract destroyed in the block it was created in ends the block with no storage");
             Assert.That(afterFlushSlot1.IsZero(), Is.True);
+            Assert.That(accountExists, Is.EqualTo(recreatedInSameBlock), "the persisted state is the block's, not an empty one: the re-created account is there and the destroyed one is not");
+            if (recreatedInSameBlock) Assert.That(account.Nonce, Is.Zero);
         }
     }
 }


### PR DESCRIPTION
## What

One regression test, no production change: a contract created and self-destructed in the same block, with or without a later re-creation in that block, ends the block with empty storage both through the snapshot bundle and in the persisted flat column.

## Why

Before #12935 the constructor's slot writes survived the clear and were persisted; a full-chain history walk on a flat archive surfaced it at mainnet block 116530 (two contracts created and destroyed in that block still answer their constructor values from the flat column, on any archive synced before 2026-08-27). #12935 fixed the clear path but landed without a test at this layer, and the existing same-block tests read only inside the block or start from storage committed in an earlier block, so a regression here would go unnoticed.

## Test

`FlatSameBlockDestroyTests`: flat scope provider, the real destroy sequence (`MarkStorageDestroyed` or `ClearStorage`, then `DeleteAccount`), optional same-block re-creation, `CommitTree`, then `IFlatDbManager.FlushCache` and a read from the persisted state. Red for all four shapes at the commit before #12935, green on master.
