### PR TITLE
Merge master into eip8141-frame-txs-devnet7

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Evm/PrecompileLookupBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Evm/PrecompileLookupBenchmark.cs
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Int256;
+
+namespace Nethermind.Benchmarks.Evm;
+
+/// <summary>
+/// The two lookups every CALL pays: "is this a precompile" against <see cref="FrozenSet{T}"/>, and, when
+/// it is, fetching it from a <see cref="FrozenDictionary{TKey, TValue}"/> — against deriving the
+/// precompile's number from the address and using it as an index.
+/// </summary>
+/// <remarks>
+/// Precompile addresses are the first sixteen bytes zero and a small number in the last four, so the
+/// number is two loads and a byte swap, and both lookups become an array index. The membership test is
+/// the one that matters: it runs on every CALL, not only the ones that land on a precompile, which is
+/// why the mix below is mostly ordinary addresses.
+/// </remarks>
+public class PrecompileLookupBenchmark
+{
+    private FrozenSet<AddressAsKey> _set = null!;
+    private FrozenDictionary<AddressAsKey, object> _dictionary = null!;
+    private ulong _mask;
+    private object?[] _byIndex = null!;
+    private Address[] _addresses = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Dictionary<AddressAsKey, object> entries = [];
+        _byIndex = new object[0x101];
+        for (int i = 1; i <= 0x11; i++)
+        {
+            Address address = Address.FromNumber((UInt256)(ulong)i);
+            object value = new();
+            entries[address] = value;
+            _mask |= 1UL << i;
+            _byIndex[i] = value;
+        }
+
+        // RIP-7212, the one precompile that sits outside the low run.
+        Address p256 = Address.FromNumber((UInt256)0x100UL);
+        object p256Value = new();
+        entries[p256] = p256Value;
+        _byIndex[0x100] = p256Value;
+
+        _dictionary = entries.ToFrozenDictionary();
+        _set = _dictionary.Keys.ToFrozenSet();
+        _realSpec = Nethermind.Specs.Forks.Prague.Instance;
+        _setSpec = new SetSpec(_set);
+        _maskSpec = new MaskSpec(_set, _mask);
+
+        // A realistic CALL mix: mostly ordinary contracts, which is what the membership test rejects.
+        _addresses = new Address[16];
+        for (int i = 0; i < _addresses.Length; i++)
+        {
+            _addresses[i] = i switch
+            {
+                3 => Address.FromNumber(UInt256.One),
+                7 => Address.FromNumber((UInt256)2UL),
+                11 => Address.FromNumber((UInt256)0x100UL),
+                _ => OrdinaryAddress(i),
+            };
+        }
+    }
+
+    /// <summary>An address no precompile could occupy: its leading bytes are set.</summary>
+    private static Address OrdinaryAddress(int seed)
+    {
+        byte[] bytes = new byte[Address.Size];
+        for (int i = 0; i < bytes.Length; i++) bytes[i] = (byte)(seed * 31 + i * 7 + 1);
+        return new Address(bytes);
+    }
+
+    [Benchmark(Baseline = true)]
+    public int Membership_FrozenSet()
+    {
+        int found = 0;
+        foreach (Address address in _addresses)
+        {
+            if (_set.Contains(address)) found++;
+        }
+
+        return found;
+    }
+
+    [Benchmark]
+    public int Membership_IndexAndMask()
+    {
+        int found = 0;
+        foreach (Address address in _addresses)
+        {
+            int index = address.PrecompileIndexOrNegative();
+            if ((uint)index < 64 ? (_mask & (1UL << index)) != 0 : index == 0x100) found++;
+        }
+
+        return found;
+    }
+
+    /// <summary>Reject on address shape first, and only then consult the set.</summary>
+    /// <remarks>Needs no per-spec state and no bound on the precompile number, so it works for a chain
+    /// whose plugin registers one far above the low run.</remarks>
+    [Benchmark]
+    public int Membership_ShapeGuardThenFrozenSet()
+    {
+        int found = 0;
+        foreach (Address address in _addresses)
+        {
+            if (address.CouldBePrecompile() && _set.Contains(address)) found++;
+        }
+
+        return found;
+    }
+
+    // A per-thread memo of the mask built for one precompile set. Thread-static rather than a plain
+    // static because the host processes blocks concurrently and specs differ between them, so a shared
+    // slot would be a race; per-thread, the reference compare below is the whole synchronisation.
+    [ThreadStatic] private static FrozenSet<AddressAsKey>? t_source;
+    [ThreadStatic] private static ulong t_mask;
+
+    /// <summary>The mask, but paid for the way the host would have to pay for it.</summary>
+    /// <remarks>Measures what <c>Membership_IndexAndMask</c> leaves out: the spec's set has to be fetched
+    /// and compared against what the memo was built from, because a mask is only valid for one fork.</remarks>
+    [Benchmark]
+    public int Membership_ThreadStaticMemoThenMask()
+    {
+        int found = 0;
+        foreach (Address address in _addresses)
+        {
+            FrozenSet<AddressAsKey> precompiles = _set;
+            if (!ReferenceEquals(t_source, precompiles))
+            {
+                t_mask = _mask;
+                t_source = precompiles;
+            }
+
+            int index = address.PrecompileIndexOrNegative();
+            bool isPrecompile = (uint)index < 64
+                ? (t_mask & (1UL << index)) != 0
+                : index >= 0 && precompiles.Contains(address);
+            if (isPrecompile) found++;
+        }
+
+        return found;
+    }
+
+    /// <summary>Stands in for <c>IReleaseSpec</c>: the membership test reached by interface dispatch.</summary>
+    private interface ISpecLike
+    {
+        bool IsPrecompile(Address address);
+    }
+
+    /// <summary>What the host does today, but through the dispatch the real call site pays.</summary>
+    private sealed class SetSpec(FrozenSet<AddressAsKey> precompiles) : ISpecLike
+    {
+        public bool IsPrecompile(Address address) => address.CouldBePrecompile() && precompiles.Contains(address);
+    }
+
+    /// <summary>The mask held by the spec itself, so no caller has to check which fork it belongs to.</summary>
+    /// <remarks>A spec is immutable and fork-fixed, so the mask can be built once beside its precompile
+    /// set and simply read - no memo, no reference compare, and nothing shared between threads.</remarks>
+    private sealed class MaskSpec(FrozenSet<AddressAsKey> precompiles, ulong mask) : ISpecLike
+    {
+        public bool IsPrecompile(Address address)
+        {
+            if (!address.CouldBePrecompile()) return false;
+
+            int index = address.PrecompileIndexOrNegative();
+            return (uint)index < 64
+                ? (mask & (1UL << index)) != 0
+                : precompiles.Contains(address);
+        }
+    }
+
+    private ISpecLike _setSpec = null!;
+    private ISpecLike _maskSpec = null!;
+
+    [Benchmark]
+    public int Membership_ViaSpec_FrozenSet()
+    {
+        int found = 0;
+        foreach (Address address in _addresses)
+        {
+            if (_setSpec.IsPrecompile(address)) found++;
+        }
+
+        return found;
+    }
+
+    [Benchmark]
+    public int Membership_ViaSpec_CachedMask()
+    {
+        int found = 0;
+        foreach (Address address in _addresses)
+        {
+            if (_maskSpec.IsPrecompile(address)) found++;
+        }
+
+        return found;
+    }
+
+    private IReleaseSpec _realSpec = null!;
+
+    /// <summary>What master does: probe the fork's set, hashing the whole address.</summary>
+    [Benchmark]
+    public int RealSpec_PrecompilesContains()
+    {
+        int found = 0;
+        foreach (Address address in _addresses)
+        {
+            if (_realSpec.Precompiles.Contains(address)) found++;
+        }
+
+        return found;
+    }
+
+    /// <summary>The shape guard in front of the fork's real set, without the mask.</summary>
+    [Benchmark]
+    public int RealSpec_ShapeGuardThenContains()
+    {
+        int found = 0;
+        foreach (Address address in _addresses)
+        {
+            if (address.CouldBePrecompile() && _realSpec.Precompiles.Contains(address)) found++;
+        }
+
+        return found;
+    }
+
+    /// <summary>The spec-held mask through the real interface dispatch — the shipped path, so this arm
+    /// cannot drift from it.</summary>
+    [Benchmark]
+    public int RealSpec_IsPrecompile()
+    {
+        int found = 0;
+        foreach (Address address in _addresses)
+        {
+            if (_realSpec.IsPrecompile(address)) found++;
+        }
+
+        return found;
+    }
+
+    [Benchmark]
+    public int Lookup_FrozenDictionary()
+    {
+        int hit = 0;
+        foreach (Address address in _addresses)
+        {
+            if (_set.Contains(address) && _dictionary[address] is not null) hit++;
+        }
+
+        return hit;
+    }
+
+    [Benchmark]
+    public int Lookup_IndexAndArray()
+    {
+        int hit = 0;
+        foreach (Address address in _addresses)
+        {
+            int index = address.PrecompileIndexOrNegative();
+            if ((uint)index < (uint)_byIndex.Length && _byIndex[index] is not null) hit++;
+        }
+
+        return hit;
+    }
+}

--- a/src/Nethermind/Nethermind.Benchmark/Scheduler/BackgroundTaskSchedulerBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Scheduler/BackgroundTaskSchedulerBenchmarks.cs
@@ -20,6 +20,8 @@ using Nethermind.TxPool;
 
 namespace Nethermind.Benchmarks.Scheduler;
 
+internal readonly struct BenchmarkRequest : IBackgroundTaskRequest<BenchmarkRequest>;
+
 /// <summary>
 /// Benchmarks the throughput of the BackgroundTaskScheduler under concurrent task
 /// scheduling with periodic block-processing pauses — the scenario that caused
@@ -75,7 +77,7 @@ public class BackgroundTaskSchedulerBenchmarks
             int batchSize = Capacity / 2;
             for (int i = 0; i < batchSize; i++)
             {
-                bool accepted = scheduler.TryScheduleTask(i, (_, token) =>
+                bool accepted = scheduler.TryScheduleTask(default(BenchmarkRequest), (_, token) =>
                 {
                     Interlocked.Increment(ref totalExecuted);
                     return Task.CompletedTask;
@@ -120,7 +122,7 @@ public class BackgroundTaskSchedulerBenchmarks
         int totalTasks = (Capacity / 2) * BlockProcessingCycles;
         for (int i = 0; i < totalTasks; i++)
         {
-            bool accepted = scheduler.TryScheduleTask(i, (_, _) =>
+            bool accepted = scheduler.TryScheduleTask(default(BenchmarkRequest), (_, _) =>
             {
                 Interlocked.Increment(ref totalExecuted);
                 return Task.CompletedTask;

--- a/src/Nethermind/Nethermind.Blockchain.Test/PrecompileCachedCodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PrecompileCachedCodeInfoRepositoryTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Evm;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.State;
+using Nethermind.Int256;
 using Nethermind.Specs.Forks;
 using NSubstitute;
 using NUnit.Framework;
@@ -72,6 +73,23 @@ public class PrecompileCachedCodeInfoRepositoryTests
     {
         caches.TryGetPartition(address ?? PrecompileAddress, out PrecompileCaches.Partition? partition);
         return partition!;
+    }
+
+    /// <summary>Precompile numbers this decorator has to resolve, on and off its index array.</summary>
+    /// <remarks>The array stops at 0x100, so 0x101 and Taiko's 0x10001 come back from the map instead, and
+    /// at 0x8000_0000 the number no longer fits an <see cref="int"/> and the index reads negative. The
+    /// decorator answers before the base repository sees the call, so a number it drops is not resolved
+    /// by anything behind it.</remarks>
+    private static readonly long[] PrecompileNumbers = [1, 9, 0x100, 0x101, 0x10001, 0x8000_0000];
+
+    [TestCaseSource(nameof(PrecompileNumbers))]
+    public void GetCachedCodeInfo_AtAnyPrecompileNumber_ResolvesFromTheCache(long number)
+    {
+        Address address = Address.FromNumber((UInt256)(ulong)number);
+        TestPrecompile precompile = new(supportsCaching: false);
+        IPrecompileProvider provider = CreateProvider((address, precompile));
+
+        Assert.That(Resolve(BuildRepository(null, provider), address), Is.SameAs(precompile));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain.Test/PrecompileCachedCodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/PrecompileCachedCodeInfoRepositoryTests.cs
@@ -12,6 +12,7 @@ using Nethermind.Evm;
 using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.State;
+using Nethermind.Int256;
 using Nethermind.Specs.Forks;
 using NSubstitute;
 using NUnit.Framework;
@@ -75,6 +76,23 @@ public class PrecompileCachedCodeInfoRepositoryTests
     {
         caches.TryGetPartition(address ?? PrecompileAddress, out PrecompileCaches.Partition? partition);
         return partition!;
+    }
+
+    /// <summary>Precompile numbers this decorator has to resolve, on and off its index array.</summary>
+    /// <remarks>The array stops at 0x100, so 0x101 and Taiko's 0x10001 come back from the map instead, and
+    /// at 0x8000_0000 the number no longer fits an <see cref="int"/> and the index reads negative. The
+    /// decorator answers before the base repository sees the call, so a number it drops is not resolved
+    /// by anything behind it.</remarks>
+    private static readonly long[] PrecompileNumbers = [1, 9, 0x100, 0x101, 0x10001, 0x8000_0000];
+
+    [TestCaseSource(nameof(PrecompileNumbers))]
+    public void GetCachedCodeInfo_AtAnyPrecompileNumber_ResolvesFromTheCache(long number)
+    {
+        Address address = Address.FromNumber((UInt256)(ulong)number);
+        TestPrecompile precompile = new(supportsCaching: false);
+        IPrecompileProvider provider = CreateProvider((address, precompile));
+
+        Assert.That(Resolve(BuildRepository(null, provider), address), Is.SameAs(precompile));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
@@ -14,40 +14,72 @@ using Nethermind.Evm.State;
 
 namespace Nethermind.Blockchain;
 
-public class PrecompileCachedCodeInfoRepository(
-    IWorldState worldState,
-    IPrecompileProvider precompileProvider,
-    ICodeInfoRepository baseCodeInfoRepository,
-    PrecompileCaches? precompileCaches) : ICodeInfoRepository
+public class PrecompileCachedCodeInfoRepository : ICodeInfoRepository
 {
-    private readonly FrozenDictionary<AddressAsKey, CodeInfo> _cachedPrecompile = precompileCaches is null
-        ? precompileProvider.GetPrecompiles()
-        : precompileProvider.GetPrecompiles().ToFrozenDictionary(kvp => kvp.Key, kvp => CreateCachedPrecompile(kvp, precompileCaches));
+    private readonly IWorldState _worldState;
+    private readonly ICodeInfoRepository _baseCodeInfoRepository;
+    private readonly FrozenDictionary<AddressAsKey, CodeInfo> _cachedPrecompile;
+    /// <summary>The cached precompiles indexed by precompile number, as the base repository holds them.</summary>
+    /// <remarks>This decorator answers precompile calls before the base repository sees them, so it needs
+    /// an index of its own — without one the dictionary probe survives on the processing path, which is
+    /// the one place it was worth removing. Built from <see cref="_cachedPrecompile"/> rather than from
+    /// the provider, so an indexed hit returns the cache-wrapped <see cref="CodeInfo"/>.</remarks>
+    private readonly CodeInfo?[] _cachedPrecompileArray;
 
-    public bool IsCodeOverridable => baseCodeInfoRepository.IsCodeOverridable;
+    public PrecompileCachedCodeInfoRepository(
+        IWorldState worldState,
+        IPrecompileProvider precompileProvider,
+        ICodeInfoRepository baseCodeInfoRepository,
+        PrecompileCaches? precompileCaches)
+    {
+        _worldState = worldState;
+        _baseCodeInfoRepository = baseCodeInfoRepository;
+        _cachedPrecompile = precompileCaches is null
+            ? precompileProvider.GetPrecompiles()
+            : precompileProvider.GetPrecompiles().ToFrozenDictionary(kvp => kvp.Key, kvp => CreateCachedPrecompile(kvp, precompileCaches));
+        _cachedPrecompileArray = CodeInfoRepository.BuildPrecompileArray(_cachedPrecompile);
+    }
+
+    public bool IsCodeOverridable => _baseCodeInfoRepository.IsCodeOverridable;
 
     public CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec,
         out Address? delegationAddress)
     {
-        if (vmSpec.IsPrecompile(codeSource) && _cachedPrecompile.TryGetValue(codeSource, out CodeInfo cachedCodeInfo))
+        if (vmSpec.IsPrecompile(codeSource) && TryGetCachedPrecompile(codeSource, out CodeInfo? cachedCodeInfo))
         {
             // EIP-7928: mirror base CodeInfoRepository.GetCachedCodeInfo precompile path so the read lands in the BAL.
-            worldState.AddAccountRead(codeSource);
+            _worldState.AddAccountRead(codeSource);
             delegationAddress = null;
             return cachedCodeInfo;
         }
-        return baseCodeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
+        return _baseCodeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
+    }
+
+    /// <summary>Resolves a precompile's cached <see cref="CodeInfo"/> from its number, then from the map.</summary>
+    /// <remarks>The map still has to answer for a number above the array — Taiko registers at 0x10001 — and
+    /// for one the spec knows but this provider does not, which falls through to the base repository.</remarks>
+    private bool TryGetCachedPrecompile(Address codeSource, [NotNullWhen(true)] out CodeInfo? cachedCodeInfo)
+    {
+        int index = codeSource.PrecompileIndexOrNegative();
+        CodeInfo?[] byIndex = _cachedPrecompileArray;
+        if ((uint)index < (uint)byIndex.Length && byIndex[index] is { } indexed)
+        {
+            cachedCodeInfo = indexed;
+            return true;
+        }
+
+        return _cachedPrecompile.TryGetValue(codeSource, out cachedCodeInfo);
     }
 
     public void InsertCode(ReadOnlyMemory<byte> code, Address codeOwner, IReleaseSpec spec) =>
-        baseCodeInfoRepository.InsertCode(code, codeOwner, spec);
+        _baseCodeInfoRepository.InsertCode(code, codeOwner, spec);
 
     public void SetDelegation(Address codeSource, Address authority, IReleaseSpec spec) =>
-        baseCodeInfoRepository.SetDelegation(codeSource, authority, spec);
+        _baseCodeInfoRepository.SetDelegation(codeSource, authority, spec);
 
     public bool TryGetDelegation(Address address, IReleaseSpec spec,
         [NotNullWhen(true)] out Address? delegatedAddress) =>
-        baseCodeInfoRepository.TryGetDelegation(address, spec, out delegatedAddress);
+        _baseCodeInfoRepository.TryGetDelegation(address, spec, out delegatedAddress);
 
     private static CodeInfo CreateCachedPrecompile(
         in KeyValuePair<AddressAsKey, CodeInfo> originalPrecompile,

--- a/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
@@ -72,7 +72,7 @@ public class PrecompileCachedCodeInfoRepository : ICodeInfoRepository
     }
 
     public IPrecompile? GetPrecompile(Address codeSource, IReleaseSpec vmSpec) =>
-        vmSpec.IsPrecompile(codeSource) && _cachedPrecompile.TryGetValue(codeSource, out CodeInfo cachedCodeInfo)
+        vmSpec.IsPrecompile(codeSource) && TryGetCachedPrecompile(codeSource, out CodeInfo? cachedCodeInfo)
             ? cachedCodeInfo.Precompile
             : _baseCodeInfoRepository.GetPrecompile(codeSource, vmSpec);
 

--- a/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Blockchain/PrecompileCachedCodeInfoRepository.cs
@@ -14,45 +14,77 @@ using Nethermind.Evm.State;
 
 namespace Nethermind.Blockchain;
 
-public class PrecompileCachedCodeInfoRepository(
-    IWorldState worldState,
-    IPrecompileProvider precompileProvider,
-    ICodeInfoRepository baseCodeInfoRepository,
-    PrecompileCaches? precompileCaches) : ICodeInfoRepository
+public class PrecompileCachedCodeInfoRepository : ICodeInfoRepository
 {
-    private readonly FrozenDictionary<AddressAsKey, CodeInfo> _cachedPrecompile = precompileCaches is null
-        ? precompileProvider.GetPrecompiles()
-        : precompileProvider.GetPrecompiles().ToFrozenDictionary(kvp => kvp.Key, kvp => CreateCachedPrecompile(kvp, precompileCaches));
+    private readonly IWorldState _worldState;
+    private readonly ICodeInfoRepository _baseCodeInfoRepository;
+    private readonly FrozenDictionary<AddressAsKey, CodeInfo> _cachedPrecompile;
+    /// <summary>The cached precompiles indexed by precompile number, as the base repository holds them.</summary>
+    /// <remarks>This decorator answers precompile calls before the base repository sees them, so it needs
+    /// an index of its own — without one the dictionary probe survives on the processing path, which is
+    /// the one place it was worth removing. Built from <see cref="_cachedPrecompile"/> rather than from
+    /// the provider, so an indexed hit returns the cache-wrapped <see cref="CodeInfo"/>.</remarks>
+    private readonly CodeInfo?[] _cachedPrecompileArray;
 
-    public bool IsCodeOverridable => baseCodeInfoRepository.IsCodeOverridable;
+    public PrecompileCachedCodeInfoRepository(
+        IWorldState worldState,
+        IPrecompileProvider precompileProvider,
+        ICodeInfoRepository baseCodeInfoRepository,
+        PrecompileCaches? precompileCaches)
+    {
+        _worldState = worldState;
+        _baseCodeInfoRepository = baseCodeInfoRepository;
+        _cachedPrecompile = precompileCaches is null
+            ? precompileProvider.GetPrecompiles()
+            : precompileProvider.GetPrecompiles().ToFrozenDictionary(kvp => kvp.Key, kvp => CreateCachedPrecompile(kvp, precompileCaches));
+        _cachedPrecompileArray = CodeInfoRepository.BuildPrecompileArray(_cachedPrecompile);
+    }
+
+    public bool IsCodeOverridable => _baseCodeInfoRepository.IsCodeOverridable;
 
     public CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec,
         out Address? delegationAddress)
     {
-        if (vmSpec.IsPrecompile(codeSource) && _cachedPrecompile.TryGetValue(codeSource, out CodeInfo cachedCodeInfo))
+        if (vmSpec.IsPrecompile(codeSource) && TryGetCachedPrecompile(codeSource, out CodeInfo? cachedCodeInfo))
         {
             // EIP-7928: mirror base CodeInfoRepository.GetCachedCodeInfo precompile path so the read lands in the BAL.
-            worldState.AddAccountRead(codeSource);
+            _worldState.AddAccountRead(codeSource);
             delegationAddress = null;
             return cachedCodeInfo;
         }
-        return baseCodeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
+        return _baseCodeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
+    }
+
+    /// <summary>Resolves a precompile's cached <see cref="CodeInfo"/> from its number, then from the map.</summary>
+    /// <remarks>The map still has to answer for a number above the array — Taiko registers at 0x10001 — and
+    /// for one the spec knows but this provider does not, which falls through to the base repository.</remarks>
+    private bool TryGetCachedPrecompile(Address codeSource, [NotNullWhen(true)] out CodeInfo? cachedCodeInfo)
+    {
+        int index = codeSource.PrecompileIndexOrNegative();
+        CodeInfo?[] byIndex = _cachedPrecompileArray;
+        if ((uint)index < (uint)byIndex.Length && byIndex[index] is { } indexed)
+        {
+            cachedCodeInfo = indexed;
+            return true;
+        }
+
+        return _cachedPrecompile.TryGetValue(codeSource, out cachedCodeInfo);
     }
 
     public IPrecompile? GetPrecompile(Address codeSource, IReleaseSpec vmSpec) =>
         vmSpec.IsPrecompile(codeSource) && _cachedPrecompile.TryGetValue(codeSource, out CodeInfo cachedCodeInfo)
             ? cachedCodeInfo.Precompile
-            : baseCodeInfoRepository.GetPrecompile(codeSource, vmSpec);
+            : _baseCodeInfoRepository.GetPrecompile(codeSource, vmSpec);
 
     public void InsertCode(ReadOnlyMemory<byte> code, Address codeOwner, IReleaseSpec spec) =>
-        baseCodeInfoRepository.InsertCode(code, codeOwner, spec);
+        _baseCodeInfoRepository.InsertCode(code, codeOwner, spec);
 
     public void SetDelegation(Address codeSource, Address authority, IReleaseSpec spec) =>
-        baseCodeInfoRepository.SetDelegation(codeSource, authority, spec);
+        _baseCodeInfoRepository.SetDelegation(codeSource, authority, spec);
 
     public bool TryGetDelegation(Address address, IReleaseSpec spec,
         [NotNullWhen(true)] out Address? delegatedAddress) =>
-        baseCodeInfoRepository.TryGetDelegation(address, spec, out delegatedAddress);
+        _baseCodeInfoRepository.TryGetDelegation(address, spec, out delegatedAddress);
 
     private static CodeInfo CreateCachedPrecompile(
         in KeyValuePair<AddressAsKey, CodeInfo> originalPrecompile,

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/AlwaysCancelTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/AlwaysCancelTxTracer.cs
@@ -83,7 +83,7 @@ public class AlwaysCancelTxTracer : ITxTracer
 
     public void ReportBalanceChange(Address address, UInt256? before, UInt256? after) => throw new OperationCanceledException(ErrorMessage);
 
-    public void ReportCodeChange(Address address, byte[] before, byte[] after) => throw new OperationCanceledException(ErrorMessage);
+    public void ReportCodeChange(Address address, byte[]? before, byte[]? after) => throw new OperationCanceledException(ErrorMessage);
 
     public void ReportNonceChange(Address address, UInt256? before, UInt256? after) => throw new OperationCanceledException(ErrorMessage);
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -189,7 +189,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     public void ReportBalanceChange(Address address, UInt256? before, UInt256? after) =>
         _currentTxTracer.ReportBalanceChange(address, before, after);
 
-    public void ReportCodeChange(Address address, byte[] before, byte[] after) =>
+    public void ReportCodeChange(Address address, byte[]? before, byte[]? after) =>
         _currentTxTracer.ReportCodeChange(address, before, after);
 
     public void ReportNonceChange(Address address, UInt256? before, UInt256? after) =>

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -220,7 +220,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     public void ReportBalanceChange(Address address, UInt256? before, UInt256? after) =>
         _currentTxTracer.ReportBalanceChange(address, before, after);
 
-    public void ReportCodeChange(Address address, byte[] before, byte[] after) =>
+    public void ReportCodeChange(Address address, byte[]? before, byte[]? after) =>
         _currentTxTracer.ReportCodeChange(address, before, after);
 
     public void ReportNonceChange(Address address, UInt256? before, UInt256? after) =>

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -124,7 +124,7 @@ public class ParityLikeTxTracer : TxTracer
 
     protected virtual Dictionary<UInt256, ParityStateChange<byte[]>> RentStorageDictionary() => [];
 
-    protected virtual ParityStateChange<byte[]> RentByteStateChange(byte[] before, byte[] after) => new(before, after);
+    protected virtual ParityStateChange<byte[]> RentByteStateChange(byte[]? before, byte[]? after) => new(before, after);
 
     protected virtual ParityStateChange<UInt256?> RentNullableUInt256StateChange(UInt256? before, UInt256? after) => new(before, after);
 
@@ -352,7 +352,7 @@ public class ParityLikeTxTracer : TxTracer
         value.Balance = RentNullableUInt256StateChange(before, after);
     }
 
-    public override void ReportCodeChange(Address address, byte[] before, byte[] after)
+    public override void ReportCodeChange(Address address, byte[]? before, byte[]? after)
     {
         if (_trace.StateChanges is null)
         {

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/ParityStateChange.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/ParityStateChange.cs
@@ -3,9 +3,8 @@
 
 namespace Nethermind.Blockchain.Tracing.ParityStyle;
 
-public class ParityStateChange<T>(T before, T after)
+public class ParityStateChange<T>(T? before, T? after)
 {
-    public T Before { get; set; } = before;
-    public T After { get; set; } = after;
+    public T? Before { get; set; } = before;
+    public T? After { get; set; } = after;
 }
-

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/StreamingParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/StreamingParityLikeTxTracer.cs
@@ -214,7 +214,7 @@ public class StreamingParityLikeTxTracer : ParityLikeTxTracer
         return PopLast(_storageDictPool);
     }
 
-    protected override ParityStateChange<byte[]> RentByteStateChange(byte[] before, byte[] after)
+    protected override ParityStateChange<byte[]> RentByteStateChange(byte[]? before, byte[]? after)
     {
         if (_byteStateChangePool.Count == 0) return new ParityStateChange<byte[]>(before, after);
         ParityStateChange<byte[]> sc = PopLast(_byteStateChangePool);

--- a/src/Nethermind/Nethermind.Consensus.Test/Scheduler/BackgroundTaskSchedulerBurstTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Scheduler/BackgroundTaskSchedulerBurstTests.cs
@@ -50,7 +50,7 @@ public class BackgroundTaskSchedulerBurstTests
 
             for (int i = 0; i < tasksPerCycle; i++)
             {
-                bool accepted = scheduler.TryScheduleTask(i, (_, _) =>
+                bool accepted = scheduler.TryScheduleTask(default(TestRequest), (_, _) =>
                 {
                     Interlocked.Increment(ref totalExecuted);
                     return Task.CompletedTask;
@@ -75,7 +75,7 @@ public class BackgroundTaskSchedulerBurstTests
         int postCycleCount = Math.Min(capacity, 100);
         for (int i = 0; i < postCycleCount; i++)
         {
-            Assert.That(scheduler.TryScheduleTask(i, (_, _) =>
+            Assert.That(scheduler.TryScheduleTask(default(TestRequest), (_, _) =>
             {
                 Interlocked.Increment(ref postCycleExecuted);
                 return Task.CompletedTask;

--- a/src/Nethermind/Nethermind.Consensus.Test/Scheduler/BackgroundTaskSchedulerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Scheduler/BackgroundTaskSchedulerTests.cs
@@ -16,6 +16,8 @@ using TaskCompletionSource = DotNetty.Common.Concurrency.TaskCompletionSource;
 
 namespace Nethermind.Consensus.Test.Scheduler;
 
+internal readonly struct TestRequest : IBackgroundTaskRequest<TestRequest>;
+
 public class BackgroundTaskSchedulerTests
 {
     private IBranchProcessor _branchProcessor;
@@ -35,7 +37,7 @@ public class BackgroundTaskSchedulerTests
         TaskCompletionSource tcs = new();
         await using BackgroundTaskScheduler scheduler = new(_branchProcessor, _chainHeadInfo, 1, 65536, LimboLogs.Instance);
 
-        scheduler.TryScheduleTask(1, (_, token) =>
+        scheduler.TryScheduleTask(default(TestRequest), (_, token) =>
         {
             tcs.SetResult(1);
             return Task.CompletedTask;
@@ -66,7 +68,7 @@ public class BackgroundTaskSchedulerTests
             new OneLoggerLogManager(new ILogger(testLogger)));
         await scheduler.DisposeAsync();
 
-        bool scheduled = scheduler.TryScheduleTask(1, static (_, _) => Task.CompletedTask, source: "Transactions");
+        bool scheduled = scheduler.TryScheduleTask(default(TestRequest), static (_, _) => Task.CompletedTask);
 
         using (Assert.EnterMultipleScope())
         {
@@ -84,13 +86,13 @@ public class BackgroundTaskSchedulerTests
         int counter = 0;
 
         SemaphoreSlim waitSignal = new(0);
-        scheduler.TryScheduleTask(1, async (_, token) =>
+        scheduler.TryScheduleTask(default(TestRequest), async (_, token) =>
         {
             Interlocked.Increment(ref counter);
             await waitSignal.WaitAsync(token);
             Interlocked.Decrement(ref counter);
         });
-        scheduler.TryScheduleTask(1, async (_, token) =>
+        scheduler.TryScheduleTask(default(TestRequest), async (_, token) =>
         {
             Interlocked.Increment(ref counter);
             await waitSignal.WaitAsync(token);
@@ -109,7 +111,7 @@ public class BackgroundTaskSchedulerTests
         bool wasCancelled = false;
 
         ManualResetEvent waitSignal = new(false);
-        scheduler.TryScheduleTask(1, async (_, token) =>
+        scheduler.TryScheduleTask(default(TestRequest), async (_, token) =>
         {
             waitSignal.Set();
             try
@@ -139,7 +141,7 @@ public class BackgroundTaskSchedulerTests
         CountdownEvent expiredRan = new(5);
         for (int i = 0; i < 5; i++)
         {
-            scheduler.TryScheduleTask(1, (_, token) =>
+            scheduler.TryScheduleTask(default(TestRequest), (_, token) =>
             {
                 if (token.IsCancellationRequested)
                     Interlocked.Increment(ref cancelledCount);
@@ -157,7 +159,7 @@ public class BackgroundTaskSchedulerTests
         CountdownEvent postBlockRan = new(3);
         for (int i = 0; i < 3; i++)
         {
-            scheduler.TryScheduleTask(1, (_, token) =>
+            scheduler.TryScheduleTask(default(TestRequest), (_, token) =>
             {
                 if (!token.IsCancellationRequested)
                     Interlocked.Increment(ref postBlockCount);
@@ -177,7 +179,7 @@ public class BackgroundTaskSchedulerTests
         BlocksProcessingEventArgs branchProcessing = RaiseBlocksProcessing();
 
         ManualResetEvent waitSignal = new(false);
-        Assert.That(scheduler.TryScheduleTask(1, (_, _) =>
+        Assert.That(scheduler.TryScheduleTask(default(TestRequest), (_, _) =>
         {
             waitSignal.Set();
             return Task.CompletedTask;
@@ -200,7 +202,7 @@ public class BackgroundTaskSchedulerTests
 
         bool wasCancelled = true;
         ManualResetEvent waitSignal = new(false);
-        Assert.That(scheduler.TryScheduleTask(1, (_, token) =>
+        Assert.That(scheduler.TryScheduleTask(default(TestRequest), (_, token) =>
         {
             wasCancelled = token.IsCancellationRequested;
             waitSignal.Set();
@@ -219,7 +221,7 @@ public class BackgroundTaskSchedulerTests
 
         bool wasCancelled = false;
         ManualResetEvent waitSignal = new(false);
-        scheduler.TryScheduleTask(1, (_, token) =>
+        scheduler.TryScheduleTask(default(TestRequest), (_, token) =>
         {
             wasCancelled = token.IsCancellationRequested;
             waitSignal.Set();
@@ -233,7 +235,7 @@ public class BackgroundTaskSchedulerTests
         RaiseBranchProcessingCompleted(branchProcessing);
 
         ManualResetEvent postBlockSignal = new(false);
-        scheduler.TryScheduleTask(1, (_, token) =>
+        scheduler.TryScheduleTask(default(TestRequest), (_, token) =>
         {
             postBlockSignal.Set();
             return Task.CompletedTask;
@@ -253,7 +255,7 @@ public class BackgroundTaskSchedulerTests
         // Fill the queue with tasks that expire in 1ms
         for (int i = 0; i < capacity; i++)
         {
-            scheduler.TryScheduleTask(1, (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(1));
+            scheduler.TryScheduleTask(default(TestRequest), (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(1));
         }
 
         // Expired tasks are drained (run with cancelled token) during block processing, freeing queue space
@@ -262,7 +264,7 @@ public class BackgroundTaskSchedulerTests
         // New tasks should be accepted because expired tasks freed up queue space
         for (int i = 0; i < capacity; i++)
         {
-            bool accepted = scheduler.TryScheduleTask(1, (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(1));
+            bool accepted = scheduler.TryScheduleTask(default(TestRequest), (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(1));
             Assert.That(accepted, Is.True, $"Task {i} should be accepted after expired tasks freed queue space");
         }
 
@@ -281,7 +283,7 @@ public class BackgroundTaskSchedulerTests
         // Fill the queue with short-lived tasks
         for (int i = 0; i < capacity; i++)
         {
-            Assert.That(scheduler.TryScheduleTask(1, (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(1)), Is.True);
+            Assert.That(scheduler.TryScheduleTask(default(TestRequest), (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(1)), Is.True);
         }
 
         // Wait for deadlines to pass and expired tasks to be drained with cancelled tokens
@@ -290,7 +292,7 @@ public class BackgroundTaskSchedulerTests
         // New tasks should be accepted because expired tasks freed up queue space
         for (int i = 0; i < capacity; i++)
         {
-            bool accepted = scheduler.TryScheduleTask(1, (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(1));
+            bool accepted = scheduler.TryScheduleTask(default(TestRequest), (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(1));
             Assert.That(accepted, Is.True, $"Task {i} should be accepted after expired tasks were drained");
         }
 
@@ -311,7 +313,7 @@ public class BackgroundTaskSchedulerTests
 
         for (int i = 0; i < capacity; i++)
         {
-            bool accepted = scheduler.TryScheduleTask(1, (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(10));
+            bool accepted = scheduler.TryScheduleTask(default(TestRequest), (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(10));
             Assert.That(accepted, Is.True, $"Phase 1: task {i} should be accepted up to capacity");
         }
 
@@ -324,7 +326,7 @@ public class BackgroundTaskSchedulerTests
         int phase2Count = capacity / 2;
         for (int i = 0; i < phase2Count; i++)
         {
-            bool accepted = scheduler.TryScheduleTask(1, (_, _) =>
+            bool accepted = scheduler.TryScheduleTask(default(TestRequest), (_, _) =>
             {
                 Interlocked.Increment(ref executedCount);
                 return Task.CompletedTask;
@@ -343,7 +345,7 @@ public class BackgroundTaskSchedulerTests
         int totalPhase3 = capacity / 2 + capacity / 4;
         for (int i = 0; i < totalPhase3; i++)
         {
-            Assert.That(scheduler.TryScheduleTask(1, (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(5)), Is.True, $"Phase 3: task {i} should be accepted");
+            Assert.That(scheduler.TryScheduleTask(default(TestRequest), (_, _) => Task.CompletedTask, TimeSpan.FromMilliseconds(5)), Is.True, $"Phase 3: task {i} should be accepted");
         }
 
         // Wait for expired tasks to drain with cancelled tokens
@@ -356,7 +358,7 @@ public class BackgroundTaskSchedulerTests
         int longLivedCount = capacity / 4;
         for (int i = 0; i < longLivedCount; i++)
         {
-            scheduler.TryScheduleTask(1, (_, token) =>
+            scheduler.TryScheduleTask(default(TestRequest), (_, token) =>
             {
                 if (!token.IsCancellationRequested)
                     Interlocked.Increment(ref phase3ExecutedCount);
@@ -374,7 +376,7 @@ public class BackgroundTaskSchedulerTests
 
         for (int i = 0; i < capacity; i++)
         {
-            Assert.That(scheduler.TryScheduleTask(1, (_, _) =>
+            Assert.That(scheduler.TryScheduleTask(default(TestRequest), (_, _) =>
             {
                 Interlocked.Increment(ref executedCount);
                 return Task.CompletedTask;
@@ -386,6 +388,75 @@ public class BackgroundTaskSchedulerTests
             Is.EqualTo(capacity).After(5000, 10),
             "all tasks in the final phase should execute successfully");
     }
+
+    [Test]
+    public async Task Stats_are_reported_when_a_task_is_dropped()
+    {
+        const int capacity = 10;
+        InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+        logger.IsWarn.Returns(true);
+        await using BackgroundTaskScheduler scheduler = new(_branchProcessor, _chainHeadInfo, 1, capacity, new OneLoggerLogManager(new ILogger(logger)));
+
+        SemaphoreSlim release = new(0);
+        await BlockTheOnlyWorker(scheduler, release);
+
+        for (int i = 0; i < capacity; i++)
+        {
+            Assert.That(Schedule(scheduler, static (_, _) => Task.CompletedTask), Is.True, $"task {i} should fit in the queue");
+        }
+
+        Assert.That(Schedule(scheduler, static (_, _) => Task.CompletedTask), Is.False, "the queue is full so the next task is dropped");
+
+        logger.Received()
+            .Warn(Arg.Is<string>(static msg =>
+                msg.Contains("Background task queue is full")
+                && msg.Contains("Capacity: 10")
+                && msg.Contains($"dropping task [{nameof(TestRequest)}]")
+                && msg.Contains($"Stats: ({nameof(TestRequest)}: {capacity})")));
+
+        release.Release();
+    }
+
+    [Test]
+    public async Task Stats_track_queue_depth_and_return_to_zero()
+    {
+        const int queued = 5;
+        await using BackgroundTaskScheduler scheduler = new(_branchProcessor, _chainHeadInfo, 1, queued + 1, LimboLogs.Instance);
+
+        SemaphoreSlim release = new(0);
+        await BlockTheOnlyWorker(scheduler, release);
+
+        for (int i = 0; i < queued; i++)
+        {
+            Assert.That(Schedule(scheduler, static (_, _) => Task.CompletedTask), Is.True);
+        }
+
+        Assert.That(scheduler.GetStats()[nameof(TestRequest)], Is.EqualTo(queued), "tasks waiting in the queue are counted");
+
+        release.Release();
+        Assert.That(() => scheduler.GetStats()[nameof(TestRequest)], Is.EqualTo(0).After(5000, 10),
+            "the counter returns to zero once the queue drains");
+    }
+
+    /// <summary>
+    /// Occupies the scheduler's single worker so that everything scheduled afterwards stays queued,
+    /// which makes queue-depth assertions deterministic.
+    /// </summary>
+    private static async Task BlockTheOnlyWorker(BackgroundTaskScheduler scheduler, SemaphoreSlim release)
+    {
+        TaskCompletionSource running = new();
+        Assert.That(Schedule(scheduler, async (_, token) =>
+        {
+            running.TrySetResult(0);
+            // Observes the token so disposing the scheduler cannot deadlock on an unreleased semaphore
+            await release.WaitAsync(token);
+        }), Is.True);
+
+        await running.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static bool Schedule(BackgroundTaskScheduler scheduler, Func<TestRequest, CancellationToken, Task> task) =>
+        scheduler.TryScheduleTask<TestRequest>(default, task, TimeSpan.FromMinutes(1));
 
     private BlocksProcessingEventArgs RaiseBlocksProcessing()
     {

--- a/src/Nethermind/Nethermind.Consensus.Test/Scheduler/BackgroundTaskTypeRegistryTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Scheduler/BackgroundTaskTypeRegistryTests.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Consensus.Scheduler;
+using NUnit.Framework;
+
+namespace Nethermind.Consensus.Test.Scheduler;
+
+public class BackgroundTaskTypeRegistryTests
+{
+    /// <remarks>
+    /// eth/62 and eth/66 both declare a <c>GetBlockHeadersMessage</c>, so reporting on the simple name
+    /// alone would put two unrelated queues under one indistinguishable label.
+    /// </remarks>
+    [Test]
+    public void Types_sharing_a_simple_name_are_reported_distinctly()
+    {
+        int first = BackgroundTaskTypeId<CollidingRequest>.Id;
+        int second = BackgroundTaskTypeId<Other.CollidingRequest>.Id;
+
+        Assert.That(first, Is.Not.EqualTo(second));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(BackgroundTaskTypeRegistry.GetName(first), Is.EqualTo(typeof(CollidingRequest).FullName));
+            Assert.That(BackgroundTaskTypeRegistry.GetName(second), Is.EqualTo(typeof(Other.CollidingRequest).FullName));
+        }
+    }
+
+    /// <remarks>
+    /// Both the in-range slot no type has claimed, which is the branch the stats renderers rely on,
+    /// and the out-of-range id that <see cref="BackgroundTaskTypeRegistry.MaxTaskTypes"/> guards.
+    /// </remarks>
+    [Test]
+    public void Unclaimed_id_has_no_name(
+        [Values(BackgroundTaskTypeRegistry.MaxTaskTypes - 1, BackgroundTaskTypeRegistry.MaxTaskTypes)] int id) =>
+        Assert.That(BackgroundTaskTypeRegistry.GetName(id), Is.Null);
+}
+
+internal readonly struct CollidingRequest : IBackgroundTaskRequest<CollidingRequest>;
+
+internal static class Other
+{
+    internal readonly struct CollidingRequest : IBackgroundTaskRequest<CollidingRequest>;
+}

--- a/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/BackgroundTaskScheduler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -37,6 +38,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
     private readonly Lock _blockProcessingLock = new();
     private int _activeBlockProcessingBranches;
     private long _queueCount;
+    private readonly int[] _stats = new int[BackgroundTaskTypeRegistry.MaxTaskTypes];
 
     private CancellationTokenSource _blockProcessorCancellationTokenSource;
     private volatile TaskCompletionSource? _blockProcessingDoneSignal;
@@ -86,6 +88,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
             return;
         }
 
+        long depth;
         lock (_blockProcessingLock)
         {
             if (_disposed)
@@ -93,16 +96,19 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
                 return;
             }
 
-            if (_activeBlockProcessingBranches++ == 0)
+            if (_activeBlockProcessingBranches++ != 0)
             {
-                long depth = Volatile.Read(ref _queueCount);
-                if (_logger.IsDebug) _logger.Debug($"Block processing starting, background queue depth: {depth}");
-                // Signal that block processing is in progress so StartChannel can async-wait
-                _blockProcessingDoneSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-                // On block processing, cancel the block process CTS so running tasks can exit quickly
-                _blockProcessorCancellationTokenSource.Cancel();
+                return;
             }
+
+            depth = Volatile.Read(ref _queueCount);
+            // Signal that block processing is in progress so StartChannel can async-wait
+            _blockProcessingDoneSignal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            // On block processing, cancel the block process CTS so running tasks can exit quickly
+            _blockProcessorCancellationTokenSource.Cancel();
         }
+
+        if (_logger.IsDebug) _logger.Debug($"Block processing starting, background queue depth: {depth} [{FormatStats()}]");
     }
 
     private void BranchProcessorOnBranchProcessingCompleted(object? sender, BranchProcessingCompletedEventArgs e)
@@ -178,6 +184,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
                             // Task already expired or re-queue failed — run with cancelled token
                         }
 
+                        AddToStats(activity.TaskId, -1);
                         await activity.Do(token);
                         Evm.Metrics.IncrementTotalBackgroundTasksExecuted();
                     }
@@ -211,7 +218,8 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
         }
     }
 
-    public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null)
+    public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+        where TReq : notnull, IBackgroundTaskRequest<TReq>
     {
         Activity<TReq> activity = Activity<TReq>.Rent(
             DateTimeOffset.UtcNow + (timeout ?? DefaultTimeout),
@@ -222,11 +230,15 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
 
         if (Interlocked.Increment(ref _queueCount) <= _capacity)
         {
+            // Counted before the write so a consumer can never decrement ahead of the increment
+            AddToStats(TReq.TaskId, 1);
             if (_taskQueue.Writer.TryWrite(activity))
             {
                 UpdateQueueCount();
                 return true;
             }
+
+            AddToStats(TReq.TaskId, -1);
         }
 
         Evm.Metrics.IncrementTotalBackgroundTasksDropped();
@@ -238,14 +250,44 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
             && Interlocked.CompareExchange(ref _lastDropLogTicks, now, lastLog) == lastLog)
         {
             _logger.Warn(
-                $"Background task queue is full (Count: {_queueCount}, Capacity: {_capacity}), dropping task [{source ?? "unknown"}]. " +
+                $"Background task queue is full (Count: {_queueCount}, Capacity: {_capacity}), dropping task [{BackgroundTaskTypeRegistry.GetName(TReq.TaskId) ?? "unknown"}]. " +
                 $"Totals: queued={Evm.Metrics.TotalBackgroundTasksQueued}, executed={Evm.Metrics.TotalBackgroundTasksExecuted}, " +
-                $"dropped={Evm.Metrics.TotalBackgroundTasksDropped}");
+                $"dropped={Evm.Metrics.TotalBackgroundTasksDropped}. " +
+                $"Stats: {FormatStats()}");
         }
         Interlocked.Decrement(ref _queueCount);
         request.TryDispose();
         activity.Return();
         return false;
+    }
+
+    /// <remarks>
+    /// Task ids are dense from 0, so counters live in a flat array and the scheduling path pays a single
+    /// interlocked add. Ids past <see cref="BackgroundTaskTypeRegistry.MaxTaskTypes"/> go untracked.
+    /// </remarks>
+    private void AddToStats(int taskId, int delta)
+    {
+        int[] stats = _stats;
+        if ((uint)taskId < (uint)stats.Length)
+        {
+            Interlocked.Add(ref stats[taskId], delta);
+        }
+    }
+
+    private string FormatStats()
+    {
+        StringBuilder builder = new();
+        for (int id = 0; id < _stats.Length; id++)
+        {
+            int count = Volatile.Read(ref _stats[id]);
+            if (count > 0 && BackgroundTaskTypeRegistry.GetName(id) is string name)
+            {
+                if (builder.Length > 0) builder.Append(", ");
+                builder.Append('(').Append(name).Append(": ").Append(count).Append(')');
+            }
+        }
+
+        return builder.ToString();
     }
 
     private void UpdateQueueCount() => Evm.Metrics.NumberOfBackgroundTasksScheduled = Volatile.Read(ref _queueCount);
@@ -272,7 +314,25 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
         _scheduler.Dispose();
     }
 
-    private sealed class Activity<TReq> : IActivity
+    /// <summary>
+    /// Snapshot of currently queued task counts, keyed by the request type's reported name.
+    /// </summary>
+    internal IReadOnlyDictionary<string, int> GetStats()
+    {
+        Dictionary<string, int> stats = [];
+        for (int id = 0; id < _stats.Length; id++)
+        {
+            if (BackgroundTaskTypeRegistry.GetName(id) is string name)
+            {
+                // Accumulate: two ids resolving to one name must merge, never replace one another
+                stats[name] = (stats.TryGetValue(name, out int existing) ? existing : 0) + Volatile.Read(ref _stats[id]);
+            }
+        }
+
+        return stats;
+    }
+
+    private sealed class Activity<TReq> : IActivity where TReq : IBackgroundTaskRequest<TReq>
     {
         private const int MaxPooled = 1024;
         private static readonly ConcurrentQueue<Activity<TReq>> Pool = new();
@@ -282,6 +342,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
         private Func<TReq, CancellationToken, Task>? _fulfillFunc;
 
         public DateTimeOffset Deadline { get; private set; }
+        public int TaskId => TReq.TaskId;
 
         public static Activity<TReq> Rent(DateTimeOffset deadline, TReq request, Func<TReq, CancellationToken, Task> fulfillFunc)
         {
@@ -350,6 +411,7 @@ public class BackgroundTaskScheduler : IBackgroundTaskScheduler, IAsyncDisposabl
     private interface IActivity : IComparable<IActivity>
     {
         DateTimeOffset Deadline { get; }
+        int TaskId { get; }
         Task Do(CancellationToken cancellationToken);
     }
 

--- a/src/Nethermind/Nethermind.Consensus/Scheduler/IBackgroundTaskRequest.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/IBackgroundTaskRequest.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Nethermind.Consensus.Scheduler;
+
+/// <summary>
+/// Marks a request type as schedulable on <see cref="IBackgroundTaskScheduler"/> and names the bucket
+/// its queue depth is reported under.
+/// </summary>
+/// <remarks>
+/// The default reports under the implementing type's own name. A wrapper request should override with
+/// <c>BackgroundTaskTypeId&lt;TWrapped&gt;.Id</c>, since its own generic type name is identical for every
+/// instantiation. Conversely, one request type scheduled for two unrelated workloads should be split in
+/// two, so that each reports separately.
+/// </remarks>
+public interface IBackgroundTaskRequest<T> where T : IBackgroundTaskRequest<T>
+{
+    static virtual int TaskId => BackgroundTaskTypeId<T>.Id;
+}
+
+/// <summary>
+/// Assigns a dense id to <typeparamref name="T"/> on first use.
+/// </summary>
+public static class BackgroundTaskTypeId<T>
+{
+    public static readonly int Id = BackgroundTaskTypeRegistry.Register(typeof(T));
+}
+
+/// <summary>
+/// Resolves the ids handed out by <see cref="BackgroundTaskTypeId{T}"/> back to names for diagnostics.
+/// </summary>
+/// <remarks>
+/// Names are resolved once per type, at registration, so that rendering a stats line is a plain array read.
+/// </remarks>
+public static class BackgroundTaskTypeRegistry
+{
+    /// <remarks>
+    /// Ids beyond this stay valid but are neither named nor counted. The repo registers ~25 request types,
+    /// so the cap only trades a growable table for a fixed one on the scheduling hot path.
+    /// </remarks>
+    public const int MaxTaskTypes = 64;
+
+    private static readonly Type?[] Types = new Type?[MaxTaskTypes];
+    private static readonly string?[] Names = new string?[MaxTaskTypes];
+    private static readonly Lock RegisterLock = new();
+    private static int _lastId = -1;
+
+    internal static int Register(Type type)
+    {
+        int id = Interlocked.Increment(ref _lastId);
+        Debug.Assert(id < MaxTaskTypes, $"More than {MaxTaskTypes} background task types; raise {nameof(MaxTaskTypes)} or the extra ones go unreported.");
+
+        if ((uint)id >= MaxTaskTypes) return id;
+
+        // Registration happens once per type, from a static constructor on first schedule
+        lock (RegisterLock)
+        {
+            string name = type.Name;
+            for (int other = 0; other < MaxTaskTypes; other++)
+            {
+                // Simple names are not unique — eth/62 and eth/66 both declare a GetBlockHeadersMessage —
+                // so a collision qualifies both this type and the one it collides with. One match is
+                // enough: any further type of that name was already qualified when it registered.
+                if (Types[other] is Type candidate && candidate.Name == type.Name)
+                {
+                    name = type.FullName!;
+                    Volatile.Write(ref Names[other], candidate.FullName);
+                    break;
+                }
+            }
+
+            Types[id] = type;
+            // Ordered after the type's name is resolved, and after the writes above, so a concurrent
+            // GetName sees either a fully resolved name or nothing
+            Volatile.Write(ref Names[id], name);
+        }
+
+        return id;
+    }
+
+    /// <summary>
+    /// Name to report <paramref name="id"/> under, or <c>null</c> if no type has claimed it.
+    /// </summary>
+    public static string? GetName(int id) => (uint)id < MaxTaskTypes ? Volatile.Read(ref Names[id]) : null;
+}

--- a/src/Nethermind/Nethermind.Consensus/Scheduler/IBackgroundTaskScheduler.cs
+++ b/src/Nethermind/Nethermind.Consensus/Scheduler/IBackgroundTaskScheduler.cs
@@ -9,5 +9,6 @@ namespace Nethermind.Consensus.Scheduler;
 
 public interface IBackgroundTaskScheduler
 {
-    bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null);
+    bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+        where TReq : notnull, IBackgroundTaskRequest<TReq>;
 }

--- a/src/Nethermind/Nethermind.Core.Test/MockSnapSyncPeer.cs
+++ b/src/Nethermind/Nethermind.Core.Test/MockSnapSyncPeer.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,8 +37,10 @@ public class MockSnapSyncPeer(ISnapServer snapServer) : ISnapSyncPeer
 
     public Task<SlotsAndProofs> GetStorageRange(StorageRange range, CancellationToken token)
     {
+        Hash256 rootHash = range.RootHash
+            ?? throw new InvalidOperationException("A storage range request must have a root hash before it is dispatched.");
         (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> slots, IByteArrayList? proof) = snapServer.GetStorageRanges(
-            range.RootHash,
+            rootHash,
             range.Accounts,
             range.StartingHash,
             range.LimitHash,
@@ -47,7 +50,7 @@ public class MockSnapSyncPeer(ISnapServer snapServer) : ISnapSyncPeer
         return Task.FromResult(new SlotsAndProofs()
         {
             PathsAndSlots = slots,
-            Proofs = proof!,
+            Proofs = proof,
         });
     }
 
@@ -63,17 +66,19 @@ public class MockSnapSyncPeer(ISnapServer snapServer) : ISnapSyncPeer
         for (int i = 0; i < request.Paths.Count; i++)
         {
             AccountWithStorageStartingHash path = request.Paths[i];
-            groups[i] = new PathGroup { Group = [path.PathAndAccount.Path.Bytes.ToArray(), _emptyBytes] };
+            PathWithAccount pathAndAccount = path.PathAndAccount
+                ?? throw new InvalidOperationException("An account refresh request must have an account path before it is dispatched.");
+            groups[i] = new PathGroup { Group = [pathAndAccount.Path.Bytes.ToArray(), _emptyBytes] };
         }
 
         using RlpPathGroupList encoded = PathGroup.EncodeToRlpPathGroupList(groups);
         IByteArrayList? res = snapServer.GetTrieNodes(encoded, request.RootHash, token);
-        return Task.FromResult(res!);
+        return Task.FromResult(res ?? EmptyByteArrayList.Instance);
     }
 
     public Task<IByteArrayList> GetTrieNodes(GetTrieNodesRequest request, CancellationToken token)
     {
         IByteArrayList? res = snapServer.GetTrieNodes(request.AccountAndStoragePaths, request.RootHash, token);
-        return Task.FromResult(res!);
+        return Task.FromResult(res ?? EmptyByteArrayList.Instance);
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/ReleaseSpecSubstitute.cs
+++ b/src/Nethermind/Nethermind.Core.Test/ReleaseSpecSubstitute.cs
@@ -8,10 +8,22 @@ namespace Nethermind.Core.Test;
 
 public static class ReleaseSpecSubstitute
 {
-    public static IReleaseSpec Create()
+    public static IReleaseSpec Create() => Configure(Substitute.For<IReleaseSpec>());
+
+    /// <summary>Arranges the members a bare <see cref="IReleaseSpec"/> substitute cannot answer itself.</summary>
+    /// <remarks>Chain-specific substitutes route through this rather than repeating the arrangement, so a
+    /// member that has to be taught to a substitute is taught to all of them at once.</remarks>
+    public static T Configure<T>(T sub) where T : class, IReleaseSpec
     {
-        IReleaseSpec sub = Substitute.For<IReleaseSpec>();
         sub.GasCosts.Returns(_ => new SpecGasCosts(sub));
+        // A substitute intercepts IsPrecompile rather than running the interface's default body, so route
+        // it back through Precompiles: a test that arranges the set still gets the membership it arranged.
+        // The read goes through the substitute, so a Received() assertion on Precompiles counts it too.
+        sub.IsPrecompile(Arg.Any<Address>()).Returns(call =>
+        {
+            Address address = (Address)call[0];
+            return address.CouldBePrecompile() && sub.Precompiles.Contains(address);
+        });
         return sub;
     }
 }

--- a/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyAndMessageSizeBasedRequestSizerTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyAndMessageSizeBasedRequestSizerTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Nethermind.Core.RequestSizer;
+using Nethermind.Core.Test.Threading;
 
 namespace Nethermind.Core.Test.RequestSizer;
 
@@ -14,26 +15,32 @@ public class LatencyAndMessageSizeBasedRequestSizerTests
 {
     private static readonly int[] _sampleRequest = Enumerable.Range(0, 10).ToArray();
 
+    /// <remarks>
+    /// Latency is advanced on a <see cref="ManualTimeProvider"/> so the case lands on a known side of the
+    /// 20ms/200ms watermarks regardless of machine load.
+    /// </remarks>
     [TestCase(0, 0, 2, 3)]
     [TestCase(0, 10000, 2, 1)]
     [TestCase(50, 0, 2, 2)]
     [TestCase(50, 10000, 2, 1)]
     [TestCase(500, 0, 2, 1)]
     [TestCase(50, 0, 1, 1)]
-    public async Task TestChangeInRequestSize(int waitTimeMs, long responseSize, int responseCount, int afterRequestSize)
+    public async Task TestChangeInRequestSize(int latencyMs, long responseSize, int responseCount, int afterRequestSize)
     {
+        ManualTimeProvider timeProvider = new();
         LatencyAndMessageSizeBasedRequestSizer sizer = new(
             1, 4,
             TimeSpan.FromMilliseconds(20),
             TimeSpan.FromMilliseconds(200),
             1000,
-            2
+            2,
+            timeProvider: timeProvider
         );
 
-        await sizer.Run<int[], int, int>(_sampleRequest, async adjustedSize =>
+        await sizer.Run<int[], int, int>(_sampleRequest, adjustedSize =>
         {
-            await Task.Delay(waitTimeMs);
-            return (new int[responseCount], responseSize);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(latencyMs));
+            return Task.FromResult((new int[responseCount], responseSize));
         });
 
         IReadOnlyList<int> modifiedRequestSize = await sizer.Run<IReadOnlyList<int>, int, int>(

--- a/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyBasedRequestSizerTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RequestSizer/LatencyBasedRequestSizerTests.cs
@@ -5,27 +5,34 @@ using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Nethermind.Core.RequestSizer;
+using Nethermind.Core.Test.Threading;
 
 namespace Nethermind.Core.Test.RequestSizer;
 
 public class LatencyBasedRequestSizerTests
 {
+    /// <remarks>
+    /// Latency is advanced on a <see cref="ManualTimeProvider"/> so the case lands on a known side of the
+    /// 20ms/200ms watermarks regardless of machine load.
+    /// </remarks>
     [TestCase(0, 3)]
     [TestCase(50, 2)]
     [TestCase(500, 1)]
-    public async Task TestWait(int waitTimeMs, int afterRequestSize)
+    public async Task TestChangeInRequestSize(int latencyMs, int afterRequestSize)
     {
+        ManualTimeProvider timeProvider = new();
         LatencyBasedRequestSizer sizer = new(
             1, 4,
             TimeSpan.FromMilliseconds(20),
-            TimeSpan.FromMilliseconds(200));
+            TimeSpan.FromMilliseconds(200),
+            timeProvider: timeProvider);
 
         await sizer.MeasureLatency((_ => Task.FromResult(0)));
-        await sizer.MeasureLatency((async _ =>
+        await sizer.MeasureLatency(_ =>
         {
-            await Task.Delay(waitTimeMs);
+            timeProvider.Advance(TimeSpan.FromMilliseconds(latencyMs));
             return Task.FromResult(0);
-        }));
+        });
 
         int modifiedRequestSize = await sizer.MeasureLatency((Task.FromResult));
 

--- a/src/Nethermind/Nethermind.Core.Test/RunImmediatelyScheduler.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RunImmediatelyScheduler.cs
@@ -16,7 +16,8 @@ public class RunImmediatelyScheduler : IBackgroundTaskScheduler
     {
     }
 
-    public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null)
+    public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+        where TReq : notnull, IBackgroundTaskRequest<TReq>
     {
         fulfillFunc(request, CancellationToken.None);
         return true;

--- a/src/Nethermind/Nethermind.Core/Address.cs
+++ b/src/Nethermind/Nethermind.Core/Address.cs
@@ -297,6 +297,39 @@ namespace Nethermind.Core
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal long GetHashCode64() => SpanExtensions.FastHash64For20Bytes(ref Unsafe.AsRef(in FirstByte));
+
+        /// <summary>Whether this address could name a precompile at all: sixteen leading zero bytes.</summary>
+        /// <remarks>The membership test every CALL pays. Two loads reject an ordinary contract, against
+        /// hashing and probing twenty bytes, and unlike <see cref="PrecompileIndexOrNegative"/> the answer
+        /// holds for every number a plugin might register at.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool CouldBePrecompile()
+        {
+            ref byte b = ref Unsafe.AsRef(in FirstByte);
+            return (Unsafe.ReadUnaligned<ulong>(ref b) | Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref b, 8))) == 0;
+        }
+
+        /// <summary>The precompile number this address names, or negative if it cannot be used as an index.</summary>
+        /// <remarks>A precompile lives at a low address, so its trailing number is the membership key and
+        /// "which one" becomes an index rather than a hash and a probe over twenty bytes. Callers bound the
+        /// index themselves, since a plugin may register far above the low run — Taiko's sit at 0x10001 and
+        /// 0x10002. This answers "which one", never "is it one": a tail that overflows <see cref="int"/>
+        /// also comes back negative, so membership is <see cref="CouldBePrecompile"/>.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int PrecompileIndexOrNegative()
+        {
+            // The shape test is repeated rather than calling CouldBePrecompile so that the base ref is
+            // loaded once: this is the zkVM guest's precompile path, measured to an exact step count.
+            ref byte b = ref Unsafe.AsRef(in FirstByte);
+            if ((Unsafe.ReadUnaligned<ulong>(ref b) | Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref b, 8))) != 0)
+            {
+                return -1;
+            }
+
+            // bytes 16..19, big-endian
+            uint tail = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref b, 16));
+            return (int)System.Buffers.Binary.BinaryPrimitives.ReverseEndianness(tail);
+        }
     }
 
     public readonly struct AddressByEip55ChecksumOrdinalComparer : IComparer<Address>

--- a/src/Nethermind/Nethermind.Core/Address.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Address.zkevm.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
 namespace Nethermind.Core;
@@ -14,20 +13,4 @@ public sealed partial class Address
         => Unsafe.ReadUnaligned<ulong>(ref a) == Unsafe.ReadUnaligned<ulong>(ref b)
             && Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref a, 8)) == Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref b, 8))
             && Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref a, 16)) == Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref b, 16));
-
-    // A precompile lives at a low address (top 16 bytes zero), so its trailing number
-    // IS the membership key. Returns that number when the top 16 bytes are zero, or -1
-    // otherwise — lets IReleaseSpec.IsPrecompile swap a FrozenSet hash+probe for a bitmask.
-    public int PrecompileIndexOrNegative()
-    {
-        ref byte b = ref Unsafe.AsRef(in FirstByte);
-        if ((Unsafe.ReadUnaligned<ulong>(ref b) | Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref b, 8))) != 0)
-        {
-            return -1;
-        }
-
-        // bytes 16..19, big-endian
-        uint tail = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref b, 16));
-        return (int)BinaryPrimitives.ReverseEndianness(tail);
-    }
 }

--- a/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/Bytes.cs
@@ -115,7 +115,7 @@ namespace Nethermind.Core.Extensions
             return a1.SequenceEqual(a2);
         }
 
-        public static bool IsZero(this byte[] bytes) => bytes.AsSpan().IndexOfAnyExcept((byte)0) < 0;
+        public static bool IsZero([NotNullWhen(false)] this byte[]? bytes) => bytes.AsSpan().IndexOfAnyExcept((byte)0) < 0;
 
         public static bool IsZero(this Span<byte> bytes) => bytes.IndexOfAnyExcept((byte)0) < 0;
 

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -409,6 +409,14 @@ namespace Nethermind.Core.Specs
         /// </summary>
         FrozenSet<AddressAsKey> Precompiles { get; }
 
+        /// <summary>Whether <paramref name="address"/> names a precompile active at this fork.</summary>
+        /// <param name="address">The call target to test.</param>
+        /// <remarks>On the interface rather than beside it because the answer depends on the fork, so only
+        /// the spec can hold a form of it faster than a set probe — a caller memoising one has to re-check
+        /// which fork it belongs to on every call, which costs more than it saves. The default is the probe
+        /// itself, so an implementation that has nothing better keeps today's behaviour.</remarks>
+        bool IsPrecompile(Address address) => address.CouldBePrecompile() && Precompiles.Contains(address);
+
         /// <summary>
         /// EIP-7939 - CLZ - Count leading zeros instruction
         /// </summary>

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpec.cs
@@ -429,6 +429,14 @@ namespace Nethermind.Core.Specs
         /// </summary>
         FrozenSet<AddressAsKey> Precompiles { get; }
 
+        /// <summary>Whether <paramref name="address"/> names a precompile active at this fork.</summary>
+        /// <param name="address">The call target to test.</param>
+        /// <remarks>On the interface rather than beside it because the answer depends on the fork, so only
+        /// the spec can hold a form of it faster than a set probe — a caller memoising one has to re-check
+        /// which fork it belongs to on every call, which costs more than it saves. The default is the probe
+        /// itself, so an implementation that has nothing better keeps today's behaviour.</remarks>
+        bool IsPrecompile(Address address) => address.CouldBePrecompile() && Precompiles.Contains(address);
+
         /// <summary>
         /// EIP-7939 - CLZ - Count leading zeros instruction
         /// </summary>

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.std.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.std.cs
@@ -25,11 +25,5 @@ public static partial class IReleaseSpecExtensions
         public bool UseNetGasMeteringWithAStipendFix => spec.UseIstanbulNetGasMetering;
         public bool Use63Over64Rule => spec.UseShanghaiDDosProtection;
 
-        /// <summary>
-        /// Determines whether the specified address is a precompiled contract for this release specification.
-        /// </summary>
-        /// <param name="address">The address to check for precompile status.</param>
-        /// <returns><c>true</c> if the address is a precompiled contract; otherwise, <c>false</c>.</returns>
-        public bool IsPrecompile(Address address) => spec.Precompiles.Contains(address);
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/IReleaseSpecExtensions.zkevm.cs
@@ -1,51 +1,11 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
-
 namespace Nethermind.Core.Specs;
 
 public static partial class IReleaseSpecExtensions
 {
     private static IReleaseSpec GetNoEip158Spec(IReleaseSpec spec) => new NoEip158Spec(spec);
-
-    // Precompile membership as a bitmask instead of a FrozenSet hash+probe.
-    // The set is fork-fixed, so it is built once per spec; a single slot suffices
-    // because the zkVM guest validates one block (one spec).
-    private static IReleaseSpec? _precompileMaskSpec;
-    private static ulong _precompileMaskLow;
-    private static bool _precompileMaskP256;
-
-    private static void BuildPrecompileMask(IReleaseSpec spec)
-    {
-        ulong low = 0UL;
-        bool p256 = false;
-
-        foreach (AddressAsKey p in spec.Precompiles)
-        {
-            int idx = ((Address)p).PrecompileIndexOrNegative();
-
-            if ((uint)idx < 64)
-            {
-                low |= 1UL << idx;
-            }
-            else if (idx == 0x100)
-            {
-                p256 = true;
-            }
-            // An out-of-range index is a new precompile the mask cannot hold; IsPrecompile would then
-            // wrongly return false and the guest would skip it, mis-validating the block.
-            else
-            {
-                throw new InvalidOperationException(
-                    $"Precompile index 0x{idx:x} is outside the precompile-mask range [0,64) or 0x100; extend BuildPrecompileMask and IsPrecompile.");
-            }
-        }
-
-        _precompileMaskLow = low;
-        _precompileMaskP256 = p256;
-        _precompileMaskSpec = spec;
-    }
 
     // Each `spec.IsEipXxxEnabled` is an IReleaseSpec interface dispatch, and the getters below are read
     // per-opcode / per-storage-access. The spec is fork-fixed and monomorphic per block, so resolve the
@@ -169,23 +129,6 @@ public static partial class IReleaseSpecExtensions
                 EnsureSpecFlags(spec);
                 return _useShanghaiDDosProtection;
             }
-        }
-
-        /// <summary>
-        /// Determines whether the specified address is a precompiled contract for this release specification.
-        /// </summary>
-        /// <param name="address">The address to check for precompile status.</param>
-        /// <returns>True if the address is a precompiled contract; otherwise, false.</returns>
-        public bool IsPrecompile(Address address)
-        {
-            if (!ReferenceEquals(_precompileMaskSpec, spec))
-                BuildPrecompileMask(spec);
-
-            int idx = address.PrecompileIndexOrNegative();
-
-            return (uint)idx < 64
-                ? (_precompileMaskLow & (1UL << idx)) != 0
-                : idx == 0x100 && _precompileMaskP256;
         }
     }
 }

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -109,6 +109,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual ulong ElasticityMultiplier => spec.ElasticityMultiplier;
     public virtual IBaseFeeCalculator BaseFeeCalculator => spec.BaseFeeCalculator;
     FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
+    bool IReleaseSpec.IsPrecompile(Address address) => spec.IsPrecompile(address);
     public virtual bool IsEip7939Enabled => spec.IsEip7939Enabled;
     public virtual bool IsEip7928Enabled => spec.IsEip7928Enabled;
     public virtual bool IsEip8037Enabled => spec.IsEip8037Enabled;

--- a/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
+++ b/src/Nethermind/Nethermind.Core/Specs/ReleaseSpecDecorator.cs
@@ -113,6 +113,7 @@ public class ReleaseSpecDecorator(IReleaseSpec spec) : IReleaseSpec
     public virtual ulong ElasticityMultiplier => spec.ElasticityMultiplier;
     public virtual IBaseFeeCalculator BaseFeeCalculator => spec.BaseFeeCalculator;
     FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => spec.Precompiles;
+    bool IReleaseSpec.IsPrecompile(Address address) => spec.IsPrecompile(address);
     public virtual bool IsEip7939Enabled => spec.IsEip7939Enabled;
     public virtual bool IsEip7928Enabled => spec.IsEip7928Enabled;
     public virtual bool IsEip8037Enabled => spec.IsEip8037Enabled;

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
@@ -752,7 +752,7 @@ public unsafe class EvmOpcodesBenchmark
         if (_vm.ReturnData is VmState<EthereumGasPolicy> nestedFrame)
         {
             nestedFrame.Dispose();
-            _vm.ReturnData = null!;
+            _vm.ReturnData = null;
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
@@ -53,6 +53,21 @@ public class BlobGasCalculatorTests
         Assert.That(blobBaseFee, Is.EqualTo(UInt256.MaxValue));
     }
 
+    [Test]
+    public void Blob_base_fee_requires_excess_blob_gas()
+    {
+        Transaction tx = Build.A.Transaction.WithType(TxType.Blob).WithBlobVersionedHashes(1).TestObject;
+        BlockHeader header = Build.A.BlockHeader.TestObject;
+
+        bool success = BlobGasCalculator.TryCalculateBlobBaseFee(header, tx, Eip4844Constants.DefaultBlobGasPriceUpdateFraction, out UInt256 blobBaseFee);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(success, Is.False);
+            Assert.That(blobBaseFee, Is.EqualTo(UInt256.MaxValue));
+        }
+    }
+
     private static IEnumerable<TestCaseData> GenerateTestCases()
     {
         (IReleaseSpec Instance, bool)[] specs =

--- a/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/BlobGasCalculatorTests.cs
@@ -87,6 +87,21 @@ public class BlobGasCalculatorTests
         }
     }
 
+    [Test]
+    public void Blob_base_fee_requires_excess_blob_gas()
+    {
+        Transaction tx = Build.A.Transaction.WithType(TxType.Blob).WithBlobVersionedHashes(1).TestObject;
+        BlockHeader header = Build.A.BlockHeader.TestObject;
+
+        bool success = BlobGasCalculator.TryCalculateBlobBaseFee(header, tx, Eip4844Constants.DefaultBlobGasPriceUpdateFraction, out UInt256 blobBaseFee);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(success, Is.False);
+            Assert.That(blobBaseFee, Is.EqualTo(UInt256.MaxValue));
+        }
+    }
+
     private static IEnumerable<TestCaseData> GenerateTestCases()
     {
         (IReleaseSpec Instance, bool)[] specs =

--- a/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Frozen;
 using Nethermind.Core;
+using Nethermind.Evm.Precompiles;
+using Nethermind.Int256;
 using NSubstitute;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -26,6 +28,48 @@ public class CodeInfoRepositoryTests
     {
         _releaseSpec = ReleaseSpecSubstitute.Create();
         _releaseSpec.Precompiles.Returns(FrozenSet<AddressAsKey>.Empty);
+    }
+
+    /// <summary>Precompile numbers a chain might register, including ones the index array cannot hold.</summary>
+    /// <remarks>Ethereum's stop at 0x100 (RIP-7212), which is what the index array is sized against, but a
+    /// plugin may register anywhere: Taiko's L1Sload and L1StaticCall sit at 0x10001 and 0x10002, and at
+    /// 0x8000_0000 the number no longer fits an <see cref="int"/>, so it comes back negative. Indexing by
+    /// precompile number is only sound if all of those are still resolved. The membership half of the same
+    /// contract is covered against the real spec in <c>ReleaseSpecTests</c>; the substitute here answers
+    /// <c>IsPrecompile</c> from its own arrangement, so it could not tell us anything about it.</remarks>
+    private static readonly long[] PrecompileNumbers = [1, 2, 9, 0x11, 0x100, 0x101, 0x10001, 0x10002, 0x8000_0000];
+
+    [TestCaseSource(nameof(PrecompileNumbers))]
+    public void Precompile_is_resolved_whatever_its_number(long number)
+    {
+        Address address = Address.FromNumber((UInt256)(ulong)number);
+        CodeInfo expected = new(Substitute.For<IPrecompile>());
+
+        IPrecompileProvider provider = Substitute.For<IPrecompileProvider>();
+        provider.GetPrecompiles().Returns(new Dictionary<AddressAsKey, CodeInfo>
+        {
+            [Address.FromNumber(UInt256.One)] = new(Substitute.For<IPrecompile>()),
+            [address] = expected,
+        }.ToFrozenDictionary());
+
+        IReleaseSpec spec = ReleaseSpecSubstitute.Create();
+        spec.Precompiles.Returns(new AddressAsKey[] { Address.FromNumber(UInt256.One), address }.ToFrozenSet());
+
+        CodeInfoRepository repository = new(Substitute.For<IWorldState>(), provider);
+
+        Assert.That(repository.GetCachedCodeInfo(address, false, spec, out _), Is.SameAs(expected));
+    }
+
+    [Test]
+    public void Ordinary_address_is_not_taken_for_a_precompile()
+    {
+        // Sixteen leading zero bytes is what makes an address a candidate; this has none.
+        Assert.That(TestItem.AddressA.CouldBePrecompile(), Is.False);
+        Assert.That(_releaseSpec.IsPrecompile(TestItem.AddressA), Is.False);
+
+        // Zero clears the shape guard — index 0 — so only the set can reject it.
+        Assert.That(Address.Zero.CouldBePrecompile(), Is.True);
+        Assert.That(_releaseSpec.IsPrecompile(Address.Zero), Is.False);
     }
 
     public static IEnumerable<TestCaseData> NotDelegationCodeCases()

--- a/src/Nethermind/Nethermind.Evm.Test/Eip152Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip152Tests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Core.Specs;
 using Nethermind.Specs;
 using Nethermind.Evm.Precompiles;
 using NUnit.Framework;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip2537Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip2537Tests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Core.Specs;
 using NUnit.Framework;
 using Nethermind.Specs;
 using Nethermind.Evm.Precompiles;

--- a/src/Nethermind/Nethermind.Evm.Test/Eip4844Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip4844Tests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Specs;
 using NUnit.Framework;
 using Nethermind.Int256;
@@ -47,6 +48,20 @@ public class Eip4844Tests : VirtualMachineTestsBase
         Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
         Assert.That(result.ReturnValue, Is.EqualTo(expectedOutput));
         AssertGas(result, gasCostOfCallingWrapper + GasCostOf.BlobHash);
+    }
+
+    [Test]
+    public void Test_blobhash_null_hash_throws()
+    {
+        byte[] code = Prepare.EvmCode
+            .PushData(UInt256.Zero)
+            .BLOBHASH()
+            .Done;
+
+        Assert.That(
+            () => Execute(Activation, 50000, code, blobVersionedHashes: [null!]),
+            Throws.TypeOf<InvalidOperationException>()
+                .With.Message.EqualTo("Blob versioned hashes must not contain null elements."));
     }
 
     protected override TestAllTracerWithOutput CreateTracer()

--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -4,6 +4,7 @@
 using System.Reflection;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Int256;
@@ -177,7 +178,7 @@ public class EthereumGasPolicyTests
 
     private static IReleaseSpec CreateAccessSpec(bool hotAndCold, bool eip8038)
     {
-        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        IReleaseSpec spec = ReleaseSpecSubstitute.Create();
         spec.UseHotAndColdStorage.Returns(hotAndCold);
         spec.IsEip8038Enabled.Returns(eip8038);
         spec.Precompiles.Returns(((IReleaseSpec)Cancun.Instance).Precompiles);

--- a/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
@@ -1500,7 +1500,7 @@ public class MyTracer : ITxTracer, IDisposable
 
     public void ReportBalanceChange(Address address, UInt256? before, UInt256? after) => throw new NotSupportedException();
 
-    public void ReportCodeChange(Address address, byte[] before, byte[] after) => throw new NotSupportedException();
+    public void ReportCodeChange(Address address, byte[]? before, byte[]? after) => throw new NotSupportedException();
 
     public void ReportNonceChange(Address address, UInt256? before, UInt256? after) => throw new NotSupportedException();
 

--- a/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
@@ -57,7 +57,7 @@ public static class BlobGasCalculator
 
     public static bool TryCalculateBlobBaseFee(BlockHeader header, Transaction transaction, ulong blobGasPriceUpdateFraction, out UInt256 blobBaseFee)
     {
-        if (!TryCalculateFeePerBlobGas(header.ExcessBlobGas.Value, blobGasPriceUpdateFraction, out UInt256 feePerBlobGas))
+        if (!TryCalculateFeePerBlobGas(header, blobGasPriceUpdateFraction, out UInt256 feePerBlobGas))
         {
             blobBaseFee = UInt256.MaxValue;
             return false;

--- a/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
+++ b/src/Nethermind/Nethermind.Evm/BlobGasCalculator.cs
@@ -55,7 +55,7 @@ public static class BlobGasCalculator
 
     public static bool TryCalculateBlobBaseFee(BlockHeader header, Transaction transaction, ulong blobGasPriceUpdateFraction, out UInt256 blobBaseFee)
     {
-        if (!TryCalculateFeePerBlobGas(header.ExcessBlobGas.Value, blobGasPriceUpdateFraction, out UInt256 feePerBlobGas))
+        if (!TryCalculateFeePerBlobGas(header, blobGasPriceUpdateFraction, out UInt256 feePerBlobGas))
         {
             blobBaseFee = UInt256.MaxValue;
             return false;

--- a/src/Nethermind/Nethermind.Evm/BytecodeBuilder.cs
+++ b/src/Nethermind/Nethermind.Evm/BytecodeBuilder.cs
@@ -21,7 +21,7 @@ namespace Nethermind.Evm
             }
             return @this;
         }
-        internal static Prepare PushSingle(this Prepare @this, byte[] value)
+        internal static Prepare PushSingle(this Prepare @this, byte[]? value)
         {
             if (value is not null)
             {
@@ -172,7 +172,7 @@ namespace Nethermind.Evm
         public static Prepare SMOD(this Prepare @this, UInt256? lhs = null, UInt256? mod = null)
             => @this.PushSequence(mod, lhs)
                     .Op(Instruction.SMOD);
-        public static Prepare SIGNEXTEND(this Prepare @this, UInt256? arg = null, byte[] bytes = null)
+        public static Prepare SIGNEXTEND(this Prepare @this, UInt256? arg = null, byte[]? bytes = null)
             => @this.PushSingle(bytes)
                     .PushSingle(arg)
                     .Op(Instruction.SIGNEXTEND);
@@ -203,7 +203,7 @@ namespace Nethermind.Evm
         public static Prepare XOR(this Prepare @this, UInt256? lhs = null, UInt256? rhs = null)
             => @this.PushSequence(rhs, lhs)
                     .Op(Instruction.XOR);
-        public static Prepare BYTE(this Prepare @this, UInt256? pos, byte[] bytes = null)
+        public static Prepare BYTE(this Prepare @this, UInt256? pos, byte[]? bytes = null)
             => @this.PushSingle(bytes)
                     .PushSingle(pos)
                     .Op(Instruction.BYTE);
@@ -219,23 +219,23 @@ namespace Nethermind.Evm
         public static Prepare SAR(this Prepare @this, UInt256? lhs = null, UInt256? rhs = null)
             => @this.PushSequence((UInt256?)rhs, lhs)
                     .Op(Instruction.SAR);
-        public static Prepare MSTORE(this Prepare @this, UInt256? pos = null, byte[] data = null)
+        public static Prepare MSTORE(this Prepare @this, UInt256? pos = null, byte[]? data = null)
             => @this.PushSingle(data)
                     .PushSingle(pos)
                     .Op(Instruction.MSTORE);
-        public static Prepare MSTORE8(this Prepare @this, UInt256? pos = null, byte[] data = null)
+        public static Prepare MSTORE8(this Prepare @this, UInt256? pos = null, byte[]? data = null)
             => @this.PushSingle(data)
                     .PushSingle(pos)
                     .Op(Instruction.MSTORE8);
-        public static Prepare TSTORE(this Prepare @this, UInt256? pos = null, byte[] data = null)
+        public static Prepare TSTORE(this Prepare @this, UInt256? pos = null, byte[]? data = null)
             => @this.PushSingle(data)
                     .PushSingle(pos)
                     .Op(Instruction.TSTORE);
-        public static Prepare SSTORE(this Prepare @this, UInt256? pos = null, byte[] data = null)
+        public static Prepare SSTORE(this Prepare @this, UInt256? pos = null, byte[]? data = null)
             => @this.PushSingle(data)
                     .PushSingle(pos)
                     .Op(Instruction.SSTORE);
-        public static Prepare JUMPI(this Prepare @this, UInt256? to = null, byte[] cond = null)
+        public static Prepare JUMPI(this Prepare @this, UInt256? to = null, byte[]? cond = null)
             => @this.PushSingle(cond)
                     .PushSingle(to)
                     .Op(Instruction.JUMPI);

--- a/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
@@ -49,7 +50,7 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
     public CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec, out Address? delegationAddress) =>
         _inner.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
 
-    public bool TryGetDelegation(Address address, IReleaseSpec spec, out Address? delegatedAddress) =>
+    public bool TryGetDelegation(Address address, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress) =>
         _inner.TryGetDelegation(address, spec, out delegatedAddress);
 
     public void InsertCode(ReadOnlyMemory<byte> code, Address codeOwner, IReleaseSpec spec)

--- a/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
@@ -53,7 +54,7 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
     public IPrecompile? GetPrecompile(Address codeSource, IReleaseSpec vmSpec) =>
         _inner.GetPrecompile(codeSource, vmSpec);
 
-    public bool TryGetDelegation(Address address, IReleaseSpec spec, out Address? delegatedAddress) =>
+    public bool TryGetDelegation(Address address, IReleaseSpec spec, [NotNullWhen(true)] out Address? delegatedAddress) =>
         _inner.TryGetDelegation(address, spec, out delegatedAddress);
 
     public void InsertCode(ReadOnlyMemory<byte> code, Address codeOwner, IReleaseSpec spec)

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -32,7 +33,7 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
     private const ulong JumpDestBytes = 0x5b5b5b5b5b5b5b5bUL;
     private const ulong PackByteHighBits = 0x0002040810204081UL;
 
-    private static readonly long[]? _emptyJumpDestinationBitmap = new long[1];
+    private static readonly long[] _emptyJumpDestinationBitmap = new long[1];
     private long[]? _jumpDestinationBitmap = (codeInfo.Code.Length == 0 || skipAnalysis) ? _emptyJumpDestinationBitmap : null;
 
     private object? _analysisComplete;
@@ -72,15 +73,17 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
         return (long[])previous;
     }
 
-    private static void WaitForAnalysisToComplete(ManualResetEventSlim resetEvent)
+    [MemberNotNull(nameof(_jumpDestinationBitmap))]
+    private void WaitForAnalysisToComplete(ManualResetEventSlim resetEvent)
     {
         // We are waiting, so drop priority to normal (BlockProcessing runs at higher priority).
         using ThreadExtensions.Disposable handle = Thread.CurrentThread.SetNormalPriority();
         // Already in progress, wait for completion.
         resetEvent.Wait();
+        Debug.Assert(_jumpDestinationBitmap is not null);
     }
 
-    private void AnalyzeJumpDestinations(out object previous)
+    private void AnalyzeJumpDestinations([NotNull] out object? previous)
     {
         ManualResetEventSlim analysisComplete = new(initialState: false);
         previous = Interlocked.CompareExchange(ref _analysisComplete, analysisComplete, null);

--- a/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -28,11 +29,19 @@ public class CodeInfoRepository : ICodeInfoRepository
     /// Kept null on the production path so <see cref="LoadCodeInfoDefault"/> can be called directly and inlined instead of going through a no-op delegate.
     /// </remarks>
     private readonly Func<Address, ValueHash256, IReleaseSpec, CodeInfo>? _codeInfoLoader;
-#if ZK_EVM
-    // Precompile CodeInfo indexed by precompile address number (0x01..0x100):
-    // replaces a FrozenDictionary hash+probe on every precompile CALL.
-    private readonly CodeInfo[] _localPrecompileArray = new CodeInfo[0x101];
-#endif
+    /// <summary>Precompile <see cref="CodeInfo"/> indexed by precompile number, for the low numbers.</summary>
+    /// <remarks>Replaces a <see cref="FrozenDictionary{TKey, TValue}"/> hash and probe on every precompile
+    /// call with an array index. A number above <see cref="MaxIndexedNumber"/> — a plugin may register one
+    /// far away, as Taiko does at 0x10001 — is left out and served by <see cref="_localPrecompiles"/>
+    /// instead, so the array never has to cover the whole address space to be correct.</remarks>
+    private readonly CodeInfo?[] _localPrecompileArray;
+
+    /// <summary>Highest precompile number the index array covers.</summary>
+    /// <remarks>Fixed at 0x100 — RIP-7212, the highest Ethereum registers — rather than derived from what
+    /// the chain registers, so that a distant one, as Taiko's at 0x10001, cannot size the array to itself.
+    /// 2 KB of references covers every number an in-tree chain indexes, sparsely: mainnet fills 18 of the
+    /// 257 slots, and anything outside the range falls back to the dictionary.</remarks>
+    private const int MaxIndexedNumber = 0x100;
 
     public CodeInfoRepository(IWorldState worldState, IPrecompileProvider precompileProvider)
         : this(worldState, precompileProvider, codeInfoLoader: null)
@@ -44,13 +53,24 @@ public class CodeInfoRepository : ICodeInfoRepository
         _localPrecompiles = precompileProvider.GetPrecompiles();
         _worldState = worldState;
         _codeInfoLoader = codeInfoLoader;
-#if ZK_EVM
-        foreach (System.Collections.Generic.KeyValuePair<AddressAsKey, CodeInfo> kv in _localPrecompiles)
+        _localPrecompileArray = BuildPrecompileArray(_localPrecompiles);
+    }
+
+    /// <summary>Indexes the precompiles numbered at or below <see cref="MaxIndexedNumber"/>.</summary>
+    /// <param name="precompiles">Every precompile the chain knows.</param>
+    /// <returns>An array holding those within the cap, indexed by number, and nothing else.</returns>
+    /// <remarks>Public so that a decorator answering precompile calls ahead of this repository can index
+    /// its own map the same way; a decorator left probing a dictionary puts the probe back on the path.</remarks>
+    public static CodeInfo?[] BuildPrecompileArray(FrozenDictionary<AddressAsKey, CodeInfo> precompiles)
+    {
+        CodeInfo?[] byIndex = new CodeInfo?[MaxIndexedNumber + 1];
+        foreach (KeyValuePair<AddressAsKey, CodeInfo> entry in precompiles)
         {
-            int idx = ((Address)kv.Key).PrecompileIndexOrNegative();
-            if ((uint)idx < (uint)_localPrecompileArray.Length) _localPrecompileArray[idx] = kv.Value;
+            int index = ((Address)entry.Key).PrecompileIndexOrNegative();
+            if ((uint)index < (uint)byIndex.Length) byIndex[index] = entry.Value;
         }
-#endif
+
+        return byIndex;
     }
 
     public bool IsCodeOverridable => false;
@@ -62,11 +82,11 @@ public class CodeInfoRepository : ICodeInfoRepository
         {
             _worldState.AddAccountRead(codeSource);
             _worldState.RecordAccountAccess(codeSource);
-#if ZK_EVM
-            return _localPrecompileArray[codeSource.PrecompileIndexOrNegative()];
-#else
-            return _localPrecompiles[codeSource];
-#endif
+            int index = codeSource.PrecompileIndexOrNegative();
+            CodeInfo?[] byIndex = _localPrecompileArray;
+            return (uint)index < (uint)byIndex.Length && byIndex[index] is { } precompile
+                ? precompile
+                : _localPrecompiles[codeSource];
         }
 
         CodeInfo codeInfo = InternalGetCodeInfo(codeSource, vmSpec);

--- a/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
@@ -83,11 +83,7 @@ public class CodeInfoRepository : ICodeInfoRepository
         {
             _worldState.AddAccountRead(codeSource);
             _worldState.RecordAccountAccess(codeSource);
-            int index = codeSource.PrecompileIndexOrNegative();
-            CodeInfo?[] byIndex = _localPrecompileArray;
-            return (uint)index < (uint)byIndex.Length && byIndex[index] is { } precompile
-                ? precompile
-                : _localPrecompiles[codeSource];
+            return PrecompileCodeInfo(codeSource);
         }
 
         CodeInfo codeInfo = InternalGetCodeInfo(codeSource, vmSpec);
@@ -106,13 +102,18 @@ public class CodeInfoRepository : ICodeInfoRepository
     public IPrecompile? GetPrecompile(Address codeSource, IReleaseSpec vmSpec) =>
         vmSpec.IsPrecompile(codeSource) ? PrecompileCodeInfo(codeSource).Precompile : null;
 
+    /// <summary>Resolves a precompile's <see cref="CodeInfo"/> from its number, then from the map.</summary>
+    /// <remarks>The map still has to answer for a number above <see cref="MaxIndexedNumber"/>, which the
+    /// index array deliberately leaves out.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private CodeInfo PrecompileCodeInfo(Address codeSource) =>
-#if ZK_EVM
-        _localPrecompileArray[codeSource.PrecompileIndexOrNegative()];
-#else
-        _localPrecompiles[codeSource];
-#endif
+    private CodeInfo PrecompileCodeInfo(Address codeSource)
+    {
+        int index = codeSource.PrecompileIndexOrNegative();
+        CodeInfo?[] byIndex = _localPrecompileArray;
+        return (uint)index < (uint)byIndex.Length && byIndex[index] is { } precompile
+            ? precompile
+            : _localPrecompiles[codeSource];
+    }
 
     private CodeInfo InternalGetCodeInfo(Address codeSource, IReleaseSpec vmSpec)
     {

--- a/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeInfoRepository.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Frozen;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -29,11 +30,19 @@ public class CodeInfoRepository : ICodeInfoRepository
     /// Kept null on the production path so <see cref="LoadCodeInfoDefault"/> can be called directly and inlined instead of going through a no-op delegate.
     /// </remarks>
     private readonly Func<Address, ValueHash256, IReleaseSpec, CodeInfo>? _codeInfoLoader;
-#if ZK_EVM
-    // Precompile CodeInfo indexed by precompile address number (0x01..0x100):
-    // replaces a FrozenDictionary hash+probe on every precompile CALL.
-    private readonly CodeInfo[] _localPrecompileArray = new CodeInfo[0x101];
-#endif
+    /// <summary>Precompile <see cref="CodeInfo"/> indexed by precompile number, for the low numbers.</summary>
+    /// <remarks>Replaces a <see cref="FrozenDictionary{TKey, TValue}"/> hash and probe on every precompile
+    /// call with an array index. A number above <see cref="MaxIndexedNumber"/> — a plugin may register one
+    /// far away, as Taiko does at 0x10001 — is left out and served by <see cref="_localPrecompiles"/>
+    /// instead, so the array never has to cover the whole address space to be correct.</remarks>
+    private readonly CodeInfo?[] _localPrecompileArray;
+
+    /// <summary>Highest precompile number the index array covers.</summary>
+    /// <remarks>Fixed at 0x100 — RIP-7212, the highest Ethereum registers — rather than derived from what
+    /// the chain registers, so that a distant one, as Taiko's at 0x10001, cannot size the array to itself.
+    /// 2 KB of references covers every number an in-tree chain indexes, sparsely: mainnet fills 18 of the
+    /// 257 slots, and anything outside the range falls back to the dictionary.</remarks>
+    private const int MaxIndexedNumber = 0x100;
 
     public CodeInfoRepository(IWorldState worldState, IPrecompileProvider precompileProvider)
         : this(worldState, precompileProvider, codeInfoLoader: null)
@@ -45,13 +54,24 @@ public class CodeInfoRepository : ICodeInfoRepository
         _localPrecompiles = precompileProvider.GetPrecompiles();
         _worldState = worldState;
         _codeInfoLoader = codeInfoLoader;
-#if ZK_EVM
-        foreach (System.Collections.Generic.KeyValuePair<AddressAsKey, CodeInfo> kv in _localPrecompiles)
+        _localPrecompileArray = BuildPrecompileArray(_localPrecompiles);
+    }
+
+    /// <summary>Indexes the precompiles numbered at or below <see cref="MaxIndexedNumber"/>.</summary>
+    /// <param name="precompiles">Every precompile the chain knows.</param>
+    /// <returns>An array holding those within the cap, indexed by number, and nothing else.</returns>
+    /// <remarks>Public so that a decorator answering precompile calls ahead of this repository can index
+    /// its own map the same way; a decorator left probing a dictionary puts the probe back on the path.</remarks>
+    public static CodeInfo?[] BuildPrecompileArray(FrozenDictionary<AddressAsKey, CodeInfo> precompiles)
+    {
+        CodeInfo?[] byIndex = new CodeInfo?[MaxIndexedNumber + 1];
+        foreach (KeyValuePair<AddressAsKey, CodeInfo> entry in precompiles)
         {
-            int idx = ((Address)kv.Key).PrecompileIndexOrNegative();
-            if ((uint)idx < (uint)_localPrecompileArray.Length) _localPrecompileArray[idx] = kv.Value;
+            int index = ((Address)entry.Key).PrecompileIndexOrNegative();
+            if ((uint)index < (uint)byIndex.Length) byIndex[index] = entry.Value;
         }
-#endif
+
+        return byIndex;
     }
 
     public bool IsCodeOverridable => false;
@@ -63,7 +83,11 @@ public class CodeInfoRepository : ICodeInfoRepository
         {
             _worldState.AddAccountRead(codeSource);
             _worldState.RecordAccountAccess(codeSource);
-            return PrecompileCodeInfo(codeSource);
+            int index = codeSource.PrecompileIndexOrNegative();
+            CodeInfo?[] byIndex = _localPrecompileArray;
+            return (uint)index < (uint)byIndex.Length && byIndex[index] is { } precompile
+                ? precompile
+                : _localPrecompiles[codeSource];
         }
 
         CodeInfo codeInfo = InternalGetCodeInfo(codeSource, vmSpec);

--- a/src/Nethermind/Nethermind.Evm/EvmObjectPool.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmObjectPool.zkevm.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Nethermind.Evm;
 
@@ -26,7 +27,7 @@ internal sealed class EvmObjectPool<T>
         ArgumentOutOfRangeException.ThrowIfNegative(maxShared);
     }
 
-    public bool TryDequeue(out T item) => _items.TryPop(out item);
+    public bool TryDequeue([MaybeNullWhen(false)] out T item) => _items.TryPop(out item);
 
     public void Enqueue(T item) => _items.Push(item);
 

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -40,12 +40,13 @@ public ref partial struct EvmStack
     public EvmStack(int head, ref byte stack, scoped in ReadOnlySpan<byte> codeSpan)
     {
         Head = head;
-        _tracer = null;
+        _tracer = null!;
         _stack = ref stack;
         Code = ref MemoryMarshal.GetReference(codeSpan);
         CodeLength = codeSpan.Length;
     }
 
+    // Null only for stacks whose compile-time tracing flag eliminates every tracer read.
     private readonly ITxTracer _tracer;
     private readonly ref byte _stack;
     internal readonly ref byte Code;
@@ -1911,7 +1912,7 @@ public ref partial struct EvmStack
         return cache.GetOrCreate(MemoryMarshal.CreateReadOnlySpan(ref Unsafe.Add(ref _stack, head * WordSize + WordSize - AddressSize), AddressSize));
     }
 
-    public bool PopAddress(out Address address)
+    public bool PopAddress([NotNullWhen(true)] out Address? address)
     {
         nint head = Head - 1;
         if (head < 0)

--- a/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
@@ -66,7 +66,7 @@ namespace Nethermind.Evm
             in UInt256 value,
             in ReadOnlyMemory<byte> inputData)
         {
-            ExecutionEnvironment env = _pool.TryDequeue(out ExecutionEnvironment pooled) ? pooled : new();
+            ExecutionEnvironment env = _pool.TryDequeue(out ExecutionEnvironment? pooled) ? pooled : new();
             env.CodeInfo = codeInfo;
             env.ExecutingAccount = executingAccount;
             env.Caller = caller;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -99,7 +99,7 @@ public static partial class EvmInstructions
         // Pop the gas limit for the call.
         if (!stack.PopUInt256(out UInt256 gasLimit)) goto StackUnderflow;
         // Pop the code source address from the stack.
-        Address codeSource = stack.PopAddress(vm.AddressCache);
+        Address? codeSource = stack.PopAddress(vm.AddressCache);
         if (codeSource is null) goto StackUnderflow;
 
         ExecutionEnvironment env = vm.VmState.Env;
@@ -266,10 +266,10 @@ public static partial class EvmInstructions
             return EvmExceptionType.None;
         }
 
-        if (TOpCall.ExecutionType == ExecutionType.STATICCALL && codeInfo.IsPrecompile &&
+        if (TOpCall.ExecutionType == ExecutionType.STATICCALL && codeInfo.Precompile is { } precompile &&
             TryInlineStaticPrecompileCall<TGasPolicy, TTracingInst>(
                 vm, ref stack, ref gas, in dataOffset, dataLength, in outputOffset, outputLength,
-                codeInfo.Precompile!, target, codeSource, gasLimitUl, out EvmExceptionType inlineResult))
+                precompile, target, codeSource, gasLimitUl, out EvmExceptionType inlineResult))
         {
             return inlineResult;
         }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
@@ -165,7 +165,7 @@ public static partial class EvmInstructions
     {
         IReleaseSpec spec = vm.Spec;
         // Retrieve the target account address.
-        Address address = stack.PopAddress(vm.AddressCache);
+        Address? address = stack.PopAddress(vm.AddressCache);
         // Pop destination offset, source offset, and length from the stack. The destination keeps its
         // vector decode here: this handler already saves seven callee-saved registers, and holding the
         // destination in general registers instead costs an eighth and measures slower.
@@ -267,7 +267,7 @@ public static partial class EvmInstructions
         TGasPolicy.Consume<ExtCodeSizeGasCost>(ref gas, spec);
 
         // Pop the account address from the stack.
-        Address address = stack.PopAddress(vm.AddressCache);
+        Address? address = stack.PopAddress(vm.AddressCache);
         if (address is null) goto StackUnderflow;
 
         // Charge gas for accessing the account's state.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
@@ -197,7 +197,7 @@ public static partial class EvmInstructions
     {
         IReleaseSpec spec = vm.Spec;
         // Retrieve the target account address.
-        Address address = stack.PopAddress(vm.AddressCache);
+        Address? address = stack.PopAddress(vm.AddressCache);
         // Pop destination offset, source offset, and length from the stack. The destination keeps its
         // vector decode here: this handler already saves seven callee-saved registers, and holding the
         // destination in general registers instead costs an eighth and measures slower.
@@ -299,7 +299,7 @@ public static partial class EvmInstructions
         TGasPolicy.Consume<ExtCodeSizeGasCost>(ref gas, spec);
 
         // Pop the account address from the stack.
-        Address address = stack.PopAddress(vm.AddressCache);
+        Address? address = stack.PopAddress(vm.AddressCache);
         if (address is null) goto StackUnderflow;
 
         // Charge gas for accessing the account's state.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -259,7 +259,7 @@ public static partial class EvmInstructions
         }
 
         // Pop the inheritor address from the stack; signal underflow if missing.
-        Address inheritor = stack.PopAddress(vm.AddressCache);
+        Address? inheritor = stack.PopAddress(vm.AddressCache);
         if (inheritor is null)
             goto StackUnderflow;
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -549,7 +550,7 @@ public static partial class EvmInstructions
         // Deduct gas cost for balance operation as per specification.
         TGasPolicy.Consume<BalanceGasCost>(ref gas, spec);
 
-        Address address = stack.PopAddress(vm.AddressCache);
+        Address? address = stack.PopAddress(vm.AddressCache);
         if (address is null) goto StackUnderflow;
 
         // Charge gas for account access. If insufficient gas remains, abort.
@@ -615,7 +616,7 @@ public static partial class EvmInstructions
         IReleaseSpec spec = vm.Spec;
         TGasPolicy.Consume<ExtCodeHashGasCost>(ref gas, spec);
 
-        Address address = stack.PopAddress(vm.AddressCache);
+        Address? address = stack.PopAddress(vm.AddressCache);
         if (address is null) goto StackUnderflow;
         // Check if enough gas for account access and charge accordingly.
         if (!TSpec.ConsumeAccountAccessGas<TGasPolicy>(ref gas, spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, address)) goto OutOfGas;
@@ -711,13 +712,17 @@ public static partial class EvmInstructions
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
 
         // Retrieve the array of versioned blob hashes from the execution context.
-        byte[][] versionedHashes = vm.TxExecutionContext.BlobVersionedHashes;
+        byte[]?[]? versionedHashes = vm.TxExecutionContext.BlobVersionedHashes;
 
         // If versioned hashes are available and the index is within range, push the corresponding blob hash.
-        // Otherwise, push zero.
-        return versionedHashes is not null && result < versionedHashes.Length
-            ? stack.PushBytes<TTracingInst>(versionedHashes[result.u0])
-            : stack.PushZero<TTracingInst>();
+        if (versionedHashes is not null && result < versionedHashes.Length)
+        {
+            byte[] versionedHash = versionedHashes[result.u0]
+                ?? throw new InvalidOperationException("Blob versioned hashes must not contain null elements.");
+            return stack.PushBytes<TTracingInst>(versionedHash);
+        }
+
+        return stack.PushZero<TTracingInst>();
         // Jump forward to be unpredicted by the branch predictor.
     StackUnderflow:
         return EvmExceptionType.StackUnderflow;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -98,7 +98,7 @@ public static unsafe partial class EvmInstructions
         if (!stack.PopUInt256(out UInt256 param)) return EvmExceptionType.StackUnderflow;
         if (param > 0x11U) return EvmExceptionType.BadInstruction;
 
-        byte[][]? blobHashes = vm.TxExecutionContext.BlobVersionedHashes;
+        byte[]?[]? blobHashes = vm.TxExecutionContext.BlobVersionedHashes;
         return param.u0 switch
         {
             0x00 => stack.PushUInt32<TTracingInst>((uint)TxType.FrameTx),

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.TxAssertions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.TxAssertions.cs
@@ -128,7 +128,7 @@ public static partial class EvmInstructions
         // Spec stack order: param on top, address second, in3 (slot key / local index / unused) third.
         if (!stack.PopUInt256(out UInt256 param)) return EvmExceptionType.StackUnderflow;
         if (param > 0x0A) return EvmExceptionType.BadInstruction;
-        Address address = stack.PopAddress(vm.AddressCache);
+        Address? address = stack.PopAddress(vm.AddressCache);
         if (address is null) return EvmExceptionType.StackUnderflow;
         if (!stack.PopUInt256(out UInt256 in3)) return EvmExceptionType.StackUnderflow;
 

--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
@@ -28,7 +28,7 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
     private int _destroyListSnapshots;
     private int _logsSnapshots;
 
-    public readonly bool IsCold(Address? address) => !_trackingState.AccessedAddresses.Contains(address);
+    public readonly bool IsCold(Address? address) => address is null || !_trackingState.AccessedAddresses.Contains(address);
 
     public readonly bool IsCold(in StorageCell storageCell) => !_trackingState.AccessedStorageCells.Contains(storageCell);
 
@@ -81,7 +81,7 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
     public void Dispose()
     {
         TrackingState state = _trackingState;
-        _trackingState = null;
+        _trackingState = null!;
         TrackingState.ResetAndReturn(state);
     }
 
@@ -93,7 +93,7 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
 
         public static TrackingState RentState()
         {
-            if (_trackerPool.TryDequeue(out TrackingState tracker)) return tracker;
+            if (_trackerPool.TryDequeue(out TrackingState? tracker)) return tracker;
             return new TrackingState();
         }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -134,7 +134,7 @@ public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token
         }
     }
 
-    public void ReportCodeChange(Address address, byte[] before, byte[] after)
+    public void ReportCodeChange(Address address, byte[]? before, byte[]? after)
     {
         token.ThrowIfCancellationRequested();
         if (innerTracer.IsTracingState)

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -86,7 +86,7 @@ public class CompositeTxTracer : ITxTracer
         }
     }
 
-    public void ReportCodeChange(Address address, byte[] before, byte[] after)
+    public void ReportCodeChange(Address address, byte[]? before, byte[]? after)
     {
         for (int index = 0; index < _txTracers.Count; index++)
         {

--- a/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/NullTxTracer.cs
@@ -65,7 +65,7 @@ public class NullTxTracer : TxTracer
     public override void ReportBalanceChange(Address address, UInt256? before, UInt256? after)
         => ThrowInvalidOperationException();
 
-    public override void ReportCodeChange(Address address, byte[] before, byte[] after)
+    public override void ReportCodeChange(Address address, byte[]? before, byte[]? after)
         => ThrowInvalidOperationException();
 
     public override void ReportNonceChange(Address address, UInt256? before, UInt256? after)

--- a/src/Nethermind/Nethermind.Evm/Tracing/TracerExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TracerExtensions.cs
@@ -14,7 +14,7 @@ public static class TracerExtensions
     public static CancellationBlockTracer WithCancellation(this IBlockTracer blockTracer, CancellationToken cancellationToken) =>
         new(blockTracer, cancellationToken);
 
-    public static T? GetTracer<T>(this ITxTracer txTracer)
+    public static T? GetTracer<T>(this ITxTracer? txTracer)
         where T : class, ITxTracer
     {
         if (txTracer is null)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/FrameTxSignatureValidator.cs
@@ -137,7 +137,7 @@ public static class FrameTxSignatureValidator
 
         Result<byte[]> result = p256Precompile.Run(input.AsMemory(0, InputLength), spec);
         ArrayPool<byte>.Shared.Return(input);
-        return result && result.Data.Length > 0 || Fail(InvalidSignature, out error);
+        return result && result.Data is { Length: > 0 } || Fail(InvalidSignature, out error);
     }
 
     private static bool Fail(string message, out string? error)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -248,29 +248,31 @@ namespace Nethermind.Evm.TransactionProcessing
                 return result;
             }
 
-            Address? recipient = tx.To;
-            bool useSimpleTransferFastPath = TryPrepareSimpleTransferFastPath(tx, spec, out CodeInfo? preloadedCodeInfo, out Address? preloadedDelegationAddress);
+            Address? simpleTransferRecipient = PrepareSimpleTransferFastPath(tx, spec, out CodeInfo? preloadedCodeInfo, out Address? preloadedDelegationAddress);
 
-            bool commitBeforeExecution = commit && (!useSimpleTransferFastPath || restore || tracer.IsTracingState);
+            bool commitBeforeExecution = commit && (simpleTransferRecipient is null || restore || tracer.IsTracingState);
             if (commitBeforeExecution) WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullTxTracer.Instance, commitRoots: false);
 
             if (!(result = CalculateAvailableGas(tx, spec, in intrinsicGas, out TGasPolicy gasAvailable))) return result;
 
-            return useSimpleTransferFastPath
-                ? ExecuteSimpleTransfer(tx, header, spec, tracer, opts, restore, commit, deleteCallerAccount, recipient!, in intrinsicGas, gasAvailable, in opcodeGasPrice, in premiumPerGas, in senderReservedGasPayment, in blobBaseFee)
-                : ExecuteEvmTransaction(tx, header, spec, tracer, opts, restore, commit, deleteCallerAccount, in intrinsicGas, gasAvailable, in opcodeGasPrice, in premiumPerGas, in senderReservedGasPayment, in blobBaseFee, preloadedCodeInfo, preloadedDelegationAddress);
+            if (simpleTransferRecipient is not null)
+            {
+                return ExecuteSimpleTransfer(tx, header, spec, tracer, opts, restore, commit, deleteCallerAccount, simpleTransferRecipient, in intrinsicGas, gasAvailable, in opcodeGasPrice, in premiumPerGas, in senderReservedGasPayment, in blobBaseFee);
+            }
+
+            return ExecuteEvmTransaction(tx, header, spec, tracer, opts, restore, commit, deleteCallerAccount, in intrinsicGas, gasAvailable, in opcodeGasPrice, in premiumPerGas, in senderReservedGasPayment, in blobBaseFee, preloadedCodeInfo, preloadedDelegationAddress);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsSimpleTransferFastPathCandidate(Transaction tx, bool isCodeOverridable)
-            => !isCodeOverridable && tx.To is not null && tx.AuthorizationList is null && !ForceSimpleTransferDisabled;
+            => !isCodeOverridable && tx.AuthorizationList is null && !ForceSimpleTransferDisabled;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool HasNoExecutableCode(CodeInfo codeInfo, Address? delegationAddress)
             => delegationAddress is null && codeInfo.IsEmpty;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool TryPrepareSimpleTransferFastPath(
+        private Address? PrepareSimpleTransferFastPath(
             Transaction tx,
             IReleaseSpec spec,
             out CodeInfo? preloadedCodeInfo,
@@ -278,10 +280,11 @@ namespace Nethermind.Evm.TransactionProcessing
         {
             preloadedCodeInfo = null;
             preloadedDelegationAddress = null;
-            if (!IsSimpleTransferFastPathCandidate(tx, _isCodeOverridable)) return false;
+            Address? recipient = tx.To;
+            if (recipient is null || !IsSimpleTransferFastPathCandidate(tx, _isCodeOverridable)) return null;
 
-            preloadedCodeInfo = _codeInfoRepository.GetCachedCodeInfo(tx.To!, followDelegation: !spec.IsEip8037Enabled, spec, out preloadedDelegationAddress);
-            return HasNoExecutableCode(preloadedCodeInfo, preloadedDelegationAddress);
+            preloadedCodeInfo = _codeInfoRepository.GetCachedCodeInfo(recipient, followDelegation: !spec.IsEip8037Enabled, spec, out preloadedDelegationAddress);
+            return HasNoExecutableCode(preloadedCodeInfo, preloadedDelegationAddress) ? recipient : null;
         }
 
         [SkipLocalsInit]
@@ -667,7 +670,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (tracer.IsTracingReceipt)
             {
-                Hash256 stateRoot = null;
+                Hash256? stateRoot = null;
                 if (!spec.IsEip658Enabled)
                 {
                     WorldState.RecalculateStateRoot();
@@ -1083,10 +1086,12 @@ namespace Nethermind.Evm.TransactionProcessing
         protected virtual TransactionResult BuyGas(Transaction tx, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts,
                 in UInt256 effectiveGasPrice, out UInt256 premiumPerGas, out UInt256 senderReservedGasPayment, out UInt256 blobBaseFee)
         {
+            Address? sender = tx.SenderAddress;
+            Debug.Assert(sender is not null, "Static transaction validation must resolve the sender before gas is charged.");
             premiumPerGas = UInt256.Zero;
             senderReservedGasPayment = UInt256.Zero;
             blobBaseFee = UInt256.Zero;
-            UInt256 balance = WorldState.GetBalance(tx.SenderAddress!);
+            UInt256 balance = WorldState.GetBalance(sender);
 
             bool validate = ShouldValidateGas(tx, opts);
 
@@ -1167,7 +1172,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 if (opts.HasFlag(ExecutionOptions.Warmup))
                 {
                     UInt256 warmCharge = UInt256.Min(senderReservedGasPayment, balance);
-                    if (!warmCharge.IsZero) WorldState.SubtractFromBalance(tx.SenderAddress, warmCharge, spec);
+                    if (!warmCharge.IsZero) WorldState.SubtractFromBalance(sender, warmCharge, spec);
                     return TransactionResult.Ok;
                 }
 
@@ -1175,7 +1180,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 return InsufficientFundsForGas(tx, balance, balanceCheck);
             }
 
-            if (!senderReservedGasPayment.IsZero) WorldState.SubtractFromBalance(tx.SenderAddress, senderReservedGasPayment, spec);
+            if (!senderReservedGasPayment.IsZero) WorldState.SubtractFromBalance(sender, senderReservedGasPayment, spec);
 
             return TransactionResult.Ok;
         }
@@ -1190,8 +1195,10 @@ namespace Nethermind.Evm.TransactionProcessing
 
         protected virtual TransactionResult IncrementNonce(Transaction tx, BlockHeader header, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts)
         {
+            Address? senderAddress = tx.SenderAddress;
+            Debug.Assert(senderAddress is not null, "Static transaction validation must resolve the sender before its nonce is updated.");
             bool validate = !opts.HasFlag(ExecutionOptions.SkipValidation);
-            ulong nonce = WorldState.GetNonce(tx.SenderAddress!);
+            ulong nonce = WorldState.GetNonce(senderAddress);
             if (validate && tx.Nonce != nonce)
             {
                 TraceLogInvalidTx(tx, $"WRONG_TRANSACTION_NONCE: {tx.Nonce} (expected {nonce})");
@@ -1205,7 +1212,7 @@ namespace Nethermind.Evm.TransactionProcessing
             }
 
             ulong newNonce = validate || nonce < ulong.MaxValue ? nonce + 1 : 0;
-            WorldState.SetNonce(tx.SenderAddress, newNonce);
+            WorldState.SetNonce(senderAddress, newNonce);
 
             return TransactionResult.Ok;
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -266,29 +266,31 @@ namespace Nethermind.Evm.TransactionProcessing
                 return result;
             }
 
-            Address? recipient = tx.To;
-            bool useSimpleTransferFastPath = TryPrepareSimpleTransferFastPath(tx, spec, out CodeInfo? preloadedCodeInfo, out Address? preloadedDelegationAddress);
+            Address? simpleTransferRecipient = PrepareSimpleTransferFastPath(tx, spec, out CodeInfo? preloadedCodeInfo, out Address? preloadedDelegationAddress);
 
-            bool commitBeforeExecution = commit && (!useSimpleTransferFastPath || restore || tracer.IsTracingState);
+            bool commitBeforeExecution = commit && (simpleTransferRecipient is null || restore || tracer.IsTracingState);
             if (commitBeforeExecution) WorldState.Commit(spec, tracer.IsTracingState ? tracer : NullTxTracer.Instance, commitRoots: false);
 
             if (!(result = CalculateAvailableGas(tx, spec, in intrinsicGas, out TGasPolicy gasAvailable))) return result;
 
-            return useSimpleTransferFastPath
-                ? ExecuteSimpleTransfer(tx, header, spec, tracer, opts, restore, commit, deleteCallerAccount, recipient!, in intrinsicGas, gasAvailable, in opcodeGasPrice, in premiumPerGas, in senderReservedGasPayment, in blobBaseFee)
-                : ExecuteEvmTransaction(tx, header, spec, tracer, opts, restore, commit, deleteCallerAccount, in intrinsicGas, gasAvailable, in opcodeGasPrice, in premiumPerGas, in senderReservedGasPayment, in blobBaseFee, preloadedCodeInfo, preloadedDelegationAddress);
+            if (simpleTransferRecipient is not null)
+            {
+                return ExecuteSimpleTransfer(tx, header, spec, tracer, opts, restore, commit, deleteCallerAccount, simpleTransferRecipient, in intrinsicGas, gasAvailable, in opcodeGasPrice, in premiumPerGas, in senderReservedGasPayment, in blobBaseFee);
+            }
+
+            return ExecuteEvmTransaction(tx, header, spec, tracer, opts, restore, commit, deleteCallerAccount, in intrinsicGas, gasAvailable, in opcodeGasPrice, in premiumPerGas, in senderReservedGasPayment, in blobBaseFee, preloadedCodeInfo, preloadedDelegationAddress);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsSimpleTransferFastPathCandidate(Transaction tx, bool isCodeOverridable)
-            => !isCodeOverridable && tx.To is not null && tx.AuthorizationList is null && !ForceSimpleTransferDisabled;
+            => !isCodeOverridable && tx.AuthorizationList is null && !ForceSimpleTransferDisabled;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool HasNoExecutableCode(CodeInfo codeInfo, Address? delegationAddress)
             => delegationAddress is null && codeInfo.IsEmpty;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool TryPrepareSimpleTransferFastPath(
+        private Address? PrepareSimpleTransferFastPath(
             Transaction tx,
             IReleaseSpec spec,
             out CodeInfo? preloadedCodeInfo,
@@ -296,10 +298,11 @@ namespace Nethermind.Evm.TransactionProcessing
         {
             preloadedCodeInfo = null;
             preloadedDelegationAddress = null;
-            if (!IsSimpleTransferFastPathCandidate(tx, _isCodeOverridable)) return false;
+            Address? recipient = tx.To;
+            if (recipient is null || !IsSimpleTransferFastPathCandidate(tx, _isCodeOverridable)) return null;
 
-            preloadedCodeInfo = _codeInfoRepository.GetCachedCodeInfo(tx.To!, followDelegation: !spec.IsEip8037Enabled, spec, out preloadedDelegationAddress);
-            return HasNoExecutableCode(preloadedCodeInfo, preloadedDelegationAddress);
+            preloadedCodeInfo = _codeInfoRepository.GetCachedCodeInfo(recipient, followDelegation: !spec.IsEip8037Enabled, spec, out preloadedDelegationAddress);
+            return HasNoExecutableCode(preloadedCodeInfo, preloadedDelegationAddress) ? recipient : null;
         }
 
         [SkipLocalsInit]
@@ -685,7 +688,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             if (tracer.IsTracingReceipt)
             {
-                Hash256 stateRoot = null;
+                Hash256? stateRoot = null;
                 if (!spec.IsEip658Enabled)
                 {
                     WorldState.RecalculateStateRoot();
@@ -1101,10 +1104,12 @@ namespace Nethermind.Evm.TransactionProcessing
         protected virtual TransactionResult BuyGas(Transaction tx, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts,
                 in UInt256 effectiveGasPrice, out UInt256 premiumPerGas, out UInt256 senderReservedGasPayment, out UInt256 blobBaseFee)
         {
+            Address? sender = tx.SenderAddress;
+            Debug.Assert(sender is not null, "Static transaction validation must resolve the sender before gas is charged.");
             premiumPerGas = UInt256.Zero;
             senderReservedGasPayment = UInt256.Zero;
             blobBaseFee = UInt256.Zero;
-            UInt256 balance = WorldState.GetBalance(tx.SenderAddress!);
+            UInt256 balance = WorldState.GetBalance(sender);
 
             bool validate = ShouldValidateGas(tx, opts);
 
@@ -1185,7 +1190,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 if (opts.HasFlag(ExecutionOptions.Warmup))
                 {
                     UInt256 warmCharge = UInt256.Min(senderReservedGasPayment, balance);
-                    if (!warmCharge.IsZero) WorldState.SubtractFromBalance(tx.SenderAddress, warmCharge, spec);
+                    if (!warmCharge.IsZero) WorldState.SubtractFromBalance(sender, warmCharge, spec);
                     return TransactionResult.Ok;
                 }
 
@@ -1193,7 +1198,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 return InsufficientFundsForGas(tx, balance, balanceCheck);
             }
 
-            if (!senderReservedGasPayment.IsZero) WorldState.SubtractFromBalance(tx.SenderAddress, senderReservedGasPayment, spec);
+            if (!senderReservedGasPayment.IsZero) WorldState.SubtractFromBalance(sender, senderReservedGasPayment, spec);
 
             return TransactionResult.Ok;
         }
@@ -1208,8 +1213,10 @@ namespace Nethermind.Evm.TransactionProcessing
 
         protected virtual TransactionResult IncrementNonce(Transaction tx, BlockHeader header, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts)
         {
+            Address? senderAddress = tx.SenderAddress;
+            Debug.Assert(senderAddress is not null, "Static transaction validation must resolve the sender before its nonce is updated.");
             bool validate = !opts.HasFlag(ExecutionOptions.SkipValidation);
-            ulong nonce = WorldState.GetNonce(tx.SenderAddress!);
+            ulong nonce = WorldState.GetNonce(senderAddress);
             if (validate && tx.Nonce != nonce)
             {
                 TraceLogInvalidTx(tx, $"WRONG_TRANSACTION_NONCE: {tx.Nonce} (expected {nonce})");
@@ -1223,7 +1230,7 @@ namespace Nethermind.Evm.TransactionProcessing
             }
 
             ulong newNonce = validate || nonce < ulong.MaxValue ? nonce + 1 : 0;
-            WorldState.SetNonce(tx.SenderAddress, newNonce);
+            WorldState.SetNonce(senderAddress, newNonce);
 
             return TransactionResult.Ok;
         }

--- a/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionSubstate.cs
@@ -126,7 +126,7 @@ public readonly ref struct TransactionSubstate
             if (span.Length < WordSize) return null;
 
             UInt256 panicCode = new(span.TakeAndMove(WordSize), isBigEndian: true);
-            if (!PanicReasons.TryGetValue(panicCode, out string panicReason))
+            if (!PanicReasons.TryGetValue(panicCode, out string? panicReason))
             {
                 return $"unknown panic code ({panicCode.ToHexString(skipLeadingZeros: true)})";
             }

--- a/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
+++ b/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
@@ -10,12 +10,12 @@ namespace Nethermind.Evm
     public readonly struct TxExecutionContext(
         Address origin,
         ICodeInfoRepository codeInfoRepository,
-        byte[][]? blobVersionedHashes,
+        byte[]?[]? blobVersionedHashes,
         in UInt256 gasPrice)
     {
         public readonly ValueHash256 Origin = origin.ToHash();
         public readonly ICodeInfoRepository CodeInfoRepository = codeInfoRepository;
-        public readonly byte[][]? BlobVersionedHashes = blobVersionedHashes;
+        public readonly byte[]?[]? BlobVersionedHashes = blobVersionedHashes;
         public readonly UInt256 GasPrice = gasPrice;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
+++ b/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
@@ -10,13 +10,13 @@ namespace Nethermind.Evm
     public readonly struct TxExecutionContext(
         Address origin,
         ICodeInfoRepository codeInfoRepository,
-        byte[][]? blobVersionedHashes,
+        byte[]?[]? blobVersionedHashes,
         in UInt256 gasPrice,
         FrameTxContext? frameTxContext = null)
     {
         public readonly ValueHash256 Origin = origin.ToHash();
         public readonly ICodeInfoRepository CodeInfoRepository = codeInfoRepository;
-        public readonly byte[][]? BlobVersionedHashes = blobVersionedHashes;
+        public readonly byte[]?[]? BlobVersionedHashes = blobVersionedHashes;
         public readonly UInt256 GasPrice = gasPrice;
 
         /// <summary>Non-null only while processing an EIP-8141 frame transaction.</summary>

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.CallResult.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.CallResult.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
 
 namespace Nethermind.Evm;
@@ -45,6 +46,7 @@ public partial class VirtualMachine<TGasPolicy>
         public EvmExceptionType ExceptionType { get; }
         public bool ShouldRevert { get; }
         public bool? PrecompileSuccess { get; }
+        [MemberNotNullWhen(false, nameof(StateToExecute))]
         public bool IsReturn => StateToExecute is null;
         //EvmExceptionType.Revert is returned when the top frame encounters a REVERT opcode, which is not an exception.
         public bool IsException => ExceptionType != EvmExceptionType.None && ExceptionType != EvmExceptionType.Revert;

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Dispatch.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Dispatch.cs
@@ -35,7 +35,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
     }
 
     /// <summary>The dispatch table the running transaction uses, resolved once by <c>PrepareOpcodes</c>.</summary>
-    private delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[] _opcodeHandlers;
+    private delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[] _opcodeHandlers = null!;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Nethermind.Config;
@@ -105,22 +106,23 @@ public partial class VirtualMachine<TGasPolicy>(
     ILogManager? logManager) : IVirtualMachine<TGasPolicy>
     where TGasPolicy : struct, IGasPolicy<TGasPolicy>
 {
-    private readonly ValueHash256 _chainId = ((UInt256)specProvider.ChainId).ToValueHash();
+    private readonly ValueHash256 _chainId = ((UInt256)(specProvider ?? throw new ArgumentNullException(nameof(specProvider))).ChainId).ToValueHash();
 
     private readonly IBlockhashProvider _blockHashProvider = blockHashProvider ?? throw new ArgumentNullException(nameof(blockHashProvider));
     protected readonly ISpecProvider _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
     protected readonly ILogger _logger = logManager?.GetClassLogger<VirtualMachine>() ?? throw new ArgumentNullException(nameof(logManager));
     protected readonly VmStateStack<TGasPolicy> _stateStack = new(MaxCallDepth + 1);
 
-    protected IWorldState _worldState;
+    // These execution-scoped fields are initialized before opcode dispatch; current state is cleared between executions.
+    protected IWorldState _worldState = null!;
     private bool _shouldRestoreRipemdTouch;
 
     protected ITxTracer _txTracer = NullTxTracer.Instance;
 
-    private ICodeInfoRepository _codeInfoRepository;
+    private ICodeInfoRepository _codeInfoRepository = null!;
 
     private ReadOnlyMemory<byte> _returnDataBuffer = Array.Empty<byte>();
-    protected VmState<TGasPolicy> _currentState;
+    protected VmState<TGasPolicy> _currentState = null!;
     protected ReadOnlyMemory<byte>? _previousCallResult;
     protected UInt256 _previousCallOutputDestination;
 
@@ -267,7 +269,7 @@ public partial class VirtualMachine<TGasPolicy>(
                         TransactionSubstate substate = HandleException(in callResult, ref previousCallOutput, out bool terminate);
                         if (terminate)
                         {
-                            _currentState = null;
+                            _currentState = null!;
                             return substate;
                         }
                         // Continue execution if the exception did not immediately finalize the transaction.
@@ -283,7 +285,7 @@ public partial class VirtualMachine<TGasPolicy>(
                         TraceTransactionActionEnd(_currentState, callResult);
                     }
                     TransactionSubstate substate = PrepareTopLevelSubstate(in callResult);
-                    _currentState = null;
+                    _currentState = null!;
                     return substate;
                 }
 
@@ -374,7 +376,7 @@ public partial class VirtualMachine<TGasPolicy>(
             TransactionSubstate failSubstate = HandleFailure<TTracingInst>(failure, substateError, ref previousCallOutput, out bool shouldExit);
             if (shouldExit)
             {
-                _currentState = null;
+                _currentState = null!;
                 return failSubstate;
             }
         }
@@ -390,7 +392,7 @@ public partial class VirtualMachine<TGasPolicy>(
             _currentState?.Dispose();
         }
 
-        _currentState = null;
+        _currentState = null!;
         while (_stateStack.Count != 0)
         {
             VmState<TGasPolicy> parent = _stateStack.Pop();
@@ -811,6 +813,7 @@ public partial class VirtualMachine<TGasPolicy>(
     /// </param>
     protected void PrepareNextCallFrame(in CallResult callResult, ref ReadOnlySpan<byte> previousCallOutput)
     {
+        Debug.Assert(callResult.StateToExecute is not null, "A non-returning call result must carry its next frame.");
         // Push the current execution state onto the state stack so it can be restored later.
         _stateStack.Push(_currentState);
 
@@ -993,7 +996,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
         catch (Exception exception) when (exception is DllNotFoundException or { InnerException: DllNotFoundException })
         {
-            if (_logger.IsError) LogMissingDependency(precompile, (exception as DllNotFoundException ?? exception.InnerException as DllNotFoundException)!);
+            if (_logger.IsError) LogMissingDependency(precompile, GetMissingDependencyException(exception));
             Environment.Exit(ExitCodes.MissingPrecompile);
             throw; // Unreachable
         }
@@ -1181,7 +1184,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
         catch (Exception exception) when (exception is DllNotFoundException or { InnerException: DllNotFoundException })
         {
-            if (_logger.IsError) LogMissingDependency(precompile, exception as DllNotFoundException ?? exception.InnerException as DllNotFoundException);
+            if (_logger.IsError) LogMissingDependency(precompile, GetMissingDependencyException(exception));
             Environment.Exit(ExitCodes.MissingPrecompile);
             throw; // Unreachable
         }
@@ -1199,6 +1202,13 @@ public partial class VirtualMachine<TGasPolicy>(
     [MethodImpl(MethodImplOptions.NoInlining)]
     protected void LogMissingDependency(IPrecompile precompile, DllNotFoundException exception)
         => _logger.Error($"Failed to load one of the dependencies of {precompile.GetType()} precompile", exception);
+
+    private static DllNotFoundException GetMissingDependencyException(Exception exception) => exception switch
+    {
+        DllNotFoundException missingDependency => missingDependency,
+        { InnerException: DllNotFoundException missingDependency } => missingDependency,
+        _ => throw new ArgumentOutOfRangeException(nameof(exception)),
+    };
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     protected static string GetErrorString(IPrecompile precompile, string? error)
@@ -1370,6 +1380,7 @@ public partial class VirtualMachine<TGasPolicy>(
         };
 
     Revert:
+        Debug.Assert(ReturnData is byte[], "REVERT must provide return data.");
         return new CallResult((byte[])ReturnData, null, shouldRevert: true, exceptionType);
 
     ReturnFailure:

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Nethermind.Config;
@@ -105,22 +106,23 @@ public partial class VirtualMachine<TGasPolicy>(
     ILogManager? logManager) : IVirtualMachine<TGasPolicy>
     where TGasPolicy : struct, IGasPolicy<TGasPolicy>
 {
-    private readonly ValueHash256 _chainId = ((UInt256)specProvider.ChainId).ToValueHash();
+    private readonly ValueHash256 _chainId = ((UInt256)(specProvider ?? throw new ArgumentNullException(nameof(specProvider))).ChainId).ToValueHash();
 
     private readonly IBlockhashProvider _blockHashProvider = blockHashProvider ?? throw new ArgumentNullException(nameof(blockHashProvider));
     protected readonly ISpecProvider _specProvider = specProvider ?? throw new ArgumentNullException(nameof(specProvider));
     protected readonly ILogger _logger = logManager?.GetClassLogger<VirtualMachine>() ?? throw new ArgumentNullException(nameof(logManager));
     protected readonly VmStateStack<TGasPolicy> _stateStack = new(MaxCallDepth + 1);
 
-    protected IWorldState _worldState;
+    // These execution-scoped fields are initialized before opcode dispatch; current state is cleared between executions.
+    protected IWorldState _worldState = null!;
     private bool _shouldRestoreRipemdTouch;
 
     protected ITxTracer _txTracer = NullTxTracer.Instance;
 
-    private ICodeInfoRepository _codeInfoRepository;
+    private ICodeInfoRepository _codeInfoRepository = null!;
 
     private ReadOnlyMemory<byte> _returnDataBuffer = Array.Empty<byte>();
-    protected VmState<TGasPolicy> _currentState;
+    protected VmState<TGasPolicy> _currentState = null!;
     protected ReadOnlyMemory<byte>? _previousCallResult;
     protected UInt256 _previousCallOutputDestination;
 
@@ -267,7 +269,7 @@ public partial class VirtualMachine<TGasPolicy>(
                         TransactionSubstate substate = HandleException(in callResult, ref previousCallOutput, out bool terminate);
                         if (terminate)
                         {
-                            _currentState = null;
+                            _currentState = null!;
                             return substate;
                         }
                         // Continue execution if the exception did not immediately finalize the transaction.
@@ -283,7 +285,7 @@ public partial class VirtualMachine<TGasPolicy>(
                         TraceTransactionActionEnd(_currentState, callResult);
                     }
                     TransactionSubstate substate = PrepareTopLevelSubstate(in callResult);
-                    _currentState = null;
+                    _currentState = null!;
                     return substate;
                 }
 
@@ -374,7 +376,7 @@ public partial class VirtualMachine<TGasPolicy>(
             TransactionSubstate failSubstate = HandleFailure<TTracingInst>(failure, substateError, ref previousCallOutput, out bool shouldExit);
             if (shouldExit)
             {
-                _currentState = null;
+                _currentState = null!;
                 return failSubstate;
             }
         }
@@ -390,7 +392,7 @@ public partial class VirtualMachine<TGasPolicy>(
             _currentState?.Dispose();
         }
 
-        _currentState = null;
+        _currentState = null!;
         while (_stateStack.Count != 0)
         {
             VmState<TGasPolicy> parent = _stateStack.Pop();
@@ -814,6 +816,7 @@ public partial class VirtualMachine<TGasPolicy>(
     /// </param>
     protected void PrepareNextCallFrame(in CallResult callResult, ref ReadOnlySpan<byte> previousCallOutput)
     {
+        Debug.Assert(callResult.StateToExecute is not null, "A non-returning call result must carry its next frame.");
         // Push the current execution state onto the state stack so it can be restored later.
         _stateStack.Push(_currentState);
 
@@ -996,7 +999,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
         catch (Exception exception) when (exception is DllNotFoundException or { InnerException: DllNotFoundException })
         {
-            if (_logger.IsError) LogMissingDependency(precompile, (exception as DllNotFoundException ?? exception.InnerException as DllNotFoundException)!);
+            if (_logger.IsError) LogMissingDependency(precompile, GetMissingDependencyException(exception));
             Environment.Exit(ExitCodes.MissingPrecompile);
             throw; // Unreachable
         }
@@ -1184,7 +1187,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
         catch (Exception exception) when (exception is DllNotFoundException or { InnerException: DllNotFoundException })
         {
-            if (_logger.IsError) LogMissingDependency(precompile, exception as DllNotFoundException ?? exception.InnerException as DllNotFoundException);
+            if (_logger.IsError) LogMissingDependency(precompile, GetMissingDependencyException(exception));
             Environment.Exit(ExitCodes.MissingPrecompile);
             throw; // Unreachable
         }
@@ -1202,6 +1205,13 @@ public partial class VirtualMachine<TGasPolicy>(
     [MethodImpl(MethodImplOptions.NoInlining)]
     protected void LogMissingDependency(IPrecompile precompile, DllNotFoundException exception)
         => _logger.Error($"Failed to load one of the dependencies of {precompile.GetType()} precompile", exception);
+
+    private static DllNotFoundException GetMissingDependencyException(Exception exception) => exception switch
+    {
+        DllNotFoundException missingDependency => missingDependency,
+        { InnerException: DllNotFoundException missingDependency } => missingDependency,
+        _ => throw new ArgumentOutOfRangeException(nameof(exception)),
+    };
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     protected static string GetErrorString(IPrecompile precompile, string? error)
@@ -1373,6 +1383,7 @@ public partial class VirtualMachine<TGasPolicy>(
         };
 
     Revert:
+        Debug.Assert(ReturnData is byte[], "REVERT must provide return data.");
         return new CallResult((byte[])ReturnData, null, shouldRevert: true, exceptionType);
 
     ReturnFailure:

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.std.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.std.cs
@@ -40,5 +40,5 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         return true;
     }
 
-    public object ReturnData { get; set; }
+    public object? ReturnData { get; set; }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.warmup.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.warmup.cs
@@ -207,7 +207,7 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         public Hash256 GetBlockhash(BlockHeader currentBlock, ulong number)
             => GetBlockhash(currentBlock, number, specProvider.GetSpec(currentBlock));
 
-        public Hash256 GetBlockhash(BlockHeader currentBlock, ulong number, IReleaseSpec spec) => Keccak.Compute(spec!.IsBlockHashInStateAvailable
+        public Hash256 GetBlockhash(BlockHeader currentBlock, ulong number, IReleaseSpec spec) => Keccak.Compute(spec.IsBlockHashInStateAvailable
                 ? (Eip2935Constants.RingBufferSize + number).ToString()
                 : number.ToString());
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.zkevm.cs
@@ -24,7 +24,7 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
     /// <remarks>The guest is compiled ahead of time, so a rebuilt table has no promoted code to capture.</remarks>
     private partial bool ShouldRefreshOpcodes() => false;
 
-    public object ReturnData;
+    public object? ReturnData;
 
     /// <summary>
     /// Inline handling of a CALL whose target is a precompile. Precompiles run

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -250,7 +250,7 @@ public class VmState<TGasPolicy> : IDisposable
     public void InitializeStacks(ReadOnlySpan<byte> codeSpan, out EvmStack stack)
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
-        byte[] dataStack = DataStack;
+        byte[]? dataStack = DataStack;
         if (dataStack is null)
         {
             DataStack = dataStack = AllocateStacks();
@@ -262,7 +262,7 @@ public class VmState<TGasPolicy> : IDisposable
     public void InitializeStacks(ITxTracer txTracer, ReadOnlySpan<byte> codeSpan, out EvmStack stack)
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
-        byte[] dataStack = DataStack;
+        byte[]? dataStack = DataStack;
         if (dataStack is null)
         {
             DataStack = dataStack = AllocateStacks();
@@ -283,7 +283,7 @@ public class VmState<TGasPolicy> : IDisposable
     public Memory<byte> MemoryStacks(int count)
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
-        byte[] dataStack = DataStack;
+        byte[]? dataStack = DataStack;
         if (dataStack is null)
         {
             DataStack = dataStack = AllocateStacks();

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -260,7 +260,7 @@ public class VmState<TGasPolicy> : IDisposable
     public void InitializeStacks(ReadOnlySpan<byte> codeSpan, out EvmStack stack)
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
-        byte[] dataStack = DataStack;
+        byte[]? dataStack = DataStack;
         if (dataStack is null)
         {
             DataStack = dataStack = AllocateStacks();
@@ -272,7 +272,7 @@ public class VmState<TGasPolicy> : IDisposable
     public void InitializeStacks(ITxTracer txTracer, ReadOnlySpan<byte> codeSpan, out EvmStack stack)
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
-        byte[] dataStack = DataStack;
+        byte[]? dataStack = DataStack;
         if (dataStack is null)
         {
             DataStack = dataStack = AllocateStacks();
@@ -293,7 +293,7 @@ public class VmState<TGasPolicy> : IDisposable
     public Memory<byte> MemoryStacks(int count)
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
-        byte[] dataStack = DataStack;
+        byte[]? dataStack = DataStack;
         if (dataStack is null)
         {
             DataStack = dataStack = AllocateStacks();

--- a/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.History.Test/HistoryPrunerTests.cs
@@ -1040,7 +1040,8 @@ public class HistoryPrunerTests
         public TimeSpan? CapturedTimeout { get; private set; }
         public TaskCompletionSource Invoked { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string source = null)
+        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
         {
             CapturedTimeout = timeout;
             Invoked.TrySetResult();

--- a/src/Nethermind/Nethermind.History/HistoryPruner.cs
+++ b/src/Nethermind/Nethermind.History/HistoryPruner.cs
@@ -32,6 +32,8 @@ namespace Nethermind.History;
 
 public class HistoryPruner : IHistoryPruner
 {
+    private readonly struct HistoryPrunerRequest : IBackgroundTaskRequest<HistoryPrunerRequest>;
+
     private const int LockWaitTimeoutMs = 100;
     private const ulong SlotsPerEpoch = 32;
 
@@ -244,7 +246,7 @@ public class HistoryPruner : IHistoryPruner
                         TimeSpan? pruningTimeout = _historyConfig.PruningTimeoutSeconds > 0
                             ? TimeSpan.FromSeconds(_historyConfig.PruningTimeoutSeconds)
                             : null;
-                        if (!_backgroundTaskScheduler.TryScheduleTask(1,
+                        if (!_backgroundTaskScheduler.TryScheduleTask(default(HistoryPrunerRequest),
                                 (_, backgroundTaskToken) =>
                                 {
                                     try
@@ -259,7 +261,7 @@ public class HistoryPruner : IHistoryPruner
                                     }
 
                                     return Task.CompletedTask;
-                                }, timeout: pruningTimeout, source: "HistoryPruner"))
+                                }, timeout: pruningTimeout))
                         {
                             Interlocked.Exchange(ref _currentlyPruning, 0);
                             if (_logger.IsDebug) _logger.Debug("Failed to schedule historical block pruning (queue full). Will retry on next trigger.");

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleCallTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Proof/ProofRpcModuleCallTests.cs
@@ -269,8 +269,8 @@ public class ProofRpcModuleCallTests
         AccountProofCollector expectedCollector = new(contractAddress, [UInt256.Zero]);
         blockchain.StateReader.RunTreeVisitor(expectedCollector, sourceHeader);
         AccountProof expectedProof = expectedCollector.BuildResult();
-        byte[][] expectedStorageProofNodes = expectedProof.StorageProofs!
-            .SelectMany(sp => sp.Proof!)
+        byte[][] expectedStorageProofNodes = expectedProof.StorageProofs
+            .SelectMany(sp => sp.Proof)
             .ToArray();
         Assert.That(expectedStorageProofNodes, Is.Not.Empty,
             "the contract should have a non-empty storage proof for slot 0 in the parent state");

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.WitnessCapture.cs
@@ -750,13 +750,13 @@ public partial class EngineModuleTests
         foreach (byte[] node in witness.State)
             witnessNodes.Add(ValueKeccak.Compute(node));
 
-        Assert.That(proof.Proof, Is.Not.Null.And.Not.Empty, $"expected a non-empty account proof for {account}");
-        foreach (byte[] node in proof.Proof!)
+        Assert.That(proof.Proof, Is.Not.Empty, $"expected a non-empty account proof for {account}");
+        foreach (byte[] node in proof.Proof)
             Assert.That(witnessNodes, Does.Contain(ValueKeccak.Compute(node)),
                 $"witness State must contain the account-proof node for {account}");
 
-        foreach (StorageProof storageProof in proof.StorageProofs ?? [])
-            foreach (byte[] node in storageProof.Proof ?? [])
+        foreach (StorageProof storageProof in proof.StorageProofs)
+            foreach (byte[] node in storageProof.Proof)
                 Assert.That(witnessNodes, Does.Contain(ValueKeccak.Compute(node)),
                     $"witness State must contain the storage-proof node for {account}");
     }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/ProtocolHandlers/ProtocolHandlerBaseTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/ProtocolHandlers/ProtocolHandlerBaseTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Network.P2P;
 using Nethermind.Network.P2P.EventArg;
 using Nethermind.Network.P2P.Messages;
 using Nethermind.Network.P2P.ProtocolHandlers;
+using Nethermind.Network.P2P.Utils;
 using Nethermind.Network.Rlpx;
 using Nethermind.Network.Rlpx.Handshake;
 using Nethermind.Serialization.Rlp;
@@ -48,11 +49,15 @@ public class ProtocolHandlerBaseTests
         public Task StartTimeoutCheck() => CheckProtocolInitTimeout();
         public void SimulateLateInitMessage() => ReceivedProtocolInitMsg(new AckMessage());
         public void ScheduleBackgroundTask(Func<int, CancellationToken, ValueTask> backgroundTask) =>
-            BackgroundTaskScheduler.TryScheduleBackgroundTask(1, backgroundTask, "test");
+            BackgroundTaskScheduler.TryScheduleBackgroundTask(1, backgroundTask);
+        public void ScheduleBackgroundTaskFor(TestRequestMessage request) =>
+            BackgroundTaskScheduler.TryScheduleBackgroundTask(request, static (_, _) => ValueTask.CompletedTask);
         public void ScheduleSyncServeTask(TestRequestMessage request, Func<TestRequestMessage, CancellationToken, Task<TestResponseMessage>> syncServe) =>
             BackgroundTaskScheduler.TryScheduleSyncServe(request, syncServe);
         public void ScheduleSyncServeValueTask(TestRequestMessage request, Func<TestRequestMessage, CancellationToken, ValueTask<TestResponseMessage>> syncServe) =>
             BackgroundTaskScheduler.TryScheduleSyncServe(request, syncServe);
+        public void ScheduleHandlerSyncServeTask(TestRequestMessage request) =>
+            BackgroundTaskScheduler.TryScheduleSyncServe<TestProtocolHandler, TestRequestMessage, TestResponseMessage, TestSyncServeRequestHandler>(this, request);
         public TestRequestMessage Deserialize(byte[] data) => Deserialize<TestRequestMessage>(data);
         public override void Init() { }
         public override void Dispose() { }
@@ -64,7 +69,8 @@ public class ProtocolHandlerBaseTests
     {
         public Task ScheduledTask { get; private set; } = Task.CompletedTask;
 
-        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null)
+        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
         {
             ScheduledTask = fulfillFunc(request, cancellationToken);
             return true;
@@ -73,13 +79,72 @@ public class ProtocolHandlerBaseTests
 
     private sealed class NoopBackgroundTaskScheduler : IBackgroundTaskScheduler
     {
-        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null) => true;
+        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq> => true;
+    }
+
+    private readonly struct TestSyncServeRequestHandler : ISyncServeRequestHandler<TestProtocolHandler, TestRequestMessage, TestResponseMessage>
+    {
+        public static Task<TestResponseMessage> Execute(TestProtocolHandler handler, TestRequestMessage request, CancellationToken cancellationToken) =>
+            Task.FromResult(new TestResponseMessage());
+    }
+
+    /// <summary>Records the name each scheduled task is reported under.</summary>
+    private sealed class NameCapturingBackgroundTaskScheduler : IBackgroundTaskScheduler
+    {
+        public string? ReportedName { get; private set; }
+
+        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
+        {
+            ReportedName = BackgroundTaskTypeRegistry.GetName(TReq.TaskId);
+            return true;
+        }
     }
 
     private sealed class TestRequestMessage : P2PMessage
     {
         public override int PacketType => 1;
         public override string Protocol => "test";
+    }
+
+    public enum SchedulingPath
+    {
+        SyncServeTask,
+        SyncServeValueTask,
+        HandlerSyncServe,
+        BackgroundTask
+    }
+
+    /// <remarks>
+    /// Each wrapper request is generic over the message it wraps, so its own type name is identical for
+    /// every instantiation. The wrappers therefore report the wrapped type instead, which nothing in the
+    /// type system enforces — this pins it for every scheduling path.
+    /// </remarks>
+    [Test]
+    public void Scheduling_reports_the_wrapped_message_type([Values] SchedulingPath path)
+    {
+        NameCapturingBackgroundTaskScheduler scheduler = new();
+        TestProtocolHandler handler = new(Substitute.For<ISession>(), TimeSpan.FromSeconds(1), scheduler);
+        TestRequestMessage request = new();
+
+        switch (path)
+        {
+            case SchedulingPath.SyncServeTask:
+                handler.ScheduleSyncServeTask(request, SyncServeTaskHandler);
+                break;
+            case SchedulingPath.SyncServeValueTask:
+                handler.ScheduleSyncServeValueTask(request, SyncServeValueTaskHandler);
+                break;
+            case SchedulingPath.HandlerSyncServe:
+                handler.ScheduleHandlerSyncServeTask(request);
+                break;
+            case SchedulingPath.BackgroundTask:
+                handler.ScheduleBackgroundTaskFor(request);
+                break;
+        }
+
+        Assert.That(scheduler.ReportedName, Is.EqualTo(nameof(TestRequestMessage)));
     }
 
     private sealed class TestResponseMessage : P2PMessage

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandlerTests.cs
@@ -505,8 +505,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         private class AlwaysTimeoutBackgroundTaskScheduler : IBackgroundTaskScheduler
         {
             internal int ScheduledTasks = 0;
-            public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc,
-                TimeSpan? timeout = null, string? source = null)
+            public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+                where TReq : notnull, IBackgroundTaskRequest<TReq>
             {
                 CancellationTokenSource cts = new();
                 cts.Cancel();
@@ -521,7 +521,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
             public List<Type> RequestTypes { get; } = [];
 
             public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc,
-                TimeSpan? timeout = null, string? source = null)
+                TimeSpan? timeout = null) where TReq : notnull, IBackgroundTaskRequest<TReq>
             {
                 RequestTypes.Add(typeof(TReq));
                 fulfillFunc(request, CancellationToken.None).GetAwaiter().GetResult();
@@ -651,7 +651,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V62
         private sealed class CallbackBackgroundTaskScheduler(Func<bool> onSchedule) : IBackgroundTaskScheduler
         {
             public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc,
-                TimeSpan? timeout = null, string? source = null) => onSchedule();
+                TimeSpan? timeout = null) where TReq : notnull, IBackgroundTaskRequest<TReq> => onSchedule();
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V66/Eth66ProtocolHandlerTests.cs
@@ -430,7 +430,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V66
             public List<Delegate> ScheduledFulfillFuncs { get; } = [];
             public List<bool> ScheduledRequestsHaveDelegateFields { get; } = [];
 
-            public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null)
+            public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+                where TReq : notnull, IBackgroundTaskRequest<TReq>
             {
                 ScheduledRequestsHaveDelegateFields.Add(HasDelegateField<TReq>());
                 ScheduledFulfillFuncs.Add(fulfillFunc);

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -2981,8 +2981,9 @@ public class Eth72ProtocolHandlerTests
     {
         ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
         registry.TryRequestCells(Arg.Any<Hash256>(), Arg.Any<BlobCellMask>(), Arg.Any<PublicKey>()).Returns(true);
+        SourceRejectingBackgroundTaskScheduler rejectingScheduler = new(ClaimedCellsResponseTypeName);
         RecreateHandler(
-            backgroundTaskScheduler: new SourceRejectingBackgroundTaskScheduler(nameof(CellsMessage72)),
+            backgroundTaskScheduler: rejectingScheduler,
             sparseBlobPoolPeerRegistry: registry);
         Transaction tx = Build.A.Transaction
             .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
@@ -2996,6 +2997,7 @@ public class Eth72ProtocolHandlerTests
         Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
         using CellsMessage72 response = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [tx.Hash!], [cells], cellMask.ToBytes());
         HandleZeroMessage(response, Eth72MessageCode.Cells);
+        Assert.That(rejectingScheduler.Rejected, Is.GreaterThan(0), "the cells response must actually have been rejected");
 
         registry.ClearReceivedCalls();
         using NewPooledTransactionHashesMessage72 announcement = new(
@@ -5259,8 +5261,8 @@ public class Eth72ProtocolHandlerTests
         public bool TryScheduleTask<TReq>(
             TReq request,
             Func<TReq, CancellationToken, Task> fulfillFunc,
-            TimeSpan? timeout = null,
-            string? source = null) => trySchedule();
+            TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq> => trySchedule();
     }
 
     private sealed class PooledTransactionsOverrideSerializationService(IMessageSerializationService inner)
@@ -5342,16 +5344,38 @@ public class Eth72ProtocolHandlerTests
         HandleZeroMessage(empty, Eth72MessageCode.Cells);
     }
 
-    /// <summary>Runs every background task inline except those tagged with the rejected source.</summary>
-    private sealed class SourceRejectingBackgroundTaskScheduler(string rejectedSource) : IBackgroundTaskScheduler
+    /// <summary>The handler wraps a cells response in its private ClaimedCellsResponse before scheduling it.</summary>
+    private const string ClaimedCellsResponseTypeName = "ClaimedCellsResponse";
+
+    /// <summary>
+    /// Runs every background task inline except those wrapping <paramref name="rejectedRequest"/>.
+    /// </summary>
+    /// <remarks>
+    /// Matches on the wrapped request's own <see cref="Type.Name"/> rather than the scheduler's reported
+    /// name, which qualifies on collision and so is not a stable key. <see cref="Rejected"/> lets a test
+    /// assert the rejection actually happened instead of silently exercising the scheduled path.
+    /// </remarks>
+    private sealed class SourceRejectingBackgroundTaskScheduler(string rejectedRequest) : IBackgroundTaskScheduler
     {
+        public int Rejected { get; private set; }
+
         public bool TryScheduleTask<TReq>(
             TReq request,
             Func<TReq, CancellationToken, Task> fulfillFunc,
-            TimeSpan? timeout = null,
-            string? source = null)
-            => source != rejectedSource
-            && RunImmediatelyScheduler.Instance.TryScheduleTask(request, fulfillFunc, timeout, source);
+            TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
+        {
+            foreach (Type wrapped in typeof(TReq).GenericTypeArguments)
+            {
+                if (wrapped.Name == rejectedRequest)
+                {
+                    Rejected++;
+                    return false;
+                }
+            }
+
+            return RunImmediatelyScheduler.Instance.TryScheduleTask(request, fulfillFunc, timeout);
+        }
     }
 
     private sealed class RejectingBackgroundTaskScheduler : IBackgroundTaskScheduler
@@ -5359,8 +5383,8 @@ public class Eth72ProtocolHandlerTests
         public bool TryScheduleTask<TReq>(
             TReq request,
             Func<TReq, CancellationToken, Task> fulfillFunc,
-            TimeSpan? timeout = null,
-            string? source = null)
+            TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
         {
             if (request is IDisposable disposable)
             {
@@ -5378,8 +5402,8 @@ public class Eth72ProtocolHandlerTests
         public bool TryScheduleTask<TReq>(
             TReq request,
             Func<TReq, CancellationToken, Task> fulfillFunc,
-            TimeSpan? timeout = null,
-            string? source = null)
+            TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
         {
             _next = cancellationToken => fulfillFunc(request, cancellationToken);
             return true;

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandlerTests.cs
@@ -3028,8 +3028,9 @@ public class Eth72ProtocolHandlerTests
     {
         ISparseBlobPoolPeerRegistry registry = Substitute.For<ISparseBlobPoolPeerRegistry>();
         registry.TryRequestCells(Arg.Any<Hash256>(), Arg.Any<BlobCellMask>(), Arg.Any<PublicKey>()).Returns(true);
+        SourceRejectingBackgroundTaskScheduler rejectingScheduler = new(ClaimedCellsResponseTypeName);
         RecreateHandler(
-            backgroundTaskScheduler: new SourceRejectingBackgroundTaskScheduler(nameof(CellsMessage72)),
+            backgroundTaskScheduler: rejectingScheduler,
             sparseBlobPoolPeerRegistry: registry);
         Transaction tx = Build.A.Transaction
             .WithShardBlobTxTypeAndFields(spec: Osaka.Instance)
@@ -3043,6 +3044,7 @@ public class Eth72ProtocolHandlerTests
         Assert.That(((ISparseBlobPoolPeer)_handler).TrySendGetCells(tx.Hash!, cellMask), Is.True);
         using CellsMessage72 response = new(GetLastGetCellsRequestId(tx.Hash!, cellMask), [tx.Hash!], [cells], cellMask.ToBytes());
         HandleZeroMessage(response, Eth72MessageCode.Cells);
+        Assert.That(rejectingScheduler.Rejected, Is.GreaterThan(0), "the cells response must actually have been rejected");
 
         registry.ClearReceivedCalls();
         using NewPooledTransactionHashesMessage72 announcement = new(
@@ -5315,8 +5317,8 @@ public class Eth72ProtocolHandlerTests
         public bool TryScheduleTask<TReq>(
             TReq request,
             Func<TReq, CancellationToken, Task> fulfillFunc,
-            TimeSpan? timeout = null,
-            string? source = null) => trySchedule();
+            TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq> => trySchedule();
     }
 
     private sealed class PooledTransactionsOverrideSerializationService(IMessageSerializationService inner)
@@ -5398,16 +5400,38 @@ public class Eth72ProtocolHandlerTests
         HandleZeroMessage(empty, Eth72MessageCode.Cells);
     }
 
-    /// <summary>Runs every background task inline except those tagged with the rejected source.</summary>
-    private sealed class SourceRejectingBackgroundTaskScheduler(string rejectedSource) : IBackgroundTaskScheduler
+    /// <summary>The handler wraps a cells response in its private ClaimedCellsResponse before scheduling it.</summary>
+    private const string ClaimedCellsResponseTypeName = "ClaimedCellsResponse";
+
+    /// <summary>
+    /// Runs every background task inline except those wrapping <paramref name="rejectedRequest"/>.
+    /// </summary>
+    /// <remarks>
+    /// Matches on the wrapped request's own <see cref="Type.Name"/> rather than the scheduler's reported
+    /// name, which qualifies on collision and so is not a stable key. <see cref="Rejected"/> lets a test
+    /// assert the rejection actually happened instead of silently exercising the scheduled path.
+    /// </remarks>
+    private sealed class SourceRejectingBackgroundTaskScheduler(string rejectedRequest) : IBackgroundTaskScheduler
     {
+        public int Rejected { get; private set; }
+
         public bool TryScheduleTask<TReq>(
             TReq request,
             Func<TReq, CancellationToken, Task> fulfillFunc,
-            TimeSpan? timeout = null,
-            string? source = null)
-            => source != rejectedSource
-            && RunImmediatelyScheduler.Instance.TryScheduleTask(request, fulfillFunc, timeout, source);
+            TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
+        {
+            foreach (Type wrapped in typeof(TReq).GenericTypeArguments)
+            {
+                if (wrapped.Name == rejectedRequest)
+                {
+                    Rejected++;
+                    return false;
+                }
+            }
+
+            return RunImmediatelyScheduler.Instance.TryScheduleTask(request, fulfillFunc, timeout);
+        }
     }
 
     private sealed class RejectingBackgroundTaskScheduler : IBackgroundTaskScheduler
@@ -5415,8 +5439,8 @@ public class Eth72ProtocolHandlerTests
         public bool TryScheduleTask<TReq>(
             TReq request,
             Func<TReq, CancellationToken, Task> fulfillFunc,
-            TimeSpan? timeout = null,
-            string? source = null)
+            TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
         {
             if (request is IDisposable disposable)
             {
@@ -5434,8 +5458,8 @@ public class Eth72ProtocolHandlerTests
         public bool TryScheduleTask<TReq>(
             TReq request,
             Func<TReq, CancellationToken, Task> fulfillFunc,
-            TimeSpan? timeout = null,
-            string? source = null)
+            TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
         {
             _next = cancellationToken => fulfillFunc(request, cancellationToken);
             return true;

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializerTests.cs
@@ -67,14 +67,14 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
         }
 
         [Test]
-        public void Deserialize_throws_on_null_root_hash()
+        public void Serialize_throws_on_null_root_hash()
         {
             GetStorageRangeMessage msg = new()
             {
                 RequestId = MessageConstants.Random.NextLong(),
                 StorageRange = new()
                 {
-                    RootHash = null!,
+                    RootHash = null,
                     Accounts = ArrayPoolList<PathWithAccount>.Empty(),
                     StartingHash = TestItem.KeccakB,
                     LimitHash = TestItem.KeccakC
@@ -82,9 +82,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
                 ResponseBytes = 1000
             };
             GetStorageRangesMessageSerializer serializer = new();
-            byte[] serialized = serializer.Serialize(msg);
 
-            Assert.That(() => serializer.Deserialize(serialized), Throws.InstanceOf<RlpException>());
+            Assert.That(() => serializer.Serialize(msg), Throws.InvalidOperationException);
         }
 
         [Test]
@@ -111,6 +110,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             }
         }
 
+        [TestCase("root")]
         [TestCase("account")]
         [TestCase("account-list")]
         public void Deserialize_throws_on_null_required_hash(string fieldName)
@@ -145,6 +145,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
 
         private static byte[] EncodeMessageWithNullHash(string fieldName)
         {
+            Hash256? rootHash = fieldName == "root" ? null : TestItem.KeccakB;
             Hash256? accountPath = fieldName == "account" ? null : TestItem.KeccakA;
             ValueHash256 startingHash = ValueKeccak.Zero;
             ValueHash256 limitHash = ValueKeccak.MaxValue;
@@ -153,7 +154,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
                 ? Rlp.OfEmptyList.Length
                 : Rlp.LengthOf(accountPath);
             int contentLength = Rlp.LengthOf(1L)
-                + Rlp.LengthOf(TestItem.KeccakB)
+                + Rlp.LengthOf(rootHash)
                 + Rlp.LengthOfSequence(accountsContentLength)
                 + Rlp.LengthOf(startingHash)
                 + Rlp.LengthOf(limitHash)
@@ -162,7 +163,7 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Snap.V1.Messages
             RlpWriter writer = new(bytes);
             writer.StartSequence(contentLength);
             writer.Encode(1L);
-            writer.Encode(TestItem.KeccakB);
+            writer.Encode(rootHash);
             writer.StartSequence(accountsContentLength);
             if (fieldName == "account-list")
             {

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Snap1ProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Snap/V1/Snap1ProtocolHandlerTests.cs
@@ -167,6 +167,28 @@ public class Snap1ProtocolHandlerTests
     public void ClampResponseBytes_clamps_to_valid_range(long input, long expected) => Assert.That(SnapMessageLimits.ClampResponseBytes(input), Is.EqualTo(expected));
 
     [Test]
+    public void GetStorageRange_rejects_missing_root_hash()
+    {
+        Context ctx = new();
+
+        Assert.That(
+            async () => await ctx.Snap1ProtocolHandler.GetStorageRange(new StorageRange(), CancellationToken.None),
+            Throws.ArgumentException);
+    }
+
+    [Test]
+    public void GetPathGroups_rejects_missing_account_path()
+    {
+        using AccountsToRefreshRequest request = new()
+        {
+            RootHash = Keccak.Zero,
+            Paths = new ArrayPoolList<AccountWithStorageStartingHash>(1) { new() }
+        };
+
+        Assert.That(() => Snap1ProtocolHandler.GetPathGroups(request), Throws.ArgumentException);
+    }
+
+    [Test]
     public void GetTrieNodes_forwards_requested_byte_budget_to_snap_server()
     {
         ISnapServer snapServer = Substitute.For<ISnapServer>();

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/ProtocolHandlerBase.cs
@@ -209,7 +209,7 @@ namespace Nethermind.Network.P2P.ProtocolHandlers
 
         /// <inheritdoc cref="HandleInBackground{TReq, TRes}(ZeroPacket, Func{TReq, CancellationToken, Task{TRes}})"/>
         protected void HandleInBackground<TReq>(ZeroPacket message, Func<TReq, CancellationToken, ValueTask> handle) where TReq : P2PMessage =>
-            BackgroundTaskScheduler.TryScheduleBackgroundTask(DeserializeAndReport<TReq>(message), handle, typeof(TReq).Name);
+            BackgroundTaskScheduler.TryScheduleBackgroundTask(DeserializeAndReport<TReq>(message), handle);
 
         private TReq DeserializeAndReport<TReq>(ZeroPacket message) where TReq : P2PMessage
         {

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V62/Eth62ProtocolHandler.cs
@@ -257,7 +257,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
         private bool TryScheduleTransactions(TransactionsMessage msg, Func<TransactionsRequest, CancellationToken, ValueTask> handler)
         {
             IOwnedReadOnlyList<Transaction> iList = msg.Transactions;
-            if (!BackgroundTaskScheduler.TryScheduleBackgroundTask(new TransactionsRequest(iList, 0), handler, "Transactions"))
+            if (!BackgroundTaskScheduler.TryScheduleBackgroundTask(new TransactionsRequest(iList, 0), handler))
             {
                 foreach (Transaction tx in iList)
                 {
@@ -297,7 +297,7 @@ namespace Nethermind.Network.P2P.Subprotocols.Eth.V62
                             return ValueTask.CompletedTask;
                         }
 
-                        if (BackgroundTaskScheduler.TryScheduleBackgroundTask(new TransactionsRequest(transactions, currentIdx), _handleSlow, "Transactions"))
+                        if (BackgroundTaskScheduler.TryScheduleBackgroundTask(new TransactionsRequest(transactions, currentIdx), _handleSlow))
                         {
                             isTransferred = true;
                         }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -262,7 +262,7 @@ public class Eth72ProtocolHandler(
                     ClaimedCellsResponse response = new(cellsMessage, sentRequest);
                     // Cell proof verification is too expensive for the network thread;
                     // failures disconnect the peer via the background task wrapper.
-                    if (!BackgroundTaskScheduler.TryScheduleBackgroundTask(response, _handleCells!, nameof(CellsMessage72)))
+                    if (!BackgroundTaskScheduler.TryScheduleBackgroundTask(response, _handleCells!))
                     {
                         // Scheduler saturated or shutting down: release the in-flight reservation and
                         // park the request for a later retry.
@@ -834,8 +834,7 @@ public class Eth72ProtocolHandler(
 
                     if (BackgroundTaskScheduler.TryScheduleBackgroundTask(
                         new TransactionsRequest(transactions, currentIdx),
-                        HandleSlow,
-                        "Transactions"))
+                        HandleSlow))
                     {
                         isTransferred = true;
                     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/Eth72ProtocolHandler.cs
@@ -262,7 +262,7 @@ public class Eth72ProtocolHandler(
                     ClaimedCellsResponse response = new(cellsMessage, sentRequest);
                     // Cell proof verification is too expensive for the network thread;
                     // failures disconnect the peer via the background task wrapper.
-                    if (!BackgroundTaskScheduler.TryScheduleBackgroundTask(response, _handleCells!, nameof(CellsMessage72)))
+                    if (!BackgroundTaskScheduler.TryScheduleBackgroundTask(response, _handleCells!))
                     {
                         // Scheduler saturated or shutting down: release the in-flight reservation and
                         // park the request for a later retry.
@@ -840,8 +840,7 @@ public class Eth72ProtocolHandler(
 
                     if (BackgroundTaskScheduler.TryScheduleBackgroundTask(
                         new TransactionsRequest(transactions, currentIdx),
-                        HandleSlow,
-                        "Transactions"))
+                        HandleSlow))
                     {
                         isTransferred = true;
                     }

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/SparseBlobPoolPeerRegistry.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V72/SparseBlobPoolPeerRegistry.cs
@@ -204,10 +204,9 @@ public sealed class SparseBlobPoolPeerRegistry : ISparseBlobPoolPeerRegistry, ID
         }
 
         if (!_backgroundTaskScheduler.TryScheduleTask(
-            new ScheduledRegistryRequest(this),
+            new CustodyUpdateRequest(this),
             static (request, cancellationToken) => request.Registry.ApplyPendingCustodyChange(cancellationToken),
-            timeout: ScheduledActionTimeout,
-            source: nameof(BlobCustodyTracker)))
+            timeout: ScheduledActionTimeout))
         {
             Interlocked.Exchange(ref _custodyUpdateScheduled, 0);
         }
@@ -1910,10 +1909,9 @@ public sealed class SparseBlobPoolPeerRegistry : ISparseBlobPoolPeerRegistry, ID
         }
 
         if (!_backgroundTaskScheduler.TryScheduleTask(
-            new ScheduledRegistryRequest(this),
+            new MaintenanceSweepRequest(this),
             static (request, cancellationToken) => request.Registry.RunMaintenance(cancellationToken),
-            timeout: ScheduledActionTimeout,
-            source: nameof(SparseBlobPoolPeerRegistry)))
+            timeout: ScheduledActionTimeout))
         {
             Interlocked.Exchange(ref _maintenanceScheduled, 0);
         }
@@ -2626,7 +2624,11 @@ public sealed class SparseBlobPoolPeerRegistry : ISparseBlobPoolPeerRegistry, ID
 
     private readonly record struct TrackedStateKey(ValueHash256 Hash, long Revision);
 
-    private readonly record struct ScheduledRegistryRequest(SparseBlobPoolPeerRegistry Registry);
+    private readonly record struct CustodyUpdateRequest(SparseBlobPoolPeerRegistry Registry)
+        : IBackgroundTaskRequest<CustodyUpdateRequest>;
+
+    private readonly record struct MaintenanceSweepRequest(SparseBlobPoolPeerRegistry Registry)
+        : IBackgroundTaskRequest<MaintenanceSweepRequest>;
 
     private readonly record struct PeerCleanupAction(
         Hash256 Hash,

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializer.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/V1/Messages/GetStorageRangesMessageSerializer.cs
@@ -3,6 +3,7 @@
 
 using DotNetty.Buffers;
 using System;
+using Nethermind.Core.Crypto;
 using Nethermind.Network.P2P.Subprotocols.Snap.Messages;
 using Nethermind.Serialization.Rlp;
 using Nethermind.State.Snap;
@@ -49,8 +50,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.V1.Messages
 
         public override int GetLength(GetStorageRangeMessage message, out int contentLength)
         {
+            Hash256 rootHash = message.StorageRange.RootHash
+                ?? throw new InvalidOperationException("A storage range request requires a root hash.");
             contentLength = Rlp.LengthOf(message.RequestId);
-            contentLength += Rlp.LengthOf(message.StorageRange.RootHash);
+            contentLength += Rlp.LengthOf(rootHash);
             int accountsCount = message.StorageRange.Accounts.Count;
             int accountsPathsContentLength = accountsCount * Rlp.LengthOfKeccakRlp;
             contentLength += Rlp.LengthOfSequence(accountsPathsContentLength);

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/V1/Snap1ProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Snap/V1/Snap1ProtocolHandler.cs
@@ -189,7 +189,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.V1
         private StorageRangeMessage FulfillStorageRangeMessage(GetStorageRangeMessage getStorageRangeMessage, CancellationToken cancellationToken)
         {
             StorageRange? storageRange = getStorageRangeMessage.StorageRange;
-            (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>? ranges, IByteArrayList? proofs) = SyncServer.GetStorageRanges(storageRange.RootHash, storageRange.Accounts,
+            Hash256 rootHash = storageRange.RootHash
+                ?? throw new InvalidOperationException("A storage range request requires a root hash.");
+            (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>? ranges, IByteArrayList? proofs) = SyncServer.GetStorageRanges(rootHash, storageRange.Accounts,
                 storageRange.StartingHash, storageRange.LimitHash, getStorageRangeMessage.ResponseBytes, cancellationToken);
             return new StorageRangeMessage { Proofs = proofs, Slots = ranges };
         }
@@ -214,6 +216,9 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.V1
 
         public async Task<SlotsAndProofs> GetStorageRange(StorageRange range, CancellationToken token)
         {
+            _ = range.RootHash
+                ?? throw new ArgumentException("A storage range request requires a root hash.", nameof(range));
+
             StorageRangeMessage response = await _nodeStats.RunLatencyRequestSizer(RequestType.SnapRanges, bytesLimit =>
                 SendRequest(new GetStorageRangeMessage()
                 {
@@ -243,7 +248,8 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.V1
             return await GetTrieNodes(request.RootHash, groups, token);
         }
 
-        public async Task<IByteArrayList> GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) => await GetTrieNodes(request.RootHash, request.AccountAndStoragePaths, token);
+        public async Task<IByteArrayList> GetTrieNodes(GetTrieNodesRequest request, CancellationToken token)
+            => await GetTrieNodes(request.RootHash, request.AccountAndStoragePaths, token);
 
         private async Task<IByteArrayList> GetTrieNodes(Hash256 rootHash, IOwnedReadOnlyList<PathGroup> groups, CancellationToken token)
         {
@@ -266,8 +272,10 @@ namespace Nethermind.Network.P2P.Subprotocols.Snap.V1
             for (int i = 0; i < paths.Length; i++)
             {
                 AccountWithStorageStartingHash path = paths[i];
+                PathWithAccount pathAndAccount = path.PathAndAccount
+                    ?? throw new ArgumentException("An account refresh request requires an account path.", nameof(request));
                 using DeferredRlpItemList.Builder.Writer groupWriter = rootWriter.BeginContainer();
-                groupWriter.WriteValue(path.PathAndAccount.Path.Bytes);
+                groupWriter.WriteValue(pathAndAccount.Path.Bytes);
                 groupWriter.WriteValue(_emptyBytes);
             }
             rootWriter.Dispose();

--- a/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Utils/BackgroundTaskSchedulerWrapper.cs
@@ -44,7 +44,7 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
     internal bool TryScheduleSyncServe<TReq, TRes>(TReq request, Func<TReq, CancellationToken, Task<TRes>> fulfillFunc) where TRes : P2PMessage
     {
         SyncServeTaskRequest<TReq, TRes> syncServeRequest = new(handler, request, fulfillFunc);
-        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, SyncServeTaskRequestRunner<TReq, TRes>.Run, source: RequestSource<TReq>.Name))
+        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, SyncServeTaskRequestRunner<TReq, TRes>.Run))
         {
             request.TryDispose();
             return false;
@@ -59,7 +59,7 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
     {
         HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler> syncServeRequest = new(requestHandler, request);
-        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes, TRequestHandler>.Run, source: RequestSource<TReq>.Name))
+        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, HandlerSyncServeTaskRequestRunner<THandler, TReq, TRes, TRequestHandler>.Run))
         {
             request.TryDispose();
             return false;
@@ -71,7 +71,7 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
     internal bool TryScheduleSyncServe<TReq, TRes>(TReq request, Func<TReq, CancellationToken, ValueTask<TRes>> fulfillFunc) where TRes : P2PMessage
     {
         SyncServeValueTaskRequest<TReq, TRes> syncServeRequest = new(handler, request, fulfillFunc);
-        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, SyncServeValueTaskRequestRunner<TReq, TRes>.Run, source: RequestSource<TReq>.Name))
+        if (!backgroundTaskScheduler.TryScheduleTask(syncServeRequest, SyncServeValueTaskRequestRunner<TReq, TRes>.Run))
         {
             request.TryDispose();
             return false;
@@ -80,12 +80,12 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
         return true;
     }
 
-    internal bool TryScheduleBackgroundTask<TReq>(TReq request, Func<TReq, CancellationToken, ValueTask> fulfillFunc, string? source = null) =>
-        TryScheduleBackgroundTask(new BackgroundTaskRequest<TReq>(handler, request, fulfillFunc), request, source);
+    internal bool TryScheduleBackgroundTask<TReq>(TReq request, Func<TReq, CancellationToken, ValueTask> fulfillFunc) =>
+        TryScheduleBackgroundTask(new BackgroundTaskRequest<TReq>(handler, request, fulfillFunc), request);
 
-    private bool TryScheduleBackgroundTask<TReq>(BackgroundTaskRequest<TReq> backgroundTaskRequest, TReq request, string? source)
+    private bool TryScheduleBackgroundTask<TReq>(BackgroundTaskRequest<TReq> backgroundTaskRequest, TReq request)
     {
-        if (backgroundTaskScheduler.TryScheduleTask(backgroundTaskRequest, BackgroundTaskRequestRunner<TReq>.Run, source: source))
+        if (backgroundTaskScheduler.TryScheduleTask(backgroundTaskRequest, BackgroundTaskRequestRunner<TReq>.Run))
         {
             return true;
         }
@@ -111,9 +111,11 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
     private readonly struct SyncServeTaskRequest<TReq, TRes>(
         ProtocolHandlerBase handler,
         TReq request,
-        Func<TReq, CancellationToken, Task<TRes>> fulfillFunc)
+        Func<TReq, CancellationToken, Task<TRes>> fulfillFunc) : IBackgroundTaskRequest<SyncServeTaskRequest<TReq, TRes>>
         where TRes : P2PMessage
     {
+        public static int TaskId => BackgroundTaskTypeId<TReq>.Id;
+
         public async Task Execute(CancellationToken cancellationToken)
         {
             try
@@ -135,11 +137,13 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
 
     private readonly struct HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler>(
         THandler handler,
-        TReq request)
+        TReq request) : IBackgroundTaskRequest<HandlerSyncServeTaskRequest<THandler, TReq, TRes, TRequestHandler>>
         where THandler : ProtocolHandlerBase
         where TRes : P2PMessage
         where TRequestHandler : struct, ISyncServeRequestHandler<THandler, TReq, TRes>
     {
+        public static int TaskId => BackgroundTaskTypeId<TReq>.Id;
+
         public async Task Execute(CancellationToken cancellationToken)
         {
             try
@@ -162,9 +166,11 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
     private readonly struct SyncServeValueTaskRequest<TReq, TRes>(
         ProtocolHandlerBase handler,
         TReq request,
-        Func<TReq, CancellationToken, ValueTask<TRes>> fulfillFunc)
+        Func<TReq, CancellationToken, ValueTask<TRes>> fulfillFunc) : IBackgroundTaskRequest<SyncServeValueTaskRequest<TReq, TRes>>
         where TRes : P2PMessage
     {
+        public static int TaskId => BackgroundTaskTypeId<TReq>.Id;
+
         public async Task Execute(CancellationToken cancellationToken)
         {
             try
@@ -187,8 +193,10 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
     private readonly struct BackgroundTaskRequest<TReq>(
         ProtocolHandlerBase handler,
         TReq request,
-        Func<TReq, CancellationToken, ValueTask> fulfillFunc)
+        Func<TReq, CancellationToken, ValueTask> fulfillFunc) : IBackgroundTaskRequest<BackgroundTaskRequest<TReq>>
     {
+        public static int TaskId => BackgroundTaskTypeId<TReq>.Id;
+
         public async Task Execute(CancellationToken cancellationToken)
         {
             try
@@ -234,10 +242,5 @@ public class BackgroundTaskSchedulerWrapper(ProtocolHandlerBase handler, IBackgr
     {
         public static readonly Func<BackgroundTaskRequest<TReq>, CancellationToken, Task> Run =
             static (request, cancellationToken) => request.Execute(cancellationToken);
-    }
-
-    private static class RequestSource<TReq>
-    {
-        public static readonly string Name = typeof(TReq).Name;
     }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/OptimismReleaseSpecSubstitute.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/OptimismReleaseSpecSubstitute.cs
@@ -1,17 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
 using NSubstitute;
 
 namespace Nethermind.Optimism.Test;
 
 public static class OptimismReleaseSpecSubstitute
 {
-    public static IOptimismReleaseSpec Create()
-    {
-        IOptimismReleaseSpec sub = Substitute.For<IOptimismReleaseSpec>();
-        sub.GasCosts.Returns(_ => new SpecGasCosts(sub));
-        return sub;
-    }
+    public static IOptimismReleaseSpec Create() =>
+        ReleaseSpecSubstitute.Configure(Substitute.For<IOptimismReleaseSpec>());
 }

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin.Test/DetectionScannerTests.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin.Test/DetectionScannerTests.cs
@@ -381,7 +381,8 @@ public class DetectionScannerTests
         public int Count => _queue.Count;
         public bool Full { get; set; }
 
-        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null, string? source = null)
+        public bool TryScheduleTask<TReq>(TReq request, Func<TReq, CancellationToken, Task> fulfillFunc, TimeSpan? timeout = null)
+            where TReq : notnull, IBackgroundTaskRequest<TReq>
         {
             if (Full) return false;
             _queue.Enqueue(ct => fulfillFunc(request, ct));

--- a/src/Nethermind/Nethermind.PortfolioViewer.Plugin/DetectionScanner.cs
+++ b/src/Nethermind/Nethermind.PortfolioViewer.Plugin/DetectionScanner.cs
@@ -54,7 +54,8 @@ public sealed class DetectionScanner(
     private void Grow(string key) => _active.AddOrUpdate(key, BaseChunkBlocks, static (_, c) => Math.Min(c * 2, MaxChunkBlocks));
     private void Shrink(string key) => _active.AddOrUpdate(key, MinChunkBlocks, static (_, c) => Math.Max(c / 2, MinChunkBlocks));
 
-    private readonly record struct DetectRequest(long ChainId, Address Account);
+    private readonly record struct DetectRequest(long ChainId, Address Account)
+        : IBackgroundTaskRequest<DetectRequest>;
 
     private static string Key(long chainId, Address account) => chainId + ":" + account.ToString().ToLowerInvariant();
 
@@ -73,7 +74,7 @@ public sealed class DetectionScanner(
 
     private void Schedule(DetectRequest req)
     {
-        if (!scheduler.TryScheduleTask(req, RunChunkAsync, ChunkTimeout, "portfolio-viewer-detection"))
+        if (!scheduler.TryScheduleTask(req, RunChunkAsync, ChunkTimeout))
         {
             // scheduler queue is full — give up this chain; the client re-triggers on its next poll
             _active.TryRemove(Key(req.ChainId, req.Account), out _);

--- a/src/Nethermind/Nethermind.Specs.Test/ReleaseSpecTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ReleaseSpecTests.cs
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using NUnit.Framework;
+
+namespace Nethermind.Specs.Test;
+
+[TestFixture]
+public class ReleaseSpecTests
+{
+    /// <summary>Precompile numbers the 64-bit mask cannot hold, so membership has to reach the set.</summary>
+    /// <remarks>0x100 is RIP-7212 and 0x10001/0x10002 are Taiko's, but 0x8000_0000 is the one that pins the
+    /// contract: there <see cref="Address.PrecompileIndexOrNegative"/> overflows and reports negative, so
+    /// only the address shape can decide, never the sign of the index.</remarks>
+    private static readonly long[] NumbersAboveTheMask = [64, 0x100, 0x10001, 0x10002, 0x8000_0000];
+
+    [TestCaseSource(nameof(NumbersAboveTheMask))]
+    public void Precompile_above_the_mask_is_found_through_the_set(long number)
+    {
+        Address registered = Address.FromNumber((UInt256)(ulong)number);
+        IReleaseSpec spec = new SpecWithPrecompileAt(registered);
+
+        Assert.That(spec.IsPrecompile(registered), Is.True);
+        Assert.That(spec.IsPrecompile(Address.FromNumber((UInt256)(ulong)number + 1)), Is.False);
+    }
+
+    /// <summary>Every named fork this assembly defines — mainnet and Gnosis alike.</summary>
+    private static IEnumerable<TestCaseData> AllForks() =>
+        typeof(NamedReleaseSpec).Assembly.GetTypes()
+            .Where(t => !t.IsAbstract && typeof(NamedReleaseSpec).IsAssignableFrom(t))
+            .Select(t => new TestCaseData((IReleaseSpec)Activator.CreateInstance(t)!).SetArgDisplayNames(t.Name));
+
+    /// <summary>Every registered precompile has to be recognised, at every fork.</summary>
+    /// <remarks>Membership answers from the mask below 64, the set above it, and neither for an address
+    /// that fails the shape guard, so this sweeps all three branches across every set a fork can build.
+    /// The shape invariant itself is enforced where the set is built, which throws — asserting it here too
+    /// could not fail, since reading <c>Precompiles</c> would throw first.</remarks>
+    [TestCaseSource(nameof(AllForks))]
+    public void Every_registered_precompile_is_recognised(IReleaseSpec spec)
+    {
+        Assert.That(spec.Precompiles, Is.Not.Empty, "a sweep over an empty set would pass without checking anything");
+
+        foreach (AddressAsKey key in spec.Precompiles)
+        {
+            Address address = key;
+            Assert.That(spec.IsPrecompile(address), Is.True, $"{address} is registered but not recognised");
+        }
+    }
+
+    [Test]
+    public void Precompile_membership_could_never_find_is_rejected_when_the_set_is_built()
+    {
+        // A test covers only the registrations that exist when it is written; this is what catches the
+        // rest, turning a silent consensus divergence into a failure on the chain that registered it.
+        IReleaseSpec spec = new SpecWithPrecompileAt(Address.FromNumber((UInt256)uint.MaxValue + 1));
+
+        Assert.That(() => spec.Precompiles, Throws.InstanceOf<InvalidOperationException>());
+    }
+
+    [Test]
+    public void Shape_guard_reaches_the_whole_thirty_two_bit_range()
+    {
+        // The number lives in the last four bytes, so 0x1_0000_0000 needs a fifth and reads as an ordinary
+        // address. That is the ceiling the sweep above defends.
+        Assert.That(Address.FromNumber(uint.MaxValue).CouldBePrecompile(), Is.True);
+        Assert.That(Address.FromNumber((UInt256)uint.MaxValue + 1).CouldBePrecompile(), Is.False);
+    }
+
+    private sealed class SpecWithPrecompileAt(Address address) : ReleaseSpec
+    {
+        public override FrozenSet<AddressAsKey> BuildPrecompilesCache() => new AddressAsKey[] { address }.ToFrozenSet();
+    }
+}

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Precompiles;
 using Nethermind.Core.Specs;
@@ -115,8 +117,65 @@ public class ReleaseSpec : IReleaseSpec
     public Address? Eip2935ContractAddress { get => IsEip2935Enabled ? field : null; set; }
     public bool IsEip7594Enabled { get; set; }
     public bool IsEip7939Enabled { get; set; }
-    private FrozenSet<AddressAsKey>? _precompiles;
-    FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => _precompiles ??= BuildPrecompilesCache();
+    /// <summary>The fork's precompiles, with the low-numbered ones also held as a bitmask.</summary>
+    /// <param name="Addresses">Every precompile active at this fork.</param>
+    /// <param name="LowMask">Bit <c>n</c> set when precompile number <c>n</c> is active, for numbers
+    /// below 64 — which is all of them on Ethereum bar RIP-7212 at 0x100.</param>
+    /// <remarks>One object so that a single reference publish carries both. Held as two fields, a thread
+    /// racing the lazy initialisation could see the set already assigned and the mask still empty, and
+    /// would then miss every precompile.</remarks>
+    private sealed record PrecompileIndex(FrozenSet<AddressAsKey> Addresses, ulong LowMask);
+
+    private PrecompileIndex? _precompiles;
+
+    private PrecompileIndex Precompiled => _precompiles ??= BuildPrecompileIndex();
+
+    private PrecompileIndex BuildPrecompileIndex()
+    {
+        FrozenSet<AddressAsKey> addresses = BuildPrecompilesCache();
+        ulong lowMask = 0;
+        foreach (AddressAsKey key in addresses)
+        {
+            Address address = key;
+            if (!address.CouldBePrecompile()) ThrowUnreachablePrecompile(address);
+
+            int index = address.PrecompileIndexOrNegative();
+            if ((uint)index < 64) lowMask |= 1UL << index;
+        }
+
+        return new PrecompileIndex(addresses, lowMask);
+    }
+
+    /// <summary>Rejects a registration <see cref="IsPrecompile"/> could never find.</summary>
+    /// <remarks>Membership rejects on address shape before consulting the set, so a precompile with a
+    /// non-zero byte above its number is unreachable: the call would resolve as an ordinary empty account,
+    /// with no exception anywhere and a consensus divergence to show for it. The set is built on first use,
+    /// so failing here surfaces as a failed block on the chain that registered one — loudly, and before it
+    /// can be mistaken for a valid state root.</remarks>
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowUnreachablePrecompile(Address address) =>
+        throw new InvalidOperationException(
+            $"Precompile {address} has a non-zero byte above its trailing number, so IsPrecompile can never find it; a precompile number must fit 32 bits.");
+
+    FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => Precompiled.Addresses;
+
+    /// <inheritdoc cref="IReleaseSpec.IsPrecompile" />
+    /// <remarks>The precompile's number is its address, so membership is a bit test rather than hashing
+    /// and probing twenty bytes. Numbers above the mask fall back to the set, which is what keeps this
+    /// correct for a chain registering one far away — Taiko's sit at 0x10001 and 0x10002.</remarks>
+    public bool IsPrecompile(Address address)
+    {
+        // The shape test is the guard, not the sign of the index: a tail that overflows int also comes
+        // back negative. Testing it first means an ordinary call target — almost all of them — is rejected
+        // on two loads without touching the index or the lazily built set.
+        if (!address.CouldBePrecompile()) return false;
+
+        PrecompileIndex precompiles = Precompiled;
+        int index = address.PrecompileIndexOrNegative();
+        return (uint)index < 64
+            ? (precompiles.LowMask & (1UL << index)) != 0
+            : precompiles.Addresses.Contains(address);
+    }
     private SpecGasCosts? _gasCosts;
     public SpecGasCosts GasCosts => _gasCosts ??= new SpecGasCosts(this);
     public ulong Eip2935RingBufferSize { get; set; } = Eip2935Constants.RingBufferSize;

--- a/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Specs/ReleaseSpec.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
 using Nethermind.Core.Precompiles;
 using Nethermind.Core.Specs;
@@ -119,8 +121,65 @@ public class ReleaseSpec : IReleaseSpec
     public Address? Eip2935ContractAddress { get => IsEip2935Enabled ? field : null; set; }
     public bool IsEip7594Enabled { get; set; }
     public bool IsEip7939Enabled { get; set; }
-    private FrozenSet<AddressAsKey>? _precompiles;
-    FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => _precompiles ??= BuildPrecompilesCache();
+    /// <summary>The fork's precompiles, with the low-numbered ones also held as a bitmask.</summary>
+    /// <param name="Addresses">Every precompile active at this fork.</param>
+    /// <param name="LowMask">Bit <c>n</c> set when precompile number <c>n</c> is active, for numbers
+    /// below 64 — which is all of them on Ethereum bar RIP-7212 at 0x100.</param>
+    /// <remarks>One object so that a single reference publish carries both. Held as two fields, a thread
+    /// racing the lazy initialisation could see the set already assigned and the mask still empty, and
+    /// would then miss every precompile.</remarks>
+    private sealed record PrecompileIndex(FrozenSet<AddressAsKey> Addresses, ulong LowMask);
+
+    private PrecompileIndex? _precompiles;
+
+    private PrecompileIndex Precompiled => _precompiles ??= BuildPrecompileIndex();
+
+    private PrecompileIndex BuildPrecompileIndex()
+    {
+        FrozenSet<AddressAsKey> addresses = BuildPrecompilesCache();
+        ulong lowMask = 0;
+        foreach (AddressAsKey key in addresses)
+        {
+            Address address = key;
+            if (!address.CouldBePrecompile()) ThrowUnreachablePrecompile(address);
+
+            int index = address.PrecompileIndexOrNegative();
+            if ((uint)index < 64) lowMask |= 1UL << index;
+        }
+
+        return new PrecompileIndex(addresses, lowMask);
+    }
+
+    /// <summary>Rejects a registration <see cref="IsPrecompile"/> could never find.</summary>
+    /// <remarks>Membership rejects on address shape before consulting the set, so a precompile with a
+    /// non-zero byte above its number is unreachable: the call would resolve as an ordinary empty account,
+    /// with no exception anywhere and a consensus divergence to show for it. The set is built on first use,
+    /// so failing here surfaces as a failed block on the chain that registered one — loudly, and before it
+    /// can be mistaken for a valid state root.</remarks>
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowUnreachablePrecompile(Address address) =>
+        throw new InvalidOperationException(
+            $"Precompile {address} has a non-zero byte above its trailing number, so IsPrecompile can never find it; a precompile number must fit 32 bits.");
+
+    FrozenSet<AddressAsKey> IReleaseSpec.Precompiles => Precompiled.Addresses;
+
+    /// <inheritdoc cref="IReleaseSpec.IsPrecompile" />
+    /// <remarks>The precompile's number is its address, so membership is a bit test rather than hashing
+    /// and probing twenty bytes. Numbers above the mask fall back to the set, which is what keeps this
+    /// correct for a chain registering one far away — Taiko's sit at 0x10001 and 0x10002.</remarks>
+    public bool IsPrecompile(Address address)
+    {
+        // The shape test is the guard, not the sign of the index: a tail that overflows int also comes
+        // back negative. Testing it first means an ordinary call target — almost all of them — is rejected
+        // on two loads without touching the index or the lazily built set.
+        if (!address.CouldBePrecompile()) return false;
+
+        PrecompileIndex precompiles = Precompiled;
+        int index = address.PrecompileIndexOrNegative();
+        return (uint)index < 64
+            ? (precompiles.LowMask & (1UL << index)) != 0
+            : precompiles.Addresses.Contains(address);
+    }
     private SpecGasCosts? _gasCosts;
     public SpecGasCosts GasCosts => _gasCosts ??= new SpecGasCosts(this);
     public ulong Eip2935RingBufferSize { get; set; } = Eip2935Constants.RingBufferSize;

--- a/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStateTree.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Sync/Snap/FlatSnapStateTree.cs
@@ -62,7 +62,9 @@ public class FlatSnapStateTree : ISnapTree<PathWithAccount>
                 {
                     if (_enableDoubleWriteCheck && _reader.GetAccountRaw(account.Path) is not null)
                         throw new Exception($"Double account flat write. {account.Path}");
-                    _writeBatch.SetAccountRaw(account.Path, account.Account);
+                    Account accountValue = account.Account
+                        ?? throw new InvalidOperationException("A SNAP account entry must contain an account value.");
+                    _writeBatch.SetAccountRaw(account.Path, accountValue);
                 }
             }
         }

--- a/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Proofs/AccountProofCollectorTests.cs
@@ -110,9 +110,9 @@ namespace Nethermind.Store.Test.Proofs
                 Assert.That(proof.CodeHash, Is.EqualTo(Hash256.Zero));
                 Assert.That(proof.StorageRoot, Is.EqualTo(Hash256.Zero));
                 Assert.That(proof.Balance, Is.EqualTo(UInt256.Zero));
-                Assert.That(proof.StorageProofs?[0].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
-                Assert.That(proof.StorageProofs?[1].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
-                Assert.That(proof.StorageProofs?[2].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
+                Assert.That(proof.StorageProofs[0].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
+                Assert.That(proof.StorageProofs[1].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
+                Assert.That(proof.StorageProofs[2].Value?.ToArray(), Is.EqualTo(new byte[] { 0 }));
             }
         }
 
@@ -309,7 +309,7 @@ namespace Nethermind.Store.Test.Proofs
         {
             (StateTree tree, _) = CreateTreeWithUInt256Storage();
             AccountProof proof = CollectProof(tree, TestItem.AddressA, StorageKeyZeroAndOne);
-            Assert.That(proof.StorageProofs?[0].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[0]));
+            Assert.That(proof.StorageProofs[0].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[0]));
             Assert.That(proof.StorageProofs[1].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[1]));
         }
 
@@ -318,8 +318,8 @@ namespace Nethermind.Store.Test.Proofs
         {
             (StateTree tree, _) = CreateTreeWithUInt256Storage();
             AccountProof proof = CollectProof(tree, TestItem.AddressA, StorageKeyZeroAndOne);
-            Assert.That(proof.StorageProofs![0].Key!, Is.EqualTo("0x0"));
-            Assert.That(proof.StorageProofs![1].Key!, Is.EqualTo("0x1"));
+            Assert.That(proof.StorageProofs[0].Key!, Is.EqualTo("0x0"));
+            Assert.That(proof.StorageProofs[1].Key!, Is.EqualTo("0x1"));
         }
 
         private static readonly byte[] StorageKeyA = Bytes.FromHexString("0x000000000000000000000000000000000000000000aaaaaaaaaaaaaaaaaaaaaa");
@@ -334,7 +334,7 @@ namespace Nethermind.Store.Test.Proofs
 
             AccountProof proof = CollectProof(tree, TestItem.AddressA, keys);
             for (int i = 0; i < 3; i++)
-                Assert.That(proof.StorageProofs?[i].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[i]));
+                Assert.That(proof.StorageProofs[i].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[i]));
         }
 
         private void Storage_proofs_have_values_set_complex_5_keys(byte[] c, byte[] d, byte[] e)
@@ -344,7 +344,7 @@ namespace Nethermind.Store.Test.Proofs
 
             AccountProof proof = CollectProof(tree, TestItem.AddressA, keys);
             for (int i = 0; i < 5; i++)
-                Assert.That(proof.StorageProofs?[i].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[i]));
+                Assert.That(proof.StorageProofs[i].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[i]));
         }
 
         [Test]
@@ -385,14 +385,14 @@ namespace Nethermind.Store.Test.Proofs
 
             byte[][] queryKeys = [StorageKeyA, StorageKeyB, c, d, e];
             AccountProof proof = CollectProof(tree, TestItem.AddressA, queryKeys);
-            Assert.That(proof.StorageProofs?[0].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo(StorageValueHexes[0]));
-            Assert.That(proof.StorageProofs?[1].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo("0x00"));
-            Assert.That(proof.StorageProofs?[2].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo(StorageValueHexes[2]));
-            Assert.That(proof.StorageProofs?[3].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo("0x00"));
-            Assert.That(proof.StorageProofs?[4].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo(StorageValueHexes[4]));
+            Assert.That(proof.StorageProofs[0].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo(StorageValueHexes[0]));
+            Assert.That(proof.StorageProofs[1].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo("0x00"));
+            Assert.That(proof.StorageProofs[2].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo(StorageValueHexes[2]));
+            Assert.That(proof.StorageProofs[3].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo("0x00"));
+            Assert.That(proof.StorageProofs[4].Value?.Span.ToHexString(true) ?? "0x", Is.EqualTo(StorageValueHexes[4]));
 
-            Assert.That(proof.StorageProofs?[1].Proof, Has.Length.EqualTo(2));
-            Assert.That(proof.StorageProofs?[3].Proof, Has.Length.EqualTo(1));
+            Assert.That(proof.StorageProofs[1].Proof, Has.Length.EqualTo(2));
+            Assert.That(proof.StorageProofs[3].Proof, Has.Length.EqualTo(1));
         }
 
         [Test]
@@ -451,9 +451,9 @@ namespace Nethermind.Store.Test.Proofs
 
             byte[][] queryKeys = [StorageKeyA, c, e];
             AccountProof proof = CollectProof(tree, TestItem.AddressA, queryKeys);
-            Assert.That(proof.StorageProofs?[0].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[0]));
-            Assert.That(proof.StorageProofs?[1].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[2]));
-            Assert.That(proof.StorageProofs?[2].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[4]));
+            Assert.That(proof.StorageProofs[0].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[0]));
+            Assert.That(proof.StorageProofs[1].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[2]));
+            Assert.That(proof.StorageProofs[2].Value?.Span.ToHexString(true), Is.EqualTo(StorageValueHexes[4]));
         }
 
 

--- a/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/ScopeProviderTests.cs
@@ -1437,6 +1437,43 @@ public class ScopeProviderTests(bool useFlat)
     }
 
     [Test]
+    public void Test_NullStorageCacheEntry_FallsBackToBackingTree()
+    {
+        using Context ctx = new(useFlat);
+
+        Hash256 stateRoot;
+        using (IWorldStateScopeProvider.IScope scope = ctx.ScopeProvider.BeginScope(null))
+        {
+            using (IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch = scope.StartWriteBatch(1))
+            {
+                writeBatch.Set(TestItem.AddressA, new Account(100, 100));
+                using IWorldStateScopeProvider.IStorageWriteBatch storage = writeBatch.CreateStorageWriteBatch(TestItem.AddressA, 1);
+                storage.Set(1, [10, 20]);
+            }
+
+            scope.Commit(1);
+            stateRoot = scope.RootHash;
+        }
+
+        PreBlockCaches caches = NewCaches();
+        StorageCell cell = new(TestItem.AddressA, 1);
+        caches.StorageCache.Set(in cell, null);
+        LocalMetrics metrics = new();
+        PrewarmerScopeProvider consumer = new(ctx.ScopeProvider, new PrewarmerState(caches, isPrewarmer: false), LimboLogs.Instance);
+        BlockHeader baseBlock = Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(1).TestObject;
+
+        using IWorldStateScopeProvider.IScope readScope = consumer.BeginScope(baseBlock, metrics);
+        byte[] value = readScope.CreateStorageTree(TestItem.AddressA).Get(1);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(value, Is.EqualTo(new byte[] { 10, 20 }));
+            Assert.That(metrics.PreBlockStorageHits, Is.Zero);
+            Assert.That(metrics.PreBlockStorageMisses, Is.EqualTo(1));
+        }
+    }
+
+    [Test]
     public void Test_PopulatorStorageCapture_SkipsBackingReadWithoutCachingSpeculativeValue()
     {
         using Context ctx = new(useFlat);

--- a/src/Nethermind/Nethermind.State.Test/Snap/SlotsAndProofsTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/Snap/SlotsAndProofsTests.cs
@@ -49,10 +49,16 @@ public class SlotsAndProofsTests
     }
 
     [Test]
-    public void Dispose_with_null_fields_does_not_throw()
+    public void Null_fields_are_normalized_to_empty_owned_lists()
     {
-        SlotsAndProofs sut = new() { PathsAndSlots = null!, Proofs = null };
-        Assert.DoesNotThrow(sut.Dispose);
+        SlotsAndProofs sut = new() { PathsAndSlots = null, Proofs = null };
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(sut.PathsAndSlots, Is.Empty);
+            Assert.That(sut.Proofs, Is.Empty);
+            Assert.DoesNotThrow(sut.Dispose);
+        }
     }
 
     private sealed class TrackingOwnedList(Action onDispose) : IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -276,6 +276,21 @@ public class StateProviderTests(bool useFlat)
         Assert.That(action, Throws.TypeOf<InvalidOperationException>());
     }
 
+    [Test]
+    public void InsertCode_after_scope_disposal_throws()
+    {
+        using Context ctx = new(useFlat);
+        WorldState worldState = (WorldState)ctx.WorldState;
+        IDisposable scope = worldState.BeginScope(IWorldState.PreGenesis);
+        scope.Dispose();
+        byte[] code = [0x00];
+        ValueHash256 codeHash = ValueKeccak.Compute(code);
+
+        Assert.That(
+            () => worldState._stateProvider.InsertCode(_address1, codeHash, code, Frontier.Instance),
+            Throws.TypeOf<InvalidOperationException>());
+    }
+
     [TestCase(false, Description = "code of a reverted deployment is dropped")]
     [TestCase(true, Description = "code redeployed after the revert is still persisted")]
     public void Code_of_restored_deployment_is_persisted_only_when_redeployed(bool redeployAfterRestore)

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -63,6 +63,23 @@ public class StorageProviderTests(bool useFlat)
     private WorldState BuildStorageProvider(Context ctx) => ctx.StateProvider;
 
     [Test]
+    public void Storage_access_after_scope_disposal_throws()
+    {
+        using Context ctx = new(useFlat, setInitialState: false);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell storageCell = new(ctx.Address1, UInt256.Zero);
+        IDisposable scope = provider.BeginScope(IWorldState.PreGenesis);
+        scope.Dispose();
+
+        Assert.That(
+            () => provider.Set(in storageCell, _values[1]),
+            Throws.InvalidOperationException);
+
+        using IDisposable nextScope = provider.BeginScope(IWorldState.PreGenesis);
+        Assert.That(provider.Get(in storageCell).IsZero(), Is.True);
+    }
+
+    [Test]
     [NonParallelizable]
     public void Oversized_per_contract_state_dictionary_is_trimmed_when_returned()
     {

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -54,6 +54,30 @@ public class TracedAccessWorldStateTests(bool parallel)
         return (tws, scope);
     }
 
+    [Test]
+    public void Mutation_without_generating_block_access_list_throws_actionable_exception()
+    {
+        IWorldState inner = TestWorldStateFactory.CreateForTest();
+        Hash256 stateRoot;
+        using (inner.BeginScope(IWorldState.PreGenesis))
+        {
+            inner.CreateAccount(TestItem.AddressA, 0);
+            inner.Commit(Spec, isGenesis: true);
+            inner.CommitTree(0);
+            stateRoot = inner.StateRoot;
+        }
+
+        TracedAccessWorldState tws = new(inner, parallel);
+        BlockHeader baseBlock = Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject;
+        using IDisposable scope = tws.BeginScope(baseBlock);
+
+        Assert.That(
+            () => tws.SetNonce(TestItem.AddressA, 1),
+            Throws.InvalidOperationException.With.Message.EqualTo(
+                "Block access list tracing requires a generating block access list to be set."));
+        Assert.That(inner.GetNonce(TestItem.AddressA), Is.Zero);
+    }
+
     [TestCase(true, 50u, 100u, 150u, TestName = "AddToBalance")]
     [TestCase(false, 30u, 100u, 70u, TestName = "SubtractFromBalance")]
     public void BalanceOp_RecordsBalanceChange(
@@ -515,7 +539,9 @@ public class TracedAccessWorldStateTests(bool parallel)
         using (scope)
         {
             tws.Set(cell, [0x01]);
+            Assert.That(new UInt256(tws.Get(cell), isBigEndian: true), Is.EqualTo(UInt256.One));
             tws.Set(cell, [0x02]);
+            Assert.That(new UInt256(tws.Get(cell), isBigEndian: true), Is.EqualTo((UInt256)2));
 
             AccountChangesAtIndex? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -54,8 +54,8 @@ public class TracedAccessWorldStateTests(bool parallel)
         return (tws, scope);
     }
 
-    [Test]
-    public void Mutation_without_generating_block_access_list_throws_actionable_exception()
+    /// <summary>Builds an untraced decorator — one that was never handed a slice — over an account A at nonce 0.</summary>
+    private (TracedAccessWorldState tws, IWorldState inner, IDisposable scope) CreateIdleState()
     {
         IWorldState inner = TestWorldStateFactory.CreateForTest();
         Hash256 stateRoot;
@@ -69,13 +69,43 @@ public class TracedAccessWorldStateTests(bool parallel)
 
         TracedAccessWorldState tws = new(inner, parallel);
         BlockHeader baseBlock = Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject;
-        using IDisposable scope = tws.BeginScope(baseBlock);
+        return (tws, inner, tws.BeginScope(baseBlock));
+    }
 
-        Assert.That(
-            () => tws.SetNonce(TestItem.AddressA, 1),
-            Throws.InvalidOperationException.With.Message.EqualTo(
+    [TestCase("SetIndex")]
+    [TestCase("IncrementIndex")]
+    [TestCase("Clear")]
+    public void Control_member_without_generating_block_access_list_throws_actionable_exception(string member)
+    {
+        (TracedAccessWorldState tws, _, IDisposable scope) = CreateIdleState();
+        using (scope)
+        {
+            Action call = member switch
+            {
+                "SetIndex" => () => tws.SetIndex(0),
+                "IncrementIndex" => tws.IncrementIndex,
+                _ => tws.Clear
+            };
+
+            Assert.That(call, Throws.InvalidOperationException.With.Message.EqualTo(
                 "Block access list tracing requires a generating block access list to be set."));
-        Assert.That(inner.GetNonce(TestItem.AddressA), Is.Zero);
+        }
+    }
+
+    [Test]
+    public void Mutation_without_generating_block_access_list_delegates_without_recording()
+    {
+        (TracedAccessWorldState tws, IWorldState inner, IDisposable scope) = CreateIdleState();
+        using (scope)
+        {
+            tws.SetNonce(TestItem.AddressA, 1);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(inner.GetNonce(TestItem.AddressA), Is.EqualTo(1UL));
+                Assert.That(tws.GetGeneratingBlockAccessList(), Is.Null);
+            }
+        }
     }
 
     [TestCase(true, 50u, 100u, 150u, TestName = "AddToBalance")]

--- a/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/TracedAccessWorldStateTests.cs
@@ -54,6 +54,30 @@ public class TracedAccessWorldStateTests(bool parallel)
         return (tws, scope);
     }
 
+    [Test]
+    public void Mutation_without_generating_block_access_list_throws_actionable_exception()
+    {
+        IWorldState inner = TestWorldStateFactory.CreateForTest();
+        Hash256 stateRoot;
+        using (inner.BeginScope(IWorldState.PreGenesis))
+        {
+            inner.CreateAccount(TestItem.AddressA, 0);
+            inner.Commit(Spec, isGenesis: true);
+            inner.CommitTree(0);
+            stateRoot = inner.StateRoot;
+        }
+
+        TracedAccessWorldState tws = new(inner, parallel);
+        BlockHeader baseBlock = Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject;
+        using IDisposable scope = tws.BeginScope(baseBlock);
+
+        Assert.That(
+            () => tws.SetNonce(TestItem.AddressA, 1),
+            Throws.InvalidOperationException.With.Message.EqualTo(
+                "Block access list tracing requires a generating block access list to be set."));
+        Assert.That(inner.GetNonce(TestItem.AddressA), Is.Zero);
+    }
+
     [TestCase(true, 50u, 100u, 150u, TestName = "AddToBalance")]
     [TestCase(false, 30u, 100u, 70u, TestName = "SubtractFromBalance")]
     public void BalanceOp_RecordsBalanceChange(
@@ -540,7 +564,9 @@ public class TracedAccessWorldStateTests(bool parallel)
         using (scope)
         {
             tws.Set(cell, [0x01]);
+            Assert.That(new UInt256(tws.Get(cell), isBigEndian: true), Is.EqualTo(UInt256.One));
             tws.Set(cell, [0x02]);
+            Assert.That(new UInt256(tws.Get(cell), isBigEndian: true), Is.EqualTo((UInt256)2));
 
             AccountChangesAtIndex? ac = tws.GetGeneratingBlockAccessList()!.GetAccountChanges(TestItem.AddressA);
             using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
+++ b/src/Nethermind/Nethermind.State/BlockAccessListBasedWorldState.cs
@@ -301,6 +301,9 @@ public class BlockAccessListBasedWorldState(IWorldState state, ILogManager logMa
         return _parentReader;
     }
 
+    private BlockHeader SuggestedBlockHeader
+        => _suggestedBlockHeader ?? throw new InvalidOperationException($"{nameof(_suggestedBlockHeader)} was not initialized.");
+
     private ReadOnlyAccountChanges GetAccountChangesOrThrow(Address address)
     {
         Debug.Assert(_suggestedBlockAccessList is not null);
@@ -389,9 +392,9 @@ public class BlockAccessListBasedWorldState(IWorldState state, ILogManager logMa
 
     [DoesNotReturn, StackTraceHidden]
     private void ThrowMissingAccount(Address address)
-        => throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader!, $"Suggested block-level access list missing account changes for {address} at index {_blockAccessIndex}.");
+        => throw new InvalidBlockLevelAccessListException(SuggestedBlockHeader, $"Suggested block-level access list missing account changes for {address} at index {_blockAccessIndex}.");
 
     [DoesNotReturn, StackTraceHidden]
     private void ThrowMissingStorage(in StorageCell storageCell)
-        => throw new InvalidBlockLevelAccessListException(_suggestedBlockHeader!, $"Storage access for {storageCell.Address} not in block access list at index {_blockAccessIndex}.");
+        => throw new InvalidBlockLevelAccessListException(SuggestedBlockHeader, $"Storage access for {storageCell.Address} not in block access list at index {_blockAccessIndex}.");
 }

--- a/src/Nethermind/Nethermind.State/Healing/HealingStateTree.cs
+++ b/src/Nethermind/Nethermind.State/Healing/HealingStateTree.cs
@@ -12,9 +12,9 @@ using Nethermind.Trie.Pruning;
 namespace Nethermind.State.Healing;
 
 [method: DebuggerStepThrough]
-public sealed class HealingStateTree(ITrieStore? store, INodeStorage nodeStorage, Lazy<IPathRecovery> recovery, ILogManager? logManager) : StateTree(store.GetTrieStore(null), logManager)
+public sealed class HealingStateTree(ITrieStore store, INodeStorage nodeStorage, Lazy<IPathRecovery> recovery, ILogManager logManager) : StateTree(store.GetTrieStore(null), logManager)
 {
-    private Lazy<IPathRecovery> _recovery = recovery;
+    private readonly Lazy<IPathRecovery> _recovery = recovery;
     private readonly INodeStorage _nodeStorage = nodeStorage;
 
     public override ReadOnlySpan<byte> Get(ReadOnlySpan<byte> rawKey, Hash256? rootHash = null)
@@ -57,18 +57,15 @@ public sealed class HealingStateTree(ITrieStore? store, INodeStorage nodeStorage
 
     private bool Recover(in TreePath missingNodePath, Hash256 hash, Hash256 fullPath)
     {
-        if (_recovery is not null)
+        using IOwnedReadOnlyList<(TreePath, byte[])>? rlps = _recovery.Value.Recover(RootHash, null, missingNodePath, hash, fullPath).GetAwaiter().GetResult();
+        if (rlps is not null)
         {
-            using IOwnedReadOnlyList<(TreePath, byte[])>? rlps = _recovery.Value.Recover(RootHash, null, missingNodePath, hash, fullPath).GetAwaiter().GetResult();
-            if (rlps is not null)
+            foreach ((TreePath, byte[]) kv in rlps)
             {
-                foreach ((TreePath, byte[]) kv in rlps)
-                {
-                    ValueHash256 nodeHash = ValueKeccak.Compute(kv.Item2);
-                    _nodeStorage.Set(null, kv.Item1, nodeHash, kv.Item2);
-                }
-                return true;
+                ValueHash256 nodeHash = ValueKeccak.Compute(kv.Item2);
+                _nodeStorage.Set(null, kv.Item1, nodeHash, kv.Item2);
             }
+            return true;
         }
 
         return false;

--- a/src/Nethermind/Nethermind.State/Healing/HealingStorageTree.cs
+++ b/src/Nethermind/Nethermind.State/Healing/HealingStorageTree.cs
@@ -11,7 +11,7 @@ using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State.Healing;
 
-public sealed class HealingStorageTree(IScopedTrieStore? trieStore, INodeStorage nodeStorage, Hash256 rootHash, ILogManager? logManager, Address address, Hash256 stateRoot, Lazy<IPathRecovery> recovery) : StorageTree(trieStore, rootHash, logManager)
+public sealed class HealingStorageTree(IScopedTrieStore trieStore, INodeStorage nodeStorage, Hash256 rootHash, ILogManager logManager, Address address, Hash256 stateRoot, Lazy<IPathRecovery> recovery) : StorageTree(trieStore, rootHash, logManager)
 {
     private readonly INodeStorage _nodeStorage = nodeStorage;
     private readonly Address _address = address;
@@ -58,19 +58,16 @@ public sealed class HealingStorageTree(IScopedTrieStore? trieStore, INodeStorage
 
     private bool Recover(in TreePath missingNodePath, Hash256 hash, Hash256 fullPath)
     {
-        if (_recovery is not null)
+        using IOwnedReadOnlyList<(TreePath, byte[])>? rlps = _recovery.Value.Recover(_stateRoot, Keccak.Compute(_address.Bytes), missingNodePath, hash, fullPath).GetAwaiter().GetResult();
+        if (rlps is not null)
         {
-            using IOwnedReadOnlyList<(TreePath, byte[])>? rlps = _recovery.Value.Recover(_stateRoot, Keccak.Compute(_address.Bytes), missingNodePath, hash, fullPath).GetAwaiter().GetResult();
-            if (rlps is not null)
+            Hash256 addressHash = _address.ToAccountPath.ToCommitment();
+            foreach ((TreePath, byte[]) kv in rlps)
             {
-                Hash256 addressHash = _address.ToAccountPath.ToCommitment();
-                foreach ((TreePath, byte[]) kv in rlps)
-                {
-                    ValueHash256 nodeHash = ValueKeccak.Compute(kv.Item2);
-                    _nodeStorage.Set(addressHash, kv.Item1, nodeHash, kv.Item2);
-                }
-                return true;
+                ValueHash256 nodeHash = ValueKeccak.Compute(kv.Item2);
+                _nodeStorage.Set(addressHash, kv.Item1, nodeHash, kv.Item2);
             }
+            return true;
         }
 
         return false;

--- a/src/Nethermind/Nethermind.State/Healing/HealingWorldStateScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/Healing/HealingWorldStateScopeProvider.cs
@@ -11,10 +11,10 @@ namespace Nethermind.State.Healing;
 
 public class HealingWorldStateScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatching codeDb, INodeStorage nodeStorage, Lazy<IPathRecovery> recovery, ILogManager logManager) : TrieStoreScopeProvider(trieStore, codeDb, logManager, codeDbIsPersistent: true)
 {
-    private readonly ILogManager? _logManager = logManager;
+    private readonly ILogManager _logManager = logManager;
     private readonly ITrieStore _trieStore = trieStore;
 
     protected override StateTree CreateStateTree() => new HealingStateTree(_trieStore, nodeStorage, recovery, _logManager);
 
-    protected override StorageTree CreateStorageTree(Address address, Hash256 storageRoot) => new HealingStorageTree(_trieStore.GetTrieStore(address), nodeStorage, storageRoot, _logManager, address, _backingStateTree.RootHash, recovery);
+    protected override StorageTree CreateStorageTree(Address address, Hash256 storageRoot) => new HealingStorageTree(_trieStore.GetTrieStore(address), nodeStorage, storageRoot, _logManager, address, BackingStateTree.RootHash, recovery);
 }

--- a/src/Nethermind/Nethermind.State/IStorageTreeFactory.cs
+++ b/src/Nethermind/Nethermind.State/IStorageTreeFactory.cs
@@ -10,5 +10,5 @@ namespace Nethermind.State;
 
 public interface IStorageTreeFactory
 {
-    StorageTree Create(Address address, IScopedTrieStore trieStore, Hash256 storageRoot, Hash256 stateRoot, ILogManager? logManager);
+    StorageTree Create(Address address, IScopedTrieStore trieStore, Hash256 storageRoot, Hash256 stateRoot, ILogManager logManager);
 }

--- a/src/Nethermind/Nethermind.State/Nethermind.State.csproj
+++ b/src/Nethermind/Nethermind.State/Nethermind.State.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Nethermind/Nethermind.State/OverridableEnv/OverridableEnvFactory.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/OverridableEnvFactory.cs
@@ -19,7 +19,9 @@ public class OverridableEnvFactory(IWorldStateManager worldStateManager, ILifeti
         ILifetimeScope childLifetimeScope = parentLifetimeScope.BeginLifetimeScope((builder) => builder
             .AddSingleton<IWorldStateScopeProvider>(overridableScope.WorldState)
             .AddDecorator<ICodeInfoRepository, OverridableCodeInfoRepository>()
-            .AddScoped<IOverridableCodeInfoRepository, ICodeInfoRepository>((codeInfoRepo) => (codeInfoRepo as OverridableCodeInfoRepository)!));
+            .AddScoped<IOverridableCodeInfoRepository, ICodeInfoRepository>((codeInfoRepo) =>
+                codeInfoRepo as OverridableCodeInfoRepository
+                ?? throw new InvalidOperationException($"{nameof(ICodeInfoRepository)} must be decorated by {nameof(OverridableCodeInfoRepository)}.")));
 
         OverridableSpecProvider overridableSpecProvider = new(specProvider);
         return new OverridableEnv(overridableScope, childLifetimeScope, specProvider, overridableSpecProvider);

--- a/src/Nethermind/Nethermind.State/OverridableEnv/OverridableEnvFactory.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/OverridableEnvFactory.cs
@@ -31,7 +31,9 @@ public class OverridableEnvFactory(IWorldStateManager worldStateManager, ILifeti
             }
             builder
                 .AddDecorator<ICodeInfoRepository, OverridableCodeInfoRepository>()
-                .AddScoped<IOverridableCodeInfoRepository, ICodeInfoRepository>((codeInfoRepo) => (codeInfoRepo as OverridableCodeInfoRepository)!);
+                .AddScoped<IOverridableCodeInfoRepository, ICodeInfoRepository>((codeInfoRepo) =>
+                    codeInfoRepo as OverridableCodeInfoRepository
+                    ?? throw new InvalidOperationException($"{nameof(ICodeInfoRepository)} must be decorated by {nameof(OverridableCodeInfoRepository)}."));
         });
 
         OverridableSpecProvider overridableSpecProvider = new(specProvider);

--- a/src/Nethermind/Nethermind.State/OverridableWorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/OverridableWorldStateManager.cs
@@ -13,7 +13,7 @@ public class OverridableWorldStateManager : IOverridableWorldScope
     private readonly StateReader _reader;
     private readonly IReadOnlyDbProvider _dbProvider;
 
-    public OverridableWorldStateManager(IDbProvider dbProvider, IReadOnlyTrieStore trieStore, ILogManager? logManager)
+    public OverridableWorldStateManager(IDbProvider dbProvider, IReadOnlyTrieStore trieStore, ILogManager logManager)
     {
         IReadOnlyDbProvider readOnlyDbProvider = new ReadOnlyDbProvider(dbProvider, true);
         _dbProvider = readOnlyDbProvider;

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
@@ -16,10 +17,10 @@ namespace Nethermind.State
     /// <summary>
     /// Contains common code for both Persistent and Transient storage providers
     /// </summary>
-    internal abstract class PartialStorageProviderBase(ILogManager? logManager)
+    internal abstract class PartialStorageProviderBase(ILogManager logManager)
     {
         protected readonly Dictionary<StorageCell, HeadChange> _intraBlockCache = [];
-        protected readonly ILogger _logger = logManager?.GetClassLogger<PartialStorageProviderBase>() ?? throw new ArgumentNullException(nameof(logManager));
+        protected readonly ILogger _logger = logManager.GetClassLogger<PartialStorageProviderBase>();
         protected readonly List<Change> _changes = new(Resettable.StartCapacity);
 
         // stack of snapshot indexes on changes for start of each transaction
@@ -162,7 +163,7 @@ namespace Nethermind.State
         /// <param name="storageCell">Storage location</param>
         /// <param name="bytes">Resulting value</param>
         /// <returns>True if value has been set</returns>
-        protected bool TryGetCachedValue(in StorageCell storageCell, out byte[]? bytes)
+        protected bool TryGetCachedValue(in StorageCell storageCell, [NotNullWhen(true)] out byte[]? bytes)
         {
             // If the cache is completely empty (no writes or reads yet this transaction),
             // skip hashing the 52-byte cell — TryGetValue would miss anyway.

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -28,7 +28,7 @@ namespace Nethermind.State;
 internal sealed partial class PersistentStorageProvider(StateProvider stateProvider, ILogManager logManager, LocalMetrics metrics)
     : PartialStorageProviderBase(logManager)
 {
-    private IWorldStateScopeProvider.IScope _currentScope;
+    private IWorldStateScopeProvider.IScope? _currentScope;
     private readonly StateProvider _stateProvider = stateProvider;
     private readonly LocalMetrics _metrics = metrics;
     private const int StoragesInitialCapacity = 4_096;
@@ -81,10 +81,14 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
     }
 
-    public void SetBackendScope(IWorldStateScopeProvider.IScope scope) => _currentScope = scope;
+    public void SetBackendScope(IWorldStateScopeProvider.IScope? scope) => _currentScope = scope;
+
+    private IWorldStateScopeProvider.IScope CurrentScope =>
+        _currentScope ?? throw new InvalidOperationException("Persistent storage can only be used within a world-state scope.");
 
     public override void Set(in StorageCell storageCell, byte[] newValue)
     {
+        IWorldStateScopeProvider.IScope currentScope = CurrentScope;
         _metrics.IncrementStorageWrites();
         // Pair with HasStorageToClear: cached writes can bypass LoadFromTree, so register before journaling.
         PerContractState state = GetOrCreateStorage(storageCell.Address);
@@ -92,11 +96,11 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         // Write-time warm-up hint: the commit-time HintSet fires too late for speculative
         // (populator) executions, which never commit. No-op for backends without trie warm-up.
         ValueAddress address = new(storageCell.Address.Bytes);
-        _currentScope.HintWarmSlot(in address, storageCell.Index);
+        currentScope.HintWarmSlot(in address, storageCell.Index);
         // The storage root lives in the account, so anything that moves it rewrites the account's leaf as well,
         // and the account write path never sees a contract the block only stores to. The same holds for
         // ResetContractState and ClearStorage, which move the root without writing a slot.
-        if (state.TakeAccountWarmHint()) _currentScope.HintWarmAccount(in address);
+        if (state.TakeAccountWarmHint()) currentScope.HintWarmAccount(in address);
     }
 
     /// <summary>
@@ -105,7 +109,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// <param name="storageCell">Storage location</param>
     /// <returns>Value at location</returns>
     protected override ReadOnlySpan<byte> GetCurrentValue(in StorageCell storageCell) =>
-        TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : LoadFromTree(storageCell);
+        TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes : LoadFromTree(storageCell);
 
     /// <summary>
     /// Return the original persistent storage value from the storage cell
@@ -114,7 +118,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// <returns></returns>
     public ReadOnlySpan<byte> GetOriginal(in StorageCell storageCell)
     {
-        if (!_originalValues.TryGetValue(storageCell, out byte[] value))
+        if (!_originalValues.TryGetValue(storageCell, out byte[]? value))
         {
             throw new InvalidOperationException("Get original should only be called after get within the same caching round");
         }
@@ -254,7 +258,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 continue;
             }
 
-            if (!_committedThisRound.Add(change!.StorageCell))
+            if (!_committedThisRound.Add(change.StorageCell))
             {
                 continue;
             }
@@ -271,7 +275,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 {
                     if (TStorageTracing.IsActive)
                     {
-                        trace![change.StorageCell] = new StorageChangeTrace(StorageTree.ZeroBytes);
+                        RequireTrace(trace)[change.StorageCell] = new StorageChangeTrace(StorageTree.ZeroBytes);
                     }
 
                     continue;
@@ -282,7 +286,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                     TraceUpdate(change);
                 }
 
-                if (_originalValues.TryGetValue(change.StorageCell, out byte[] initialValue) &&
+                if (_originalValues.TryGetValue(change.StorageCell, out byte[]? initialValue) &&
                     initialValue.AsSpan().SequenceEqual(change.Value))
                 {
                     // no need to update the tree if the value is the same
@@ -297,7 +301,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
                 if (TStorageTracing.IsActive)
                 {
-                    trace![change.StorageCell] = new StorageChangeTrace(change.Value);
+                    RequireTrace(trace)[change.StorageCell] = new StorageChangeTrace(change.Value);
                 }
             }
         }
@@ -306,6 +310,10 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void TraceUpdate(in Change change)
         => _logger.Trace($"  Update {change.StorageCell.Address}_{change.StorageCell.Index} V = {change.Value.ToHexString(true)}");
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Dictionary<StorageCell, StorageChangeTrace> RequireTrace(Dictionary<StorageCell, StorageChangeTrace>? trace)
+        => trace ?? throw new InvalidOperationException("Storage tracing is active without a trace accumulator.");
 
     internal void FlushToTree(IWorldStateScopeProvider.IWorldStateWriteBatch writeBatch)
     {
@@ -326,7 +334,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         {
             if (!kvp.Value) continue;
 
-            if (!_storages.TryGetValue(kvp.Key, out PerContractState contractState))
+            if (!_storages.TryGetValue(kvp.Key, out PerContractState? contractState))
             {
                 Debug.Fail($"Storage root marked changed for {kvp.Key} but no contract state is present");
                 continue;
@@ -481,17 +489,22 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
     private PerContractState GetOrCreateStorage(Address address)
     {
-        if (_lastStorageAddress == address)
+        if (_lastStorageAddress == address && _lastStorage is not null)
         {
-            return _lastStorage!;
+            return _lastStorage;
         }
 
         ref PerContractState? value = ref CollectionsMarshal.GetValueRefOrAddDefault(_storages, address, out bool exists);
         if (!exists) value = PerContractState.Rent(address, this);
+        PerContractState storage = value ?? ThrowNoStorageState(address);
         _lastStorageAddress = address;
-        _lastStorage = value;
-        return value;
+        _lastStorage = storage;
+        return storage;
     }
+
+    [DoesNotReturn, StackTraceHidden]
+    private static PerContractState ThrowNoStorageState(Address address) =>
+        throw new InvalidOperationException($"No storage state is available for {address}.");
 
     public void WarmUp(in StorageCell storageCell, bool isEmpty)
     {
@@ -570,14 +583,16 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
     private void ResetContractState(Address address)
     {
+        IWorldStateScopeProvider.IScope currentScope = CurrentScope;
         _toUpdateRoots.TryAdd(address, true);
         PerContractState state = GetOrCreateStorage(address);
         state.Clear();
-        if (state.TakeAccountWarmHint()) _currentScope.HintWarmAccount(new ValueAddress(address.Bytes));
+        if (state.TakeAccountWarmHint()) currentScope.HintWarmAccount(new ValueAddress(address.Bytes));
     }
 
     public override void ClearStorage(Address address)
     {
+        IWorldStateScopeProvider.IScope currentScope = CurrentScope;
         if (!HasStorageToClear(address))
         {
             return;
@@ -609,7 +624,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         PerContractState contractState = GetOrCreateStorage(address);
         DefaultableDictionary.ClearSnapshot blockChange = contractState.ClearRevertibly();
         _toUpdateRoots[address] = true;
-        if (contractState.TakeAccountWarmHint()) _currentScope.HintWarmAccount(new ValueAddress(address.Bytes));
+        if (contractState.TakeAccountWarmHint()) currentScope.HintWarmAccount(new ValueAddress(address.Bytes));
         int journalIndex = _storageClearJournal.Count;
         _storageClearJournal.Add(new StorageClearChange(address, blockChange, originalValues, rootUpdate));
         PushStorageClear(journalIndex);
@@ -637,7 +652,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             return true;
         }
 
-        return _currentScope.Get(address)?.HasStorage == true;
+        return CurrentScope.Get(address)?.HasStorage == true;
     }
 
     protected override void RestoreStorageClear(int journalIndex)
@@ -797,8 +812,8 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         private bool _storageRootSeen;
         private bool _wasCleared;
         private bool _accountHinted;
-        private PersistentStorageProvider _provider;
-        private Address _address;
+        private PersistentStorageProvider? _provider;
+        private Address? _address;
 
         private PerContractState(Address address, PersistentStorageProvider provider) => Initialize(address, provider);
 
@@ -809,6 +824,12 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
 
         public int EstimatedChanges => BlockChange.EstimatedSize;
+
+        private PersistentStorageProvider Provider =>
+            _provider ?? throw new InvalidOperationException("A returned storage state cannot be used.");
+
+        private Address Address =>
+            _address ?? throw new InvalidOperationException("A returned storage state cannot be used.");
 
         public bool WasWritten => _wasWritten;
 
@@ -846,6 +867,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MemberNotNull(nameof(_backend))]
         internal void EnsureStorageTree()
         {
             if (_backend is not null) return;
@@ -853,9 +875,10 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
+        [MemberNotNull(nameof(_backend))]
         private void CreateStorageTree()
         {
-            _backend = _provider._currentScope.CreateStorageTree(_address);
+            _backend = Provider.CurrentScope.CreateStorageTree(Address);
 
             bool isEmpty = _backend.RootHash == Keccak.EmptyTreeHash;
             if (!_storageRootSeen)
@@ -931,13 +954,14 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             }
             else
             {
-                _provider._metrics.IncrementStorageTreeCache();
+                Provider._metrics.IncrementStorageTreeCache();
             }
 
-            uint round = _provider._originalsRound;
+            PersistentStorageProvider provider = Provider;
+            uint round = provider._originalsRound;
             if (valueChange.CapturedRound != round)
             {
-                _provider.CaptureOriginalValue(storageCell, valueChange.After);
+                provider.CaptureOriginalValue(storageCell, valueChange.After);
                 valueChange = valueChange.WithCapturedRound(round);
             }
 
@@ -946,7 +970,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         private byte[] LoadFromTreeStorage(StorageCell storageCell)
         {
-            _provider._metrics.IncrementStorageTreeReads();
+            Provider._metrics.IncrementStorageTreeReads();
 
             EnsureStorageTree();
             return _backend.Get(storageCell.Index);
@@ -1030,7 +1054,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         {
             if (BlockChange.Count == 0) return;
 
-            using IWorldStateScopeProvider.IStorageWriteBatch storageWriteBatch = writeBatch.CreateStorageWriteBatch(_address, BlockChange.Count);
+            using IWorldStateScopeProvider.IStorageWriteBatch storageWriteBatch = writeBatch.CreateStorageWriteBatch(Address, BlockChange.Count);
             foreach (KeyValuePair<UInt256, StorageChangeTrace> kvp in BlockChange)
             {
                 storageWriteBatch.Set(kvp.Key, kvp.Value.After);
@@ -1049,7 +1073,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
             public static PerContractState Rent(Address address, PersistentStorageProvider provider)
             {
-                if (Volatile.Read(ref _poolCount) > 0 && _pool.TryDequeue(out PerContractState item))
+                if (Volatile.Read(ref _poolCount) > 0 && _pool.TryDequeue(out PerContractState? item))
                 {
                     Interlocked.Decrement(ref _poolCount);
                     item.Initialize(address, provider);

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.std.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.std.cs
@@ -33,7 +33,7 @@ internal sealed partial class PersistentStorageProvider
         foreach (KeyValuePair<AddressAsKey, bool> kv in _toUpdateRoots)
         {
             if (!kv.Value) continue;
-            if (!_storages.TryGetValue(kv.Key, out PerContractState contractState))
+            if (!_storages.TryGetValue(kv.Key, out PerContractState? contractState))
             {
                 Debug.Fail($"Storage root marked changed for {kv.Key} but no contract state is present");
                 continue;

--- a/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/PrewarmerScopeProvider.cs
@@ -311,7 +311,7 @@ public class PrewarmerScopeProvider(
         {
             StorageCell storageCell = new(address, in index); // TODO: Make the dictionary use UInt256 directly
             long sw = _measureMetric ? Stopwatch.GetTimestamp() : 0;
-            if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
+            if (preBlockCache.TryGetValue(in storageCell, out byte[]? value) && value is not null)
             {
                 if (_measureMetric) _metricObserver.Observe(Stopwatch.GetTimestamp() - sw, _labels.SlotGetHit);
                 _metrics.IncrementStorageTreeCache();
@@ -353,7 +353,7 @@ public class PrewarmerScopeProvider(
         public byte[] Get(in UInt256 index)
         {
             StorageCell storageCell = new(address, in index);
-            if (preBlockCache.TryGetValue(in storageCell, out byte[] value))
+            if (preBlockCache.TryGetValue(in storageCell, out byte[]? value) && value is not null)
             {
                 return value;
             }

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProof.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProof.cs
@@ -19,9 +19,9 @@ namespace Nethermind.State.Proofs
     [JsonConverter(typeof(ProofJsonConverter))]
     public class AccountProof
     {
-        public Address? Address { get; set; }
+        public Address Address { get; set; } = Address.Zero;
 
-        public byte[][]? Proof { get; set; }
+        public byte[][] Proof { get; set; } = [];
 
         public UInt256 Balance { get; set; }
 
@@ -31,7 +31,7 @@ namespace Nethermind.State.Proofs
 
         public Hash256 StorageRoot { get; set; } = Keccak.EmptyTreeHash;
 
-        public StorageProof[]? StorageProofs { get; set; }
+        public StorageProof[] StorageProofs { get; set; } = [];
     }
 
     /// <summary>
@@ -97,7 +97,7 @@ namespace Nethermind.State.Proofs
             JsonSerializer.Serialize(writer, value.Proof, options);
 
             writer.WritePropertyName("address"u8);
-            _addressConverter.Write(writer, value.Address!, options);
+            _addressConverter.Write(writer, value.Address, options);
 
             writer.WritePropertyName("balance"u8);
             _uint256Converter.Write(writer, value.Balance, options);

--- a/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/AccountProofCollector.cs
@@ -85,20 +85,20 @@ namespace Nethermind.State.Proofs
         public AccountProofCollector(ReadOnlySpan<byte> hashedAddress, params byte[][]? storageKeys)
             : this(hashedAddress, storageKeys?.Select(ToKey), storageKeys?.Length ?? 0, storageKeys) { }
 
-        public AccountProofCollector(Address? address, params byte[][] storageKeys)
-            : this(Keccak.Compute((address ?? Address.Zero).Bytes).Bytes, storageKeys)
-            => _accountProof.Address = _address = address ?? throw new ArgumentNullException(nameof(address));
+        public AccountProofCollector(Address address, params byte[][] storageKeys)
+            : this(Keccak.Compute(address.Bytes).Bytes, storageKeys)
+            => _accountProof.Address = _address = address;
 
-        public AccountProofCollector(Address? address, IEnumerable<UInt256> storageKeys)
+        public AccountProofCollector(Address address, IEnumerable<UInt256> storageKeys)
             : this(address, storageKeys.Select(ToKey).ToArray()) { }
 
-        public AccountProofCollector(Address? address, IReadOnlyCollection<UInt256> storageKeys, CancellationToken cancellationToken = default)
+        public AccountProofCollector(Address address, IReadOnlyCollection<UInt256> storageKeys, CancellationToken cancellationToken = default)
         {
             _cancellationToken = cancellationToken;
             _accountProof = new AccountProof
             {
                 StorageProofs = new StorageProof[storageKeys.Count],
-                Address = _address = address ?? throw new ArgumentNullException(nameof(address))
+                Address = _address = address
             };
             _fullAccountPath = Nibbles.FromBytes(Keccak.Compute(_address.Bytes).Bytes);
             _fullStoragePaths = new Nibble[storageKeys.Count][];
@@ -111,7 +111,7 @@ namespace Nethermind.State.Proofs
                 storageKey.ToBigEndian(keyBuffer);
                 _fullStoragePaths[j] = Nibbles.FromBytes(ValueKeccak.Compute(keyBuffer).Bytes);
                 _storageProofItems[j] = [];
-                _accountProof.StorageProofs![j] = new StorageProof
+                _accountProof.StorageProofs[j] = new StorageProof
                 {
                     Key = keyBuffer.ToHexString(true, true),
                     Value = Bytes.ZeroByte
@@ -133,7 +133,7 @@ namespace Nethermind.State.Proofs
             _accountProof.Proof = _accountProofItems.ToArray();
             for (int i = 0; i < _storageProofItems.Length; i++)
             {
-                _accountProof.StorageProofs![i].Proof = _storageProofItems[i].ToArray();
+                _accountProof.StorageProofs[i].Proof = _storageProofItems[i].ToArray();
             }
             return _accountProof;
         }
@@ -210,7 +210,7 @@ namespace Nethermind.State.Proofs
             // RLP, so EIP-1186 / go-ethereum convention is to omit them from the proof entries.
             if (node.Keccak is null) return;
 
-            byte[] rlp = node.FullRlp.ToArray();
+            byte[] rlp = node.FullRlp.ToArray() ?? throw new TrieException("A visited proof node must have encoded RLP.");
             if (ctx.Storage is null)
             {
                 _accountProofItems.Add(rlp);

--- a/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofCollector.cs
@@ -50,8 +50,15 @@ namespace Nethermind.State.Proofs
         public void VisitBranch(in EmptyContext _, TrieNode node)
         {
             AddProofBits(node);
-            _visitingFilter.Remove(node.Keccak);
-            _visitingFilter.Add(node.GetChildHash((byte)Prefix[_pathIndex]));
+            if (node.Keccak is { } nodeHash)
+            {
+                _visitingFilter.Remove(nodeHash);
+            }
+
+            if (node.GetChildHash((byte)Prefix[_pathIndex]) is { } childHash)
+            {
+                _visitingFilter.Add(childHash);
+            }
 
             _pathIndex++;
         }
@@ -59,20 +66,29 @@ namespace Nethermind.State.Proofs
         public void VisitExtension(in EmptyContext _, TrieNode node)
         {
             AddProofBits(node);
-            _visitingFilter.Remove(node.Keccak);
+            if (node.Keccak is { } nodeHash)
+            {
+                _visitingFilter.Remove(nodeHash);
+            }
 
-            Hash256 childHash = node.GetChildHash(0);
-            _visitingFilter.Add(childHash); // always accept so can optimize
+            if (node.GetChildHash(0) is { } childHash)
+            {
+                _visitingFilter.Add(childHash); // always accept so can optimize
+            }
 
-            _pathIndex += node.Key.Length;
+            _pathIndex += (node.Key ?? throw new TrieException("A resolved extension node must have a key.")).Length;
         }
 
-        protected virtual void AddProofBits(TrieNode node) => _proofBits.Add(node.FullRlp.ToArray());
+        protected virtual void AddProofBits(TrieNode node) =>
+            _proofBits.Add(node.FullRlp.ToArray() ?? throw new TrieException("A visited proof node must have encoded RLP."));
 
         public void VisitLeaf(in EmptyContext _, TrieNode node)
         {
             AddProofBits(node);
-            _visitingFilter.Remove(node.Keccak);
+            if (node.Keccak is { } nodeHash)
+            {
+                _visitingFilter.Remove(nodeHash);
+            }
             _pathIndex = 0;
         }
 

--- a/src/Nethermind/Nethermind.State/Proofs/ProofVerifier.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ProofVerifier.cs
@@ -7,6 +7,7 @@ using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Trie;
+using Nethermind.Trie.Pruning;
 
 namespace Nethermind.State.Proofs
 {
@@ -43,7 +44,7 @@ namespace Nethermind.State.Proofs
             }
 
             TrieNode trieNode = new(NodeType.Unknown, proof.Last());
-            trieNode.ResolveNode(null, TreePath.Empty);
+            trieNode.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
 
             return trieNode.Value;
         }

--- a/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
@@ -39,7 +39,7 @@ public sealed class ReceiptTrie : PatriciaTrie<TxReceipt>
             | RlpBehaviors.SkipTypedWrapping;
         int key = 0;
 
-        foreach (TxReceipt? receipt in receipts)
+        foreach (TxReceipt receipt in receipts)
         {
             CappedArray<byte> buffer = _decoder.EncodeToCappedArray(receipt, rlpBehaviors: behavior, bufferPool: _bufferPool);
             CappedArray<byte> keyBuffer = Rlp.EncodeToCappedArray(key, _bufferPool);

--- a/src/Nethermind/Nethermind.State/Proofs/StorageProof.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/StorageProof.cs
@@ -13,7 +13,7 @@ namespace Nethermind.State.Proofs;
 public class StorageProof
 {
     public string? Key { get; set; }
-    public byte[][]? Proof { get; set; }
+    public byte[][] Proof { get; set; } = [];
 
     [JsonConverter(typeof(ProofStorageValueConverter))]
     public ReadOnlyMemory<byte>? Value { get; set; }

--- a/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/TxTrie.cs
@@ -26,7 +26,7 @@ public sealed class TxTrie : PatriciaTrie<Transaction>
     {
         int key = 0;
 
-        foreach (Transaction? transaction in list)
+        foreach (Transaction transaction in list)
         {
             ref readonly Memory<byte> rlp = ref transaction.PreHash;
             CappedArray<byte> buffer = (rlp.Length > 0) ?

--- a/src/Nethermind/Nethermind.State/Proofs/WithdrawalTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/WithdrawalTrie.cs
@@ -20,7 +20,7 @@ public sealed class WithdrawalTrie : PatriciaTrie<Withdrawal>
     public WithdrawalTrie(ReadOnlySpan<Withdrawal> withdrawals, bool canBuildProof = false)
         : base(withdrawals, canBuildProof, canBeParallel: false) { }
 
-    public static Hash256? CalculateRoot(ReadOnlySpan<Withdrawal> withdrawals) =>
+    public static Hash256 CalculateRoot(ReadOnlySpan<Withdrawal> withdrawals) =>
         new WithdrawalTrie(withdrawals).RootHash;
 
     protected override void Initialize(ReadOnlySpan<Withdrawal> withdrawals)

--- a/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/Repositories/ChainLevelInfoRepository.cs
@@ -20,7 +20,8 @@ namespace Nethermind.State.Repositories
 
         private readonly object _writeLock = new();
         private readonly ClockCache<ulong, ChainLevelInfo> _blockInfoCache = new(CacheSize);
-        private readonly IRlpDecoder<ChainLevelInfo> _decoder = Rlp.GetDecoder<ChainLevelInfo>();
+        private readonly IRlpDecoder<ChainLevelInfo> _decoder = Rlp.GetDecoder<ChainLevelInfo>()
+            ?? throw new InvalidOperationException($"No RLP decoder is registered for {nameof(ChainLevelInfo)}.");
 
         private readonly IDb _blockInfoDb = blockInfoDb ?? throw new ArgumentNullException(nameof(blockInfoDb));
 
@@ -32,8 +33,7 @@ namespace Nethermind.State.Repositories
                 _blockInfoDb.Delete(number);
             }
 
-            bool needLock = batch?.Disposed != false;
-            if (needLock)
+            if (batch is null || batch.Disposed)
             {
                 lock (_writeLock)
                 {
@@ -56,8 +56,7 @@ namespace Nethermind.State.Repositories
                 _blockInfoDb.PutSpan(number.ToBigEndianSpanWithoutLeadingZeros(out _), rlp);
             }
 
-            bool needLock = batch?.Disposed != false;
-            if (needLock)
+            if (batch is null || batch.Disposed)
             {
                 lock (_writeLock)
                 {
@@ -88,7 +87,7 @@ namespace Nethermind.State.Repositories
 
             return data.Select(kv =>
                 {
-                    if (kv.Value == null || kv.Value.Length == 0) return null;
+                    if (kv.Value is null || kv.Value.Length == 0) return null;
                     RlpReader reader = new(kv.Value);
                     return _decoder.Decode(ref reader, RlpBehaviors.AllowExtraBytes);
                 })

--- a/src/Nethermind/Nethermind.State/Snap/AccountsAndProofs.cs
+++ b/src/Nethermind/Nethermind.State/Snap/AccountsAndProofs.cs
@@ -2,19 +2,34 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core.Collections;
 
 namespace Nethermind.State.Snap
 {
     public class AccountsAndProofs : IDisposable
     {
-        public IOwnedReadOnlyList<PathWithAccount> PathAndAccounts { get; set; }
-        public IByteArrayList Proofs { get; set; }
+        private IOwnedReadOnlyList<PathWithAccount> _pathAndAccounts = IOwnedReadOnlyList<PathWithAccount>.Empty;
+        private IByteArrayList _proofs = EmptyByteArrayList.Instance;
+
+        [AllowNull]
+        public IOwnedReadOnlyList<PathWithAccount> PathAndAccounts
+        {
+            get => _pathAndAccounts;
+            set => _pathAndAccounts = value ?? IOwnedReadOnlyList<PathWithAccount>.Empty;
+        }
+
+        [AllowNull]
+        public IByteArrayList Proofs
+        {
+            get => _proofs;
+            set => _proofs = value ?? EmptyByteArrayList.Instance;
+        }
 
         public void Dispose()
         {
-            PathAndAccounts?.Dispose();
-            Proofs?.Dispose();
+            PathAndAccounts.Dispose();
+            Proofs.Dispose();
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/Snap/AccountsToRefreshRequest.cs
+++ b/src/Nethermind/Nethermind.State/Snap/AccountsToRefreshRequest.cs
@@ -12,18 +12,18 @@ namespace Nethermind.State.Snap
         /// <summary>
         /// Root hash of the account trie to serve
         /// </summary>
-        public Hash256 RootHash { get; set; }
+        public required Hash256 RootHash { get; set; }
 
-        public IOwnedReadOnlyList<AccountWithStorageStartingHash> Paths { get; set; }
+        public IOwnedReadOnlyList<AccountWithStorageStartingHash> Paths { get; set; } = IOwnedReadOnlyList<AccountWithStorageStartingHash>.Empty;
 
         public override string ToString() => $"AccountsToRefreshRequest: ({RootHash}, {Paths.Count})";
 
-        public void Dispose() => Paths?.Dispose();
+        public void Dispose() => Paths.Dispose();
     }
 
     public class AccountWithStorageStartingHash
     {
-        public PathWithAccount PathAndAccount { get; set; }
+        public PathWithAccount? PathAndAccount { get; set; }
         public ValueHash256 StorageStartingHash { get; set; }
         public ValueHash256 StorageHashLimit { get; set; }
     }

--- a/src/Nethermind/Nethermind.State/Snap/GetTrieNodesRequest.cs
+++ b/src/Nethermind/Nethermind.State/Snap/GetTrieNodesRequest.cs
@@ -9,10 +9,10 @@ namespace Nethermind.State.Snap
 {
     public class GetTrieNodesRequest : IDisposable
     {
-        public Hash256 RootHash { get; set; }
+        public required Hash256 RootHash { get; set; }
 
-        public IOwnedReadOnlyList<PathGroup> AccountAndStoragePaths { get; set; }
+        public IOwnedReadOnlyList<PathGroup> AccountAndStoragePaths { get; set; } = IOwnedReadOnlyList<PathGroup>.Empty;
 
-        public void Dispose() => AccountAndStoragePaths?.Dispose();
+        public void Dispose() => AccountAndStoragePaths.Dispose();
     }
 }

--- a/src/Nethermind/Nethermind.State/Snap/PathGroup.cs
+++ b/src/Nethermind/Nethermind.State/Snap/PathGroup.cs
@@ -8,7 +8,7 @@ namespace Nethermind.State.Snap
 {
     public class PathGroup
     {
-        public byte[][] Group { get; set; }
+        public byte[][] Group { get; set; } = [];
 
         public static RlpPathGroupList EncodeToRlpPathGroupList(IReadOnlyList<PathGroup> groups) =>
             new(EncodeToRlpItemList(groups));

--- a/src/Nethermind/Nethermind.State/Snap/PathWithAccount.cs
+++ b/src/Nethermind/Nethermind.State/Snap/PathWithAccount.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Serialization.Rlp;
@@ -11,16 +12,19 @@ namespace Nethermind.State.Snap
     {
         public PathWithAccount() { }
 
-        public PathWithAccount(ValueHash256 path, Account account)
+        public PathWithAccount(ValueHash256 path, Account? account)
         {
             Path = path;
             Account = account;
         }
 
         public ValueHash256 Path { get; set; }
-        public Account Account { get; set; }
+        public Account? Account { get; set; }
 
-        public byte[] ToRlpValue() =>
-            (Account.IsTotallyEmpty ? StateTree.EmptyAccountRlp : Rlp.Encode(Account)).Bytes;
+        public byte[] ToRlpValue()
+        {
+            Account account = Account ?? throw new InvalidOperationException("An account value is required when encoding a SNAP trie entry.");
+            return (account.IsTotallyEmpty ? StateTree.EmptyAccountRlp : Rlp.Encode(account)).Bytes;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State/Snap/PathWithStorageSlot.cs
+++ b/src/Nethermind/Nethermind.State/Snap/PathWithStorageSlot.cs
@@ -23,7 +23,7 @@ namespace Nethermind.State.Snap
 
         public static bool operator !=(PathWithStorageSlot left, PathWithStorageSlot right) => !left.Equals(in right);
 
-        public override bool Equals(object obj) => obj is PathWithStorageSlot pws && Equals(in pws);
+        public override bool Equals(object? obj) => obj is PathWithStorageSlot pws && Equals(in pws);
 
         public override int GetHashCode() => throw new NotImplementedException();
     }

--- a/src/Nethermind/Nethermind.State/Snap/SlotsAndProofs.cs
+++ b/src/Nethermind/Nethermind.State/Snap/SlotsAndProofs.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Nethermind.Core.Collections;
 
@@ -9,17 +10,32 @@ namespace Nethermind.State.Snap
 {
     public class SlotsAndProofs : IDisposable
     {
-        public IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> PathsAndSlots { get; set; }
+        private IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> _pathsAndSlots =
+            IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty;
 
-        public IByteArrayList Proofs { get; set; }
+        private IByteArrayList _proofs = EmptyByteArrayList.Instance;
+
+        [AllowNull]
+        public IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>> PathsAndSlots
+        {
+            get => _pathsAndSlots;
+            set => _pathsAndSlots = value ?? IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty;
+        }
+
+        [AllowNull]
+        public IByteArrayList Proofs
+        {
+            get => _proofs;
+            set => _proofs = value ?? EmptyByteArrayList.Instance;
+        }
 
         private int _disposed;
 
         public void Dispose()
         {
             if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
-            PathsAndSlots?.DisposeRecursive();
-            Proofs?.Dispose();
+            PathsAndSlots.DisposeRecursive();
+            Proofs.Dispose();
         }
     }
 }

--- a/src/Nethermind/Nethermind.State/Snap/StorageRange.cs
+++ b/src/Nethermind/Nethermind.State/Snap/StorageRange.cs
@@ -15,12 +15,12 @@ namespace Nethermind.State.Snap
         /// <summary>
         /// Root hash of the account trie to serve
         /// </summary>
-        public Hash256 RootHash { get; set; }
+        public Hash256? RootHash { get; set; }
 
         /// <summary>
         /// Accounts of the storage tries to serve
         /// </summary>
-        public IOwnedReadOnlyList<PathWithAccount> Accounts { get; set; }
+        public IOwnedReadOnlyList<PathWithAccount> Accounts { get; set; } = IOwnedReadOnlyList<PathWithAccount>.Empty;
 
         /// <summary>
         /// Account hash of the first to retrieve
@@ -43,6 +43,6 @@ namespace Nethermind.State.Snap
 
         public override string ToString() => $"StorageRange: ({BlockNumber}, {RootHash}, {StartingHash}, {LimitHash})";
 
-        public void Dispose() => Accounts?.Dispose();
+        public void Dispose() => Accounts.Dispose();
     }
 }

--- a/src/Nethermind/Nethermind.State/SnapServer/AccountCollector.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/AccountCollector.cs
@@ -24,9 +24,9 @@ public class AccountCollector : RangeQueryVisitor.ILeafValueCollector
         }
 
         RlpReader ctx = new(value.AsSpan());
-        Account accnt = AccountDecoder.Instance.Decode(ref ctx);
+        Account accnt = AccountDecoder.Instance.Decode(ref ctx)
+            ?? throw new TrieException("An account leaf must contain a decodable account value.");
         Accounts.Add(new PathWithAccount(path, accnt));
         return 32 + AccountDecoder.Slim.GetLength(accnt);
     }
 }
-

--- a/src/Nethermind/Nethermind.State/SnapServer/NoopSnapServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/NoopSnapServer.cs
@@ -15,10 +15,10 @@ public class NoopSnapServer : ISnapServer
 
     public bool CanServe => false;
 
-    public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken) =>
+    public IByteArrayList GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, CancellationToken cancellationToken) =>
         EmptyByteArrayList.Instance;
 
-    public IByteArrayList? GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, long byteLimit, CancellationToken cancellationToken) =>
+    public IByteArrayList GetTrieNodes(IReadOnlyList<PathGroup> pathSet, Hash256 rootHash, long byteLimit, CancellationToken cancellationToken) =>
         EmptyByteArrayList.Instance;
 
     public IByteArrayList GetByteCodes(IReadOnlyList<ValueHash256> requestedHashes, long byteLimit, CancellationToken cancellationToken) =>
@@ -31,7 +31,7 @@ public class NoopSnapServer : ISnapServer
         in ValueHash256 startingHash, in ValueHash256? limitHash, long byteLimit, CancellationToken cancellationToken) =>
         (ArrayPoolList<PathWithAccount>.Empty(), EmptyByteArrayList.Instance);
 
-    public (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>, IByteArrayList?) GetStorageRanges(
+    public (IOwnedReadOnlyList<IOwnedReadOnlyList<PathWithStorageSlot>>, IByteArrayList) GetStorageRanges(
         Hash256 rootHash, IReadOnlyList<PathWithAccount> accounts, in ValueHash256? startingHash,
         in ValueHash256? limitHash, long byteLimit, CancellationToken cancellationToken) =>
         (ArrayPoolList<IOwnedReadOnlyList<PathWithStorageSlot>>.Empty(), EmptyByteArrayList.Instance);

--- a/src/Nethermind/Nethermind.State/SnapServer/PathWithStorageCollector.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/PathWithStorageCollector.cs
@@ -15,7 +15,8 @@ public class PathWithStorageCollector : RangeQueryVisitor.ILeafValueCollector
 
     public int Collect(in ValueHash256 path, CappedArray<byte> value)
     {
-        Slots.Add(new PathWithStorageSlot(in path, value.ToArray()));
+        byte[] slotRlpValue = value.ToArray() ?? throw new TrieException("A storage leaf must have an encoded value.");
+        Slots.Add(new PathWithStorageSlot(in path, slotRlpValue));
         return 32 + value.Length;
     }
 }

--- a/src/Nethermind/Nethermind.State/SnapServer/SnapStateServer.cs
+++ b/src/Nethermind/Nethermind.State/SnapServer/SnapStateServer.cs
@@ -192,7 +192,7 @@ public class SnapStateServer : ISnapStateServer
                 break;
             }
 
-            Account accountNeth = GetAccountByPath(tree, rootHash, accounts[i].Path.Bytes.ToArray());
+            Account? accountNeth = GetAccountByPath(tree, rootHash, accounts[i].Path.Bytes.ToArray());
             if (accountNeth is null)
             {
                 break;

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -60,6 +60,12 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     private bool _needsStateRootUpdate;
     private IWorldStateScopeProvider.ICodeDb? _codeDb;
 
+    private IWorldStateScopeProvider.IScope Tree =>
+        _tree ?? throw new InvalidOperationException("State can only be used within a world-state scope.");
+
+    private IWorldStateScopeProvider.ICodeDb CodeDb =>
+        _codeDb ?? throw new InvalidOperationException("Code storage can only be used within a world-state scope.");
+
     // Invalidates the guest front cache when a restore/commit/reset recycles the change stacks; elided on
     // mainline, which has no front cache (no implementing declaration).
     partial void InvalidateFrontCache();
@@ -82,7 +88,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
     public void RecalculateStateRoot()
     {
-        _tree.UpdateRootHash();
+        Tree.UpdateRootHash();
         _needsStateRootUpdate = false;
     }
 
@@ -91,7 +97,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         get
         {
             if (_needsStateRootUpdate) ThrowStateRootNeedsToBeUpdated();
-            return _tree.RootHash;
+            return Tree.RootHash;
 
             [DoesNotReturn, StackTraceHidden]
             static void ThrowStateRootNeedsToBeUpdated() => throw new InvalidOperationException("State root needs to be updated");
@@ -142,7 +148,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         // Don't reinsert if already inserted. This can be the case when the same
         // code is used by multiple deployments. Either from factory contracts (e.g. LPs)
         // or people copy and pasting popular contracts
-        if (!_blockCodeInsertFilter.Get(codeHash) && !(_codeDb?.ContainsCode(codeHash) == true))
+        if (!_blockCodeInsertFilter.Get(codeHash) && !CodeDb.ContainsCode(codeHash))
         {
             if (_codeBatch is null)
             {
@@ -156,9 +162,10 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
             if (MemoryMarshal.TryGetArray(code, out ArraySegment<byte> codeArray)
                 && codeArray.Offset == 0
-                && codeArray.Count == code.Length)
+                && codeArray.Count == code.Length
+                && codeArray.Array is { } array)
             {
-                _codeBatchAlternate[codeHash] = codeArray.Array;
+                _codeBatchAlternate[codeHash] = array;
             }
             else
             {
@@ -211,7 +218,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
         Account GetThroughCacheCheckExists()
         {
-            Account result = GetThroughCache(address);
+            Account? result = GetThroughCache(address);
             if (result is null)
             {
                 ThrowNonExistingAccount();
@@ -338,7 +345,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
         if (_codeBatch is null || !_codeBatchAlternate.TryGetValue(codeHash, out byte[]? code))
         {
-            code = _codeDb.GetCode(codeHash);
+            code = CodeDb.GetCode(codeHash);
         }
         return code ?? ThrowMissingCode(in codeHash);
 
@@ -405,7 +412,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         for (int nextPosition = changes.Length - 1; nextPosition > snapshot; nextPosition--)
         {
             ref readonly Change change = ref changes[nextPosition];
-            ref int head = ref CollectionsMarshal.GetValueRefOrNullRef(_intraTxCache, change!.Address);
+            ref int head = ref CollectionsMarshal.GetValueRefOrNullRef(_intraTxCache, change.Address);
 
             if (Unsafe.IsNullRef(ref head)) ThrowUnexpectedPosition(nextPosition, -1);
             if (head != nextPosition) ThrowUnexpectedPosition(nextPosition, head);
@@ -501,7 +508,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             //we don't want to do it for account empty due to a change (e.g. changed balance to zero)
             Change lastChange = _changes[head];
             if (lastChange.ChangeType == ChangeType.Delete ||
-                (lastChange.ChangeType is ChangeType.Touch or ChangeType.New && lastChange.Account.IsEmpty))
+                (lastChange.ChangeType is ChangeType.Touch or ChangeType.New && lastChange.RequiredAccount.IsEmpty))
             {
                 _needsStateRootUpdate = true;
                 if (_logger.IsTrace) Trace(address);
@@ -546,7 +553,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
         Task codeFlushTask = !commitRoots || _codeBatch is null || _codeBatch.Count == 0
             ? Task.CompletedTask
-            : CommitCodeAsync(_codeDb);
+            : CommitCodeAsync(CodeDb);
 
         bool isTracing = _logger.IsTrace;
         int stepsBack = _changes.Count - 1;
@@ -600,7 +607,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
         Task CommitCodeAsync(IWorldStateScopeProvider.ICodeDb codeDb)
         {
-            Dictionary<Hash256AsKey, byte[]> dict = Interlocked.Exchange(ref _codeBatch, null);
+            Dictionary<Hash256AsKey, byte[]>? dict = Interlocked.Exchange(ref _codeBatch, null);
 
             if (dict is null)
                 return Task.CompletedTask;
@@ -629,7 +636,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                 dict.Clear();
 
                 if (Interlocked.CompareExchange(ref _codeBatch, dict, null) is null)
-                    _codeBatchAlternate = _codeBatch.GetAlternateLookup<ValueHash256>();
+                    _codeBatchAlternate = dict.GetAlternateLookup<ValueHash256>();
             }
             // A single processor gains nothing from the hop to the pool, and the guest folds it away.
             if (Core.Cpu.RuntimeInformation.IsSingleProcessor)
@@ -664,7 +671,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         for (int i = changes.Length - 1; i >= 0; i--)
         {
             ref readonly Change change = ref changes[i];
-            if (!TStateTracing.IsActive && change!.ChangeType == ChangeType.JustCache)
+            if (!TStateTracing.IsActive && change.ChangeType == ChangeType.JustCache)
             {
                 // Safe to skip without touching the head: JustCache is always the bottom of its chain.
                 Debug.Assert(change.PrevIdx == -1);
@@ -672,13 +679,13 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             }
 
             bool alreadyCommitted = TStateTracing.IsActive
-                ? _committedThisRound.Contains(change!.Address)
-                : !_committedThisRound.Add(change!.Address);
+                ? _committedThisRound.Contains(change.Address)
+                : !_committedThisRound.Add(change.Address);
             if (alreadyCommitted)
             {
                 if (TStateTracing.IsActive && change.ChangeType == ChangeType.JustCache)
                 {
-                    trace!.UpdateTrace(change.Address, change.Account);
+                    RequireTrace(trace).UpdateTrace(change.Address, change.Account);
                 }
 
                 continue;
@@ -707,37 +714,40 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                 case ChangeType.Touch:
                 case ChangeType.Update:
                     {
-                        if (removeEmptyAccounts && change.Account.IsEmpty)
+                        Account account = change.RequiredAccount;
+                        if (removeEmptyAccounts && account.IsEmpty)
                         {
                             if (isTracing) TraceRemoveEmpty(change);
                             SetState(change.Address, null);
-                            if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, null);
+                            if (TStateTracing.IsActive) RequireTrace(trace).AddToTrace(change.Address, null);
                         }
                         else
                         {
                             if (isTracing) TraceUpdate(change);
-                            SetState(change.Address, change.Account);
-                            if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, change.Account);
+                            SetState(change.Address, account);
+                            if (TStateTracing.IsActive) RequireTrace(trace).AddToTrace(change.Address, account);
                         }
 
                         break;
                     }
                 case ChangeType.New:
                     {
-                        if (!removeEmptyAccounts || !change.Account.IsEmpty)
+                        Account account = change.RequiredAccount;
+                        if (!removeEmptyAccounts || !account.IsEmpty)
                         {
                             if (isTracing) TraceCreate(change);
-                            SetState(change.Address, change.Account);
-                            if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, change.Account);
+                            SetState(change.Address, account);
+                            if (TStateTracing.IsActive) RequireTrace(trace).AddToTrace(change.Address, account);
                         }
 
                         break;
                     }
                 case ChangeType.RecreateEmpty:
                     {
+                        Account account = change.RequiredAccount;
                         if (isTracing) TraceCreate(change);
-                        SetState(change.Address, change.Account);
-                        if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, change.Account);
+                        SetState(change.Address, account);
+                        if (TStateTracing.IsActive) RequireTrace(trace).AddToTrace(change.Address, account);
 
                         break;
                     }
@@ -757,7 +767,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
                         if (!wasItCreatedNow)
                         {
                             SetState(change.Address, null);
-                            if (TStateTracing.IsActive) trace!.AddToTrace(change.Address, null);
+                            if (TStateTracing.IsActive) RequireTrace(trace).AddToTrace(change.Address, null);
                         }
 
                         break;
@@ -769,20 +779,24 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Dictionary<AddressAsKey, ChangeTrace> RequireTrace(Dictionary<AddressAsKey, ChangeTrace>? trace) =>
+        trace ?? throw new InvalidOperationException("State tracing is active without a trace accumulator.");
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void TraceRemove(in Change change) => _logger.Trace($"Commit remove {change.Address}");
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void TraceCreate(in Change change)
-        => _logger.Trace($"Commit create {change.Address} B = {change.Account.Balance.ToHexString(skipLeadingZeros: true)} N = {change.Account.Nonce.ToHexString(skipLeadingZeros: true)}");
+        => _logger.Trace($"Commit create {change.Address} B = {change.RequiredAccount.Balance.ToHexString(skipLeadingZeros: true)} N = {change.RequiredAccount.Nonce.ToHexString(skipLeadingZeros: true)}");
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void TraceUpdate(in Change change)
-        => _logger.Trace($"Commit update {change.Address} B = {change.Account.Balance.ToHexString(skipLeadingZeros: true)} N = {change.Account.Nonce.ToHexString(skipLeadingZeros: true)} C = {change.Account.CodeHash}");
+        => _logger.Trace($"Commit update {change.Address} B = {change.RequiredAccount.Balance.ToHexString(skipLeadingZeros: true)} N = {change.RequiredAccount.Nonce.ToHexString(skipLeadingZeros: true)} C = {change.RequiredAccount.CodeHash}");
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void TraceRemoveEmpty(in Change change)
-        => _logger.Trace($"Commit remove empty {change.Address} B = {change.Account.Balance.ToHexString(skipLeadingZeros: true)} N = {change.Account.Nonce.ToHexString(skipLeadingZeros: true)}");
+        => _logger.Trace($"Commit remove empty {change.Address} B = {change.RequiredAccount.Balance.ToHexString(skipLeadingZeros: true)} N = {change.RequiredAccount.Nonce.ToHexString(skipLeadingZeros: true)}");
 
     [DoesNotReturn, StackTraceHidden]
     private static void ThrowUnknownChangeType() => throw new ArgumentOutOfRangeException("changeType", "Unknown change type.");
@@ -878,7 +892,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         if (!exists)
         {
             _metrics.IncrementStateTreeReads();
-            Account? account = _tree.Get(address);
+            Account? account = Tree.Get(address);
 
             accountChanges = new(account, account);
         }
@@ -1071,6 +1085,7 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         public readonly int PrevIdx = prevIdx;
 
         public bool IsNull => ChangeType == ChangeType.Null;
+        public Account RequiredAccount => Account ?? throw new InvalidOperationException($"{ChangeType} changes require an account value.");
     }
 
     internal struct ChangeTrace(Account? before, Account? after)
@@ -1093,7 +1108,7 @@ internal static class Extensions
     public static void UpdateTrace(this Dictionary<AddressAsKey, ChangeTrace> trace, Address address, Account? change) => trace[address] = new ChangeTrace(change, trace[address].After);
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void ReportStateTrace(this Dictionary<AddressAsKey, ChangeTrace>? trace, IWorldStateTracer stateTracer, HashSet<AddressAsKey> nullAccountReads, StateProvider stateProvider)
+    public static void ReportStateTrace(this Dictionary<AddressAsKey, ChangeTrace> trace, IWorldStateTracer stateTracer, HashSet<AddressAsKey> nullAccountReads, StateProvider stateProvider)
     {
         foreach (Address nullRead in nullAccountReads)
         {
@@ -1105,8 +1120,10 @@ internal static class Extensions
 
     private static void ReportChanges(Dictionary<AddressAsKey, ChangeTrace> trace, IStateTracer stateTracer, StateProvider stateProvider)
     {
-        foreach ((Address address, ChangeTrace change) in trace)
+        foreach (KeyValuePair<AddressAsKey, ChangeTrace> entry in trace)
         {
+            Address address = entry.Key;
+            ChangeTrace change = entry.Value;
             bool someChangeReported = false;
 
             Account? before = change.Before;

--- a/src/Nethermind/Nethermind.State/StateReader.cs
+++ b/src/Nethermind/Nethermind.State/StateReader.cs
@@ -13,7 +13,7 @@ using Metrics = Nethermind.Db.Metrics;
 
 namespace Nethermind.State
 {
-    public class StateReader(ITrieStore trieStore, IKeyValueStore? codeDb, ILogManager? logManager) : IStateReader
+    public class StateReader(ITrieStore trieStore, IKeyValueStore codeDb, ILogManager logManager) : IStateReader
     {
         private readonly IKeyValueStore _codeDb = codeDb ?? throw new ArgumentNullException(nameof(codeDb));
         private readonly StateTree _state = new(trieStore.GetTrieStore(null), logManager);

--- a/src/Nethermind/Nethermind.State/StateTree.cs
+++ b/src/Nethermind/Nethermind.State/StateTree.cs
@@ -26,10 +26,10 @@ namespace Nethermind.State
             : base(new MemDb(), Keccak.EmptyTreeHash, true, NullLogManager.Instance, bufferPool: bufferPool) => TrieType = TrieType.State;
 
         [DebuggerStepThrough]
-        public StateTree(IScopedTrieStore? store, ILogManager? logManager)
+        public StateTree(IScopedTrieStore store, ILogManager logManager)
             : base(store, Keccak.EmptyTreeHash, true, logManager) => TrieType = TrieType.State;
 
-        public StateTree(ITrieStore? store, ILogManager? logManager)
+        public StateTree(ITrieStore store, ILogManager logManager)
             : base(store.GetTrieStore(null), logManager)
         {
         }
@@ -109,7 +109,7 @@ namespace Nethermind.State
         [DebuggerStepThrough]
         public Rlp? Set(Hash256 keccak, Account? account)
         {
-            Rlp rlp = account is null ? null : account.IsTotallyEmpty ? EmptyAccountRlp : _decoder.Encode(account);
+            Rlp? rlp = account is null ? null : account.IsTotallyEmpty ? EmptyAccountRlp : _decoder.Encode(account);
 
             Set(keccak.Bytes, rlp);
             return rlp;
@@ -117,7 +117,7 @@ namespace Nethermind.State
 
         public Rlp? Set(in ValueHash256 keccak, Account? account)
         {
-            Rlp rlp = account is null ? null : account.IsTotallyEmpty ? EmptyAccountRlp : _decoder.Encode(account);
+            Rlp? rlp = account is null ? null : account.IsTotallyEmpty ? EmptyAccountRlp : _decoder.Encode(account);
 
             Set(keccak.Bytes, rlp);
             return rlp;

--- a/src/Nethermind/Nethermind.State/StorageTree.cs
+++ b/src/Nethermind/Nethermind.State/StorageTree.cs
@@ -39,12 +39,12 @@ namespace Nethermind.State
             return lookup;
         }
 
-        public StorageTree(IScopedTrieStore? trieStore, ILogManager? logManager)
+        public StorageTree(IScopedTrieStore trieStore, ILogManager logManager)
             : this(trieStore, Keccak.EmptyTreeHash, logManager)
         {
         }
 
-        public StorageTree(IScopedTrieStore? trieStore, Hash256 rootHash, ILogManager? logManager)
+        public StorageTree(IScopedTrieStore trieStore, Hash256 rootHash, ILogManager logManager)
             : base(trieStore, rootHash, true, logManager) => TrieType = TrieType.Storage;
 
         [SkipLocalsInit]
@@ -97,7 +97,7 @@ namespace Nethermind.State
             return GetWithKeyGenerate(in index, storageRoot);
 
             [SkipLocalsInit]
-            byte[] GetWithKeyGenerate(in UInt256 index, Hash256 storageRoot)
+            byte[] GetWithKeyGenerate(in UInt256 index, Hash256? storageRoot)
             {
                 ComputeKey(index, out ValueHash256 key);
                 return GetArray(in key, storageRoot);

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
@@ -19,9 +20,8 @@ namespace Nethermind.State;
 
 /// <remarks>
 /// Setup contract: <see cref="SetGeneratingBlockAccessList"/> must run with a non-null slice
-/// before any state-mutating method. Hot-path mutators dereference
-/// <c>_generatingBlockAccessList</c> without a null-check, so a missed setup fails fast with
-/// <see cref="NullReferenceException"/> at the first write rather than silently corrupting BAL output.
+/// before any operation that records or mutates the block access list. The guarded accessor fails fast
+/// with <see cref="InvalidOperationException"/> when setup is missing.
 /// </remarks>
 public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldStateDecorator(state), IBlockAccessListSource
 {
@@ -37,7 +37,16 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
     // read-recording. Reset in Clear() and Restore() (a revert can un-record the cell's slot).
     private StorageCell _lastReadStorageCell;
     private AccountChangesAtIndex? _lastReadStorageChanges;
-    private bool _hasLastReadCell;
+    private BlockAccessListAtIndex GeneratingBlockAccessList
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _generatingBlockAccessList ?? ThrowGeneratingBlockAccessListNotSet();
+    }
+
+    [DoesNotReturn, StackTraceHidden]
+    private static BlockAccessListAtIndex ThrowGeneratingBlockAccessListNotSet() =>
+        throw new InvalidOperationException("Block access list tracing requires a generating block access list to be set.");
+
     public BlockAccessListAtIndex? GetGeneratingBlockAccessList() => _generatingBlockAccessList;
     public void SetGeneratingBlockAccessList(BlockAccessListAtIndex? bal) => _generatingBlockAccessList = bal;
 
@@ -50,7 +59,7 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         UInt256 newBalance = oldBalance + balanceChange;
         if (!ShouldSuppressSystemUserZeroBalanceChange(address, in balanceChange))
         {
-            _generatingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
+            GeneratingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
         }
     }
 
@@ -65,7 +74,7 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         UInt256 newBalance = oldBalance + balanceChange;
         if (!ShouldSuppressSystemUserZeroBalanceChange(address, in balanceChange))
         {
-            _generatingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
+            GeneratingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
         }
 
         return res;
@@ -76,17 +85,16 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
     public override ReadOnlySpan<byte> Get(in StorageCell storageCell)
     {
         AccountChangesAtIndex accountChanges;
-        if (_hasLastReadCell && _lastReadStorageCell.Equals(storageCell))
+        if (_lastReadStorageChanges is { } cached && _lastReadStorageCell.Equals(storageCell))
         {
             // Already recorded this exact cell; reuse its entry and skip the read-recording.
-            accountChanges = _lastReadStorageChanges!;
+            accountChanges = cached;
         }
         else
         {
-            accountChanges = _generatingBlockAccessList.RecordStorageReadAndGet(storageCell.Address, storageCell.Index);
+            accountChanges = GeneratingBlockAccessList.RecordStorageReadAndGet(storageCell.Address, storageCell.Index);
             _lastReadStorageCell = storageCell;
             _lastReadStorageChanges = accountChanges;
-            _hasLastReadCell = true;
         }
         return GetInternal(accountChanges, in storageCell);
     }
@@ -96,26 +104,27 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         ulong? currentNonce = GetNonceCurrent(address);
         base.IncrementNonce(address, delta, out oldNonce);
         oldNonce = currentNonce ?? oldNonce;
-        _generatingBlockAccessList.AddNonceChange(address, oldNonce + delta);
+        GeneratingBlockAccessList.AddNonceChange(address, oldNonce + delta);
     }
 
     public override void SetNonce(Address address, in ulong nonce)
     {
+        BlockAccessListAtIndex generatingBlockAccessList = GeneratingBlockAccessList;
         base.SetNonce(address, nonce);
-        _generatingBlockAccessList.AddNonceChange(address, nonce);
+        generatingBlockAccessList.AddNonceChange(address, nonce);
     }
 
     public override bool InsertCode(Address address, in ValueHash256 codeHash, ReadOnlyMemory<byte> code, IReleaseSpec spec, bool isGenesis = false)
     {
         byte[] oldCode = GetCodeInternal(address) ?? [];
-        _generatingBlockAccessList.AddCodeChange(address, oldCode, code);
+        GeneratingBlockAccessList.AddCodeChange(address, oldCode, code);
         return base.InsertCode(address, codeHash, code, spec, isGenesis);
     }
 
     public override void Set(in StorageCell storageCell, byte[] newValue)
     {
         ReadOnlySpan<byte> oldValue = GetInternal(storageCell);
-        _generatingBlockAccessList.AddStorageChange(storageCell, new(oldValue, true), new(newValue, true));
+        GeneratingBlockAccessList.AddStorageChange(storageCell, new(oldValue, true), new(newValue, true));
         base.Set(storageCell, newValue);
     }
 
@@ -169,12 +178,12 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         oldBalance = currentBalance ?? oldBalance;
 
         UInt256 newBalance = oldBalance - balanceChange;
-        _generatingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
+        GeneratingBlockAccessList.AddBalanceChange(address, oldBalance, newBalance);
     }
 
     public override void DeleteAccount(Address address)
     {
-        _generatingBlockAccessList.DeleteAccount(address, GetBalanceInternal(address));
+        GeneratingBlockAccessList.DeleteAccount(address, GetBalanceInternal(address));
         base.DeleteAccount(address);
     }
 
@@ -205,7 +214,7 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
     {
         if (_systemAccountReadSuppressionDepth == 0 || address != Address.SystemUser)
         {
-            _generatingBlockAccessList.AddAccountRead(address);
+            GeneratingBlockAccessList.AddAccountRead(address);
         }
     }
 
@@ -216,20 +225,19 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
     private AccountChangesAtIndex? RecordReadAndGetChanges(Address address)
         // Suppressed SystemUser reads must not be recorded: use a non-mutating lookup.
         => _systemAccountReadSuppressionDepth != 0 && address == Address.SystemUser
-            ? _generatingBlockAccessList.GetAccountChanges(address)
-            : _generatingBlockAccessList.RecordReadAndGet(address);
+            ? GeneratingBlockAccessList.GetAccountChanges(address)
+            : GeneratingBlockAccessList.RecordReadAndGet(address);
 
     public void SetIndex(uint index)
-        => _generatingBlockAccessList.Index = index;
+        => GeneratingBlockAccessList.Index = index;
 
     public void IncrementIndex()
-        => _generatingBlockAccessList.Index++;
+        => GeneratingBlockAccessList.Index++;
 
     public void Clear()
     {
-        _generatingBlockAccessList.Clear();
+        GeneratingBlockAccessList.Clear();
         _systemAccountReadSuppressionDepth = 0;
-        _hasLastReadCell = false;
         _lastReadStorageChanges = null;
     }
 
@@ -238,15 +246,14 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
     public override void Restore(Snapshot snapshot)
     {
         // A revert can un-record the last cell's slot, so drop the single-slot cache.
-        _hasLastReadCell = false;
         _lastReadStorageChanges = null;
-        _generatingBlockAccessList.Restore(snapshot.BlockAccessListSnapshot);
+        GeneratingBlockAccessList.Restore(snapshot.BlockAccessListSnapshot);
         base.Restore(snapshot);
     }
 
     public override Snapshot TakeSnapshot(bool newTransactionStart = false)
     {
-        int blockAccessListSnapshot = _generatingBlockAccessList.TakeSnapshot();
+        int blockAccessListSnapshot = GeneratingBlockAccessList.TakeSnapshot();
         Snapshot snapshot = base.TakeSnapshot(newTransactionStart);
         return new(snapshot.StorageSnapshot, snapshot.StateSnapshot, blockAccessListSnapshot);
     }
@@ -284,14 +291,14 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         ulong? currentNonce = GetNonceCurrent(address);
         base.DecrementNonce(address, delta);
         ulong oldNonce = currentNonce ?? (GetNonce(address) + delta);
-        _generatingBlockAccessList.AddNonceChange(address, oldNonce - delta);
+        GeneratingBlockAccessList.AddNonceChange(address, oldNonce - delta);
     }
     private UInt256 GetBalanceInternal(Address address)
         => GetBalanceCurrent(address) ?? base.GetBalance(address);
 
     private UInt256? GetBalanceCurrent(Address address)
     {
-        AccountChangesAtIndex? accountChanges = _generatingBlockAccessList.GetAccountChanges(address);
+        AccountChangesAtIndex? accountChanges = GeneratingBlockAccessList.GetAccountChanges(address);
         return accountChanges?.BalanceChange?.Value;
     }
 
@@ -300,47 +307,55 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
 
     private ulong? GetNonceCurrent(Address address)
     {
-        AccountChangesAtIndex? accountChanges = _generatingBlockAccessList.GetAccountChanges(address);
+        AccountChangesAtIndex? accountChanges = GeneratingBlockAccessList.GetAccountChanges(address);
         return accountChanges?.NonceChange?.Value;
     }
 
     private byte[]? GetCodeCurrent(Address address)
-        => TryGetCodeChangeCurrent(address, out CodeChange? codeChange) ? codeChange.Value.Code : null;
+        => TryGetCodeChangeCurrent(address, out CodeChange codeChange) ? codeChange.Code : null;
 
-    private bool GetCodeHashCurrent(Address address, [NotNullWhen(true)] out ValueHash256? hash)
+    private bool GetCodeHashCurrent(Address address, out ValueHash256 hash)
     {
-        hash = null;
-        bool res = TryGetCodeChangeCurrent(address, out CodeChange? codeChange);
-        if (res)
+        if (TryGetCodeChangeCurrent(address, out CodeChange codeChange))
         {
-            hash = codeChange.Value.CodeHash;
+            hash = codeChange.CodeHash;
+            return true;
         }
-        return res;
+
+        hash = default;
+        return false;
     }
 
-    private bool TryGetCodeChangeCurrent(Address address, [NotNullWhen(true)] out CodeChange? codeChange)
+    private bool TryGetCodeChangeCurrent(Address address, out CodeChange codeChange)
     {
-        AccountChangesAtIndex? accountChanges = _generatingBlockAccessList.GetAccountChanges(address);
-        codeChange = accountChanges?.CodeChange;
-        return codeChange is not null;
+        AccountChangesAtIndex? accountChanges = GeneratingBlockAccessList.GetAccountChanges(address);
+        if (accountChanges?.CodeChange is { } currentCodeChange)
+        {
+            codeChange = currentCodeChange;
+            return true;
+        }
+
+        codeChange = default;
+        return false;
     }
 
     private byte[]? GetCodeInternal(Address address)
         => GetCodeCurrent(address) ?? base.GetCode(address);
 
     private ValueHash256 GetCodeHashInternal(Address address)
-        => GetCodeHashCurrent(address, out ValueHash256? hash) ? hash.Value : base.GetCodeHash(address);
+        => GetCodeHashCurrent(address, out ValueHash256 hash) ? hash : base.GetCodeHash(address);
 
     private ReadOnlySpan<byte> GetInternal(in StorageCell storageCell)
-        => GetInternal(parallel ? _generatingBlockAccessList.GetAccountChanges(storageCell.Address) : null, in storageCell);
+        => GetInternal(parallel ? GeneratingBlockAccessList.GetAccountChanges(storageCell.Address) : null, in storageCell);
 
     private ReadOnlySpan<byte> GetInternal(AccountChangesAtIndex? accountChanges, in StorageCell storageCell)
     {
-        if (parallel && accountChanges?.TryGetStorageChange(storageCell.Index, out StorageChange? change) == true)
+        if (parallel && accountChanges is not null &&
+            accountChanges.TryGetStorageChange(storageCell.Index, out StorageChange? change))
         {
             // Store the 32-byte word straight into _scratchStorage; the returned span outlives this
             // frame without allocating a new byte[32] per SLOAD.
-            Unsafe.WriteUnaligned(ref MemoryMarshal.GetArrayDataReference(_scratchStorage), change.Value.Value);
+            change.Value.Value.CopyTo(_scratchStorage);
             return _scratchStorage;
         }
 
@@ -352,7 +367,7 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
 
     private bool? AccountExistsCurrent(Address address)
     {
-        AccountChangesAtIndex? accountChanges = _generatingBlockAccessList.GetAccountChanges(address);
+        AccountChangesAtIndex? accountChanges = GeneratingBlockAccessList.GetAccountChanges(address);
         if (accountChanges is not null && (accountChanges.NonceChange is not null || accountChanges.BalanceChange is not null))
         {
             // if nonce or balance is changed in this tx must exist (could have been created this tx)
@@ -373,11 +388,11 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
         AddAccountRead(address);
         if (!balance.IsZero)
         {
-            _generatingBlockAccessList.AddBalanceChange(address, 0, balance);
+            GeneratingBlockAccessList.AddBalanceChange(address, 0, balance);
         }
         if (nonce != 0)
         {
-            _generatingBlockAccessList.AddNonceChange(address, nonce);
+            GeneratingBlockAccessList.AddNonceChange(address, nonce);
         }
     }
 

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -20,8 +21,9 @@ namespace Nethermind.State;
 /// <remarks>
 /// Records only while <see cref="SetGeneratingBlockAccessList"/> holds a slice, so the decorator can sit
 /// idle in a simulation stack; with none installed every member delegates to the decorated state.
-/// <see cref="Clear"/>, <see cref="SetIndex"/> and <see cref="IncrementIndex"/> still dereference it, so a
-/// missed setup in block processing fails fast at <c>Setup</c> instead of emitting an empty BAL.
+/// <see cref="Clear"/>, <see cref="SetIndex"/> and <see cref="IncrementIndex"/> instead go through the
+/// guarded <see cref="GeneratingBlockAccessList"/>, so a missed setup in block processing fails fast with
+/// an <see cref="InvalidOperationException"/> naming it instead of emitting an empty BAL.
 /// </remarks>
 public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldStateDecorator(state), IBlockAccessListSource
 {
@@ -256,15 +258,28 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
             ? _generatingBlockAccessList!.GetAccountChanges(address)
             : _generatingBlockAccessList!.RecordReadAndGet(address);
 
+    /// <summary>The live slice, for the control members that must not silently no-op without one.</summary>
+    /// <remarks>Every recording member checks <see cref="_generatingBlockAccessList"/> for null and delegates
+    /// to the decorated state instead; see the class remarks.</remarks>
+    private BlockAccessListAtIndex GeneratingBlockAccessList
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _generatingBlockAccessList ?? ThrowGeneratingBlockAccessListNotSet();
+    }
+
+    [DoesNotReturn, StackTraceHidden]
+    private static BlockAccessListAtIndex ThrowGeneratingBlockAccessListNotSet() =>
+        throw new InvalidOperationException("Block access list tracing requires a generating block access list to be set.");
+
     public void SetIndex(uint index)
-        => _generatingBlockAccessList!.Index = index;
+        => GeneratingBlockAccessList.Index = index;
 
     public void IncrementIndex()
-        => _generatingBlockAccessList!.Index++;
+        => GeneratingBlockAccessList.Index++;
 
     public void Clear()
     {
-        _generatingBlockAccessList!.Clear();
+        GeneratingBlockAccessList.Clear();
         _systemAccountReadSuppressionDepth = 0;
         _hasLastReadCell = false;
         _lastReadStorageChanges = null;

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -257,14 +257,14 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
             : _generatingBlockAccessList!.RecordReadAndGet(address);
 
     public void SetIndex(uint index)
-        => _generatingBlockAccessList.Index = index;
+        => _generatingBlockAccessList!.Index = index;
 
     public void IncrementIndex()
-        => _generatingBlockAccessList.Index++;
+        => _generatingBlockAccessList!.Index++;
 
     public void Clear()
     {
-        _generatingBlockAccessList.Clear();
+        _generatingBlockAccessList!.Clear();
         _systemAccountReadSuppressionDepth = 0;
         _hasLastReadCell = false;
         _lastReadStorageChanges = null;
@@ -356,13 +356,13 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
 
     private bool GetCodeHashCurrent(Address address, [NotNullWhen(true)] out ValueHash256? hash)
     {
-        hash = null;
-        bool res = TryGetCodeChangeCurrent(address, out CodeChange? codeChange);
-        if (res)
+        if (TryGetCodeChangeCurrent(address, out CodeChange? codeChange))
         {
             hash = codeChange.Value.CodeHash;
+            return true;
         }
-        return res;
+        hash = null;
+        return false;
     }
 
     private bool TryGetCodeChangeCurrent(Address address, [NotNullWhen(true)] out CodeChange? codeChange)

--- a/src/Nethermind/Nethermind.State/TransientStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/TransientStorageProvider.cs
@@ -11,7 +11,7 @@ namespace Nethermind.State
     /// EIP-1153 provides a transient store for contracts that doesn't persist
     /// storage across calls. Reverts will rollback any transient state changes.
     /// </summary>
-    internal sealed class TransientStorageProvider(ILogManager? logManager) : PartialStorageProviderBase(logManager)
+    internal sealed class TransientStorageProvider(ILogManager logManager) : PartialStorageProviderBase(logManager)
     {
 
         /// <summary>
@@ -20,6 +20,6 @@ namespace Nethermind.State
         /// <param name="storageCell">Storage location</param>
         /// <returns>Value at cell</returns>
         protected override ReadOnlySpan<byte> GetCurrentValue(in StorageCell storageCell) =>
-            TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes! : StorageTree.ZeroBytes;
+            TryGetCachedValue(storageCell, out byte[]? bytes) ? bytes : StorageTree.ZeroBytes;
     }
 }

--- a/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
+++ b/src/Nethermind/Nethermind.State/TrieStoreScopeProvider.cs
@@ -37,8 +37,11 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
 {
     private readonly ITrieStore _trieStore = trieStore;
     private readonly ILogManager _logManager = logManager;
-    protected StateTree _backingStateTree;
+    protected StateTree? _backingStateTree;
     private readonly KeyValueWithBatchingBackedCodeDb _codeDb = new(codeDb, codeDbIsPersistent);
+
+    protected StateTree BackingStateTree =>
+        _backingStateTree ?? throw new InvalidOperationException("A state tree is only available within a world-state scope.");
 
     protected virtual StateTree CreateStateTree() => new(_trieStore.GetTrieStore(null), _logManager);
 
@@ -47,10 +50,10 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
     public IWorldStateScopeProvider.IScope BeginScope(BlockHeader? baseBlock, LocalMetrics metrics)
     {
         IDisposable trieStoreCloser = _trieStore.BeginScope(baseBlock);
-        _backingStateTree ??= CreateStateTree();
-        _backingStateTree.RootHash = baseBlock?.StateRoot ?? Keccak.EmptyTreeHash;
+        StateTree backingStateTree = _backingStateTree ??= CreateStateTree();
+        backingStateTree.RootHash = baseBlock?.StateRoot ?? Keccak.EmptyTreeHash;
 
-        return new TrieStoreWorldStateBackendScope(_backingStateTree, this, _codeDb, trieStoreCloser, _logManager);
+        return new TrieStoreWorldStateBackendScope(backingStateTree, this, _codeDb, trieStoreCloser, _logManager);
     }
 
     protected virtual StorageTree CreateStorageTree(Address address, Hash256 storageRoot) => new(_trieStore.GetTrieStore(address), storageRoot, _logManager);
@@ -257,7 +260,8 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
                     {
                         commitTask.Add(Task.Factory.StartNew((ctx) =>
                         {
-                            StorageTree st = (StorageTree)ctx;
+                            StorageTree st = ctx as StorageTree
+                                ?? throw new InvalidOperationException("A storage commit task requires a storage tree.");
                             st.Commit();
                             blockCommitter.ReturnConcurrencyQuota();
                         }, storage.Value, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default));
@@ -277,7 +281,7 @@ public class TrieStoreScopeProvider(ITrieStore trieStore, IKeyValueStoreWithBatc
 
         internal StorageTree LookupStorageTree(Address address)
         {
-            if (_storages.TryGetValue(address, out StorageTree storageTree))
+            if (_storages.TryGetValue(address, out StorageTree? storageTree))
             {
                 return storageTree;
             }

--- a/src/Nethermind/Nethermind.State/VerifyTrieStarter.cs
+++ b/src/Nethermind/Nethermind.State/VerifyTrieStarter.cs
@@ -34,11 +34,11 @@ public class VerifyTrieStarter(IWorldStateManager worldStateManager, IProcessExi
         {
             try
             {
-                if (_logger.IsInfo) _logger!.Info($"Collecting trie stats and verifying that no nodes are missing staring from block {stateAtBlock} with state root {stateAtBlock.StateRoot}...");
+                if (_logger.IsInfo) _logger.Info($"Collecting trie stats and verifying that no nodes are missing staring from block {stateAtBlock} with state root {stateAtBlock.StateRoot}...");
 
                 if (!worldStateManager.VerifyTrie(stateAtBlock, exitSource.Token))
                 {
-                    if (_logger.IsError) _logger!.Error($"Verify trie failed");
+                    if (_logger.IsError) _logger.Error($"Verify trie failed");
                 }
             }
             // Only a shutdown-driven cancellation is expected here; an OCE from any other token means the

--- a/src/Nethermind/Nethermind.State/WorldState.cs
+++ b/src/Nethermind/Nethermind.State/WorldState.cs
@@ -54,7 +54,7 @@ namespace Nethermind.State
 
         public WorldState(
             IWorldStateScopeProvider scopeProvider,
-            ILogManager? logManager)
+            ILogManager logManager)
         {
             ScopeProvider = scopeProvider;
             _stateProvider = new StateProvider(logManager, _localMetrics);
@@ -68,6 +68,7 @@ namespace Nethermind.State
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [MemberNotNull(nameof(_currentScope))]
         private void GuardInScope()
         {
             if (_currentScope is null) ThrowOutOfScope();
@@ -226,7 +227,7 @@ namespace Nethermind.State
 
         public void CommitTree(ulong blockNumber)
         {
-            DebugGuardInScope();
+            GuardInScope();
             _stateProvider.UpdateStateRootIfNeeded();
             _currentScope.Commit(blockNumber);
             // The scope may cache the state it reads; it takes the block's final values before the providers drop them.
@@ -281,6 +282,7 @@ namespace Nethermind.State
                     _localMetrics.Flush();
                     Reset();
                     _stateProvider.SetScope(null);
+                    _persistentStorageProvider.SetBackendScope(null);
                     _currentScope.Dispose();
                 }
             }
@@ -297,7 +299,7 @@ namespace Nethermind.State
         public Task HintBal(ReadOnlyBlockAccessList bal)
         {
             GuardInScope();
-            return _currentScope!.HintBal(bal);
+            return _currentScope.HintBal(bal);
         }
 
         public ref readonly UInt256 GetBalance(Address address)
@@ -342,7 +344,7 @@ namespace Nethermind.State
             DebugGuardInScope();
             Account? account = _stateProvider.GetThroughCache(address);
             accountExists = account is not null;
-            return accountExists && (account!.IsContract || account.Nonce != 0);
+            return account is not null && (account.IsContract || account.Nonce != 0);
         }
 
         public bool IsDeadAccount(Address address)
@@ -355,7 +357,7 @@ namespace Nethermind.State
 
         public void Commit(IReleaseSpec releaseSpec, IWorldStateTracer tracer, bool isGenesis = false, bool commitRoots = true)
         {
-            DebugGuardInScope();
+            GuardInScope();
             _transientStorageProvider.Commit(tracer);
             _persistentStorageProvider.Commit(tracer);
             _stateProvider.Commit(releaseSpec, tracer, commitRoots, isGenesis);

--- a/src/Nethermind/Nethermind.State/WorldStateManager.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateManager.cs
@@ -19,8 +19,8 @@ public class WorldStateManager : IWorldStateManager
     private readonly ILogManager _logManager;
     private readonly ReadOnlyDb _readaOnlyCodeCb;
     private readonly IDbProvider _dbProvider;
-    private readonly BlockingVerifyTrie? _blockingVerifyTrie;
-    private readonly ILastNStateRootTracker _lastNStateRootTracker;
+    private readonly BlockingVerifyTrie _blockingVerifyTrie;
+    private readonly ILastNStateRootTracker? _lastNStateRootTracker;
 
     public WorldStateManager(
         IWorldStateScopeProvider worldState,
@@ -28,7 +28,7 @@ public class WorldStateManager : IWorldStateManager
         IDbProvider dbProvider,
         ILogManager logManager,
         StateBoundaryStore boundaryStore,
-        ILastNStateRootTracker lastNStateRootTracker = null
+        ILastNStateRootTracker? lastNStateRootTracker = null
     )
     {
         _dbProvider = dbProvider;
@@ -43,7 +43,7 @@ public class WorldStateManager : IWorldStateManager
         IReadOnlyDbProvider readOnlyDbProvider = dbProvider.AsReadOnly(false);
         _readaOnlyCodeCb = readOnlyDbProvider.GetDb<IDb>(DbNames.Code).AsReadOnly(true);
         GlobalStateReader = new StateReader(_readOnlyTrieStore, _readaOnlyCodeCb, _logManager);
-        _blockingVerifyTrie = new BlockingVerifyTrie(trieStore, GlobalStateReader, _readaOnlyCodeCb!, logManager);
+        _blockingVerifyTrie = new BlockingVerifyTrie(trieStore, GlobalStateReader, _readaOnlyCodeCb, logManager);
         _lastNStateRootTracker = lastNStateRootTracker;
         SnapStateServer = trieStore.Scheme == INodeStorage.KeyScheme.Hash
             ? NoopSnapServer.Instance
@@ -64,7 +64,7 @@ public class WorldStateManager : IWorldStateManager
 
     public IOverridableWorldScope CreateOverridableWorldScope() => new OverridableWorldStateManager(_dbProvider, _readOnlyTrieStore, _logManager);
 
-    public bool VerifyTrie(BlockHeader stateAtBlock, CancellationToken cancellationToken) => _blockingVerifyTrie?.VerifyTrie(stateAtBlock, cancellationToken) ?? true;
+    public bool VerifyTrie(BlockHeader stateAtBlock, CancellationToken cancellationToken) => _blockingVerifyTrie.VerifyTrie(stateAtBlock, cancellationToken);
 
     public void FlushCache(CancellationToken cancellationToken) => _trieStore.PersistCache(cancellationToken);
 }

--- a/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateScopeOperationLogger.cs
@@ -91,8 +91,8 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
 
         public byte[] Get(in UInt256 index)
         {
-            byte[]? bytes = storageTree.Get(in index);
-            logger.Trace($"{scopeId}: S:{address} Get slot {index}, got {bytes?.ToHexString()}");
+            byte[] bytes = storageTree.Get(in index);
+            logger.Trace($"{scopeId}: S:{address} Get slot {index}, got {bytes.ToHexString()}");
             return bytes;
         }
 
@@ -156,7 +156,7 @@ public class WorldStateScopeOperationLogger(IWorldStateScopeProvider baseScopePr
         public void Set(in UInt256 index, byte[] value)
         {
             writeBatch.Set(in index, value);
-            logger.Trace($"{scopeId}: {address}, Set {index} to {value?.ToHexString()}");
+            logger.Trace($"{scopeId}: {address}, Set {index} to {value.ToHexString()}");
         }
 
         public void Clear()

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedHealingTests.cs
@@ -189,10 +189,10 @@ public class StateSyncFeedHealingTests : StateSyncFeedTestsBase
 
         AccountProofCollector accountProofCollector = new(startingHash.Bytes);
         remoteStateTree.Accept(accountProofCollector, remoteStateTree.RootHash);
-        byte[][] firstProof = accountProofCollector.BuildResult().Proof!;
+        byte[][] firstProof = accountProofCollector.BuildResult().Proof;
         accountProofCollector = new(endHash.Bytes);
         remoteStateTree.Accept(accountProofCollector, remoteStateTree.RootHash);
-        byte[][] lastProof = accountProofCollector.BuildResult().Proof!;
+        byte[][] lastProof = accountProofCollector.BuildResult().Proof;
 
         _ = SnapProviderHelper.AddAccountRange(snapTrieFactory, blockNumber, rootHash, startingHash, limitHash, accounts, new ByteArrayListAdapter(new ArrayPoolList<byte[]>(firstProof.Length + lastProof.Length, firstProof.Concat(lastProof))));
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/StateSyncFeedTestsBase.cs
@@ -341,7 +341,10 @@ public abstract class StateSyncFeedTestsBase(
             }, token);
 
         public override Task<IByteArrayList> GetTrieNodes(GetTrieNodesRequest request, CancellationToken token) =>
-            Task.FromResult(_snapServer.GetTrieNodes(request.AccountAndStoragePaths, request.RootHash, token)!);
+            Task.FromResult(_snapServer.GetTrieNodes(
+                request.AccountAndStoragePaths,
+                request.RootHash,
+                token) ?? EmptyByteArrayList.Instance);
     }
 }
 

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/RecreateStateFromStorageRangesTests.cs
@@ -63,7 +63,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
             StorageRange storageRange = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
-            AddRangeResult result = snapProvider.AddStorageRangeForAccount(storageRange, 0, TestItem.Tree.SlotsWithPaths, new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
+            AddRangeResult result = snapProvider.AddStorageRangeForAccount(storageRange, 0, TestItem.Tree.SlotsWithPaths, new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof.StorageProofs[0].Proof.Length + proof.StorageProofs[1].Proof.Length, proof.StorageProofs[0].Proof.Concat(proof.StorageProofs[1].Proof))));
 
             Assert.That(result, Is.EqualTo(AddRangeResult.OK));
         }
@@ -81,7 +81,7 @@ namespace Nethermind.Synchronization.Test.SnapSync
             SnapProvider snapProvider = container.Resolve<SnapProvider>();
 
             StorageRange storageRange = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
-            AddRangeResult result = snapProvider.AddStorageRangeForAccount(storageRange, 0, TestItem.Tree.SlotsWithPaths, new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
+            AddRangeResult result = snapProvider.AddStorageRangeForAccount(storageRange, 0, TestItem.Tree.SlotsWithPaths, new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof.StorageProofs[0].Proof.Length + proof.StorageProofs[1].Proof.Length, proof.StorageProofs[0].Proof.Concat(proof.StorageProofs[1].Proof))));
 
             Assert.That(result, Is.EqualTo(AddRangeResult.OK));
         }
@@ -114,21 +114,21 @@ namespace Nethermind.Synchronization.Test.SnapSync
             AccountProof proof = accountProofCollector.BuildResult();
 
             StorageRange storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
-            AddRangeResult result1 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[0..2], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
+            AddRangeResult result1 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[0..2], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof.StorageProofs[0].Proof.Length + proof.StorageProofs[1].Proof.Length, proof.StorageProofs[0].Proof.Concat(proof.StorageProofs[1].Proof))));
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[2].Path, TestItem.Tree.SlotsWithPaths[3].Path]);
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             proof = accountProofCollector.BuildResult();
 
             storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[2].Path);
-            AddRangeResult result2 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[2..4], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
+            AddRangeResult result2 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[2..4], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof.StorageProofs[0].Proof.Length + proof.StorageProofs[1].Proof.Length, proof.StorageProofs[0].Proof.Concat(proof.StorageProofs[1].Proof))));
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[4].Path, TestItem.Tree.SlotsWithPaths[5].Path]);
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             proof = accountProofCollector.BuildResult();
 
             storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[4].Path);
-            AddRangeResult result3 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[4..6], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
+            AddRangeResult result3 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[4..6], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof.StorageProofs[0].Proof.Length + proof.StorageProofs[1].Proof.Length, proof.StorageProofs[0].Proof.Concat(proof.StorageProofs[1].Proof))));
 
             Assert.That(result1, Is.EqualTo(AddRangeResult.OK));
             Assert.That(result2, Is.EqualTo(AddRangeResult.OK));
@@ -149,21 +149,21 @@ namespace Nethermind.Synchronization.Test.SnapSync
             AccountProof proof = accountProofCollector.BuildResult();
 
             StorageRange storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, Keccak.Zero);
-            AddRangeResult result1 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[0..2], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
+            AddRangeResult result1 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[0..2], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof.StorageProofs[0].Proof.Length + proof.StorageProofs[1].Proof.Length, proof.StorageProofs[0].Proof.Concat(proof.StorageProofs[1].Proof))));
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[2].Path, TestItem.Tree.SlotsWithPaths[3].Path]);
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             proof = accountProofCollector.BuildResult();
 
             storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[2].Path);
-            AddRangeResult result2 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[3..4], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
+            AddRangeResult result2 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[3..4], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof.StorageProofs[0].Proof.Length + proof.StorageProofs[1].Proof.Length, proof.StorageProofs[0].Proof.Concat(proof.StorageProofs[1].Proof))));
 
             accountProofCollector = new(TestItem.Tree.AccountAddress0.Bytes, [TestItem.Tree.SlotsWithPaths[4].Path, TestItem.Tree.SlotsWithPaths[5].Path]);
             _inputStateTree!.Accept(accountProofCollector, _inputStateTree.RootHash);
             proof = accountProofCollector.BuildResult();
 
             storageRangeRequest = PrepareStorageRequest(TestItem.Tree.AccountAddress0, rootHash, TestItem.Tree.SlotsWithPaths[4].Path);
-            AddRangeResult result3 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[4..6], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof!.StorageProofs![0].Proof!.Length + proof!.StorageProofs![1].Proof!.Length, proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!))));
+            AddRangeResult result3 = snapProvider.AddStorageRangeForAccount(storageRangeRequest, 0, TestItem.Tree.SlotsWithPaths[4..6], new ByteArrayListAdapter(new ArrayPoolList<byte[]>(proof.StorageProofs[0].Proof.Length + proof.StorageProofs[1].Proof.Length, proof.StorageProofs[0].Proof.Concat(proof.StorageProofs[1].Proof))));
 
             Assert.That(result1, Is.EqualTo(AddRangeResult.OK));
             Assert.That(result2, Is.EqualTo(AddRangeResult.DifferentRootHash));

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
@@ -352,7 +352,7 @@ public class SnapProviderTests
 
         Assert.That(snapProvider.AddStorageRangeForAccount(
             storageRange, 0, slots,
-            new ByteArrayListAdapter(proof!.StorageProofs![0].Proof!.Concat(proof!.StorageProofs![1].Proof!).ToArray().ToPooledList())), Is.EqualTo(AddRangeResult.OK));
+            new ByteArrayListAdapter(proof.StorageProofs[0].Proof.Concat(proof.StorageProofs[1].Proof).ToArray().ToPooledList())), Is.EqualTo(AddRangeResult.OK));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapStateServerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapStateServerTests.cs
@@ -122,7 +122,8 @@ public class SnapStateServerTests
     {
         using IWriteBatch batch = context.BeginWriteBatch();
         foreach (PathWithAccount pwa in TestItem.Tree.AccountsWithPaths)
-            batch.SetAccount(pwa.Path.ToCommitment(), pwa.Account);
+            batch.SetAccount(pwa.Path.ToCommitment(), pwa.Account
+                ?? throw new InvalidOperationException("A test account entry must contain an account value."));
     }
 
     private static void FillMultipleAccounts(ISnapServerContext context, int count)
@@ -224,7 +225,7 @@ public class SnapStateServerTests
         {
             Assert.That(result, Is.EqualTo(expectedResult));
             // On success the stale empty storage root must be replaced by the verified one.
-            Assert.That(stale.Account.StorageRoot, Is.EqualTo(useCorrectRoot ? storageRoot : Keccak.EmptyTreeHash));
+            Assert.That(stale.Account?.StorageRoot, Is.EqualTo(useCorrectRoot ? storageRoot : Keccak.EmptyTreeHash));
         }
     }
 
@@ -269,7 +270,7 @@ public class SnapStateServerTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.EqualTo(AddRangeResult.OK));
-            Assert.That(stale.Account.StorageRoot, Is.EqualTo(storageRoot));
+            Assert.That(stale.Account?.StorageRoot, Is.EqualTo(storageRoot));
         }
     }
 
@@ -303,7 +304,7 @@ public class SnapStateServerTests
         {
             Assert.That(result, Is.EqualTo(AddRangeResult.OK));
             // Absent account: nothing adopted, storage root unchanged.
-            Assert.That(stale.Account.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash));
+            Assert.That(stale.Account?.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash));
         }
     }
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncDownloader.cs
@@ -44,9 +44,12 @@ namespace Nethermind.Synchronization.SnapSync
                         // Refresh a single account via GetAccountRange so its storage root is verified against
                         // the state root. Use limit = path + 1 to avoid start == limit, which some peers treat as
                         // an empty range. (IncrementPath is a no-op only for the unreachable MaxValue path.)
-                        AccountWithStorageStartingHash account = batch.AccountsToRefreshRequest.Paths[0];
-                        ValueHash256 path = account.PathAndAccount.Path;
-                        AccountRange range = new(batch.AccountsToRefreshRequest.RootHash, path, path.IncrementPath());
+                        AccountsToRefreshRequest request = batch.AccountsToRefreshRequest;
+                        AccountWithStorageStartingHash account = request.Paths[0];
+                        PathWithAccount pathAndAccount = account.PathAndAccount
+                            ?? throw new InvalidOperationException("An account refresh request requires an account path.");
+                        ValueHash256 path = pathAndAccount.Path;
+                        AccountRange range = new(request.RootHash, path, path.IncrementPath());
                         batch.AccountsToRefreshResponse = await handler.GetAccountRange(range, cancellationToken);
                     }
                 }

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoPrecompileMembershipTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoPrecompileMembershipTests.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Taiko.Precompiles;
+using Nethermind.Taiko.TaikoSpec;
+using NUnit.Framework;
+
+namespace Nethermind.Taiko.Test;
+
+/// <summary>Taiko registers the only in-tree precompiles outside Ethereum's range, at 0x10001 and
+/// 0x10002, which makes it the chain that exercises membership beyond the mask and the index array.</summary>
+[TestFixture]
+public class TaikoPrecompileMembershipTests
+{
+    /// <summary>Every Taiko fork spec, with the flags that register the two far precompiles set.</summary>
+    /// <remarks>The flags are set before <c>Precompiles</c> is first read, which is what builds the set, so
+    /// each fork is swept with its full registration rather than its default one. Nothing is filtered out:
+    /// a fork this cannot construct has to break the sweep, since one that quietly shrinks stops defending
+    /// the newest registration — the one most likely to need it.</remarks>
+    private static IEnumerable<TestCaseData> TaikoForks() =>
+        typeof(ITaikoReleaseSpec).Assembly.GetTypes()
+            .Where(t => !t.IsAbstract && typeof(ITaikoReleaseSpec).IsAssignableFrom(t))
+            .Select(t =>
+            {
+                object spec = Activator.CreateInstance(t)!;
+                // Get-only on the interface, settable on every fork class that declares them.
+                t.GetProperty(nameof(ITaikoReleaseSpec.IsRip7728Enabled))!.SetValue(spec, true);
+                t.GetProperty(nameof(ITaikoReleaseSpec.IsL1StaticCallEnabled))!.SetValue(spec, true);
+                return new TestCaseData((ITaikoReleaseSpec)spec).SetArgDisplayNames(t.Name);
+            });
+
+    /// <summary>Every registered precompile has to be recognised, at every Taiko fork.</summary>
+    /// <remarks>Taiko's two sit above the 64-bit mask and above the index array, so they are the in-tree
+    /// case for the set fallback; the shape invariant they also depend on is enforced where the set is
+    /// built, which throws before an assertion here could see it.</remarks>
+    [TestCaseSource(nameof(TaikoForks))]
+    public void Every_registered_precompile_is_recognised(ITaikoReleaseSpec taikoSpec)
+    {
+        IReleaseSpec spec = taikoSpec;
+
+        Assert.That(spec.Precompiles, Does.Contain((AddressAsKey)L1SloadPrecompile.Address)
+            .And.Contain((AddressAsKey)L1StaticCallPrecompile.Address), "the far precompiles must be in the sweep");
+
+        foreach (AddressAsKey key in spec.Precompiles)
+        {
+            Assert.That(spec.IsPrecompile(key), Is.True, $"{(Address)key} is registered but not recognised");
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/StateTestTxTracer.cs
@@ -178,7 +178,7 @@ public class StateTestTxTracer : ITxTracer, IDisposable
 
     public void ReportBalanceChange(Address address, UInt256? before, UInt256? after) => throw new NotSupportedException();
 
-    public void ReportCodeChange(Address address, byte[] before, byte[] after) => throw new NotSupportedException();
+    public void ReportCodeChange(Address address, byte[]? before, byte[]? after) => throw new NotSupportedException();
 
     public void ReportNonceChange(Address address, UInt256? before, UInt256? after) => throw new NotSupportedException();
 

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -720,6 +720,32 @@ public class TrieNodeTests
     }
 
     [Test]
+    public void Can_encode_branch_with_every_child_a_hash()
+    {
+        TrieNode node = new(NodeType.Branch);
+        for (int i = 0; i < TrieNode.BranchesCount; i++)
+        {
+            node.SetChild(i, new TrieNode(NodeType.Unknown, Keccak.Compute([(byte)i])));
+        }
+
+        TreePath emptyPath = TreePath.Empty;
+        CappedArray<byte> rlp = node.RlpEncode(NullTrieNodeResolver.Instance, ref emptyPath);
+
+        TrieNode restoredNode = new(NodeType.Unknown, rlp);
+        restoredNode.ResolveNode(NullTrieNodeResolver.Instance, TreePath.Empty);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // The widest a branch encodes to: sixteen 33-byte hash items plus the value and the header.
+            Assert.That(rlp.Length, Is.EqualTo(532), "RLP length");
+            for (int i = 0; i < TrieNode.BranchesCount; i++)
+            {
+                Assert.That(restoredNode.GetChildHash(i), Is.EqualTo(Keccak.Compute([(byte)i])), $"child {i}");
+            }
+        }
+    }
+
+    [Test]
     public void Size_of_a_heavy_leaf_is_correct()
     {
         Context ctx = new();

--- a/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieTests.cs
@@ -244,6 +244,7 @@ namespace Nethermind.Trie.Test
             Assert.That(checkTree.GetNodeByKey(Nibbles.CompactToHexEncode(emptyByteCompactEncoded), patriciaTree.RootHash), Is.EqualTo(rootNodeHash));
 
             Assert.That(checkTree.GetNodeByKey(branchNodeKey1, patriciaTree.RootHash), Is.EqualTo(branchNodeValue1));
+            Assert.That(checkTree.GetNodeByKey([0xff], patriciaTree.RootHash), Is.Empty);
             Assert.That(checkTree.Get(branchNodeKey1).ToArray(), Is.Empty);
         }
 

--- a/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/BatchedTrieVisitor.cs
@@ -351,7 +351,7 @@ public class BatchedTrieVisitor<TNodeContext>
                         (TrieNode nodeToResolve, TNodeContext nodeContext, SmallTrieVisitContext ctx) = currentBatch[idx];
                         try
                         {
-                            Hash256 theKeccak = nodeToResolve.Keccak;
+                            Hash256? theKeccak = nodeToResolve.Keccak;
                             nodeToResolve.ResolveNode(_resolver, emptyPath, flags);
                             nodeToResolve.Keccak = theKeccak; // The resolve may set a key which clear the keccak
                         }
@@ -408,7 +408,7 @@ public class BatchedTrieVisitor<TNodeContext>
 
                     for (int i = 0; i < TrieNode.BranchesCount; i++)
                     {
-                        TrieNode child = node.GetChild(nodeResolver, ref emptyPath, i);
+                        TrieNode? child = node.GetChild(nodeResolver, ref emptyPath, i);
                         if (child is not null)
                         {
                             child.ResolveKey(nodeResolver, ref emptyPath);
@@ -467,7 +467,7 @@ public class BatchedTrieVisitor<TNodeContext>
 
                             if (node.TryResolveStorageRoot(nodeResolver, ref emptyPath, out TrieNode? storageRoot))
                             {
-                                nextToVisit.Add((storageRoot!, storageContext, trieVisitContext));
+                                nextToVisit.Add((storageRoot, storageContext, trieVisitContext));
                             }
                             else
                             {
@@ -507,7 +507,7 @@ public class BatchedTrieVisitor<TNodeContext>
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Compare(int item1, int item2) =>
-            _items[item1].Item1.Keccak.CompareTo(_items[item2].Item1.Keccak);
+            _items[item1].Item1.Keccak!.CompareTo(_items[item2].Item1.Keccak);
     }
 }
 

--- a/src/Nethermind/Nethermind.Trie/MissingTrieNodeException.cs
+++ b/src/Nethermind/Nethermind.Trie/MissingTrieNodeException.cs
@@ -8,7 +8,7 @@ namespace Nethermind.Trie;
 
 public class MissingTrieNodeException(string message, Hash256? address, TreePath path, Hash256 hash, Exception? innerException = null) : TrieException(message, innerException)
 {
-    public Hash256 Address { get; } = address;
+    public Hash256? Address { get; } = address;
     public TreePath Path { get; } = path;
     public Hash256 Hash { get; } = hash;
 }

--- a/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
+++ b/src/Nethermind/Nethermind.Trie/Nethermind.Trie.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/Nethermind/Nethermind.Trie/NodeData.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeData.cs
@@ -15,13 +15,13 @@ public interface INodeData
     public NodeType NodeType { get; }
     public INodeData Clone();
     public int Length { get; }
-    public ref object this[int index] { get; }
+    public ref object? this[int index] { get; }
     public int MemorySize { get; }
 }
 
 interface INodeWithKey : INodeData
 {
-    public byte[] Key { get; set; }
+    public byte[]? Key { get; set; }
 }
 
 public sealed class BranchData : INodeData
@@ -39,7 +39,7 @@ public sealed class BranchData : INodeData
     private BranchData(in BranchArray branches) => _branches = branches;
 
     public ref readonly BranchArray Branches => ref _branches;
-    public ref object this[int index] => ref _branches[index];
+    public ref object? this[int index] => ref _branches[index];
 
     INodeData INodeData.Clone() => new BranchData(in _branches);
 
@@ -63,7 +63,7 @@ public class ExtensionData : INodeWithKey
     public byte[]? _key;
     public object? _value;
 
-    public byte[] Key
+    public byte[]? Key
     {
         get => _key;
         set => _key = value;
@@ -75,7 +75,7 @@ public class ExtensionData : INodeWithKey
         set => _value = value;
     }
 
-    public ref object this[int index]
+    public ref object? this[int index]
     {
         get
         {
@@ -103,7 +103,7 @@ public class ExtensionData : INodeWithKey
         Value = value;
     }
 
-    private ExtensionData(byte[] key, object? value)
+    private ExtensionData(byte[]? key, object? value)
     {
         Key = key;
         Value = value;
@@ -125,26 +125,26 @@ public class LeafData : INodeWithKey
 
     private readonly CappedArray<byte> _value;
 
-    public byte[] Key { get; set; }
+    public byte[]? Key { get; set; }
     public CappedArray<byte> Value => _value;
     public TrieNode? StorageRoot { get; set; }
 
     public LeafData() => _value = CappedArray<byte>.Empty;
 
-    internal LeafData(byte[] key, CappedArray<byte> value)
+    internal LeafData(byte[]? key, CappedArray<byte> value)
     {
         Key = key;
         _value = value;
     }
 
-    private LeafData(byte[] key, CappedArray<byte> value, TrieNode? storageRoot)
+    private LeafData(byte[]? key, CappedArray<byte> value, TrieNode? storageRoot)
     {
         Key = key;
         _value = value;
         StorageRoot = storageRoot;
     }
 
-    public ref object this[int index] => throw new IndexOutOfRangeException();
+    public ref object? this[int index] => throw new IndexOutOfRangeException();
 
     INodeData INodeData.Clone() => new LeafData(Key, _value);
 

--- a/src/Nethermind/Nethermind.Trie/NodeStorageFactory.cs
+++ b/src/Nethermind/Nethermind.Trie/NodeStorageFactory.cs
@@ -15,7 +15,7 @@ public class NodeStorageFactory(INodeStorage.KeyScheme preferredKeyScheme, ILogM
     private INodeStorage.KeyScheme? _currentKeyScheme = null;
     private readonly ILogger _logger = logManager.GetClassLogger<NodeStorageFactory>();
 
-    public INodeStorage.KeyScheme? CurrentKeyScheme => _currentKeyScheme!;
+    public INodeStorage.KeyScheme? CurrentKeyScheme => _currentKeyScheme;
 
     public void DetectCurrentKeySchemeFrom(IDb mainStateDb)
     {

--- a/src/Nethermind/Nethermind.Trie/NullKeyValueStore.cs
+++ b/src/Nethermind/Nethermind.Trie/NullKeyValueStore.cs
@@ -13,7 +13,7 @@ namespace Nethermind.Trie
         {
         }
 
-        private static NullKeyValueStore _instance;
+        private static NullKeyValueStore? _instance;
         public static NullKeyValueStore Instance => LazyInitializer.EnsureInitialized(ref _instance, static () => new NullKeyValueStore());
 
         public byte[]? Get(ReadOnlySpan<byte> key, ReadFlags flags = ReadFlags.None) => null;

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.BulkSet.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.BulkSet.cs
@@ -27,10 +27,10 @@ public partial class PatriciaTree
         DoNotParallelize = 2
     }
 
-    public readonly struct BulkSetEntry(in ValueHash256 path, byte[] value) : IComparable<BulkSetEntry>
+    public readonly struct BulkSetEntry(in ValueHash256 path, byte[]? value) : IComparable<BulkSetEntry>
     {
         public readonly ValueHash256 Path = path;
-        public readonly byte[] Value = value;
+        public readonly byte[]? Value = value;
 
         public int CompareTo(BulkSetEntry entry) => Path.CompareTo(entry.Path);
 
@@ -296,7 +296,7 @@ public partial class PatriciaTree
                 else
                     endRange = entries.Length;
 
-                TrieNode newChild = (endRange - startRange == 1)
+                TrieNode? newChild = (endRange - startRange == 1)
                     ? BulkSetOne(traverseStack, entries[startRange], ref path, child)
                     : BulkSet(in ctx,
                         traverseStack,
@@ -341,15 +341,16 @@ public partial class PatriciaTree
         Nibbles.BytesToNibbleBytes(entry.Path.BytesAsSpan, nibble);
         Span<byte> remainingKey = nibble[path.Length..];
 
-        byte[] value = entry.Value;
+        byte[]? value = entry.Value;
         return SetNew(traverseStack, remainingKey, value, ref path, node);
     }
 
-    private TrieNode? MakeFakeBranch(ref TreePath currentPath, TrieNode? existingNode)
+    private TrieNode MakeFakeBranch(ref TreePath currentPath, TrieNode existingNode)
     {
-        ReadOnlySpan<byte> shortenedKey = existingNode.Key.AsSpan(1, existingNode.Key.Length - 1);
+        byte[] existingKey = existingNode.Key!;
+        ReadOnlySpan<byte> shortenedKey = existingKey.AsSpan(1, existingKey.Length - 1);
 
-        int branchIdx = existingNode.Key[0];
+        int branchIdx = existingKey[0];
 
         TrieNode newChild;
 
@@ -359,9 +360,10 @@ public partial class PatriciaTree
         }
         else
         {
-            TrieNode child = existingNode.GetChild(TrieStore, ref currentPath, 0);
+            TrieNode child = existingNode.GetChild(TrieStore, ref currentPath, 0)
+                ?? throw new InvalidOperationException("An extension node cannot be converted to a branch without a child.");
 
-            if (existingNode.Key.Length == 1)
+            if (existingKey.Length == 1)
             {
                 newChild = child;
             }

--- a/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
+++ b/src/Nethermind/Nethermind.Trie/PatriciaTree.cs
@@ -206,7 +206,7 @@ namespace Nethermind.Trie
                     path.AppendMut(0);
                     for (int i = 0; i < 16; i++)
                     {
-                        if (node.TryGetDirtyChild(i, out TrieNode childNode))
+                        if (node.TryGetDirtyChild(i, out TrieNode? childNode))
                         {
                             path.SetLast(i);
                             if (i < 15 && committer.TryRequestConcurrentQuota())
@@ -291,7 +291,7 @@ namespace Nethermind.Trie
             [MethodImpl(MethodImplOptions.NoInlining)]
             void Trace(TrieNode node, ref TreePath path, int i)
             {
-                TrieNode child = node.GetChildWithChildPath(TrieStore, ref path, i);
+                TrieNode? child = node.GetChildWithChildPath(TrieStore, ref path, i);
                 if (child is not null)
                 {
                     _logger.Trace($"Skipping commit of {child}");
@@ -360,7 +360,7 @@ namespace Nethermind.Trie
                 Nibbles.BytesToNibbleBytes(rawKey, nibbles);
 
                 TreePath emptyPath = TreePath.Empty;
-                TrieNode root = RootRef;
+                TrieNode? root = RootRef;
 
                 if (rootHash is not null)
                 {
@@ -398,7 +398,7 @@ namespace Nethermind.Trie
                 Nibbles.BytesToNibbleBytes(rawKey, nibbles);
 
                 TreePath emptyPath = TreePath.Empty;
-                TrieNode root = RootRef;
+                TrieNode? root = RootRef;
 
                 DoWarmUpPath(nibbles, ref emptyPath, root);
             }
@@ -419,7 +419,7 @@ namespace Nethermind.Trie
             try
             {
                 TreePath emptyPath = TreePath.Empty;
-                TrieNode root = RootRef;
+                TrieNode? root = RootRef;
                 if (rootHash is not null)
                 {
                     root = TrieStore.FindCachedOrUnknown(emptyPath, rootHash);
@@ -436,7 +436,7 @@ namespace Nethermind.Trie
 
         [SkipLocalsInit]
         [DebuggerStepThrough]
-        public byte[]? GetNodeByKey(Span<byte> rawKey, Hash256? rootHash = null)
+        public byte[] GetNodeByKey(Span<byte> rawKey, Hash256? rootHash = null)
         {
             byte[]? array = null;
             try
@@ -449,7 +449,7 @@ namespace Nethermind.Trie
                 Nibbles.BytesToNibbleBytes(rawKey, nibbles);
 
                 TreePath emptyPath = TreePath.Empty;
-                TrieNode root = RootRef;
+                TrieNode? root = RootRef;
                 if (rootHash is not null)
                 {
                     root = TrieStore.FindCachedOrUnknown(emptyPath, rootHash);
@@ -715,7 +715,7 @@ namespace Nethermind.Trie
                         if (child.IsExtension || child.IsLeaf)
                         {
                             // Merge current node with child
-                            node = child.CloneWithChangedKey(HexPrefix.ConcatNibbles(node.Key, child.Key));
+                            node = child.CloneWithChangedKey(HexPrefix.ConcatNibbles(node.Key!, child.Key!));
                         }
                         else
                         {
@@ -761,7 +761,7 @@ namespace Nethermind.Trie
             if (!ReferenceEquals(oldChild, newChild)) return true;
             // So that recalculate root knows to recalculate the parent root.
             // Parent's hash can also be null depending on nesting level - still need to update child, otherwise combine will remain original value
-            return newChild.Keccak is null;
+            return newChild!.Keccak is null;
         }
 
         /// <summary>
@@ -770,8 +770,10 @@ namespace Nethermind.Trie
         /// <param name="path"></param>
         /// <param name="node"></param>
         /// <returns></returns>
-        internal TrieNode? MaybeCombineNode(ref TreePath path, in TrieNode? node, TrieNode? originalNode)
+        internal TrieNode? MaybeCombineNode(ref TreePath path, in TrieNode node, TrieNode? originalNode)
         {
+            Debug.Assert(node.IsBranch, "MaybeCombineNode requires a branch node.");
+
             int onlyChildIdx = -1;
             for (int i = 0; i < TrieNode.BranchesCount; i++)
             {
@@ -830,7 +832,7 @@ namespace Nethermind.Trie
 
             // 35%
             // Replace the only child with something with extra key.
-            byte[] newKey = HexPrefix.PrependNibble((byte)onlyChildIdx, onlyChildNode.Key);
+            byte[] newKey = HexPrefix.PrependNibble((byte)onlyChildIdx, onlyChildNode.Key!);
             if (originalNode is not null) // Only bulkset provide original node
             {
                 if (originalNode.IsExtension && onlyChildNode.IsExtension)
@@ -1129,7 +1131,7 @@ namespace Nethermind.Trie
             if (!visitor.IsFullDbScan)
             {
                 visitor.VisitTree(default, rootHash);
-                if (TryGetRootRef(out TrieNode rootRef))
+                if (TryGetRootRef(out TrieNode? rootRef))
                 {
                     TreePath emptyPath = TreePath.Empty;
                     rootRef?.Accept(visitor, default, resolver, ref emptyPath, trieVisitContext);
@@ -1142,7 +1144,7 @@ namespace Nethermind.Trie
                 BatchedTrieVisitor<TNodeContext> batchedTrieVisitor = new(visitor, resolver, visitingOptions);
                 batchedTrieVisitor.Start(rootHash, trieVisitContext);
             }
-            else if (TryGetRootRef(out TrieNode rootRef))
+            else if (TryGetRootRef(out TrieNode? rootRef))
             {
                 TreePath emptyPath = TreePath.Empty;
                 visitor.VisitTree(default, rootHash);

--- a/src/Nethermind/Nethermind.Trie/Pruning/CommitSetQueue.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/CommitSetQueue.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 
@@ -23,19 +24,21 @@ public class CommitSetQueue
     }
 
     public bool IsEmpty => Count == 0;
-    public ulong? MinBlockNumber
-    {
-        get
-        {
-            lock (_queue) return _queue.Min?.BlockNumber;
-        }
-    }
 
-    public ulong? MaxBlockNumber
+    internal bool TryGetBounds(out ulong minBlockNumber, out ulong maxBlockNumber)
     {
-        get
+        lock (_queue)
         {
-            lock (_queue) return _queue.Max?.BlockNumber;
+            if (_queue.Min is not { } min || _queue.Max is not { } max)
+            {
+                minBlockNumber = default;
+                maxBlockNumber = default;
+                return false;
+            }
+
+            minBlockNumber = min.BlockNumber;
+            maxBlockNumber = max.BlockNumber;
+            return true;
         }
     }
 
@@ -44,32 +47,30 @@ public class CommitSetQueue
         lock (_queue) _queue.Add(set);
     }
 
-    public bool TryPeek(out BlockCommitSet? blockCommitSet)
+    public bool TryPeek([NotNullWhen(true)] out BlockCommitSet? blockCommitSet)
     {
         lock (_queue)
         {
-            if (_queue.Count == 0)
+            blockCommitSet = _queue.Min;
+            if (blockCommitSet is null)
             {
-                blockCommitSet = null;
                 return false;
             }
 
-            blockCommitSet = _queue.Min;
             return true;
         }
     }
 
-    public bool TryDequeue(out BlockCommitSet? blockCommitSet)
+    public bool TryDequeue([NotNullWhen(true)] out BlockCommitSet? blockCommitSet)
     {
         lock (_queue)
         {
-            if (_queue.Count == 0)
+            blockCommitSet = _queue.Min;
+            if (blockCommitSet is null)
             {
-                blockCommitSet = null;
                 return false;
             }
 
-            blockCommitSet = _queue.Min;
             _queue.Remove(blockCommitSet);
             return true;
         }
@@ -95,9 +96,8 @@ public class CommitSetQueue
         lock (_queue)
         {
             ArrayPoolListRef<BlockCommitSet> result = new();
-            while (_queue.Count > 0)
+            while (_queue.Min is { } min)
             {
-                BlockCommitSet min = _queue.Min;
                 if (min.BlockNumber > blockNumber) break;
                 result.Add(min);
                 _queue.Remove(min);

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieNodeResolver.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Trie.Pruning
         public TrieNode FindCachedOrUnknown(in TreePath path, Hash256 hash) => new(NodeType.Unknown, hash);
         public byte[]? LoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
         public byte[]? TryLoadRlp(in TreePath path, Hash256 hash, ReadFlags flags = ReadFlags.None) => null;
-        public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256 storage) => this;
+        public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? storage) => this;
 
         public INodeStorage.KeyScheme Scheme => INodeStorage.KeyScheme.HalfPath;
     }

--- a/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/NullTrieStore.cs
@@ -22,7 +22,7 @@ namespace Nethermind.Trie.Pruning
 
         public void Set(in TreePath path, in ValueHash256 keccak, byte[] rlp) { }
 
-        public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256 storageRoot) => this;
+        public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? storageRoot) => this;
 
         public INodeStorage.KeyScheme Scheme => INodeStorage.KeyScheme.HalfPath;
     }

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -54,6 +54,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     // Small optimization to not re-create CommitBuffer
     private CommitBuffer? _commitBufferUnused = null;
 
+    [MemberNotNullWhen(true, nameof(_commitBuffer))]
     internal bool IsInCommitBufferMode => _commitBuffer is not null;
 
     // Only one scope can be active at the same time. Any mutation to trieStore as part of block processing need to
@@ -303,7 +304,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         TrieNode node,
         ulong blockNumber)
     {
-        TrieStoreDirtyNodesCache shard = _dirtyNodes[GetNodeShardIdx(path, node.Keccak)];
+        Hash256 keccak = node.Keccak ?? ThrowUnknownHash(node);
+        TrieStoreDirtyNodesCache shard = _dirtyNodes[GetNodeShardIdx(path, keccak)];
         return SaveOrReplaceInDirtyNodesCache(shard, address, ref path, node, blockNumber);
     }
 
@@ -315,7 +317,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         ulong blockNumber
     )
     {
-        TrieStoreDirtyNodesCache.Key key = new(address, path, node.Keccak);
+        Hash256 keccak = node.Keccak ?? ThrowUnknownHash(node);
+        TrieStoreDirtyNodesCache.Key key = new(address, path, keccak);
         TrieNode cachedNodeCopy = shard.GetOrAdd(in key, new TrieStoreDirtyNodesCache.NodeRecord(node, blockNumber)).Node;
         if (!ReferenceEquals(cachedNodeCopy, node))
         {
@@ -328,6 +331,10 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         return cachedNodeCopy;
     }
+
+    [DoesNotReturn, StackTraceHidden]
+    private static Hash256 ThrowUnknownHash(TrieNode node) =>
+        throw new TrieStoreException($"The hash of {node} should be known at the time of saving.");
 
     public IDisposable BeginScope(BlockHeader? baseBlock)
     {
@@ -522,15 +529,14 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
     public IReadOnlyTrieStore AsReadOnly() => new ReadOnlyTrieStore(this);
 
-    public bool IsNodeCached(Hash256? address, in TreePath path, Hash256? hash) => DirtyNodesIsNodeCached(new TrieStoreDirtyNodesCache.Key(address, path, hash));
+    public bool IsNodeCached(Hash256? address, in TreePath path, Hash256? hash) =>
+        hash is not null && DirtyNodesIsNodeCached(new TrieStoreDirtyNodesCache.Key(address, path, hash));
 
-    public TrieNode FindCachedOrUnknown(Hash256? address, in TreePath path, Hash256? hash) =>
+    public TrieNode FindCachedOrUnknown(Hash256? address, in TreePath path, Hash256 hash) =>
         FindCachedOrUnknown(address, path, hash, false);
 
-    internal TrieNode FindCachedOrUnknown(Hash256? address, in TreePath path, Hash256? hash, bool isReadOnly)
+    internal TrieNode FindCachedOrUnknown(Hash256? address, in TreePath path, Hash256 hash, bool isReadOnly)
     {
-        ArgumentNullException.ThrowIfNull(hash);
-
         TrieStoreDirtyNodesCache.Key key = new(address, path, hash);
         return _commitBuffer is { } commitBuffer
             ? commitBuffer.FindCachedOrUnknown(key, isReadOnly)
@@ -697,7 +703,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     {
         if (_logger.IsDebug) _logger.Debug("Elevated pruning starting");
 
-        int count = _commitSetQueue?.Count ?? 0;
+        int count = _commitSetQueue.Count;
         if (count == 0) return;
 
         (ArrayPoolList<BlockCommitSet> candidateSets, ulong? finalizedBlockNumber) = DetermineCommitSetToPersistInSnapshot(count);
@@ -772,7 +778,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         ArrayPoolList<BlockCommitSet> candidateSets = new(count);
         try
         {
-            if (_commitSetQueue.IsEmpty)
+            if (!_commitSetQueue.TryGetBounds(out ulong minBlockNumber, out ulong maxBlockNumber))
             {
                 if (_logger.IsDebug) _logger.Debug("Unable to persist commit set due to empty queue");
                 return (candidateSets, null);
@@ -780,10 +786,10 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
             ulong finalizedBlockNumber = _finalizedStateProvider.FinalizedBlockNumber;
             // When _maxDepth exceeds MaxBlockNumber the pruning boundary is conceptually "before block 0"; clamp to 0.
-            ulong pruningBoundaryBlock = _commitSetQueue.MaxBlockNumber!.Value.SaturatingSub(_maxDepth);
+            ulong pruningBoundaryBlock = maxBlockNumber.SaturatingSub(_maxDepth);
             ulong effectiveFinalizedBlockNumber = Math.Min(pruningBoundaryBlock, finalizedBlockNumber);
 
-            if (effectiveFinalizedBlockNumber < _commitSetQueue.MinBlockNumber!.Value)
+            if (effectiveFinalizedBlockNumber < minBlockNumber)
             {
                 // Finalized block number far behind any commit. Persist everything so that it can be pruned, but not after
                 // pruning boundary point as snap sync need it.
@@ -797,7 +803,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
                 else
                 {
                     // This can happen if the Max-Min of the commit set queue is less than pruning boundary
-                    if (_logger.IsDebug) _logger.Debug($"Block commits are all after finalized block. Min block commit: {_commitSetQueue.MinBlockNumber}, Effective finalized block: {effectiveFinalizedBlockNumber}, Finalized block number: {finalizedBlockNumber}");
+                    if (_logger.IsDebug) _logger.Debug($"Block commits are all after finalized block. Min block commit: {minBlockNumber}, Effective finalized block: {effectiveFinalizedBlockNumber}, Finalized block number: {finalizedBlockNumber}");
                 }
                 return (candidateSets, null);
             }
@@ -859,15 +865,19 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         }
     }
 
-    private void PersistedNodeRecorder(TreePath treePath, Hash256 address, TrieNode tn)
+    private void PersistedNodeRecorder(TreePath treePath, Hash256? address, TrieNode tn)
     {
         if (treePath.Length <= TinyTreePath.MaxNibbleLength)
         {
-            int shardIdx = GetNodeShardIdx(treePath, tn.Keccak);
+            Hash256 keccak = tn.Keccak ?? ThrowUnknownHash(tn);
+            int shardIdx = GetNodeShardIdx(treePath, keccak);
 
             HashAndTinyPath key = new(address, new TinyTreePath(treePath));
-            RecordPersistedHash(_persistedHashes[shardIdx], key, tn.Keccak, _deleteOldNodes);
+            RecordPersistedHash(_persistedHashes[shardIdx], key, keccak, _deleteOldNodes);
         }
+
+        [DoesNotReturn, StackTraceHidden]
+        static Hash256 ThrowUnknownHash(TrieNode node) => throw new TrieStoreException($"The hash of {node} should be known when recording persisted nodes.");
     }
 
     internal static void RecordPersistedHash(
@@ -896,7 +906,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         }
     }
 
-    private void PersistedNodeRecorderNoop(TreePath treePath, Hash256 address, TrieNode tn)
+    private void PersistedNodeRecorderNoop(TreePath treePath, Hash256? address, TrieNode tn)
     {
     }
 
@@ -1168,7 +1178,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         LastPersistedBlockNumber = commitSet.BlockNumber;
     }
 
-    private async Task PersistNodeStartingFrom(TrieNode tn, Hash256 address2, TreePath path,
+    private async Task PersistNodeStartingFrom(TrieNode tn, Hash256? address2, TreePath path,
         ulong blockNumber,
         Action<TreePath, Hash256?, TrieNode> persistedNodeRecorder,
         WriteFlags writeFlags, Channel<INodeStorage.IWriteBatch> disposeQueue)
@@ -1274,7 +1284,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         (ArrayPoolList<BlockCommitSet> candidateSets, ulong? finalizedBlockNumber) = DetermineCommitSetToPersistInSnapshot(_commitSetQueue.Count);
         using ArrayPoolList<BlockCommitSet> _ = candidateSets;
-        if (LastPersistedBlockNumber == 0 && candidateSets.Count == 0 && _commitSetQueue.TryDequeue(out BlockCommitSet anyCommitSet))
+        if (LastPersistedBlockNumber == 0 && candidateSets.Count == 0 && _commitSetQueue.TryDequeue(out BlockCommitSet? anyCommitSet))
         {
             // No commit set to persist, likely as not enough block was processed to reached prune boundary
             // This happens when node is shutdown right after sync.
@@ -1317,7 +1327,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
 
         void ClearCommitSetQueue()
         {
-            while (commitSetQueue.TryPeek(out BlockCommitSet commitSet) && commitSet.IsSealed)
+            while (commitSetQueue.TryPeek(out BlockCommitSet? commitSet) && commitSet.IsSealed)
             {
                 if (!commitSetQueue.TryDequeue(out commitSet)) break;
                 if (!commitSet.IsSealed)
@@ -1433,7 +1443,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         TrieNode node = FindCachedOrUnknown(null, TreePath.Empty, stateRoot, true);
         if (node.NodeType == NodeType.Unknown)
         {
-            return TryLoadRlp(null, TreePath.Empty, node.Keccak!) is not null;
+            return node.Keccak is { } keccak && TryLoadRlp(null, TreePath.Empty, keccak) is not null;
         }
 
         return true;
@@ -1494,17 +1504,22 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         TrieNode? root
     ) : ICommitter
     {
-        private readonly bool _needToResetRoot = root is not null && root.IsDirty;
+        private readonly TrieNode? _rootToReset = root is { IsDirty: true } ? root : null;
 
         public void Dispose()
         {
-            if (_needToResetRoot)
+            if (address is null && _rootToReset is { } rootToReset)
             {
                 // During commit it PatriciaTrie, the root may get resolved to an existing node (same keccak).
                 // This ensure that the root that we use here is the same.
                 // This is only needed for state tree as the root need to be put in the block commit set.
-                if (address == null) blockCommitter.StateRoot = ((IScopableTrieStore)trieStore).FindCachedOrUnknown(address, TreePath.Empty, root?.Keccak);
+                Hash256 keccak = rootToReset.Keccak ?? ThrowUnknownRootHash(rootToReset);
+                blockCommitter.StateRoot = ((IScopableTrieStore)trieStore).FindCachedOrUnknown(null, TreePath.Empty, keccak);
             }
+
+            [DoesNotReturn, StackTraceHidden]
+            static Hash256 ThrowUnknownRootHash(TrieNode root) =>
+                throw new TrieStoreException($"The hash of dirty root {root} should be known after commit.");
         }
 
         public TrieNode CommitNode(ref TreePath path, TrieNode node) =>
@@ -1680,7 +1695,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             });
 
             int count = 0;
-            while (_commitSetQueueBuffer.TryDequeue(out BlockCommitSet commitSet))
+            while (_commitSetQueueBuffer.TryDequeue(out BlockCommitSet? commitSet))
             {
                 _trieStore._commitSetQueue.Enqueue(commitSet);
                 _trieStore.PushToMainCommitSetQueue(commitSet);
@@ -1696,7 +1711,8 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         public TrieNode SaveOrReplaceInDirtyNodesCache(Hash256? address, ref TreePath path, in TrieNode node, ulong blockNumber)
         {
             // Change the shard to the one from commit buffer.
-            TrieStoreDirtyNodesCache shard = GetDirtyNodeShard(path, node.Keccak);
+            Hash256 keccak = node.Keccak ?? TrieStore.ThrowUnknownHash(node);
+            TrieStoreDirtyNodesCache shard = GetDirtyNodeShard(path, keccak);
             return _trieStore.SaveOrReplaceInDirtyNodesCache(shard, address, ref path, node, blockNumber);
         }
 
@@ -1706,10 +1722,10 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             TrieStoreDirtyNodesCache bufferShard = _dirtyNodesBuffer[shardIdx];
             TrieStoreDirtyNodesCache mainShard = _trieStore._dirtyNodes[shardIdx];
 
-            bool hasInBuffer = bufferShard.TryGetValue(key, out TrieNode bufferNode);
+            bool hasInBuffer = bufferShard.TryGetValue(key, out TrieNode? bufferNode);
             if (isReadOnly)
             {
-                if (hasInBuffer)
+                if (bufferNode is not null)
                 {
                     return _trieStore.CloneForReadOnly(key, bufferNode);
                 }
@@ -1741,13 +1757,13 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
                 }
             }
 
-            return hasInBuffer ? bufferNode : bufferShard.FindCachedOrUnknown(key);
+            return bufferNode ?? bufferShard.FindCachedOrUnknown(key);
         }
     }
 
     internal TrieNode CloneForReadOnly(in TrieStoreDirtyNodesCache.Key key, TrieNode node)
     {
-        CappedArray<byte> fullRlp = node!.FullRlp;
+        CappedArray<byte> fullRlp = node.FullRlp;
         if (fullRlp.IsNull)
         {
             // // this happens in SyncProgressResolver

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStoreDirtyNodesCache.cs
@@ -27,8 +27,12 @@ internal class TrieStoreDirtyNodesCache
     private long _totalDirtyMemory = 0;
     private readonly ILogger _logger;
     private readonly bool _storeByHash;
-    private readonly ConcurrentDictionary<Key, NodeRecord> _byKeyObjectCache;
-    private readonly ConcurrentDictionary<Hash256AsKey, NodeRecord> _byHashObjectCache;
+    private readonly ConcurrentDictionary<Key, NodeRecord>? _byKeyObjectCache;
+    private readonly ConcurrentDictionary<Hash256AsKey, NodeRecord>? _byHashObjectCache;
+    private ConcurrentDictionary<Key, NodeRecord> ByKeyObjectCache =>
+        _byKeyObjectCache ?? throw new InvalidOperationException("This cache is keyed by hash, not by path.");
+    private ConcurrentDictionary<Hash256AsKey, NodeRecord> ByHashObjectCache =>
+        _byHashObjectCache ?? throw new InvalidOperationException("This cache is keyed by path, not by hash.");
 
     public long Count => _count;
     public long DirtyCount => _dirtyCount;
@@ -97,7 +101,7 @@ internal class TrieStoreDirtyNodesCache
     public TrieNode FromCachedRlpOrUnknown(in Key key)
     {
         // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-        if (TryGetValue(key, out TrieNode trieNode))
+        if (TryGetValue(key, out TrieNode? trieNode))
         {
             trieNode = _trieStore.CloneForReadOnly(key, trieNode);
 
@@ -117,8 +121,8 @@ internal class TrieStoreDirtyNodesCache
 
     public bool IsNodeCached(in Key key)
     {
-        if (_storeByHash) return _byHashObjectCache.ContainsKey(key.Keccak);
-        return _byKeyObjectCache.ContainsKey(key);
+        if (_storeByHash) return ByHashObjectCache.ContainsKey(key.Keccak);
+        return ByKeyObjectCache.ContainsKey(key);
     }
 
     // We use a ulong sentinel (ulong.MaxValue) instead of ulong? (Nullable<ulong>)
@@ -138,15 +142,15 @@ internal class TrieStoreDirtyNodesCache
         {
             if (_storeByHash)
             {
-                return _byHashObjectCache.Select(
+                return ByHashObjectCache.Select(
                     static pair => new KeyValuePair<Key, NodeRecord>(new Key(null, TreePath.Empty, pair.Key.Value), pair.Value));
             }
 
-            return _byKeyObjectCache;
+            return ByKeyObjectCache;
         }
     }
 
-    public bool TryGetValue(in Key key, out TrieNode node)
+    public bool TryGetValue(in Key key, [NotNullWhen(true)] out TrieNode? node)
     {
         bool ok = TryGetRecord(key, out NodeRecord nodeRecord);
 
@@ -161,8 +165,8 @@ internal class TrieStoreDirtyNodesCache
     }
 
     public bool TryGetRecord(Key key, out NodeRecord nodeRecord) => _storeByHash
-            ? _byHashObjectCache.TryGetValue(key.Keccak, out nodeRecord)
-            : _byKeyObjectCache.TryGetValue(key, out nodeRecord);
+            ? ByHashObjectCache.TryGetValue(key.Keccak, out nodeRecord)
+            : ByKeyObjectCache.TryGetValue(key, out nodeRecord);
 
     // Sentinel for "no real block number assigned yet" (node discovered/created without a
     // numbered commit). IsNoLongerNeeded treats this as always-live since the sentinel is
@@ -170,13 +174,13 @@ internal class TrieStoreDirtyNodesCache
     private const ulong NoCommitSentinel = ulong.MaxValue;
 
     private NodeRecord GetOrAdd(in Key key, TrieStoreDirtyNodesCache cache) => _storeByHash
-        ? _byHashObjectCache.GetOrAdd(key.Keccak, static (keccak, cache) =>
+        ? ByHashObjectCache.GetOrAdd(key.Keccak, static (keccak, cache) =>
         {
             TrieNode trieNode = new(NodeType.Unknown, keccak);
             cache.IncrementMemory(trieNode);
             return new NodeRecord(trieNode, NoCommitSentinel);
         }, cache)
-        : _byKeyObjectCache.GetOrAdd(key, static (key, cache) =>
+        : ByKeyObjectCache.GetOrAdd(key, static (key, cache) =>
         {
             TrieNode trieNode = new(NodeType.Unknown, key.Keccak);
             cache.IncrementMemory(trieNode);
@@ -184,8 +188,8 @@ internal class TrieStoreDirtyNodesCache
         }, cache);
 
     public NodeRecord GetOrAdd(in Key key, NodeRecord record) => _storeByHash
-            ? GetOrAdd(_byHashObjectCache, key.Keccak, record)
-            : GetOrAdd(_byKeyObjectCache, key, record);
+            ? GetOrAdd(ByHashObjectCache, key.Keccak, record)
+            : GetOrAdd(ByKeyObjectCache, key, record);
 
     private static NodeRecord GetOrAdd<TKey>(ConcurrentDictionary<TKey, NodeRecord> dictionary, TKey key, NodeRecord record)
         where TKey : notnull
@@ -273,14 +277,14 @@ internal class TrieStoreDirtyNodesCache
     {
         if (_storeByHash)
         {
-            if (_byHashObjectCache.Remove(key.Keccak, out NodeRecord nodeRecord))
+            if (ByHashObjectCache.Remove(key.Keccak, out NodeRecord nodeRecord))
             {
                 DecrementMemory(nodeRecord.Node);
             }
 
             return;
         }
-        if (_byKeyObjectCache.Remove(key, out NodeRecord nodeRecord2))
+        if (ByKeyObjectCache.Remove(key, out NodeRecord nodeRecord2))
         {
             DecrementMemory(nodeRecord2.Node);
         }
@@ -388,7 +392,7 @@ internal class TrieStoreDirtyNodesCache
         {
             Hash256 keccak;
             TreePath path2 = key.Path;
-            keccak = node.GenerateKey(_trieStore.GetTrieStore(key.Address), ref path2);
+            keccak = node.GenerateKey(_trieStore.GetTrieStore(key.Address), ref path2) ?? ThrowUnableToGenerateKeccak(key, node);
             if (keccak != key.Keccak)
             {
                 ThrowPersistedNodeDoesNotMatch(key, node, keccak);
@@ -422,6 +426,10 @@ internal class TrieStoreDirtyNodesCache
         [DoesNotReturn, StackTraceHidden]
         static void ThrowPersistedNodeDoesNotMatch(in Key key, TrieNode node, Hash256 keccak)
             => throw new InvalidOperationException($"Persisted {node} {key} != {keccak}");
+
+        [DoesNotReturn, StackTraceHidden]
+        static Hash256 ThrowUnableToGenerateKeccak(in Key key, TrieNode node)
+            => throw new InvalidOperationException($"Unable to generate Keccak for persisted {node} {key}");
     }
 
     private void Delete(Key key, ConcurrentNodeWriteBatcher? writeBatch)

--- a/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
+++ b/src/Nethermind/Nethermind.Trie/RangeQueryVisitor.cs
@@ -124,15 +124,15 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
             int i = 0;
             while (true)
             {
-                TrieNode node = boundaryNodes[i];
+                TrieNode? node = boundaryNodes[i];
                 if (node is null) break;
 
-                proofs.Add(node.FullRlp.ToArray());
+                proofs.Add(node.FullRlp.ToArray() ?? throw new TrieException("A visited trie node must have encoded RLP."));
 
                 if (node.IsBranch)
                     i++;
                 else if (node.IsExtension)
-                    i += node.Key.Length;
+                    i += (node.Key ?? throw new TrieException("A resolved extension node must have a key.")).Length;
                 else
                     break;
             }
@@ -163,7 +163,8 @@ public class RangeQueryVisitor : ITreeVisitor<TreePathContext>, IDisposable
         _leftmostNodes[ctx.Path.Length] ??= node;
         _rightmostNodes[ctx.Path.Length] = node;
 
-        TreePath path = ctx.Path.Append(node.Key);
+        byte[] key = node.Key ?? throw new TrieException("A resolved leaf node must have a key.");
+        TreePath path = ctx.Path.Append(key);
         if (!ShouldVisit(path))
         {
             return;

--- a/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.std.cs
+++ b/src/Nethermind/Nethermind.Trie/TrackingCappedArrayPool.std.cs
@@ -50,7 +50,7 @@ public sealed class TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>
 
     public void Dispose()
     {
-        ArrayPool<byte> pool = arrayPool;
+        ArrayPool<byte>? pool = arrayPool;
         if (pool is not null)
         {
             DisposeCustomArrayPool(pool);
@@ -60,7 +60,7 @@ public sealed class TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>
         ConcurrentQueue<byte[]>? rentedQueue = _rentedQueue;
         if (rentedQueue is not null)
         {
-            while (rentedQueue.TryDequeue(out byte[] rentedBuffer))
+            while (rentedQueue.TryDequeue(out byte[]? rentedBuffer))
             {
                 // Devirtualize the shared array pool by referring directly to it
                 SafeArrayPool<byte>.Shared.Return(rentedBuffer);
@@ -68,7 +68,7 @@ public sealed class TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>
         }
         else
         {
-            Span<byte[]> items = CollectionsMarshal.AsSpan(_rentedList);
+            Span<byte[]> items = CollectionsMarshal.AsSpan(_rentedList!);
             foreach (byte[] rentedBuffer in items)
             {
                 SafeArrayPool<byte>.Shared.Return(rentedBuffer);
@@ -81,14 +81,14 @@ public sealed class TrackingCappedArrayPool(int initialCapacity, ArrayPool<byte>
     {
         if (_rentedQueue is not null)
         {
-            while (_rentedQueue.TryDequeue(out byte[] rentedBuffer))
+            while (_rentedQueue.TryDequeue(out byte[]? rentedBuffer))
             {
                 arrayPool.Return(rentedBuffer);
             }
         }
         else
         {
-            Span<byte[]> items = CollectionsMarshal.AsSpan(_rentedList);
+            Span<byte[]> items = CollectionsMarshal.AsSpan(_rentedList!);
             foreach (byte[] rentedBuffer in items)
             {
                 arrayPool.Return(rentedBuffer);

--- a/src/Nethermind/Nethermind.Trie/TreeDumper.cs
+++ b/src/Nethermind/Nethermind.Trie/TreeDumper.cs
@@ -41,20 +41,20 @@ namespace Nethermind.Trie
 
         public void VisitBranch(in OldStyleTrieVisitContext context, TrieNode node) => _builder.AppendLine($"{GetPrefix(context)}BRANCH | -> {KeccakOrRlpStringOfNode(node)}");
 
-        public void VisitExtension(in OldStyleTrieVisitContext context, TrieNode node) => _builder.AppendLine($"{GetPrefix(context)}EXTENSION {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
+        public void VisitExtension(in OldStyleTrieVisitContext context, TrieNode node) => _builder.AppendLine($"{GetPrefix(context)}EXTENSION {Nibbles.FromBytes(node.Key!).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
 
         public void VisitLeaf(in OldStyleTrieVisitContext context, TrieNode node)
         {
             if (!expectAccounts)
             {
-                _builder.AppendLine($"{GetPrefix(context)}LEAF {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
+                _builder.AppendLine($"{GetPrefix(context)}LEAF {Nibbles.FromBytes(node.Key!).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
             }
         }
 
         public void VisitAccount(in OldStyleTrieVisitContext context, TrieNode node, in AccountStruct account)
         {
             string leafDescription = context.IsStorage ? "LEAF " : "ACCOUNT ";
-            _builder.AppendLine($"{GetPrefix(context)}{leafDescription} {Nibbles.FromBytes(node.Key).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
+            _builder.AppendLine($"{GetPrefix(context)}{leafDescription} {Nibbles.FromBytes(node.Key!).ToPackedByteArray().ToHexString(false)} -> {KeccakOrRlpStringOfNode(node)}");
             RlpReader valueReader = new(node.Value.AsSpan());
             if (!context.IsStorage)
             {
@@ -70,6 +70,7 @@ namespace Nethermind.Trie
 
         public override string ToString() => _builder.ToString();
 
-        private static string? KeccakOrRlpStringOfNode(TrieNode node) => node.Keccak is not null ? node.Keccak!.Bytes.ToHexString() : node.FullRlp.AsSpan().ToHexString();
+        private static string KeccakOrRlpStringOfNode(TrieNode node) =>
+            node.Keccak is { } keccak ? keccak.Bytes.ToHexString() : node.FullRlp.AsSpan().ToHexString();
     }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -142,19 +142,61 @@ namespace Nethermind.Trie
             [DoesNotReturn, StackTraceHidden]
             private static void ThrowNullKey(TrieNode node) => throw new TrieException($"Hex prefix of a leaf node is null at node {node.Keccak}");
 
+            /// <summary>Scratch for one branch's children, before the sequence header is known.</summary>
+            /// <remarks>Sixteen children at most, each either a 33-byte hash item or a node small enough
+            /// to be embedded, which the trie only does below 32 bytes. A struct local rather than a
+            /// stackalloc, for the reason given on <c>KeccakHash</c>'s state buffer: localloc would pin
+            /// the method at Tier0-FullOpts and add stack-probe overhead per call. Writes go through a
+            /// span, so an over-long branch throws rather than running off the buffer.</remarks>
+            [InlineArray(BranchesCount * Rlp.LengthOfKeccakRlp)]
+            private struct BranchScratch
+            {
+                private byte _element0;
+            }
+
+            [SkipLocalsInit]
             public static CappedArray<byte> RlpEncodeBranch(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? pool, bool canBeParallel)
             {
                 Metrics.IncrementTreeNodeRlpEncodings();
 
                 const int valueRlpLength = 1;
-                int contentLength = valueRlpLength + (UseParallel(canBeParallel, item) ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel) : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));
-                int sequenceLength = Rlp.LengthOfSequence(contentLength);
-                CappedArray<byte> result = pool.SafeRent(sequenceLength);
-                Span<byte> resultSpan = result.AsSpan();
-                int position = Rlp.StartSequence(resultSpan, 0, contentLength);
-                WriteChildrenRlpBranch(tree, ref path, item, resultSpan.Slice(position, contentLength - valueRlpLength), pool, canBeParallel);
-                position = sequenceLength - valueRlpLength;
-                resultSpan[position] = 128;
+                int contentLength;
+                int sequenceLength;
+                CappedArray<byte> result;
+                Span<byte> resultSpan;
+                int position;
+
+                // The sequence header carries the children's length and CappedArray has no offset to write
+                // it backwards into, so the length has to be known before the children can go in. Writing
+                // them into a scratch buffer and copying them in behind the header trades the measuring
+                // walk for one bounded copy. The walk is kept where it does something else as well:
+                // spreading the children over cores, or collecting branch pairs for batched hashing.
+                bool useParallel = UseParallel(canBeParallel, item);
+                if (useParallel || (Avx512F.VL.IsSupported && HasBatchableChildPair(item)))
+                {
+                    contentLength = valueRlpLength + (useParallel
+                        ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel)
+                        : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));
+                    sequenceLength = Rlp.LengthOfSequence(contentLength);
+                    result = pool.SafeRent(sequenceLength);
+                    resultSpan = result.AsSpan();
+                    position = Rlp.StartSequence(resultSpan, 0, contentLength);
+                    WriteChildrenRlpBranch(tree, ref path, item, resultSpan.Slice(position, contentLength - valueRlpLength), pool, canBeParallel);
+                    resultSpan[sequenceLength - valueRlpLength] = 128;
+
+                    return result;
+                }
+
+                Unsafe.SkipInit(out BranchScratch scratch);
+                Span<byte> children = scratch;
+                int childrenLength = WriteChildrenRlpBranch(tree, ref path, item, children, pool, canBeParallel);
+                contentLength = valueRlpLength + childrenLength;
+                sequenceLength = Rlp.LengthOfSequence(contentLength);
+                result = pool.SafeRent(sequenceLength);
+                resultSpan = result.AsSpan();
+                position = Rlp.StartSequence(resultSpan, 0, contentLength);
+                children[..childrenLength].CopyTo(resultSpan[position..]);
+                resultSpan[sequenceLength - valueRlpLength] = 128;
 
                 return result;
 
@@ -178,6 +220,27 @@ namespace Nethermind.Trie
 
                     return false;
                 }
+            }
+
+            /// <summary>Whether the measuring walk could pair up child hashes for <see cref="HashPreparedBranches" />.</summary>
+            /// <remarks>Only a dirty branch child is a candidate, and a lone candidate is hashed on its own, so
+            /// a branch without two of them gains nothing from the walk. The walk narrows the set further — a
+            /// candidate whose RLP is not a full branch drops out — so an upper bound is all this needs to be.</remarks>
+            private static bool HasBatchableChildPair(TrieNode item)
+            {
+                const int MinChildrenForBatchedHashing = 2;
+                int candidates = 0;
+                Debug.Assert(item._nodeData is BranchData, "Data is not BranchData");
+                BranchData branchData = Unsafe.As<BranchData>(item._nodeData!);
+                for (int i = 0; i < BranchesCount; i++)
+                {
+                    if (branchData[i] is TrieNode { IsBranch: true, Keccak: null } && ++candidates >= MinChildrenForBatchedHashing)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
 
             private static void HashPreparedBranches(TrieNode item, ushort candidateMask)
@@ -444,20 +507,17 @@ namespace Nethermind.Trie
                 return totalLength;
             }
 
-            private static void WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
-            {
+            /// <summary>Writes a branch's sixteen children into <paramref name="destination" />, each as a hash
+            /// item or an embedded node.</summary>
+            /// <returns>The number of bytes written.</returns>
+            private static int WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel) =>
                 // Tail call optimized.
-                if (item.HasRlp)
-                {
-                    WriteChildrenRlpBranchRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
-                }
-                else
-                {
-                    WriteChildrenRlpBranchNonRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
-                }
-            }
+                item.HasRlp
+                    ? WriteChildrenRlpBranchRlp(tree, ref path, item, destination, bufferPool, canBeParallel)
+                    : WriteChildrenRlpBranchNonRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
 
-            private static void WriteChildrenRlpBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
+            /// <inheritdoc cref="WriteChildrenRlpBranch" />
+            private static int WriteChildrenRlpBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int position = 0;
                 for (int i = 0; i < BranchesCount; i++)
@@ -492,9 +552,12 @@ namespace Nethermind.Trie
                         }
                     }
                 }
+
+                return position;
             }
 
-            private static void WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
+            /// <inheritdoc cref="WriteChildrenRlpBranch" />
+            private static int WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 RlpReader rlpReader = item.RlpReader;
                 item.SeekChild(ref rlpReader, 0);
@@ -562,7 +625,10 @@ namespace Nethermind.Trie
                 if (runStart >= 0)
                 {
                     rlpReader.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
+                    position += runLength;
                 }
+
+                return position;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -42,7 +42,7 @@ namespace Nethermind.Trie
                 Debug.Assert(item.Key is not null,
                     "Extension key is null when encoding");
 
-                byte[] hexPrefix = item.Key;
+                byte[] hexPrefix = item.Key!;
                 int hexLength = HexPrefix.ByteLength(hexPrefix);
                 byte[]? rentedBuffer = hexLength > StackallocByteThreshold
                     ? ArrayPool<byte>.Shared.Rent(hexLength)
@@ -57,7 +57,12 @@ namespace Nethermind.Trie
                 // Fast path: child was unresolved to a Hash256 (e.g. by pruning) — encode the hash directly
                 // without materializing a TrieNode via FindCachedOrUnknown + ResolveKey.
                 TrieNode? nodeRef = null;
-                if (item._nodeData[0] is not Hash256 childKeccak)
+                Hash256? childKeccak;
+                if (item._nodeData![0] is Hash256 dataKeccak)
+                {
+                    childKeccak = dataKeccak;
+                }
+                else
                 {
                     int previousLength = item.AppendChildPath(ref path, 0);
                     nodeRef = item.GetChildWithChildPath(tree, ref path, 0);
@@ -211,7 +216,7 @@ namespace Nethermind.Trie
                     int nonNullChildren = 0;
                     for (int i = 0; i < BranchesCount; i++)
                     {
-                        object? data = item._nodeData[i];
+                        object? data = item._nodeData![i];
                         if (data is not null && !ReferenceEquals(data, _nullNode) && ++nonNullChildren >= MinChildrenForParallel)
                         {
                             return true;
@@ -249,7 +254,7 @@ namespace Nethermind.Trie
                 candidateMask ^= (ushort)(1 << firstIndex);
                 if (candidateMask == 0)
                 {
-                    Unsafe.As<TrieNode>(item._nodeData[firstIndex]).ResolvePreparedKey();
+                    Unsafe.As<TrieNode>(item._nodeData![firstIndex])!.ResolvePreparedKey();
                     return;
                 }
 
@@ -266,8 +271,8 @@ namespace Nethermind.Trie
                 {
                     int secondIndex = BitOperations.TrailingZeroCount(candidateMask);
                     candidateMask ^= (ushort)(1 << secondIndex);
-                    TrieNode first = Unsafe.As<TrieNode>(item._nodeData[firstIndex]);
-                    TrieNode second = Unsafe.As<TrieNode>(item._nodeData[secondIndex]);
+                    TrieNode first = Unsafe.As<TrieNode>(item._nodeData![firstIndex])!;
+                    TrieNode second = Unsafe.As<TrieNode>(item._nodeData[secondIndex])!;
                     CappedArray<byte> firstRlp = first.FullRlp;
                     CappedArray<byte> secondRlp = second.FullRlp;
                     if (firstRlp.Length != FullBranchRlpLength || secondRlp.Length != FullBranchRlpLength)
@@ -292,7 +297,7 @@ namespace Nethermind.Trie
                     candidateMask ^= (ushort)(1 << firstIndex);
                     if (candidateMask == 0)
                     {
-                        Unsafe.As<TrieNode>(item._nodeData[firstIndex]).ResolvePreparedKey();
+                        Unsafe.As<TrieNode>(item._nodeData![firstIndex])!.ResolvePreparedKey();
                         return;
                     }
                 }
@@ -314,14 +319,14 @@ namespace Nethermind.Trie
                     ? GetChildrenRlpLengthForBranchRlpParallel(tree, path, item, bufferPool, canBeParallel)
                     : GetChildrenRlpLengthForBranchNonRlpParallel(tree, path, item, bufferPool, canBeParallel);
 
-            private static int GetChildrenRlpLengthForBranchNonRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool bufferPool, bool canBeParallel)
+            private static int GetChildrenRlpLengthForBranchNonRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
                 ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
                     (local: 0, item, tree, bufferPool, rootPath, canBeParallel),
                     static (i, state) =>
                     {
-                        object? data = state.item._nodeData[i];
+                        object? data = state.item._nodeData![i];
                         if (ReferenceEquals(data, _nullNode) || data is null)
                         {
                             state.local++;
@@ -349,13 +354,13 @@ namespace Nethermind.Trie
                 return totalLength;
             }
 
-            private static int GetChildrenRlpLengthForBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool bufferPool, bool canBeParallel)
+            private static int GetChildrenRlpLengthForBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
                 ushort candidateMask = 0;
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    object? data = item._nodeData[i];
+                    object? data = item._nodeData![i];
                     if (ReferenceEquals(data, _nullNode) || data is null)
                     {
                         totalLength++;
@@ -408,7 +413,7 @@ namespace Nethermind.Trie
                     {
                         RlpReader rlpReader = state.item.RlpReader;
                         state.item.SeekChild(ref rlpReader, i);
-                        object? data = state.item._nodeData[i];
+                        object? data = state.item._nodeData![i];
                         if (data is null)
                         {
                             state.local += rlpReader.PeekNextRlpLength();
@@ -451,7 +456,7 @@ namespace Nethermind.Trie
                 BranchData branchData = Unsafe.As<BranchData>(item._nodeData!);
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    object data = branchData[i];
+                    object? data = branchData[i];
                     if (data is null)
                     {
                         int length = rlpReader.PeekNextRlpLength();
@@ -522,7 +527,7 @@ namespace Nethermind.Trie
                 int position = 0;
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    object data = item._nodeData[i];
+                    object? data = item._nodeData![i];
                     if (ReferenceEquals(data, _nullNode) || data is null)
                     {
                         destination[position++] = 128;
@@ -539,8 +544,8 @@ namespace Nethermind.Trie
                         childNode!.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
                         path.TruncateOne();
 
-                        hash = childNode.Keccak;
-                        if (hash is null)
+                        Hash256? childHash = childNode.Keccak;
+                        if (childHash is null)
                         {
                             Span<byte> fullRlp = childNode.FullRlp.AsSpan();
                             fullRlp.CopyTo(destination.Slice(position, fullRlp.Length));
@@ -548,7 +553,7 @@ namespace Nethermind.Trie
                         }
                         else
                         {
-                            position = Rlp.Encode(destination, position, hash);
+                            position = Rlp.Encode(destination, position, childHash);
                         }
                     }
                 }
@@ -571,7 +576,7 @@ namespace Nethermind.Trie
                 BranchData branchData = Unsafe.As<BranchData>(item._nodeData!);
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    object data = branchData[i];
+                    object? data = branchData[i];
                     if (data is null)
                     {
                         int length = rlpReader.PeekNextRlpLength();
@@ -605,8 +610,8 @@ namespace Nethermind.Trie
                             childNode!.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
                             path.TruncateOne();
 
-                            hash = childNode.Keccak;
-                            if (hash is null)
+                            Hash256? childHash = childNode.Keccak;
+                            if (childHash is null)
                             {
                                 Span<byte> fullRlp = childNode.FullRlp.AsSpan();
                                 fullRlp.CopyTo(destination.Slice(position, fullRlp.Length));
@@ -614,7 +619,7 @@ namespace Nethermind.Trie
                             }
                             else
                             {
-                                position = Rlp.Encode(destination, position, hash);
+                                position = Rlp.Encode(destination, position, childHash);
                             }
                         }
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -42,7 +42,7 @@ namespace Nethermind.Trie
                 Debug.Assert(item.Key is not null,
                     "Extension key is null when encoding");
 
-                byte[] hexPrefix = item.Key;
+                byte[] hexPrefix = item.Key!;
                 int hexLength = HexPrefix.ByteLength(hexPrefix);
                 byte[]? rentedBuffer = hexLength > StackallocByteThreshold
                     ? ArrayPool<byte>.Shared.Rent(hexLength)
@@ -57,7 +57,12 @@ namespace Nethermind.Trie
                 // Fast path: child was unresolved to a Hash256 (e.g. by pruning) — encode the hash directly
                 // without materializing a TrieNode via FindCachedOrUnknown + ResolveKey.
                 TrieNode? nodeRef = null;
-                if (item._nodeData[0] is not Hash256 childKeccak)
+                Hash256? childKeccak;
+                if (item._nodeData![0] is Hash256 dataKeccak)
+                {
+                    childKeccak = dataKeccak;
+                }
+                else
                 {
                     int previousLength = item.AppendChildPath(ref path, 0);
                     nodeRef = item.GetChildWithChildPath(tree, ref path, 0);
@@ -142,19 +147,61 @@ namespace Nethermind.Trie
             [DoesNotReturn, StackTraceHidden]
             private static void ThrowNullKey(TrieNode node) => throw new TrieException($"Hex prefix of a leaf node is null at node {node.Keccak}");
 
+            /// <summary>Scratch for one branch's children, before the sequence header is known.</summary>
+            /// <remarks>Sixteen children at most, each either a 33-byte hash item or a node small enough
+            /// to be embedded, which the trie only does below 32 bytes. A struct local rather than a
+            /// stackalloc, for the reason given on <c>KeccakHash</c>'s state buffer: localloc would pin
+            /// the method at Tier0-FullOpts and add stack-probe overhead per call. Writes go through a
+            /// span, so an over-long branch throws rather than running off the buffer.</remarks>
+            [InlineArray(BranchesCount * Rlp.LengthOfKeccakRlp)]
+            private struct BranchScratch
+            {
+                private byte _element0;
+            }
+
+            [SkipLocalsInit]
             public static CappedArray<byte> RlpEncodeBranch(TrieNode item, ITrieNodeResolver tree, ref TreePath path, ICappedArrayPool? pool, bool canBeParallel)
             {
                 Metrics.IncrementTreeNodeRlpEncodings();
 
                 const int valueRlpLength = 1;
-                int contentLength = valueRlpLength + (UseParallel(canBeParallel, item) ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel) : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));
-                int sequenceLength = Rlp.LengthOfSequence(contentLength);
-                CappedArray<byte> result = pool.SafeRent(sequenceLength);
-                Span<byte> resultSpan = result.AsSpan();
-                int position = Rlp.StartSequence(resultSpan, 0, contentLength);
-                WriteChildrenRlpBranch(tree, ref path, item, resultSpan.Slice(position, contentLength - valueRlpLength), pool, canBeParallel);
-                position = sequenceLength - valueRlpLength;
-                resultSpan[position] = 128;
+                int contentLength;
+                int sequenceLength;
+                CappedArray<byte> result;
+                Span<byte> resultSpan;
+                int position;
+
+                // The sequence header carries the children's length and CappedArray has no offset to write
+                // it backwards into, so the length has to be known before the children can go in. Writing
+                // them into a scratch buffer and copying them in behind the header trades the measuring
+                // walk for one bounded copy. The walk is kept where it does something else as well:
+                // spreading the children over cores, or collecting branch pairs for batched hashing.
+                bool useParallel = UseParallel(canBeParallel, item);
+                if (useParallel || (Avx512F.VL.IsSupported && HasBatchableChildPair(item)))
+                {
+                    contentLength = valueRlpLength + (useParallel
+                        ? GetChildrenRlpLengthForBranchParallel(tree, ref path, item, pool, canBeParallel)
+                        : GetChildrenRlpLengthForBranch(tree, ref path, item, pool, canBeParallel));
+                    sequenceLength = Rlp.LengthOfSequence(contentLength);
+                    result = pool.SafeRent(sequenceLength);
+                    resultSpan = result.AsSpan();
+                    position = Rlp.StartSequence(resultSpan, 0, contentLength);
+                    WriteChildrenRlpBranch(tree, ref path, item, resultSpan.Slice(position, contentLength - valueRlpLength), pool, canBeParallel);
+                    resultSpan[sequenceLength - valueRlpLength] = 128;
+
+                    return result;
+                }
+
+                Unsafe.SkipInit(out BranchScratch scratch);
+                Span<byte> children = scratch;
+                int childrenLength = WriteChildrenRlpBranch(tree, ref path, item, children, pool, canBeParallel);
+                contentLength = valueRlpLength + childrenLength;
+                sequenceLength = Rlp.LengthOfSequence(contentLength);
+                result = pool.SafeRent(sequenceLength);
+                resultSpan = result.AsSpan();
+                position = Rlp.StartSequence(resultSpan, 0, contentLength);
+                children[..childrenLength].CopyTo(resultSpan[position..]);
+                resultSpan[sequenceLength - valueRlpLength] = 128;
 
                 return result;
 
@@ -169,7 +216,7 @@ namespace Nethermind.Trie
                     int nonNullChildren = 0;
                     for (int i = 0; i < BranchesCount; i++)
                     {
-                        object? data = item._nodeData[i];
+                        object? data = item._nodeData![i];
                         if (data is not null && !ReferenceEquals(data, _nullNode) && ++nonNullChildren >= MinChildrenForParallel)
                         {
                             return true;
@@ -180,13 +227,34 @@ namespace Nethermind.Trie
                 }
             }
 
+            /// <summary>Whether the measuring walk could pair up child hashes for <see cref="HashPreparedBranches" />.</summary>
+            /// <remarks>Only a dirty branch child is a candidate, and a lone candidate is hashed on its own, so
+            /// a branch without two of them gains nothing from the walk. The walk narrows the set further — a
+            /// candidate whose RLP is not a full branch drops out — so an upper bound is all this needs to be.</remarks>
+            private static bool HasBatchableChildPair(TrieNode item)
+            {
+                const int MinChildrenForBatchedHashing = 2;
+                int candidates = 0;
+                Debug.Assert(item._nodeData is BranchData, "Data is not BranchData");
+                BranchData branchData = Unsafe.As<BranchData>(item._nodeData!);
+                for (int i = 0; i < BranchesCount; i++)
+                {
+                    if (branchData[i] is TrieNode { IsBranch: true, Keccak: null } && ++candidates >= MinChildrenForBatchedHashing)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
             private static void HashPreparedBranches(TrieNode item, ushort candidateMask)
             {
                 int firstIndex = BitOperations.TrailingZeroCount(candidateMask);
                 candidateMask ^= (ushort)(1 << firstIndex);
                 if (candidateMask == 0)
                 {
-                    Unsafe.As<TrieNode>(item._nodeData[firstIndex]).ResolvePreparedKey();
+                    Unsafe.As<TrieNode>(item._nodeData![firstIndex])!.ResolvePreparedKey();
                     return;
                 }
 
@@ -203,8 +271,8 @@ namespace Nethermind.Trie
                 {
                     int secondIndex = BitOperations.TrailingZeroCount(candidateMask);
                     candidateMask ^= (ushort)(1 << secondIndex);
-                    TrieNode first = Unsafe.As<TrieNode>(item._nodeData[firstIndex]);
-                    TrieNode second = Unsafe.As<TrieNode>(item._nodeData[secondIndex]);
+                    TrieNode first = Unsafe.As<TrieNode>(item._nodeData![firstIndex])!;
+                    TrieNode second = Unsafe.As<TrieNode>(item._nodeData[secondIndex])!;
                     CappedArray<byte> firstRlp = first.FullRlp;
                     CappedArray<byte> secondRlp = second.FullRlp;
                     if (firstRlp.Length != FullBranchRlpLength || secondRlp.Length != FullBranchRlpLength)
@@ -229,7 +297,7 @@ namespace Nethermind.Trie
                     candidateMask ^= (ushort)(1 << firstIndex);
                     if (candidateMask == 0)
                     {
-                        Unsafe.As<TrieNode>(item._nodeData[firstIndex]).ResolvePreparedKey();
+                        Unsafe.As<TrieNode>(item._nodeData![firstIndex])!.ResolvePreparedKey();
                         return;
                     }
                 }
@@ -251,14 +319,14 @@ namespace Nethermind.Trie
                     ? GetChildrenRlpLengthForBranchRlpParallel(tree, path, item, bufferPool, canBeParallel)
                     : GetChildrenRlpLengthForBranchNonRlpParallel(tree, path, item, bufferPool, canBeParallel);
 
-            private static int GetChildrenRlpLengthForBranchNonRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool bufferPool, bool canBeParallel)
+            private static int GetChildrenRlpLengthForBranchNonRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
                 ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
                     (local: 0, item, tree, bufferPool, rootPath, canBeParallel),
                     static (i, state) =>
                     {
-                        object? data = state.item._nodeData[i];
+                        object? data = state.item._nodeData![i];
                         if (ReferenceEquals(data, _nullNode) || data is null)
                         {
                             state.local++;
@@ -286,13 +354,13 @@ namespace Nethermind.Trie
                 return totalLength;
             }
 
-            private static int GetChildrenRlpLengthForBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool bufferPool, bool canBeParallel)
+            private static int GetChildrenRlpLengthForBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
                 ushort candidateMask = 0;
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    object? data = item._nodeData[i];
+                    object? data = item._nodeData![i];
                     if (ReferenceEquals(data, _nullNode) || data is null)
                     {
                         totalLength++;
@@ -345,7 +413,7 @@ namespace Nethermind.Trie
                     {
                         RlpReader rlpReader = state.item.RlpReader;
                         state.item.SeekChild(ref rlpReader, i);
-                        object? data = state.item._nodeData[i];
+                        object? data = state.item._nodeData![i];
                         if (data is null)
                         {
                             state.local += rlpReader.PeekNextRlpLength();
@@ -388,7 +456,7 @@ namespace Nethermind.Trie
                 BranchData branchData = Unsafe.As<BranchData>(item._nodeData!);
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    object data = branchData[i];
+                    object? data = branchData[i];
                     if (data is null)
                     {
                         int length = rlpReader.PeekNextRlpLength();
@@ -444,25 +512,22 @@ namespace Nethermind.Trie
                 return totalLength;
             }
 
-            private static void WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
-            {
+            /// <summary>Writes a branch's sixteen children into <paramref name="destination" />, each as a hash
+            /// item or an embedded node.</summary>
+            /// <returns>The number of bytes written.</returns>
+            private static int WriteChildrenRlpBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel) =>
                 // Tail call optimized.
-                if (item.HasRlp)
-                {
-                    WriteChildrenRlpBranchRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
-                }
-                else
-                {
-                    WriteChildrenRlpBranchNonRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
-                }
-            }
+                item.HasRlp
+                    ? WriteChildrenRlpBranchRlp(tree, ref path, item, destination, bufferPool, canBeParallel)
+                    : WriteChildrenRlpBranchNonRlp(tree, ref path, item, destination, bufferPool, canBeParallel);
 
-            private static void WriteChildrenRlpBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
+            /// <inheritdoc cref="WriteChildrenRlpBranch" />
+            private static int WriteChildrenRlpBranchNonRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int position = 0;
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    object data = item._nodeData[i];
+                    object? data = item._nodeData![i];
                     if (ReferenceEquals(data, _nullNode) || data is null)
                     {
                         destination[position++] = 128;
@@ -479,8 +544,8 @@ namespace Nethermind.Trie
                         childNode!.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
                         path.TruncateOne();
 
-                        hash = childNode.Keccak;
-                        if (hash is null)
+                        Hash256? childHash = childNode.Keccak;
+                        if (childHash is null)
                         {
                             Span<byte> fullRlp = childNode.FullRlp.AsSpan();
                             fullRlp.CopyTo(destination.Slice(position, fullRlp.Length));
@@ -488,13 +553,16 @@ namespace Nethermind.Trie
                         }
                         else
                         {
-                            position = Rlp.Encode(destination, position, hash);
+                            position = Rlp.Encode(destination, position, childHash);
                         }
                     }
                 }
+
+                return position;
             }
 
-            private static void WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
+            /// <inheritdoc cref="WriteChildrenRlpBranch" />
+            private static int WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 RlpReader rlpReader = item.RlpReader;
                 item.SeekChild(ref rlpReader, 0);
@@ -508,7 +576,7 @@ namespace Nethermind.Trie
                 BranchData branchData = Unsafe.As<BranchData>(item._nodeData!);
                 for (int i = 0; i < BranchesCount; i++)
                 {
-                    object data = branchData[i];
+                    object? data = branchData[i];
                     if (data is null)
                     {
                         int length = rlpReader.PeekNextRlpLength();
@@ -542,8 +610,8 @@ namespace Nethermind.Trie
                             childNode!.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
                             path.TruncateOne();
 
-                            hash = childNode.Keccak;
-                            if (hash is null)
+                            Hash256? childHash = childNode.Keccak;
+                            if (childHash is null)
                             {
                                 Span<byte> fullRlp = childNode.FullRlp.AsSpan();
                                 fullRlp.CopyTo(destination.Slice(position, fullRlp.Length));
@@ -551,7 +619,7 @@ namespace Nethermind.Trie
                             }
                             else
                             {
-                                position = Rlp.Encode(destination, position, hash);
+                                position = Rlp.Encode(destination, position, childHash);
                             }
                         }
 
@@ -562,7 +630,10 @@ namespace Nethermind.Trie
                 if (runStart >= 0)
                 {
                     rlpReader.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
+                    position += runLength;
                 }
+
+                return position;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Visitor.cs
@@ -132,7 +132,7 @@ namespace Nethermind.Trie
 
                                     TNodeContext storageContext = leafContext.AddStorage(storageAccount);
                                     TreePath emptyPath = TreePath.Empty;
-                                    actualSubtreeSize += Accept(storageRoot!, storageContext, nodeResolver.GetStorageTrieNodeResolver(storageAccount), ref emptyPath, true, subtreeSizeHint);
+                                    actualSubtreeSize += Accept(storageRoot, storageContext, nodeResolver.GetStorageTrieNodeResolver(storageAccount), ref emptyPath, true, subtreeSizeHint);
                                 }
                                 else
                                 {
@@ -192,7 +192,7 @@ namespace Nethermind.Trie
             for (int i = 0; i < TrieNode.BranchesCount; i++)
             {
                 if (output[i] is null) continue;
-                TrieNode child = output[i];
+                TrieNode child = output[i]!;
                 path.SetLast(i);
                 child.ResolveKey(nodeResolver, ref path);
                 TNodeContext childContext = nodeContext.Add((byte)i);
@@ -226,7 +226,7 @@ namespace Nethermind.Trie
             {
                 if (output[i] is null) continue;
                 handledChild++;
-                TrieNode child = output[i];
+                TrieNode child = output[i]!;
                 path.SetLast(i);
                 child.ResolveKey(trieNodeResolver, ref path);
                 TNodeContext childContext = nodeContext.Add((byte)i);
@@ -251,7 +251,7 @@ namespace Nethermind.Trie
 
             for (int i = 0; i < tasks.Count; i++)
             {
-                actualSubtreeSize += tasks[i].Result;
+                actualSubtreeSize += tasks[i]!.Result;
             }
 
             return actualSubtreeSize;

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -325,7 +325,7 @@ namespace Nethermind.Trie
             }
         }
 
-        private INodeData CreateNodeData(NodeType nodeType) => nodeType switch
+        private INodeData? CreateNodeData(NodeType nodeType) => nodeType switch
         {
             NodeType.Branch => new BranchData(),
             NodeType.Extension => new ExtensionData(),
@@ -375,11 +375,7 @@ namespace Nethermind.Trie
             CappedArray<byte> rlp = ReadRlp();
             if (rlp.IsNull)
             {
-                Hash256 keccak = Keccak;
-                if (keccak is null)
-                {
-                    ThrowMissingKeccak();
-                }
+                Hash256 keccak = Keccak ?? ThrowMissingKeccak();
 
                 byte[]? fullRlp = tree.LoadRlp(path, keccak, readFlags);
 
@@ -398,7 +394,7 @@ namespace Nethermind.Trie
             }
 
             [DoesNotReturn, StackTraceHidden]
-            static void ThrowMissingKeccak() => throw new TrieException("Unable to resolve node without Keccak");
+            static Hash256 ThrowMissingKeccak() => throw new TrieException("Unable to resolve node without Keccak");
 
             [DoesNotReturn, StackTraceHidden]
             void ThrowNullRlp() => throw new TrieException($"Trie returned a NULL RLP for node {Keccak}");
@@ -420,7 +416,7 @@ namespace Nethermind.Trie
                 CappedArray<byte> rlp = ReadRlp();
                 if (rlp.IsNull)
                 {
-                    Hash256 keccak = Keccak;
+                    Hash256? keccak = Keccak;
                     if (keccak is null)
                     {
                         ThrowMissingKeccak();
@@ -502,13 +498,13 @@ namespace Nethermind.Trie
                 {
                     if (rlp.IsNull)
                     {
-                        Hash256 keccak = Keccak;
+                        Hash256? keccak = Keccak;
                         if (keccak is null)
                         {
                             return false;
                         }
 
-                        byte[] fullRlp = tree.TryLoadRlp(path, keccak, readFlags);
+                        byte[]? fullRlp = tree.TryLoadRlp(path, keccak, readFlags);
 
                         if (fullRlp is null)
                         {
@@ -543,7 +539,7 @@ namespace Nethermind.Trie
                 CappedArray<byte> rlp = ReadRlp();
                 if (rlp.IsNull)
                 {
-                    Hash256 keccak = Keccak;
+                    Hash256? keccak = Keccak;
                     if (keccak is null)
                     {
                         return false;
@@ -633,7 +629,7 @@ namespace Nethermind.Trie
         private bool VerifyWarmerOwnedRlp(in CappedArray<byte> rlp) =>
             Keccak is not { } keccak || ValueKeccak.Compute(rlp.AsSpan()) == keccak;
 
-        private bool DecodeRlp(RlpReader rlpReader, ICappedArrayPool bufferPool, out int itemsCount)
+        private bool DecodeRlp(RlpReader rlpReader, ICappedArrayPool? bufferPool, out int itemsCount)
         {
             Metrics.IncrementTreeNodeRlpDecodings();
 
@@ -824,7 +820,7 @@ namespace Nethermind.Trie
             }
 
             CappedArray<byte> rlp = ReadRlp();
-            ref object data = ref _nodeData[i];
+            ref object? data = ref _nodeData![i];
             if (rlp.IsNotNull && data is null)
             {
                 RlpReader rlpReader = new(rlp);
@@ -846,7 +842,7 @@ namespace Nethermind.Trie
                 i++;
             }
 
-            ref object data = ref _nodeData[i];
+            ref object? data = ref _nodeData![i];
             if (data is null)
             {
                 dirtyChild = null;
@@ -911,7 +907,7 @@ namespace Nethermind.Trie
              * so just to treat them in the same way we update index on extensions
              */
             childIndex = IsExtension ? childIndex + 1 : childIndex;
-            object childOrRef = ResolveChildWithChildPath(tree, ref childPath, childIndex);
+            object? childOrRef = ResolveChildWithChildPath(tree, ref childPath, childIndex);
 
             TrieNode? child;
             if (ReferenceEquals(childOrRef, _nullNode) || childOrRef is null)
@@ -985,10 +981,10 @@ namespace Nethermind.Trie
         /// when setting to object[] array
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void SetItem(int i, TrieNode node)
+        private void SetItem(int i, TrieNode? node)
         {
             int index = IsExtension ? i + 1 : i;
-            _nodeData[i] = node ?? _nullNode;
+            _nodeData![i] = node ?? _nullNode;
         }
 
         public long GetMemorySize(bool recursive)
@@ -1004,7 +1000,7 @@ namespace Nethermind.Trie
             {
                 for (int i = 0; i < data.Length; i++)
                 {
-                    object child = data[i];
+                    object? child = data[i];
                     dataSize += child switch
                     {
                         null => 0,
@@ -1307,7 +1303,7 @@ namespace Nethermind.Trie
                     ref readonly BranchArray data = ref branchData.Branches;
                     for (int i = 0; i < BranchArray.Length; i++)
                     {
-                        object o = data[i];
+                        object? o = data[i];
                         if (o is TrieNode child)
                         {
                             if (child.IsPersisted)
@@ -1352,7 +1348,7 @@ namespace Nethermind.Trie
         }
 
         internal bool TryResolveStorageRoot(ITrieNodeResolver resolver, ref TreePath currentPath,
-            out TrieNode? storageRoot)
+            [NotNullWhen(true)] out TrieNode? storageRoot)
         {
             bool hasStorage = false;
 
@@ -1429,7 +1425,7 @@ namespace Nethermind.Trie
         {
             object? childOrRef;
             CappedArray<byte> rlp = ReadRlp();
-            ref object data = ref _nodeData[i];
+            ref object? data = ref _nodeData![i];
             if (rlp.IsNull)
             {
                 childOrRef = data;
@@ -1494,7 +1490,7 @@ namespace Nethermind.Trie
                 for (int i = 0; i < 16; i++)
                 {
                     path.SetLast(i);
-                    TrieNode n = GetChildWithChildPath(tree, ref path, i);
+                    TrieNode? n = GetChildWithChildPath(tree, ref path, i);
                     if (n is not null) chCount++;
                     output[i] = n;
                 }
@@ -1550,7 +1546,7 @@ namespace Nethermind.Trie
 
         internal void UnresolveChild(int i)
         {
-            ref object data = ref _nodeData[i];
+            ref object? data = ref _nodeData![i];
             if (IsPersisted)
             {
                 data = null;
@@ -1586,7 +1582,7 @@ namespace Nethermind.Trie
             {
                 object? childOrRef;
                 CappedArray<byte> rlp = node.ReadRlp();
-                ref object data = ref node._nodeData[i];
+                ref object? data = ref node._nodeData![i];
                 if (rlp.IsNull)
                 {
                     childOrRef = data;
@@ -1663,7 +1659,7 @@ namespace Nethermind.Trie
                  * so just to treat them in the same way we update index on extensions
                  */
                 childIndex = node.IsExtension ? childIndex + 1 : childIndex;
-                object childOrRef = ResolveChildWithChildPath(tree, ref childPath, childIndex);
+                object? childOrRef = ResolveChildWithChildPath(tree, ref childPath, childIndex);
 
                 TrieNode? child;
                 if (ReferenceEquals(childOrRef, _nullNode) || childOrRef is null)

--- a/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNodeResolverWithReadFlags.cs
@@ -34,7 +34,7 @@ public class TrieNodeResolverWithReadFlags(ITrieNodeResolver baseResolver, ReadF
         return _baseResolver.LoadRlp(treePath, hash, _defaultFlags);
     }
 
-    public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256 address) => new TrieNodeResolverWithReadFlags(_baseResolver.GetStorageTrieNodeResolver(address), _defaultFlags);
+    public ITrieNodeResolver GetStorageTrieNodeResolver(Hash256? address) => new TrieNodeResolverWithReadFlags(_baseResolver.GetStorageTrieNodeResolver(address), _defaultFlags);
 
     public INodeStorage.KeyScheme Scheme => _baseResolver.Scheme;
 }

--- a/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieStatsCollector.cs
@@ -147,10 +147,10 @@ namespace Nethermind.Trie
             bool codeExist = _existingCodeHash.TryGet(key, out int codeLength);
             if (!codeExist)
             {
-                byte[] code = _codeKeyValueStore[key.Bytes];
-                codeExist = code is not null;
-                if (codeExist)
+                byte[]? code = _codeKeyValueStore[key.Bytes];
+                if (code is not null)
                 {
+                    codeExist = true;
                     codeLength = code.Length;
                     _existingCodeHash.Set(key, codeLength);
                 }

--- a/src/Nethermind/Nethermind.Trie/Utils/ConcurrentNodeWriteBatcher.cs
+++ b/src/Nethermind/Nethermind.Trie/Utils/ConcurrentNodeWriteBatcher.cs
@@ -21,7 +21,7 @@ public class ConcurrentNodeWriteBatcher(INodeStorage underlyingDb, long batchSiz
     public void Dispose()
     {
         _disposing = true;
-        while (_batches.TryDequeue(out INodeStorage.IWriteBatch batch))
+        while (_batches.TryDequeue(out INodeStorage.IWriteBatch? batch))
         {
             batch.Dispose();
         }
@@ -37,7 +37,7 @@ public class ConcurrentNodeWriteBatcher(INodeStorage underlyingDb, long batchSiz
     private INodeStorage.IWriteBatch RentBatch()
     {
         if (_disposing) throw new InvalidOperationException("Trying to set while disposing");
-        if (!_batches.TryDequeue(out INodeStorage.IWriteBatch currentBatch))
+        if (!_batches.TryDequeue(out INodeStorage.IWriteBatch? currentBatch))
         {
             currentBatch = underlyingDb.StartWriteBatch();
         }


### PR DESCRIPTION
Brings `master` into `eip8141-frame-txs-devnet7`. `master` had moved 5 commits ahead since the last sync, so the branch was `dirty` and blocked #12526.

Master commits merged: #13099 (enable nullables in Evm/Trie/State), #13183 (precompile membership bitmask), #13167 (single-pass branch node encode), #9956 (background scheduler stats), #13192 (request-sizer ManualTimeProvider).

## Conflict resolution (6 files)

- **TxExecutionContext.cs** — kept master's nullable `byte[]?[]?` element type for `blobVersionedHashes` and kept the frame `FrameTxContext?` parameter.
- **CacheCodeInfoRepository.cs** — kept the frame `GetPrecompile` delegate and adopted master's `[NotNullWhen(true)]` on `TryGetDelegation`.
- **CodeInfoRepository.cs** — took master's index/bitmask precompile lookup; the frame branch's `_worldState.AddAccountRead`/`RecordAccountAccess` on the precompile path is untouched (it merged cleanly before the hunk).
- **OverridableEnvFactory.cs** — kept the frame conditional `TracedAccessWorldState` decorator (EIP-7906) and adopted master's `?? throw` form for the `IOverridableCodeInfoRepository` resolution.
- **BlobGasCalculatorTests.cs** — kept both sides' new tests (frame blob-gas tests plus master's `Blob_base_fee_requires_excess_blob_gas`).
- **TracedAccessWorldState.cs** — kept the frame idle-able recorder (early return with no slice, so the decorator can sit in a simulation stack); master's only change here was the nullable enablement, which the frame guards already satisfy.

## Build breaks fixed (surfaced by master's nullable enablement in frame-only code)

- **EvmInstructions.FrameTx.cs** — `blobHashes` local retyped to `byte[]?[]?` to match `TxExecutionContext.BlobVersionedHashes` (read only as `?.Length`).
- **EvmInstructions.TxAssertions.cs** — `PopAddress` result typed `Address?`; the existing null guard narrows it.
- **FrameTxSignatureValidator.cs** — `result.Data is { Length: > 0 }` instead of dereferencing a possibly-null `Data`.
- **TracedAccessWorldState.cs** — null-forgiving on the fail-fast control methods (`SetIndex`/`IncrementIndex`/`Clear`, which intentionally throw on a missing slice) and restructured `GetCodeHashCurrent` so `[NotNullWhen(true)]` narrows the code-change.
- **PrecompileCachedCodeInfoRepository.cs** — `GetPrecompile` referenced the constructor parameter rather than the `_baseCodeInfoRepository` field the rest of the class uses.

## Testing

Full solution builds clean in Release (0 errors, 0 warnings). `BlobGasCalculatorTests` 175/175. CI runs the rest.
