### PR TITLE
test(eip8141): validate frame signatures in the transaction-test harness

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
+++ b/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
@@ -26,10 +26,10 @@ namespace Ethereum.Test.Base;
 /// themselves.
 /// </para>
 /// <para>
-/// <c>BlockchainTestBase</c> maps all three labels. <c>TransactionTestBase</c> maps only
-/// <c>TYPE_6_INVALID_FRAME_FORMAT</c>, from <see cref="Format"/> and <see cref="Decode"/>: it stops at
-/// <c>TxValidator.IsWellFormed</c>, which runs neither the signature validator nor the transaction
-/// processor, so no <see cref="Signature"/> or <see cref="Execution"/> message can reach it.
+/// <c>BlockchainTestBase</c> maps all three labels. <c>TransactionTestBase</c> maps
+/// <c>TYPE_6_INVALID_FRAME_FORMAT</c> and <c>TYPE_6_INVALID_SIGNATURE</c>, from <see cref="Format"/>,
+/// <see cref="Decode"/> and <see cref="Signature"/>: it models raw-transaction admission, which runs the
+/// signature validator but not the transaction processor, so no <see cref="Execution"/> message reaches it.
 /// </para>
 /// </remarks>
 public static class FrameExceptionFragments

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -6,6 +6,9 @@ using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Crypto;
+using Nethermind.Evm.Precompiles;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 
@@ -14,6 +17,7 @@ namespace Ethereum.Test.Base;
 public abstract class TransactionTestBase
 {
     private static readonly TxValidator s_mainnetTxValidator = new(MainnetSpecProvider.Instance.ChainId);
+    private static readonly EthereumEcdsa s_mainnetEcdsa = new(MainnetSpecProvider.Instance.ChainId);
 
     protected static Result RunTest(TransactionTest test)
     {
@@ -37,7 +41,7 @@ public abstract class TransactionTestBase
         }
 
         bool decoded = TryDecode(test.TxBytes, out Transaction? tx, out string? decodeError);
-        string? observedError = decoded ? s_mainnetTxValidator.IsWellFormed(tx!, spec).Error : decodeError;
+        string? observedError = decoded ? ValidateRawTransaction(tx!, spec) : decodeError;
 
         bool expectFailure = !string.IsNullOrEmpty(test.ExpectedException);
         if (expectFailure)
@@ -57,6 +61,33 @@ public abstract class TransactionTestBase
         }
 
         return Result.Success;
+    }
+
+    /// <summary>Runs the stateless validation a client applies to a raw transaction before pooling it.</summary>
+    /// <remarks>
+    /// <para>
+    /// EIP-8141 §Signature Validation is stateless but does not live in <see cref="TxValidator"/>: a frame
+    /// transaction carries no envelope signature, so the pool runs <c>validate_signature</c> in its own
+    /// incoming filter and the processor repeats it before any frame executes. Both are outside
+    /// <see cref="TxValidator.IsWellFormed"/>, so a harness that stops there accepts every transaction whose
+    /// only defect is a frame signature. Composing the two here mirrors the pool's own admission order.
+    /// </para>
+    /// <para>
+    /// The precompile is resolved exactly as the pool filter resolves it, so a chain reaching P256VERIFY
+    /// through RIP-7212 rather than EIP-7951 is not refused a signature the processor would verify.
+    /// </para>
+    /// </remarks>
+    private static string? ValidateRawTransaction(Transaction tx, IReleaseSpec spec)
+    {
+        string? error = s_mainnetTxValidator.IsWellFormed(tx, spec).Error;
+        if (error is not null || !tx.SupportsFrames) return error;
+
+        IPrecompile? p256Precompile = spec.IsPrecompile(FrameTxSignatureValidator.P256VerifyPrecompileAddress)
+            ? SecP256r1Precompile.Instance
+            : null;
+        return FrameTxSignatureValidator.Validate(tx, s_mainnetEcdsa, p256Precompile, spec, out string? signatureError)
+            ? null
+            : signatureError;
     }
 
     private static bool TryDecode(string txBytesHex, out Transaction? tx, out string? error)
@@ -171,6 +202,7 @@ public abstract class TransactionTestBase
         // Not s_rlpDecodeFragments: its "Invalid signature" fragment also matches the frame
         // signature failures, which the fixtures file under a separate label.
         ["TransactionException.TYPE_6_INVALID_FRAME_FORMAT"] = [.. FrameExceptionFragments.Format, .. FrameExceptionFragments.Decode],
+        ["TransactionException.TYPE_6_INVALID_SIGNATURE"] = [.. FrameExceptionFragments.Signature],
         // EIP-7825's per-transaction gas cap under both wordings: a frame transaction reports it
         // against its own budget, every other type against its envelope gas limit.
         ["TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM"] = ["exceeds the transaction gas cap of", "TxGasLimitCapExceeded"],

--- a/src/Nethermind/Ethereum.Transaction.Test/FrameTxSignatureTransactionTestTests.cs
+++ b/src/Nethermind/Ethereum.Transaction.Test/FrameTxSignatureTransactionTestTests.cs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Ethereum.Test.Base;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Specs;
+using NUnit.Framework;
+
+namespace Ethereum.Transaction.Test;
+
+/// <summary>
+/// Guards that the <c>transaction_tests</c> harness applies EIP-8141 <c>validate_signature</c>.
+/// </summary>
+/// <remarks>
+/// The rule is stateless but sits outside <c>TxValidator</c>, so a harness stopping there accepts every
+/// frame transaction whose only defect is a signature — silently passing the reject-shaped fixtures. Each
+/// case perturbs only the signature entry of one otherwise valid transaction, so the control below fails
+/// with them if the shared payload stops validating for an unrelated reason.
+/// </remarks>
+public class FrameTxSignatureTransactionTestTests : TransactionTestBase
+{
+    private const string Fork = "Eip8141Prototype";
+    private static readonly Ecdsa s_ecdsa = new();
+
+    [Test]
+    public void ValidFrameSignatureIsAccepted()
+    {
+        Result result = RunTest(TestFor(SignedFrameTx(), expectedException: null));
+
+        Assert.That((bool)result, Is.True, result.Error);
+    }
+
+    [Test]
+    public void HighSFrameSignatureIsRejectedAsInvalidSignature()
+    {
+        // EIP-2 low-s: the malleable complement of an otherwise verifying signature.
+        Nethermind.Core.Transaction tx = SignedFrameTx();
+        byte[] raw = tx.FrameSignatures![0].Signature.ToArray();
+        UInt256 s = new(raw.AsSpan(33, 32), isBigEndian: true);
+        (SecP256k1Curve.N - s).ToBigEndian(raw.AsSpan(33, 32));
+        tx.FrameSignatures = [WithSignature(tx.FrameSignatures[0], raw)];
+
+        Result result = RunTest(TestFor(tx, "TransactionException.TYPE_6_INVALID_SIGNATURE"));
+
+        Assert.That((bool)result, Is.True, result.Error);
+    }
+
+    [Test]
+    public void FrameSignatureFromAnotherKeyIsRejectedAsInvalidFrameFormat()
+    {
+        // The fixtures file a signer that does not match the recovered address as a format failure.
+        Nethermind.Core.Transaction tx = SignedFrameTx(signer: TestItem.PrivateKeyC.Address);
+
+        Result result = RunTest(TestFor(tx, "TransactionException.TYPE_6_INVALID_FRAME_FORMAT"));
+
+        Assert.That((bool)result, Is.True, result.Error);
+    }
+
+    /// <summary>A frame transaction that <c>TxValidator</c> accepts, signed over its canonical sig hash.</summary>
+    private static Nethermind.Core.Transaction SignedFrameTx(Address signer = null)
+    {
+        Nethermind.Core.Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = MainnetSpecProvider.Instance.ChainId,
+            Nonce = 0,
+            SenderAddress = TestItem.PrivateKeyB.Address,
+            Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, null, 100_000, default, default)],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 100,
+        };
+
+        // compute_sig_hash covers the entry's metadata and elides only its raw bytes, so the placeholder
+        // entry must be installed before hashing.
+        TxFrameSignature entry = new(TxFrameSignature.SchemeSecp256k1, signer, default, default);
+        tx.FrameSignatures = [entry];
+        Signature signature = s_ecdsa.Sign(TestItem.PrivateKeyB, FrameTxSigHash.ComputeValue(tx));
+
+        byte[] raw = new byte[TxFrameSignature.Secp256k1SignatureLength];
+        raw[0] = signature.RecoveryId; // strict yParity encoding (0/1)
+        signature.Bytes.CopyTo(raw.AsSpan(1));
+        tx.FrameSignatures = [WithSignature(entry, raw)];
+        return tx;
+    }
+
+    private static TxFrameSignature WithSignature(TxFrameSignature entry, byte[] raw) =>
+        new(entry.Scheme, entry.Signer, entry.Msg, raw);
+
+    private static TransactionTest TestFor(Nethermind.Core.Transaction tx, string expectedException) =>
+        new()
+        {
+            Name = TestContext.CurrentContext.Test.Name,
+            Fork = Fork,
+            TxBytes = Rlp.Encode(tx, RlpBehaviors.SkipTypedWrapping).Bytes.ToHexString(true),
+            ExpectedException = expectedException,
+        };
+}


### PR DESCRIPTION
## Changes

The frames fixture archive ships 78 `transaction_tests` cases that no lane has run. 24 fail; 20 of them are `signature_constraints_transaction.json` cases the harness **accepts** and the fixture requires **rejected**.

The suspicion was that we defer frame signature verification to execution and so legitimately accept them. That is not what is happening.

- EIP-8141 `validate_signature` is stateless. The reference implementation runs it inside `validate_frame_transaction` — the frame-transaction analogue of `validate_transaction` — alongside the blob-count, frame-count and frame-constraint checks. So a transaction test may legitimately assert all 20.
- We already enforce it in both places that matter: `FrameTxSignatureFilter` rejects on pool entry, and the processor runs `FrameTxSignatureValidator.Validate` before any frame executes, returning `MalformedTransaction` and so invalidating the block.
- It is only absent from `TxValidator`, because a frame transaction has no envelope signature — and `TxValidator.IsWellFormed` is all the transaction-test harness ran.

So the gap is in the harness, not in the client. `TransactionTestBase` now composes the two the way pool admission does, and maps `TYPE_6_INVALID_SIGNATURE`.

**No consensus change.** Nothing under `src/Nethermind/Nethermind.*` is touched — `Ethereum.Test.Base` has no production dependents. The blockchain-test forms of all 32 signature cases already pass unmodified, which is what makes this a harness fix rather than a client fix.

## Types of changes

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Optimization
- [x] Refactoring

## Testing

New `FrameTxSignatureTransactionTestTests` drives the harness over one frame transaction perturbed only in its signature entry:

| | with the fix | mechanism reverted |
|---|---|---|
| `ValidFrameSignatureIsAccepted` (control) | pass | pass |
| `HighSFrameSignatureIsRejectedAsInvalidSignature` | pass | **fail** |
| `FrameSignatureFromAnotherKeyIsRejectedAsInvalidFrameFormat` | pass | **fail** |

`Ethereum.Transaction.Test` 23/23 with the fix, 21/23 with only the `ValidateRawTransaction` call reverted (the mapping left in place, so the perturbation isolates the mechanism).

Executed counts:

- frame `transaction_tests`: **74/78** (was 54/78). All 20 accept-vs-reject cases now pass, each rejected with a message matching its own label — no case is absorbed by a broad fragment.
- frame `blockTest` **218/218**, `engineTest` **218/218** (`--forkAlias Bogota=Eip8141Prototype`) — unmoved.
- Release / Debug, 0 failed in every run: `Nethermind.Evm.Test` 6368 / 6366, `Nethermind.Core.Test` 6376 / 6377, `Nethermind.TxPool.Test` 1116 / 1116.
- `Nethermind.Blockchain.Test` (Release) 2012, 0 failed.
- Full Release build: 0 Error(s).

### Still red, and not this PR

The remaining 4 are exception-name mapping gaps — the client rejects for the right reason under a name the table does not carry: `TYPE_3_TX_BLOB_COUNT_EXCEEDED`, `GASPRICE_OVERFLOW`, `PRIORITY_OVERFLOW`, `PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS`. Separate cause, separate PR.

### Note on overlap

This edits the same line of `TransactionTestBase.cs` as the in-flight transaction-test lane work. Whichever lands second should keep both the `ValidateRawTransaction` composition and the mapping-table additions.

## Documentation

Requires documentation update: no
Requires explanation in Release Notes: no
