### PR TITLE
perf: walk the old branch RLP with a cursor instead of an RlpReader

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Nethermind.Serialization.Rlp.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Nethermind.Core.Test" />
+    <InternalsVisibleTo Include="Nethermind.Trie" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -559,72 +559,77 @@ namespace Nethermind.Trie
             /// <inheritdoc cref="WriteChildrenRlpBranch" />
             private static int WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
-                RlpReader rlpReader = item.RlpReader;
-                item.SeekChild(ref rlpReader, 0);
+                // Walking the old RLP with a plain cursor rather than an RlpReader: handing the reader
+                // to SeekChild by reference exposes its address, after which every read and write of
+                // its Position is a real 4-byte memory access, which the zkVM charges about eight
+                // times an aligned 8-byte read and eleven times an 8-byte write.
+                ReadOnlySpan<byte> source = item.FullRlp.AsSpan();
+                int cursor = RlpHelpers.GetPrefixLength(source[0]);
                 int position = 0;
                 // Unchanged children are consecutive bytes of the old RLP, so a run of them is one
                 // copy rather than one per child. Most branches change a single child, so this turns
-                // sixteen short copies into two.
+                // sixteen short copies into two. The run's length is how far the cursor has moved
+                // since it started, so it needs no separate accumulator.
                 int runStart = -1;
-                int runLength = 0;
                 Debug.Assert(item._nodeData is BranchData, "Data is not BranchData");
                 BranchData branchData = Unsafe.As<BranchData>(item._nodeData!);
-                for (int i = 0; i < BranchesCount; i++)
+                // Native-width index over the inline array: the loop counter gets a stack home here,
+                // and a 4-byte spill slot costs the zkVM about eight times an aligned 8-byte one.
+                ref object children = ref branchData[0];
+                for (nint i = 0; i < BranchesCount; i++)
                 {
-                    object data = branchData[i];
+                    object data = Unsafe.Add(ref children, i);
                     if (data is null)
                     {
-                        int length = rlpReader.PeekNextRlpLength();
-                        if (runStart < 0) runStart = rlpReader.Position;
-                        runLength += length;
-                        rlpReader.SkipBytes(length);
+                        if (runStart < 0) runStart = cursor;
+                        cursor += RlpHelpers.PeekNextRlpLength(source, cursor);
+                        continue;
+                    }
+
+                    if (runStart >= 0)
+                    {
+                        int runLength = cursor - runStart;
+                        source.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
+                        position += runLength;
+                        runStart = -1;
+                    }
+
+                    if (ReferenceEquals(data, _nullNode))
+                    {
+                        destination[position++] = 128;
+                    }
+                    else if (data is Hash256 hash)
+                    {
+                        position = Rlp.Encode(destination, position, hash);
                     }
                     else
                     {
-                        if (runStart >= 0)
-                        {
-                            rlpReader.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
-                            position += runLength;
-                            runStart = -1;
-                            runLength = 0;
-                        }
+                        path.AppendMut((int)i);
+                        Debug.Assert(data is TrieNode, "Data is not TrieNode");
+                        TrieNode childNode = Unsafe.As<TrieNode>(data);
+                        childNode!.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
+                        path.TruncateOne();
 
-                        if (ReferenceEquals(data, _nullNode) || data is null)
+                        hash = childNode.Keccak;
+                        if (hash is null)
                         {
-                            destination[position++] = 128;
-                        }
-                        else if (data is Hash256 hash)
-                        {
-                            position = Rlp.Encode(destination, position, hash);
+                            Span<byte> fullRlp = childNode.FullRlp.AsSpan();
+                            fullRlp.CopyTo(destination.Slice(position, fullRlp.Length));
+                            position += fullRlp.Length;
                         }
                         else
                         {
-                            path.AppendMut(i);
-                            Debug.Assert(data is TrieNode, "Data is not TrieNode");
-                            TrieNode childNode = Unsafe.As<TrieNode>(data);
-                            childNode!.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
-                            path.TruncateOne();
-
-                            hash = childNode.Keccak;
-                            if (hash is null)
-                            {
-                                Span<byte> fullRlp = childNode.FullRlp.AsSpan();
-                                fullRlp.CopyTo(destination.Slice(position, fullRlp.Length));
-                                position += fullRlp.Length;
-                            }
-                            else
-                            {
-                                position = Rlp.Encode(destination, position, hash);
-                            }
+                            position = Rlp.Encode(destination, position, hash);
                         }
-
-                        rlpReader.SkipItem();
                     }
+
+                    cursor += RlpHelpers.PeekNextRlpLength(source, cursor);
                 }
 
                 if (runStart >= 0)
                 {
-                    rlpReader.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
+                    int runLength = cursor - runStart;
+                    source.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
                     position += runLength;
                 }
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -1397,13 +1397,16 @@ namespace Nethermind.Trie
                 return;
             }
 
-            SeekChildNotNull(ref rlpReader, index);
+            rlpReader.Position = SeekChildPosition(rlpReader.Data, index);
         }
 
-        private void SeekChildNotNull(ref RlpReader rlpReader, int index)
+        /// <summary>Offset of child <paramref name="index"/> within this node's RLP.</summary>
+        /// <remarks>The walk keeps its cursor in a local rather than in the reader: a reader's Position
+        /// is a 4-byte field access, which the zkVM charges about eight times an aligned 8-byte read and
+        /// eleven times an 8-byte write.</remarks>
+        private int SeekChildPosition(ReadOnlySpan<byte> source, int index)
         {
-            rlpReader.Reset();
-            rlpReader.SkipLength();
+            int cursor = RlpHelpers.GetPrefixLength(source[0]);
             if (index == 0 && IsExtension)
             {
                 // Corner case, index is zero, but we are an extension
@@ -1411,7 +1414,12 @@ namespace Nethermind.Trie
                 index = 1;
             }
 
-            rlpReader.SkipItems(index);
+            for (int i = 0; i < index; i++)
+            {
+                cursor += RlpHelpers.PeekNextRlpLength(source, cursor);
+            }
+
+            return cursor;
         }
 
         private TrieNode CreateInlineChild(ReadOnlySpan<byte> fullRlp)
@@ -1441,8 +1449,8 @@ namespace Nethermind.Trie
                 {
                     // Allows to load children in parallel
                     RlpReader rlpReader = new(rlp);
-                    SeekChild(ref rlpReader, i);
-                    int prefix = rlpReader.ReadByte();
+                    rlpReader.Position = SeekChildPosition(rlp.AsSpan(), i);
+                    int prefix = rlpReader.PeekByte();
 
                     switch (prefix)
                     {
@@ -1454,7 +1462,6 @@ namespace Nethermind.Trie
                             }
                         case 160:
                             {
-                                rlpReader.Position--;
                                 Hash256 keccak = rlpReader.DecodeKeccak();
 
                                 TrieNode child = tree.FindCachedOrUnknown(childPath, keccak);
@@ -1464,7 +1471,6 @@ namespace Nethermind.Trie
                             }
                         default:
                             {
-                                rlpReader.Position--;
                                 ReadOnlySpan<byte> fullRlp = rlpReader.PeekNextItem();
                                 TrieNode child = CreateInlineChild(fullRlp);
                                 data = childOrRef = child;


### PR DESCRIPTION
## Changes

`RlpReader` has eight leaf fields (`Data` 2, `Memory _memory` 3, two bools, `Position`), past RyuJIT's four-field promotion limit, so a local one is never enregistered; passing it by `ref` to a non-inlined `SeekChild` also exposes its address. In `WriteChildrenRlpBranchRlp` that turned every `Position` touch into a real stack access — **530,260 reads and 275,604 writes**, which the zkVM prover charges 122 and 193 units against 16 and 18 for an aligned 8-byte access. That one function was **60% of the guest's entire 4-byte spill bill**.

- `WriteChildrenRlpBranchRlp` walks the old RLP with an `int cursor` over `item.FullRlp.AsSpan()` instead of a local `RlpReader`, and derives the run length as `cursor - runStart` rather than carrying an accumulator (two fewer loop-carried locals).
- Index the branch inline array through `ref object children = ref branchData[0]` + `Unsafe.Add` with a native-width counter — the `int` counter was getting its own 4-byte stack home, one `lw`+`sw` pair per child across 259,392 iterations.
- `SeekChildNotNull` folds into `SeekChildPosition(ReadOnlySpan<byte>, int)`, which returns the offset from a register-resident cursor; `SeekChild` becomes a single `Position` write, and `ResolveChildWithChildPath` uses `PeekByte()` instead of `ReadByte()` followed by `Position--`.
- Drop a `|| data is null` that cannot be reached.
- `InternalsVisibleTo("Nethermind.Trie")` on `Nethermind.Serialization.Rlp`, so the cursor walk can call `RlpHelpers.GetPrefixLength`/`PeekNextRlpLength`. This is the one surface-area cost; the alternative was making `RlpHelpers` public, which is worse.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Existing coverage is what this needs: the change is a rewrite of an encoder whose output is consensus-critical and already exercised. `Nethermind.Trie.Test` 537 passed / 0 failed / 12 skipped, `Nethermind.Core.Test` 6,096 passed / 0 failed / 108 skipped.

The strongest check is the guest run itself — it recomputes a mainnet block's state root over ~26k witness nodes, exercising branches, extensions and inline children, and the output hash is byte-identical to master on every build measured.

Not run: `Nethermind.Blockchain.Test`, `Ethereum.Trie.Test`.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

**Guest measurement.** Master `25a750d4e27` measures 453,942,688 steps / 50,606,977,989 prover cost on block 25532382; `ziskemu` is deterministic, so these are exact. Measured in three increments:

| bucket | master | +cursor | +ref index | +SeekChildPosition | Δ |
|---|---:|---:|---:|---:|---:|
| STEPS | 453,942,688 | 452,318,247 | 450,793,008 | 449,375,735 | **−1.006%** |
| OPCODES | 6,865,881,260 | 6,817,568,834 | 6,761,182,154 | 6,747,132,239 | −1.730% |
| PRECOMPILES | 8,001,263,166 | — | — | 8,001,263,166 | 0.000% |
| MEMORY | 4,584,420,955 | 4,500,732,235 | 4,415,161,964 | 4,362,428,050 | **−4.842%** |
| **TOTAL** | 50,606,977,989 | 50,364,514,855 | 50,118,841,652 | 49,955,683,259 | **−1.287%** |

Unaligned memory cost falls **−9.45%** and unaligned 4-byte access cost **−14.22%** (10,010,912 → 8,633,564 accesses). `OP signextend_w`, one per `lw`, is down by exactly 953,190 and `signextend_b` by 243,181, matching the removed loads instruction for instruction. `WriteChildrenRlpBranchRlp` itself goes 11,989,131 → 9,769,156 steps (−18.5%) and its spill cost 153,473,742 → 12,043,080; the guest's global spill cost goes 254,185,879 → 108,736,444.

**Host gate — no regression, measured on an idle machine.** `*RlpTrieNodeEncodingBenchmark*`, `--job short --inProcess`, base and branch interleaved over two rounds so base-to-base spread is visible in the same session:

| row | base 1 | base 2 | branch 1 | branch 2 | base→branch |
|---|---:|---:|---:|---:|---:|
| `Encode_Branch` | 100.12 ns | 122.71 ns | 92.71 ns | 110.26 ns | **−8.9%** |
| `Encode_Leaf` | 33.66 ns | 36.90 ns | 32.35 ns | 35.94 ns | −3.2% |
| `Encode_Extension` | 38.83 ns | 36.31 ns | 36.23 ns | 45.33 ns | +8.5% |

`Encode_Branch` is lower in both paired rounds (−7.4% and −10.1%), so the direction is consistent rather than an artifact of one ordering. `Encode_Extension` flips sign between rounds (−6.7% then +24.8%) and lands inside its own 25% branch-to-branch spread; extension encoding does not go through the rewritten code, so read that row as noise.

`*RlpDecodeBlockBenchmark*` over the same interleaving: the large scenario reads 41.0 µs base against 38.9 µs branch (−5%, consistent in both rounds and on both benchmark arms) and the small scenario is flat within its StdDev.

Two honest caveats on the gate. `--inProcess` is required here (BDN's out-of-process project search picks up multiple worktree copies and reports `NA` for every row) but it **overrides `--quick`'s ShortRun job**, so `--job short` has to be passed explicitly or BDN silently falls back to 100 iterations of 8.4M ops. And the `Allocated` column for `Encode_Branch` reads `-` on base against `128 B` on branch, consistently across rounds — but `Gen0` is essentially identical (0.0039 vs 0.0037), and a `-` with non-zero `Gen0` is self-contradictory. An earlier session measured base at `128 B` too. By inspection the change introduces no allocation (a struct local becomes an `int`; `AsSpan()` allocates nothing), so I read this as BDN's in-process allocation diagnoser rather than a real difference — but it is worth one out-of-process confirmation.

**Composition.** This is one of four independent guest changes measured this round, in mutually disjoint files. Together they compose to −4.504% cost / −4.430% steps (433,833,116 steps / 48,327,642,331), against an additive prediction of −4.529% — so they do not interfere.
