### PR TITLE
chore(db): demote RocksDbMem log from info to debug

### DIFF
--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -177,7 +177,7 @@ public partial class DbMetricsUpdater<T>(string dbName, Options<T> dbOptions, Ro
 
     private void LogMemoryProfile()
     {
-        if (!logger.IsInfo) return;
+        if (!logger.IsDebug) return;
 
         long Prop(string name)
         {
@@ -210,7 +210,7 @@ public partial class DbMetricsUpdater<T>(string dbName, Options<T> dbOptions, Ro
             ? $"block_cache={Mb(blockCache)}(shared)"
             : $"block_cache={Mb(blockCache)}(pinned {Mb(blockCachePinned)})";
 
-        logger.Info($"[RocksDbMem] {dbName}: table_readers={Mb(tableReaders)} memtables={Mb(memtables)} " +
+        logger.Debug($"[RocksDbMem] {dbName}: table_readers={Mb(tableReaders)} memtables={Mb(memtables)} " +
                     $"{blockCacheField} " +
                     $"live_sst={Gb(liveSst)} sst_files={liveFiles} keys={(numKeys < 0 ? "n/a" : numKeys.ToString())}");
     }


### PR DESCRIPTION
## Changes

- Demote the `[RocksDbMem]` memory-profile log emitted by `DbMetricsUpdater.LogMemoryProfile()` from `Info` to `Debug`.

Enabling the DB metrics updater (for scraping RocksDB metrics) previously forced an `Info`-level `[RocksDbMem]` line per database and column family on every stats dump period, with no way to get the metrics without the log spam. The message is now only emitted when debug logging is enabled; the `Warn`/`Error` logs and the metrics themselves are unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [ ] No

#### Notes on testing

`Nethermind.Db.Test` full suite passes in release (621 passed, 0 failed, 544 skipped).

## Documentation

#### Requires documentation update

- [ ] No

#### Requires explanation in Release Notes

- [ ] No
