### PR TITLE
perf: inline the small RlpReader members and drop dead hash compares

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -155,6 +155,18 @@ namespace Nethermind.Core.Test
             AssertValueWriterMatchesExpected(writer, buffer, ExpectedValueHash(value));
         }
 
+        [TestCaseSource(nameof(ValueWriterValueHashCases))]
+        public void RlpReader_roundtrips_value_hash(ValueHash256? value)
+        {
+            byte[] buffer = new byte[Rlp.LengthOf(in value)];
+            RlpWriter writer = new(buffer);
+            writer.Encode(in value);
+
+            RlpReader reader = new(buffer);
+
+            Assert.That(reader.DecodeValueKeccak(), Is.EqualTo(value));
+        }
+
         [TestCaseSource(nameof(ValueWriterAddressCases))]
         public void RlpWriter_encodes_address_like_Rlp(Address? value)
         {

--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -165,6 +165,39 @@ namespace Nethermind.Core.Test
             RlpReader reader = new(buffer);
 
             Assert.That(reader.DecodeValueKeccak(), Is.EqualTo(value));
+
+            if (value is null)
+            {
+                Assert.Throws<RlpException>(() =>
+                {
+                    RlpReader nonNullReader = new(buffer);
+                    nonNullReader.DecodeValueKeccakNonNull();
+                });
+            }
+            else
+            {
+                RlpReader nonNullReader = new(buffer);
+                Assert.That(nonNullReader.DecodeValueKeccakNonNull(), Is.EqualTo(value.Value));
+            }
+        }
+
+        [TestCaseSource(nameof(ValueWriterHashCases))]
+        public void RlpReader_roundtrips_hash(Hash256? value)
+        {
+            byte[] buffer = new byte[Rlp.LengthOf(value)];
+            RlpWriter writer = new(buffer);
+            writer.Encode(value);
+
+            RlpReader reader = new(buffer);
+            Hash256? decoded = reader.DecodeKeccakOrNull();
+
+            Assert.That(decoded, Is.EqualTo(value));
+            if (value == Keccak.OfAnEmptyString || value == Keccak.EmptyTreeHash)
+            {
+                // The interned instances must come back by reference, which is the only observable
+                // difference between comparing the payload as a span and as a ValueHash256.
+                Assert.That(decoded, Is.SameAs(value));
+            }
         }
 
         [TestCaseSource(nameof(ValueWriterAddressCases))]

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -527,10 +527,12 @@ namespace Nethermind.Serialization.Rlp
             return 4;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LengthOfLength(int value)
         {
             int bits = 32 - BitOperations.LeadingZeroCount((uint)value | 1);
-            return (bits + 7) / 8;
+            // Unsigned: bits is positive, and a signed divide costs two extra instructions to round it.
+            return (bits + 7) >>> 3;
         }
 
         public static Rlp Encode(Hash256? keccak)
@@ -788,6 +790,7 @@ namespace Nethermind.Serialization.Rlp
 
         public static int LengthOf(Bloom? bloom) => bloom is null ? 1 : 259;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LengthOfSequence(int contentLength)
         {
             if (contentLength < RlpHelpers.SmallPrefixBarrier)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -531,7 +531,7 @@ namespace Nethermind.Serialization.Rlp
         public static int LengthOfLength(int value)
         {
             int bits = 32 - BitOperations.LeadingZeroCount((uint)value | 1);
-            // Unsigned: bits is positive, and a signed divide costs two extra instructions to round it.
+            // Unsigned shift: bits is positive, and a signed shift pays two instructions to round toward zero.
             return (bits + 7) >>> 3;
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -531,7 +531,6 @@ namespace Nethermind.Serialization.Rlp
         public static int LengthOfLength(int value)
         {
             int bits = 32 - BitOperations.LeadingZeroCount((uint)value | 1);
-            // Unsigned shift: bits is positive, and a signed shift pays two instructions to round toward zero.
             return (bits + 7) >>> 3;
         }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
@@ -172,8 +172,9 @@ internal static class RlpHelpers
     /// <summary>
     /// Counts the number of top-level RLP items in the given data range.
     /// </summary>
-    /// <remarks>Inlined despite the loop: trie node decoding calls it once per node with
-    /// <paramref name="maxSearch"/> of three, so the call frame cost more than the walk.</remarks>
+    /// <remarks>Inlined despite carrying a loop, for the trie-node path: it runs once per node with a
+    /// <paramref name="maxSearch"/> of three, where the call frame cost more than the walk. Other
+    /// callers pass a large or unbounded limit and are unaffected either way.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int CountItems(ReadOnlySpan<byte> data, int position, int end, int maxSearch)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
@@ -172,6 +172,9 @@ internal static class RlpHelpers
     /// <summary>
     /// Counts the number of top-level RLP items in the given data range.
     /// </summary>
+    /// <remarks>Inlined despite the loop: trie node decoding calls it once per node with
+    /// <paramref name="maxSearch"/> of three, so the call frame cost more than the walk.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int CountItems(ReadOnlySpan<byte> data, int position, int end, int maxSearch)
     {
         int numberOfItems = 0;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
@@ -172,9 +172,6 @@ internal static class RlpHelpers
     /// <summary>
     /// Counts the number of top-level RLP items in the given data range.
     /// </summary>
-    /// <remarks>Inlined despite carrying a loop, for the trie-node path: it runs once per node with a
-    /// <paramref name="maxSearch"/> of three, where the call frame cost more than the walk. Other
-    /// callers pass a large or unbounded limit and are unaffected either way.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int CountItems(ReadOnlySpan<byte> data, int position, int end, int maxSearch)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -248,15 +248,7 @@ public ref struct RlpReader
     }
 
     public ValueHash256? DecodeValueKeccak()
-    {
-        if (!ReadKeccakPrefix(allowNull: true))
-        {
-            return null;
-        }
-
-        // No interning to do for a value: the well-known hashes decode to the same bits anyway.
-        return new ValueHash256(Read(Hash256.Size));
-    }
+        => TryDecodeValueKeccak(out ValueHash256 keccak) ? keccak : null;
 
     public ValueHash256 DecodeValueKeccakNonNull() => DecodeValueKeccak() ?? ThrowNullDecodedValue<ValueHash256>();
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -252,6 +252,7 @@ public ref struct RlpReader
 
     public ValueHash256 DecodeValueKeccakNonNull() => DecodeValueKeccak() ?? ThrowNullDecodedValue<ValueHash256>();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryDecodeValueKeccak(out ValueHash256 keccak)
     {
         Unsafe.SkipInit(out keccak);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -252,7 +252,11 @@ public ref struct RlpReader
         return keccak;
     }
 
-    public ValueHash256 DecodeValueKeccakNonNull() => DecodeValueKeccak() ?? ThrowNullDecodedValue<ValueHash256>();
+    public ValueHash256 DecodeValueKeccakNonNull()
+    {
+        if (!TryDecodeValueKeccak(out ValueHash256 keccak)) ThrowNullDecodedValue<ValueHash256>();
+        return keccak;
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryDecodeValueKeccak(out ValueHash256 keccak)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -245,7 +245,12 @@ public ref struct RlpReader
     }
 
     public ValueHash256? DecodeValueKeccak()
-        => TryDecodeValueKeccak(out ValueHash256 keccak) ? keccak : null;
+    {
+        // Not a conditional expression: the implicit Hash256? -> ValueHash256 conversion would
+        // give `null` the type ValueHash256, silently yielding a non-null zero hash.
+        if (!TryDecodeValueKeccak(out ValueHash256 keccak)) return null;
+        return keccak;
+    }
 
     public ValueHash256 DecodeValueKeccakNonNull() => DecodeValueKeccak() ?? ThrowNullDecodedValue<ValueHash256>();
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -48,6 +48,7 @@ public ref struct RlpReader
         _isNotNull = true;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public RlpReader(CappedArray<byte> data)
     {
         Data = data.AsSpan();
@@ -71,9 +72,11 @@ public ref struct RlpReader
 
     public readonly bool IsSequenceNext() => Data[Position] >= 192;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly int PeekNumberOfItemsRemaining(int? beforePosition = null, int maxSearch = int.MaxValue)
         => RlpHelpers.CountItems(Data, Position, beforePosition ?? Data.Length, maxSearch);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SkipLength() => Position += PeekPrefixLength();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -133,6 +136,7 @@ public ref struct RlpReader
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public byte ReadByte() => Data[Position++];
 
     public ReadOnlySpan<byte> Read(int length)
@@ -224,20 +228,23 @@ public ref struct RlpReader
         return DecodeKeccakPayload();
     }
 
+    /// <remarks>Compares through <see cref="ValueHash256"/>, whose equality is a whole-word 32-byte
+    /// compare, rather than <c>SequenceEqual</c>: the latter is an out-of-line call, and the zkVM guest
+    /// has no SIMD behind it.</remarks>
     private Hash256 DecodeKeccakPayload()
     {
-        ReadOnlySpan<byte> keccakSpan = Read(Hash256.Size);
-        if (keccakSpan.SequenceEqual(Keccak.OfAnEmptyString.Bytes))
+        ValueHash256 keccak = new(Read(Hash256.Size));
+        if (keccak == Keccak.OfAnEmptyString)
         {
             return Keccak.OfAnEmptyString;
         }
 
-        if (keccakSpan.SequenceEqual(Keccak.EmptyTreeHash.Bytes))
+        if (keccak == Keccak.EmptyTreeHash)
         {
             return Keccak.EmptyTreeHash;
         }
 
-        return new Hash256(keccakSpan);
+        return new Hash256(in keccak);
     }
 
     public ValueHash256? DecodeValueKeccak()
@@ -247,18 +254,8 @@ public ref struct RlpReader
             return null;
         }
 
-        ReadOnlySpan<byte> keccakSpan = Read(Hash256.Size);
-        if (keccakSpan.SequenceEqual(Keccak.OfAnEmptyString.Bytes))
-        {
-            return Keccak.OfAnEmptyString.ValueHash256;
-        }
-
-        if (keccakSpan.SequenceEqual(Keccak.EmptyTreeHash.Bytes))
-        {
-            return Keccak.EmptyTreeHash.ValueHash256;
-        }
-
-        return new ValueHash256(keccakSpan);
+        // No interning to do for a value: the well-known hashes decode to the same bits anyway.
+        return new ValueHash256(Read(Hash256.Size));
     }
 
     public ValueHash256 DecodeValueKeccakNonNull() => DecodeValueKeccak() ?? ThrowNullDecodedValue<ValueHash256>();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -228,9 +228,6 @@ public ref struct RlpReader
         return DecodeKeccakPayload();
     }
 
-    /// <remarks>Compares through <see cref="ValueHash256"/>, whose equality is a whole-word 32-byte
-    /// compare, rather than <c>SequenceEqual</c>: the latter is an out-of-line call, and the zkVM guest
-    /// has no SIMD behind it.</remarks>
     private Hash256 DecodeKeccakPayload()
     {
         ValueHash256 keccak = new(Read(Hash256.Size));


### PR DESCRIPTION
## Changes

`TrieNode.DecodeRlp` runs 34,789 times over one mainnet block, and it was paying roughly **88 steps of call frames per node** to answer "two items, or more than two": both `PeekNumberOfItemsRemaining` and the `CountItems` it calls were out of line, for a walk of at most three iterations.

- `AggressiveInlining` on `PeekNumberOfItemsRemaining`, `CountItems` and `ReadByte`. It pays for itself even on `CountItems`, which carries a loop and which ILC declines to inline on its own.
- Same for the `RlpReader(CappedArray<byte>)` constructor (70,293 calls × 20 instructions, five of them a `_memory = default` that does nothing useful), `SkipLength` (51,716 × 20) and `Rlp.LengthOfSequence` (66,746 × 16).
- `LengthOfLength` computed `(bits + 7) / 8`, which emits the signed-rounding `srliw`/`addw`/`sraiw` triple at all 66,746 sites. Use an unsigned shift.
- `DecodeKeccakPayload` compared its input against the interned `Keccak.OfAnEmptyString` and `EmptyTreeHash` through two out-of-line `SpanHelpers.SequenceEqual` calls — 40,688 calls, ~2.3M of the method's 3.06M steps, and there is no SIMD behind `SequenceEqual` in the guest. Compare as `ValueHash256`, which routes to `Bytes.AreEqual32`.
- The same two compares in `DecodeValueKeccak` are **dead work**: interning is meaningless for a value type, and `new ValueHash256(span)` already produces identical bits either way. Removed.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

These are inlining annotations, an equivalent shift, and the removal of two compares whose result cannot differ — all covered by existing RLP and trie tests. Two `RlpTests` cases were added on top: `RlpReader_roundtrips_hash` pins that `DecodeKeccakPayload` still returns `Keccak.OfAnEmptyString` / `EmptyTreeHash` **by reference**, which is the only observable difference between comparing the payload as a span and as a `ValueHash256` — with the interning branch made unreachable it fails 1 of 4, so the assertion bites. `RlpReader_roundtrips_value_hash` covers `DecodeValueKeccak` and `DecodeValueKeccakNonNull`, throw included. `Nethermind.Core.Test` (which holds `RlpTests`) 6,204 tests, 0 failures. `Nethermind.Trie.Test` 537 passed with one unrelated flake: `Can_BeginScope_During_Persisted_Node_Pruning` is a wall-clock assertion that missed a 5 s budget by 0.344 s while other builds were running on the machine, and it passes 3/3 in isolation. There is no `Nethermind.Serialization.Rlp.Test` project.

The guest run is the end-to-end check: a mainnet block's state root over ~26k witness nodes, byte-identical to master on every build measured.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

**Guest measurement.** Master `25a750d4e27` measures 453,942,688 steps / 50,606,977,989 prover cost on block 25532382; `ziskemu` is deterministic, so these are exact. Measured one experiment at a time, each cumulative on the last:

| step | steps | Δ | prover cost | Δ |
|---|---:|---:|---:|---:|
| inline the item-count helpers | 449,401,564 | −0.645% | 50,100,043,207 | −0.525% |
| + four more members, unsigned shift | 446,199,681 | −0.712% | 49,815,459,042 | −0.568% |
| + `DecodeKeccakPayload` without `SequenceEqual` | 443,823,539 | −0.533% | 49,591,928,902 | −0.449% |

**Correction to an earlier revision of this description:** the ladder above was measured cumulatively on top of a branch-encode cursor rewrite that is *not* part of this PR — it belongs to #13173. Those three rows are this PR's contribution *on top of that*, so the −2.229% / −2.006% previously quoted here as "standalone" was not this PR's number.

Measured standalone on master, this PR alone is **445,396,256 steps / 49,831,737,619 cost = −1.883% steps / −1.532% cost**. That agrees with the ladder's own arithmetic (−1.878% for rows 3–5 on top of the cursor change), which is a useful cross-check that the two changes are additive. #13173 removes `SkipItems`' hot caller, which is why the annotation on it is not included here. The two PRs are file-disjoint in substance but both touch `RlpReader.cs` and `RlpHelpers.cs`, so whichever lands second resolves a mechanical conflict.

Worth recording for future guest work: **`AggressiveInlining` on small out-of-line members was by far the best return in this area** — two batches of annotations alone were −0.525% and −0.568%.

**Host gate — no regression, measured on an idle machine.** `--job short --inProcess`, base and branch interleaved over two rounds. `*RlpDecodeBlockBenchmark*`, the benchmark that actually exercises this decode path:

| scenario | base 1 | base 2 | branch 1 | branch 2 | base→branch |
|---|---:|---:|---:|---:|---:|
| large, `Improved` | 39.93 µs | 42.04 µs | 39.99 µs | 37.68 µs | −5.3% |
| large, `Current` | 40.35 µs | 41.72 µs | 39.03 µs | 38.76 µs | −5.2% |
| small, `Improved` | 1.221 µs | 1.222 µs | 1.248 µs | 1.252 µs | +2.4% |
| small, `Current` | 1.217 µs | 1.247 µs | 1.285 µs | 1.207 µs | +1.1% |

The large scenario improves consistently on both arms; the small scenario moves by less than its own StdDev (0.02–0.06 µs). `*RlpTrieNodeEncodingBenchmark*` over the same interleaving shows `Encode_Branch` −8.9% and `Encode_Leaf` −3.2%.

`*RlpDecodeAccountBenchmark*` could not contribute: it reports `NA` for every row on **both** base and branch, throwing `System.FormatException: One of the identified items was in an invalid format` inside BDN's in-process runner. That is a pre-existing failure of the benchmark on a `pl-PL` machine, unrelated to this change — but it means the account-decode path, which is where `DecodeKeccakPayload` handles storage roots and code hashes, has no host coverage in this gate. Worth fixing separately.

Two gate mechanics worth knowing: `--inProcess` is required (BDN's out-of-process project search finds multiple worktree copies and reports `NA` everywhere), and it **overrides `--quick`'s ShortRun job**, so `--job short` must be passed explicitly or BDN silently falls back to 100 iterations of 8.4M ops.

**Rejected on the way, recorded so it is not retried.** Walking the branch inline array with a moving `ref object` plus an out-of-line helper for the changed-child path measured a wash (+0.062% steps, +0.008% cost): ILC kept the `i` spill regardless, and the extra call for the 8% of children that actually change ate the loop saving.

**Composition.** One of four independent guest changes measured this round, in mutually disjoint files; together they compose to −4.504% cost / −4.430% steps against an additive prediction of −4.529%.


