### PR TITLE
test(eip8141): map the frame truncation wording to the format label

### DIFF
--- a/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
+++ b/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
@@ -18,8 +18,8 @@ namespace Ethereum.Test.Base;
 /// referenced rather than copied wherever one exists.
 /// </para>
 /// <para>
-/// <see cref="Decode"/> is deliberately outside that invariant. Its fragments are generic RLP-decoder text
-/// carrying no frame context, so they also match decode failures from unrelated payloads. That only widens
+/// <see cref="Decode"/> is deliberately outside that invariant. Most of its fragments are generic RLP-decoder
+/// text carrying no frame context, so they also match decode failures from unrelated payloads. That only widens
 /// what satisfies <c>TYPE_6_INVALID_FRAME_FORMAT</c> — the exception table is additive and a fixture passes
 /// when its expected label is among those matched, so a broad fragment can mask a rejection for the wrong
 /// reason but can never turn a passing lane red. Narrowing it needs frame context in the decoder messages
@@ -124,6 +124,9 @@ public static class FrameExceptionFragments
         // sequence and is not. The latter is trimmed of the byte range it goes on to name.
         "Unexpected RLP prefix",
         "Expected a sequence prefix",
+        // An overlong declared payload length runs the trailing recent-root-reference list off the end
+        // of the buffer. Frame context, so this does not widen the label to unrelated truncations.
+        "frame transaction recent root reference list is incomplete",
         // Kept in step with FeeOverflow by DecodeCarriesEveryFeeOverflowWording, rather than spread
         // from it: a static initialiser reading a field declared below it silently reads null.
         "Collection count",

--- a/src/Nethermind/Ethereum.Transaction.Test/FrameExceptionFragmentsTests.cs
+++ b/src/Nethermind/Ethereum.Transaction.Test/FrameExceptionFragmentsTests.cs
@@ -80,21 +80,17 @@ public class FrameExceptionFragmentsTests
         Assert.That(Covers(FrameExceptionFragments.Decode, message), Is.True, message);
     }
 
-    // Every overrun that keeps the short-form sequence prefix (0xc0 + 55 at most), so the inflated
-    // byte still declares a length rather than a length of length.
-    [TestCase(1)]
-    [TestCase(2)]
-    [TestCase(3)]
-    [TestCase(4)]
-    public void Decode_CoversAPayloadLengthThatOverrunsTheBuffer(int overrun)
+    [Test]
+    public void Decode_CoversAPayloadLengthThatOverrunsTheBuffer()
     {
-        // A frame transaction has no envelope signature, so an overlong declared length leaves the
-        // end-of-payload checkpoint past the last field and the trailing reference list reads off the end.
+        // A frame transaction has no envelope signature, so an overlong declared length leaves the end-of-payload
+        // checkpoint past the last field; every overrun then fails at the same peek, so one case says it all.
         byte[] payload = EncodePayload(
             frames: Rlp.Encode(Array.Empty<Rlp>()),
             maxPriorityFeePerGas: Rlp.Encode(0L));
-        Assert.That(payload[1] + overrun, Is.LessThanOrEqualTo(ShortSequencePrefixMax));
-        payload[1] += (byte)overrun;
+        Assert.That(payload[1] + 1, Is.LessThanOrEqualTo(ShortSequencePrefixMax),
+            "the overrun must keep the short-form prefix, or it declares a length of length instead");
+        payload[1]++;
 
         string message = DecodeFailureMessage(payload);
 

--- a/src/Nethermind/Ethereum.Transaction.Test/FrameExceptionFragmentsTests.cs
+++ b/src/Nethermind/Ethereum.Transaction.Test/FrameExceptionFragmentsTests.cs
@@ -15,13 +15,16 @@ namespace Ethereum.Transaction.Test;
 /// Guards the client wordings behind each frame-transaction fixture label.
 /// </summary>
 /// <remarks>
-/// The two <c>DecodeFailureMessage</c> tests drive the real decoder, so they fail if its wording moves
+/// The <c>DecodeFailureMessage</c> tests drive the real decoder, so they fail if its wording moves
 /// away from the table. The rest assert the table against literals and cannot: a processor reword
 /// leaves both the case and the fragment green while the mapping goes dead. Reaching the processor
 /// wordings the same way needs constants behind them, which this fixture cannot add on its own.
 /// </remarks>
 public class FrameExceptionFragmentsTests
 {
+    /// <summary>The largest RLP sequence prefix still carrying its content length inline (0xc0 + 55).</summary>
+    private const int ShortSequencePrefixMax = 0xf7;
+
     private static bool Covers(IEnumerable<string> fragments, string message)
     {
         foreach (string fragment in fragments)
@@ -32,8 +35,8 @@ public class FrameExceptionFragmentsTests
         return false;
     }
 
-    /// <summary>Encodes a frame transaction payload, defective only in the field the caller varies.</summary>
-    private static string DecodeFailureMessage(Rlp frames, Rlp maxPriorityFeePerGas)
+    /// <summary>Encodes a frame transaction payload, varying only the fields the caller supplies.</summary>
+    private static byte[] EncodePayload(Rlp frames, Rlp maxPriorityFeePerGas)
     {
         Rlp payloadSequence = Rlp.Encode(
             Rlp.Encode(1L),                      // chain_id
@@ -47,7 +50,14 @@ public class FrameExceptionFragmentsTests
         byte[] payload = new byte[1 + payloadSequence.Length];
         payload[0] = (byte)TxType.FrameTx;
         payloadSequence.Bytes.CopyTo(payload, 1);
+        return payload;
+    }
 
+    private static string DecodeFailureMessage(Rlp frames, Rlp maxPriorityFeePerGas) =>
+        DecodeFailureMessage(EncodePayload(frames, maxPriorityFeePerGas));
+
+    private static string DecodeFailureMessage(byte[] payload)
+    {
         // Catch, not Throws: the length guard raises the RlpLimitException subclass.
         RlpException thrown = Assert.Catch<RlpException>(() =>
         {
@@ -67,6 +77,28 @@ public class FrameExceptionFragmentsTests
             maxPriorityFeePerGas: Rlp.Encode(0L));
 
         Assert.That(message, Does.Contain("Expected a sequence prefix"));
+        Assert.That(Covers(FrameExceptionFragments.Decode, message), Is.True, message);
+    }
+
+    // Every overrun that keeps the short-form sequence prefix (0xc0 + 55 at most), so the inflated
+    // byte still declares a length rather than a length of length.
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(3)]
+    [TestCase(4)]
+    public void Decode_CoversAPayloadLengthThatOverrunsTheBuffer(int overrun)
+    {
+        // A frame transaction has no envelope signature, so an overlong declared length leaves the
+        // end-of-payload checkpoint past the last field and the trailing reference list reads off the end.
+        byte[] payload = EncodePayload(
+            frames: Rlp.Encode(Array.Empty<Rlp>()),
+            maxPriorityFeePerGas: Rlp.Encode(0L));
+        Assert.That(payload[1] + overrun, Is.LessThanOrEqualTo(ShortSequencePrefixMax));
+        payload[1] += (byte)overrun;
+
+        string message = DecodeFailureMessage(payload);
+
+        Assert.That(message, Does.Contain("RLP data is truncated"));
         Assert.That(Covers(FrameExceptionFragments.Decode, message), Is.True, message);
     }
 


### PR DESCRIPTION
## Changes

PR #13163 made `FrameTxDecoder.DecodeTrailing` classify a truncated frame transaction as a truncation, throwing `RlpException("RLP data is truncated: frame transaction recent root reference list is incomplete.", inner)` instead of letting a bare index-out-of-range escape. It shipped a unit test but no fixture-harness coverage, and the new wording reached no frame fixture label.

Traced through both harnesses on a real truncated type-6 payload (outer sequence prefix inflated by 1-4, driven through the real decoder):

| expected label | before |
|---|---|
| `RLP_ERROR_EOF` | matches (`TransactionTestBase`, `"RLP data is truncated"`) |
| `RLP_TOO_FEW_ELEMENTS` | matches |
| `TYPE_6_INVALID_FRAME_FORMAT` | **no match** |

`TYPE_6_INVALID_FRAME_FORMAT` is how the shipped frames fixtures file every other decode-level rejection of a type-6 payload — `signer_too_long`/`signer_too_short`, `frame_gas_above_64_bits`, `frame_state_gas_above_64_bits`, `msg_too_long`/`msg_too_short`, `expiry_data_too_long`/`too_short` — which is exactly what `FrameExceptionFragments.Decode` exists to cover. It was one entry short. `BlockchainTestBase` maps neither `RLP_ERROR_EOF` nor `RLP_TOO_FEW_ELEMENTS` at all, so on the block and engine lanes the message matched nothing under any label.

This adds the frame-specific half of the wording to `Decode`. It carries frame context, so unlike the rest of that set it does not widen the label to truncations from unrelated payloads. A new `[TestCase]`-parameterised case inflates the declared payload length and drives the real decoder, so the fragment tracks a reword rather than a hardcoded literal.

No fixture is added: the pinned `tests-frames-devnet@v0.3.0` archive ships no truncated type-6 case, and CI's frame matrix runs only `frameTest` (engine) and `frameBlockTest` (block) — there is no frames `txTest` lane, so a transaction-test fixture would exist and never execute. Wiring that lane in is a separate decision.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring/testing

## Testing

Red control — with the fragment reverted to the base tip and the new test in place, exactly the 4 new cases fail on the decoder's real output (`16/20` pass); with the fragment, `24/24` pass. The filter selects 20 of the assembly's 24 tests, so it is not running vacuously.

- Full `Nethermind.slnx` Release build: `0 Warning(s) / 0 Error(s)`. The touched projects live in `EthereumTests.slnx`, not `Nethermind.slnx`, so both were also built directly with `-p:EnforceCodeStyleInBuild=true -p:GenerateDocumentationFile=true`: 0 IDE/CA warnings, positive-controlled (an injected unused `using` reports `IDE0005`). `dotnet format whitespace --verify-no-changes` exits 0 on both.
- Frame lanes with `--forkAlias Bogota=Eip8141Prototype`: `blockTest` 218/218, `engineTest` 218/218.
- Frames `txTest` (not in CI): 78 total, 54 pass, 24 fail — failure set byte-identical to a base-tip build, so no regression. The change is inert on the currently shipped fixtures, as expected.
- Disjointness probe: `Format`/`Signature`/`Execution` stay pairwise disjoint across 76 substring checks, 0 violations; injecting a bare `"frame"` into `Execution` as a negative control produces 25. No fragment in any set matches any of the 25 `TxErrorMessages` constants (100 checks, 0 hits).

## Documentation

Requires documentation update

- [ ] Yes
- [x] No