### PR TITLE
fix(eip8141): guard the frame-tx warm-up gas write and close the nonce_keys sequence

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -445,8 +445,11 @@ public class FrameTxDecoderTests
         _txDecoder.Encode(ref writer, keyed);
 
         // `c3 82 01 2c` is the whole nonce_keys list; `c1` under-declares it without moving any other byte.
-        int headerIndex = bytes.AsSpan().IndexOf<byte>([0xc3, 0x82, 0x01, 0x2c]);
+        ReadOnlySpan<byte> canonical = [0xc3, 0x82, 0x01, 0x2c];
+        int headerIndex = bytes.AsSpan().IndexOf(canonical);
         Assert.That(headerIndex, Is.GreaterThanOrEqualTo(0), "canonical nonce_keys encoding not found");
+        // A second occurrence would let the patch corrupt an unrelated list and still throw, i.e. pass for the wrong reason.
+        Assert.That(bytes.AsSpan(headerIndex + 1).IndexOf(canonical), Is.LessThan(0), "the nonce_keys encoding is not unique");
 
         if (underDeclare)
         {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -432,6 +432,34 @@ public class FrameTxDecoderTests
         Assert.That(() => { RlpReader reader = new(bytes); _txDecoder.Decode(ref reader); }, Throws.InstanceOf<RlpException>());
     }
 
+    // An under-declared nonce_keys header consumes the same bytes as the canonical one, so without a closing
+    // checkpoint one signed transaction would have two wire forms and so two hashes.
+    [TestCase(false, TestName = "Decode_CanonicalNonceKeysListHeader_IsAccepted")]
+    [TestCase(true, TestName = "Decode_UnderDeclaredNonceKeysListHeader_Throws")]
+    public void Decode_NonceKeysListHeaderMustMatchItsContent(bool underDeclare)
+    {
+        Transaction keyed = CreateFrameTx();
+        keyed.NonceKeys = [300];
+        byte[] bytes = new byte[_txDecoder.GetLength(keyed, RlpBehaviors.None)];
+        RlpWriter writer = new(bytes);
+        _txDecoder.Encode(ref writer, keyed);
+
+        // `c3 82 01 2c` is the whole nonce_keys list; `c1` under-declares it without moving any other byte.
+        int headerIndex = bytes.AsSpan().IndexOf<byte>([0xc3, 0x82, 0x01, 0x2c]);
+        Assert.That(headerIndex, Is.GreaterThanOrEqualTo(0), "canonical nonce_keys encoding not found");
+
+        if (underDeclare)
+        {
+            bytes[headerIndex] = 0xc1;
+            Assert.That(() => { RlpReader reader = new(bytes); _txDecoder.Decode(ref reader); }, Throws.InstanceOf<RlpException>());
+        }
+        else
+        {
+            RlpReader reader = new(bytes);
+            Assert.That(_txDecoder.Decode(ref reader)!.NonceKeys, Is.EqualTo(new UInt256[] { 300 }));
+        }
+    }
+
     [Test]
     public void Decode_MoreNonceKeysThanTheCap_Throws()
     {

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -381,4 +381,64 @@ public class FrameTxReceiptDecoderTests
         Assert.That(seen[0], Is.EqualTo((TestItem.AddressD.ToString(), 1000UL, TxType.Legacy)));
         Assert.That(seen[2], Is.EqualTo((TestItem.AddressE.ToString(), 2000UL, TxType.Legacy)));
     }
+
+    // The payload defines only failure, success and skipped. An out-of-range byte round-trips, so the decoder is
+    // the only place it can be caught before AggregateStatus folds it to failure and RPC surfaces it raw.
+    [TestCase(TxFrameReceipt.StatusFailure, false)]
+    [TestCase(TxFrameReceipt.StatusSuccess, false)]
+    [TestCase(TxFrameReceipt.StatusSkipped, false)]
+    [TestCase((byte)3, true)]
+    [TestCase(byte.MaxValue, true)]
+    public void MessageDecode_FrameStatusOutsideThePayloadValues_Throws(byte status, bool rejected)
+    {
+        TxReceipt receipt = CreateReceipt(new TxFrameReceipt(status, 21_000, 0, []));
+
+        if (rejected)
+        {
+            Assert.That(() => DecodeMessage(receipt), Throws.InstanceOf<RlpException>());
+        }
+        else
+        {
+            Assert.That(DecodeMessage(receipt).FrameReceipts![0].Status, Is.EqualTo(status));
+        }
+    }
+
+    // The log ceiling is derived from a whole transaction's gas, so the frames share one budget; spent per frame
+    // it would admit MaxFrames times the emissions it stands for.
+    [TestCase(0, false, TestName = "MessageDecode_FrameLogsAtTheReceiptBudget_IsAccepted")]
+    [TestCase(1, true, TestName = "MessageDecode_FrameLogsOverTheReceiptBudget_Throws")]
+    public void MessageDecode_FrameLogBudgetIsSpentPerReceiptNotPerFrame(int excess, bool rejected)
+    {
+        const int firstFrameLogs = ReceiptMessageDecoder.MaxReceiptLogs / 2;
+        int secondFrameLogs = ReceiptMessageDecoder.MaxReceiptLogs - firstFrameLogs + excess;
+        // Each frame stays under the ceiling on its own, so only their sum can trip the guard.
+        TxReceipt receipt = CreateReceipt(
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, RepeatedLogs(firstFrameLogs)),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, RepeatedLogs(secondFrameLogs)));
+
+        if (rejected)
+        {
+            Assert.That(() => DecodeMessage(receipt), Throws.InstanceOf<RlpException>());
+        }
+        else
+        {
+            Assert.That(DecodeMessage(receipt).Logs, Has.Length.EqualTo(ReceiptMessageDecoder.MaxReceiptLogs));
+        }
+    }
+
+    private static TxReceipt DecodeMessage(TxReceipt receipt)
+    {
+        ReceiptMessageDecoder decoder = new();
+        byte[] encoded = decoder.EncodeNew(receipt, RlpBehaviors.None);
+        RlpReader reader = new(encoded);
+        return decoder.Decode(ref reader)!;
+    }
+
+    // One shared instance: only the count matters here, and encoding never mutates a log entry.
+    private static LogEntry[] RepeatedLogs(int count)
+    {
+        LogEntry[] logs = new LogEntry[count];
+        Array.Fill(logs, new LogEntry(TestItem.AddressB, [], []));
+        return logs;
+    }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -150,6 +150,30 @@ public class FrameTxProcessorTests
         Assert.That(balance, Is.GreaterThan(1.Ether - (UInt256)frame.GasLimit), "unused gas refunded");
     }
 
+    // A pre-warm worker runs on its own thread against parent state, so its gas is speculative; block
+    // validation sums tx.BlockGasUsed into the block's execution-gas dimension, so only the main thread writes it.
+    [TestCase(true, TestName = "Warmup_LeavesBlockGasUsedAlone")]
+    [TestCase(false, TestName = "Execute_PublishesBlockGasUsed")]
+    public void FrameTxBlockGasUsedIsWrittenByTheExecutingPathOnly(bool warmup)
+    {
+        const ulong sentinel = 123_456_789;
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
+        tx.BlockGasUsed = sentinel;
+
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        BlockExecutionContext context = new(block.Header, Spec);
+        TransactionResult result = warmup
+            ? _transactionProcessor.Warmup(tx, context, NullTxTracer.Instance)
+            : _transactionProcessor.Execute(tx, context, NullTxTracer.Instance);
+
+        Assert.That(result.TransactionExecuted, Is.True, "must reach settlement, else this pins nothing");
+        Assert.That(tx.BlockGasUsed, warmup ? Is.EqualTo(sentinel) : Is.Not.EqualTo(sentinel));
+    }
+
     [Test]
     public void Execute_FrameCreatesAndSelfDestructsContractInSameTx_DeletesTheCreatedAccount()
     {

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -491,7 +491,10 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         ulong spentGas = payerRegularGas + blockStateGas;
         // Set explicitly like the regular path: the BlockGasUsed getter otherwise falls back to tx.GasLimit,
         // which for a frame tx is the frame-gas sum rather than the gas spent that block validation sums.
-        tx.BlockGasUsed = blockRegularGas;
+        if (!opts.HasFlag(ExecutionOptions.Warmup)) // only the main thread updates the transaction
+        {
+            tx.BlockGasUsed = blockRegularGas;
+        }
         Address payer = frameContext.Payer;
 
         // The payer was charged max_cost at approval; refund the remainder, keeping the burned base-fee

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -482,7 +482,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         ulong grossGasBeforeCorrection = intrinsicGas + totalFrameGasUsed;
         ulong stateGasCorrectionApplied = (ulong)Math.Max(0, stateGasCorrection);
         ulong grossGas = grossGasBeforeCorrection > stateGasCorrectionApplied ? grossGasBeforeCorrection - stateGasCorrectionApplied : 0;
-        System.Diagnostics.Debug.Assert(refundCounter >= 0, $"frame-tx settlement invariant violated: negative refund counter ({refundCounter}).");
+        Debug.Assert(refundCounter >= 0, $"frame-tx settlement invariant violated: negative refund counter ({refundCounter}).");
         ulong gasAfterRefund = grossGas - RefundHelper.CalculateClaimableRefund(grossGas, (ulong)Math.Max(0, refundCounter), spec);
         ulong blockStateGas = (ulong)Math.Max(0, totalFrameStateGasUsed - stateGasCorrection);
         // EIP-7778: the payer pays the post-refund execution dimension, but the block counts it before the refund.

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -175,6 +175,8 @@ namespace Nethermind.Serialization.Rlp
 
             if (item.TxType == TxType.FrameTx)
             {
+                // Repeats the logs the top-level union already holds, at the cost noted above: DecodeStructRef
+                // hands eth_getLogs one contiguous LogsRlp span, which N per-frame sequences cannot supply.
                 writer.Encode(item.Payer);
                 EncodeFrameReceipts(ref writer, item.FrameReceipts ?? []);
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -15,7 +15,8 @@ namespace Nethermind.Serialization.Rlp
     public sealed class ReceiptMessageDecoder(bool skipStateAndStatus = false, bool skipBloom = false) : RlpDecoder<TxReceipt>
     {
         // A 100M gas ceiling still allows roughly 266k LOG0 emissions after intrinsic gas.
-        private static readonly RlpLimit LogsRlpLimit = RlpLimit.For<TxReceipt>(270_000, nameof(TxReceipt.Logs));
+        internal const int MaxReceiptLogs = 270_000;
+        private static readonly RlpLimit LogsRlpLimit = RlpLimit.For<TxReceipt>(MaxReceiptLogs, nameof(TxReceipt.Logs));
         private static readonly RlpLimit FrameReceiptsRlpLimit = RlpLimit.For<TxReceipt>(Eip8141Constants.MaxFrames, nameof(TxReceipt.FrameReceipts));
 
         [return: MaybeNull]
@@ -120,6 +121,12 @@ namespace Nethermind.Serialization.Rlp
             {
                 int frameEnd = ctx.ReadSequenceLength() + ctx.Position;
                 byte status = ctx.DecodeByte();
+                if (status > TxFrameReceipt.StatusSkipped)
+                {
+                    // AggregateStatus folds anything but success to failure while RPC surfaces the raw byte,
+                    // so an out-of-range status would read differently at the two ends of the same receipt.
+                    ThrowUnknownFrameStatus(status);
+                }
                 int gasUsedEnd = ctx.ReadSequenceLength() + ctx.Position;
                 ulong executionGasUsed = ctx.DecodeULong();
                 ulong stateGasUsed = ctx.DecodeULong();
@@ -128,6 +135,14 @@ namespace Nethermind.Serialization.Rlp
                 int logsEnd = ctx.ReadSequenceLength() + ctx.Position;
                 int logCount = ctx.PeekNumberOfItemsRemaining(logsEnd, LogsRlpLimit.Limit + 1);
                 ctx.GuardLimit(logCount, LogsRlpLimit);
+                // The limit is derived from a whole transaction's gas, so it budgets the receipt rather than
+                // each frame; spending it per frame would admit MaxFrames times the emissions it stands for.
+                totalLogs += logCount;
+                if (totalLogs > LogsRlpLimit.Limit)
+                {
+                    ThrowTooManyFrameLogs(totalLogs);
+                }
+
                 LogEntry[] logs = new LogEntry[logCount];
                 for (int j = 0; j < logCount; j++)
                 {
@@ -135,7 +150,6 @@ namespace Nethermind.Serialization.Rlp
                 }
 
                 frameReceipts[i] = new TxFrameReceipt(status, executionGasUsed, stateGasUsed, logs);
-                totalLogs += logCount;
                 ctx.Check(frameEnd);
             }
 
@@ -165,6 +179,14 @@ namespace Nethermind.Serialization.Rlp
             [DoesNotReturn, StackTraceHidden]
             static void ThrowEmptyFrameReceipts()
                 => throw new RlpException("Frame transaction receipt carries no frame receipts");
+
+            [DoesNotReturn, StackTraceHidden]
+            static void ThrowUnknownFrameStatus(byte status)
+                => throw new RlpException($"Frame receipt status {status} is not one of failure, success or skipped");
+
+            [DoesNotReturn, StackTraceHidden]
+            static void ThrowTooManyFrameLogs(int totalLogs)
+                => throw new RlpException($"Frame transaction receipt carries {totalLogs} logs, over the {LogsRlpLimit.Limit} a receipt may hold");
         }
 
         private static (int Total, int Frames) GetFrameTxContentLength(TxReceipt item)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -121,7 +121,7 @@ namespace Nethermind.Serialization.Rlp
             {
                 int frameEnd = ctx.ReadSequenceLength() + ctx.Position;
                 byte status = ctx.DecodeByte();
-                if (status > TxFrameReceipt.StatusSkipped)
+                if (status is not (TxFrameReceipt.StatusFailure or TxFrameReceipt.StatusSuccess or TxFrameReceipt.StatusSkipped))
                 {
                     // AggregateStatus folds anything but success to failure while RPC surfaces the raw byte,
                     // so an out-of-range status would read differently at the two ends of the same receipt.

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -193,6 +193,8 @@ namespace Nethermind.Serialization.Rlp
 
             if (item.TxType == TxType.FrameTx)
             {
+                // Repeats the logs the top-level union already holds: DecodeStructRef hands eth_getLogs one
+                // contiguous LogsRlp span, which N per-frame sequences cannot supply.
                 writer.Encode(item.Payer);
                 EncodeFrameReceipts(ref writer, item.FrameReceipts ?? []);
             }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -351,6 +351,10 @@ public static class FrameTxNonceCalldata
             buffer[count++] = decoderContext.DecodeUInt256();
         }
 
+        // An element may not overrun the list's declared content length: without this the under-declared
+        // header c1 82 01 2c decodes as [300] just like canonical c3 82 01 2c — two hashes, one signature.
+        decoderContext.Check(end);
+
         return buffer[..count].ToArray();
     }
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSimulationFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxSimulationFilter.cs
@@ -14,7 +14,9 @@ namespace Nethermind.TxPool.Filters;
 /// frame may spend here — with no simulator-side floor under it, unlike execution gas, so zeroing
 /// <see cref="ITxPoolConfig.FrameTxMaxVerifyStateGas"/> lifts that bound entirely. Runs inside the pool's
 /// head read lock, so the simulator has to bound its own wait.
-/// The simulation re-verifies the frame signatures unless <see cref="FrameTxSignatureFilter"/> already has.</remarks>
+/// The simulation re-verifies the frame signatures unless <see cref="FrameTxSignatureFilter"/> already has.
+/// Admitting an opaque transaction with no verdict leaves no payer, so <see cref="FrameTxPayerExposureFilter"/>
+/// reserves nothing against it: the exposure bound lapses while this node's own simulator is faulting.</remarks>
 internal sealed class FrameTxSimulationFilter(IFrameTxPrefixSimulator? simulator, ILogger logger) : IIncomingTxFilter
 {
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)


### PR DESCRIPTION
Addresses the two `claude[bot]` High findings on #12526, against that PR's own head branch.

## Changes

- **`TransactionProcessorBase.FrameTx.cs`** — guard the `tx.BlockGasUsed` write on `ExecutionOptions.Warmup`, as the regular path at `TransactionProcessor.cs:648` already does. Frame transactions do reach warm-up: `ITransactionProcessor.Warmup` passes `Warmup | SkipValidation`, and `ExecuteCore` diverts to the system processor only on `opts == ExecutionOptions.SkipValidation` exactly, so the combination falls through to `ExecuteFrameTx`; `BlockCachePreWarmer` warms every transaction in the block with no type filter. The field is read cross-thread into block gas accounting — `BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs:110/190` feeds it to `BlockAccessListManager`, which sums it into `totalExecutionGas` and thence `header.GasUsed` — so a late worker write moves the block's execution-gas dimension.
- **`FrameTxDecoder.cs`** — close the `nonce_keys` sequence with `Check(end)`, matching every sibling decoder in the file. Without it an element may overrun the list's declared content length: `c1 82 01 2c` decodes as `[300]` exactly like the canonical `c3 82 01 2c` and consumes the same four bytes, so the outer payload checkpoint still passes. The frame signatures are verified against a canonical re-encoding (`FrameTxSigHash`) while `Transaction.Hash` covers the received bytes, so one signed transaction had two distinct hashes — verified empirically before the fix.

Two other unconditional transaction-object writes in the frame path, `tx.FrameCalldataStats` and `tx.ReferenceCalldataStats`, are left alone: both are pure recomputations of the transaction's own immutable content, so a warm-up worker writes bit-identical values, and suppressing them under warm-up would only leave the warm-up's own gas budget reading stale stats. The frame path never writes `tx.SpentGas` at all, so there is no unguarded write to guard there.

## Review follow-ups

From the completed review on #12526, whose seven Lows were posted in the summary body rather than as threads. Five taken, two declined with reasons in [this comment](https://github.com/NethermindEth/nethermind/pull/12526#issuecomment-5570665065).

- **`ReceiptMessageDecoder.cs`** — the 270k log ceiling is derived from a whole transaction's gas but was spent once per frame. The frames now share one budget, matching the regular receipt path in the same decoder. The exposure was never `MaxFrames`x: `GuardLimit` also rejects `count > bytesLeft` and the inbound cap is `SnappyParameters.MaxSnappyLength` (16 MiB), so one receipt topped out near 699k entries, ~2.6x what a regular receipt gets. Folding the running total into `GuardLimit`'s count would be wrong — that parameter is also checked against `bytesLeft` — so it is an explicit check, placed before the array allocation.
- **`ReceiptMessageDecoder.cs`** — per-frame `status` is now range-checked. Only failure, success and skipped are defined; an out-of-range byte round-trips, so the decoder is the only place it can be caught before `AggregateStatus` folds it to failure while RPC surfaces it raw.
- **`FrameTxDecoderTests.cs`** — the `nonce_keys` patch site is pinned to a unique match. The byte scan found only the first occurrence, so a wrong hit would have corrupted an unrelated list and still thrown `RlpException`, passing for the wrong reason.
- **Comments only** — why frame logs are stored twice (`DecodeStructRef` needs one contiguous `LogsRlp` span that N per-frame sequences cannot supply; verified not removable), and that the payer-exposure bound lapses while this node's prefix simulator is faulting. Plus the fully-qualified `Debug.Assert` nit.

Declined: the `TxFrameReceipt.GasUsed` unchecked add (no production reader — RPC surfaces the two dimensions separately, and the only readers are test assertions), and the frame `SELFDESTRUCT` EIP-8246 assumption (balance preservation is not in fact dropped — the flag is threaded into `DestroyAccount`; the EIP-7708 burn log is, but it has no frame to attribute to once the per-frame log slices are frozen, so it stays with M6).

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Both regression tests were confirmed to fail with only their own fix reverted, and to pass with it restored:

- `FrameTxProcessorTests.FrameTxBlockGasUsedIsWrittenByTheExecutingPathOnly` — the warm-up case fails without the guard (the transaction comes back carrying the warm-up's `12584` instead of the sentinel) while the executing case stays green, so the pair isolates the guard rather than the path.
- `FrameTxDecoderTests.Decode_NonceKeysListHeaderMustMatchItsContent` — the under-declared case is accepted without `Check(end)`; the canonical case passes either way.

Frame `blockTest` 218/218 and `engineTest` 218/218 (`--forkAlias Bogota=Eip8141Prototype`, fixtures `tests-frames-devnet@v0.3.0`), `engineTest` also green in Debug. `Nethermind.Evm.Test`, `Nethermind.Core.Test` and `Nethermind.TxPool.Test` green in both Release and Debug, plus `Nethermind.Blockchain.Test`; full solution builds clean in both configurations and the CI lint gate passes (positive-controlled).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

