### PR TITLE
ci(eip8141): add the frame transaction-test lane

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -422,7 +422,7 @@ jobs:
     name: EEST nethtest
     uses: ./.github/workflows/run-nethtest.yml
     with:
-      test_types: engineTest,blockTest,stateTest,syncTest,txTest,zkevmTest,focilTest,frameTest,frameBlockTest
+      test_types: engineTest,blockTest,stateTest,syncTest,txTest,zkevmTest,focilTest,frameTest,frameBlockTest,frameTxTest
       setup_group: sequential
 
   matrix-guard:

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -140,6 +140,8 @@ env:
   # Minimum cases the pinned release ships across the frame lanes. Asserted so a scope resolving to
   # nothing fails rather than reporting a clean run of no tests.
   FRAME_MIN_CASES: '214'
+  # The same floor for the frame transaction-test lane, whose subtree is a much smaller fixture set.
+  FRAME_TX_MIN_CASES: '74'
   # ubuntu-latest runners have 16 GB of RAM. The runner ships with server GC
   # (throughput-oriented, collects lazily), which previously ballooned past the
   # runner limit on the full fixture set. Workstation GC keeps the heap tight,
@@ -338,6 +340,13 @@ jobs:
                   emit "$type" sequential frames '' false false 4 1
                 fi
                 ;;
+              frameTxTest)
+                # The same subtree's raw-tx fixtures. Like txTest these touch neither the state
+                # layout nor block execution, so the layout and BAL toggles are left unset.
+                if run_sequential; then
+                  emit "$type" sequential frames '' '' '' 4 1
+                fi
+                ;;
               *)
                 echo "::error::Unknown test type: '$type'"
                 exit 1
@@ -399,7 +408,7 @@ jobs:
             echo "Resolved FOCIL release: $RESOLVED_FOCIL"
           fi
 
-          if [[ "$TEST_TYPES" == *frameTest* || "$TEST_TYPES" == *frameBlockTest* ]]; then
+          if [[ "$TEST_TYPES" == *frameTest* || "$TEST_TYPES" == *frameBlockTest* || "$TEST_TYPES" == *frameTxTest* ]]; then
             RESOLVED_FRAMES="$(resolve "$FRAMES_VERSION")"
             echo "frames_version=$RESOLVED_FRAMES" >> "$GITHUB_OUTPUT"
             echo "Resolved frame-transaction release: $RESOLVED_FRAMES"
@@ -455,7 +464,7 @@ jobs:
             RESOLVED_EEST_VERSION="$RESOLVED_FOCIL"
             VERSION_INPUT="$FOCIL_VERSION"
             EEST_ARCHIVE="fixtures_focil-devnet.tar.gz"
-          elif [ "$TEST_TYPE" = "frameTest" ] || [ "$TEST_TYPE" = "frameBlockTest" ]; then
+          elif [ "$TEST_TYPE" = "frameTest" ] || [ "$TEST_TYPE" = "frameBlockTest" ] || [ "$TEST_TYPE" = "frameTxTest" ]; then
             RESOLVED_EEST_VERSION="$RESOLVED_FRAMES"
             VERSION_INPUT="$FRAMES_VERSION"
             EEST_ARCHIVE="fixtures_frames-devnet.tar.gz"
@@ -525,6 +534,8 @@ jobs:
             frameTest)  FIXTURE_NAME=blockchain_tests_engine; RUNNER_FLAG=--engineTest ;;
             # The same archive's block-import fixtures for the frame-transaction subtree.
             frameBlockTest) FIXTURE_NAME=blockchain_tests;    RUNNER_FLAG=--blockTest ;;
+            # And its raw-tx fixtures, which gate on validation alone without executing a block.
+            frameTxTest) FIXTURE_NAME=transaction_tests;      RUNNER_FLAG=--txTest ;;
             *) echo "::error::Unknown test type: '$TEST_TYPE'"; exit 1 ;;
           esac
 
@@ -908,10 +919,15 @@ jobs:
 
             # A scope that resolved to nothing reports no failures, so the narrowed lanes assert they
             # actually ran their fixtures. Only the unfiltered run has a known count.
-            if { [ "$TEST_TYPE" = "frameTest" ] || [ "$TEST_TYPE" = "frameBlockTest" ]; } && [ -z "$FILTER" ] && [ $rc -eq 0 ]; then
+            MIN_CASES=""
+            case "$TEST_TYPE" in
+              frameTest|frameBlockTest) MIN_CASES="$FRAME_MIN_CASES" ;;
+              frameTxTest)              MIN_CASES="$FRAME_TX_MIN_CASES" ;;
+            esac
+            if [ -n "$MIN_CASES" ] && [ -z "$FILTER" ] && [ $rc -eq 0 ]; then
               RAN=$(jq 'length' "$RESULTS_FILE" 2>/dev/null || echo 0)
-              if [ "$RAN" -lt "$FRAME_MIN_CASES" ]; then
-                echo "::error::$TEST_TYPE ran $RAN cases, fewer than the $FRAME_MIN_CASES expected; the fixture scope or the release pin has moved"
+              if [ "$RAN" -lt "$MIN_CASES" ]; then
+                echo "::error::$TEST_TYPE ran $RAN cases, fewer than the $MIN_CASES expected; the fixture scope or the release pin has moved"
                 rc=1
               fi
             fi

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -918,13 +918,13 @@ jobs:
             fi
 
             # A scope that resolved to nothing reports no failures, so the narrowed lanes assert they
-            # actually ran their fixtures. Only the unfiltered run has a known count.
+            # actually ran their fixtures. Only an unfiltered, single-chunk run has a known count.
             MIN_CASES=""
             case "$TEST_TYPE" in
               frameTest|frameBlockTest) MIN_CASES="$FRAME_MIN_CASES" ;;
               frameTxTest)              MIN_CASES="$FRAME_TX_MIN_CASES" ;;
             esac
-            if [ -n "$MIN_CASES" ] && [ -z "$FILTER" ] && [ $rc -eq 0 ]; then
+            if [ -n "$MIN_CASES" ] && [ "$CHUNK" = "1of1" ] && [ -z "$FILTER" ] && [ $rc -eq 0 ]; then
               RAN=$(jq 'length' "$RESULTS_FILE" 2>/dev/null || echo 0)
               if [ "$RAN" -lt "$MIN_CASES" ]; then
                 echo "::error::$TEST_TYPE ran $RAN cases, fewer than the $MIN_CASES expected; the fixture scope or the release pin has moved"

--- a/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
+++ b/src/Nethermind/Ethereum.Test.Base/FrameExceptionFragments.cs
@@ -26,10 +26,10 @@ namespace Ethereum.Test.Base;
 /// themselves.
 /// </para>
 /// <para>
-/// <c>BlockchainTestBase</c> maps all three labels. <c>TransactionTestBase</c> maps only
-/// <c>TYPE_6_INVALID_FRAME_FORMAT</c>, from <see cref="Format"/> and <see cref="Decode"/>: it stops at
-/// <c>TxValidator.IsWellFormed</c>, which runs neither the signature validator nor the transaction
-/// processor, so no <see cref="Signature"/> or <see cref="Execution"/> message can reach it.
+/// <c>BlockchainTestBase</c> maps all three labels. <c>TransactionTestBase</c> maps the first two: it runs
+/// <c>TxValidator.IsWellFormed</c> and then <c>FrameTxSignatureValidator</c>, the pair a transaction must
+/// clear to be accepted off the wire, but never the transaction processor, so no <see cref="Execution"/>
+/// message can reach it.
 /// </para>
 /// </remarks>
 public static class FrameExceptionFragments

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Crypto;
 using Nethermind.Evm.Precompiles;
@@ -64,7 +65,7 @@ public abstract class TransactionTestBase
     }
 
     /// <summary>
-    /// Every check Nethermind applies to a raw transaction before accepting it off the wire, as one error.
+    /// The stateless checks a raw transaction must clear before pool admission, as one error.
     /// </summary>
     /// <remarks>
     /// <see cref="TxValidator.IsWellFormed"/> alone is not that set for EIP-8141: a frame transaction names
@@ -81,7 +82,8 @@ public abstract class TransactionTestBase
             return error;
         }
 
-        // Same availability test the pool filter and the processor make.
+        // Same availability test the pool's ingress filter makes; the processor resolves the same
+        // precompile through its code-info repository instead.
         IPrecompile? p256Precompile = spec.IsPrecompile(FrameTxSignatureValidator.P256VerifyPrecompileAddress)
             ? SecP256r1Precompile.Instance
             : null;
@@ -204,7 +206,7 @@ public abstract class TransactionTestBase
         ["TransactionException.TYPE_6_INVALID_FRAME_FORMAT"] = [.. FrameExceptionFragments.Format, .. FrameExceptionFragments.Decode],
         ["TransactionException.TYPE_6_INVALID_SIGNATURE"] = [.. FrameExceptionFragments.Signature],
         ["TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED"] = ["BlobTxGasLimitExceeded"],
-        ["TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS"] = ["InvalidMaxPriorityFeePerGas"],
+        ["TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS"] = [TxErrorMessages.InvalidMaxPriorityFeePerGas],
         // A fee field wider than its type: the decoder's length guard names neither field nor type.
         ["TransactionException.GASPRICE_OVERFLOW"] = [.. FrameExceptionFragments.FeeOverflow],
         ["TransactionException.PRIORITY_OVERFLOW"] = [.. FrameExceptionFragments.FeeOverflow],

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -18,7 +18,7 @@ namespace Ethereum.Test.Base;
 public abstract class TransactionTestBase
 {
     private static readonly TxValidator s_mainnetTxValidator = new(MainnetSpecProvider.Instance.ChainId);
-    private static readonly EthereumEcdsa s_mainnetEcdsa = new(MainnetSpecProvider.Instance.ChainId);
+    private static readonly EthereumEcdsa _mainnetEcdsa = new(MainnetSpecProvider.Instance.ChainId);
 
     protected static Result RunTest(TransactionTest test)
     {
@@ -87,7 +87,7 @@ public abstract class TransactionTestBase
         IPrecompile? p256Precompile = spec.IsPrecompile(FrameTxSignatureValidator.P256VerifyPrecompileAddress)
             ? SecP256r1Precompile.Instance
             : null;
-        return FrameTxSignatureValidator.Validate(tx, s_mainnetEcdsa, p256Precompile, spec, out string? signatureError)
+        return FrameTxSignatureValidator.Validate(tx, _mainnetEcdsa, p256Precompile, spec, out string? signatureError)
             ? null
             : signatureError;
     }

--- a/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TransactionTestBase.cs
@@ -6,6 +6,9 @@ using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Crypto;
+using Nethermind.Evm.Precompiles;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 
@@ -14,6 +17,7 @@ namespace Ethereum.Test.Base;
 public abstract class TransactionTestBase
 {
     private static readonly TxValidator s_mainnetTxValidator = new(MainnetSpecProvider.Instance.ChainId);
+    private static readonly EthereumEcdsa s_mainnetEcdsa = new(MainnetSpecProvider.Instance.ChainId);
 
     protected static Result RunTest(TransactionTest test)
     {
@@ -37,7 +41,7 @@ public abstract class TransactionTestBase
         }
 
         bool decoded = TryDecode(test.TxBytes, out Transaction? tx, out string? decodeError);
-        string? observedError = decoded ? s_mainnetTxValidator.IsWellFormed(tx!, spec).Error : decodeError;
+        string? observedError = decoded ? ValidateRawTransaction(tx!, spec) : decodeError;
 
         bool expectFailure = !string.IsNullOrEmpty(test.ExpectedException);
         if (expectFailure)
@@ -57,6 +61,33 @@ public abstract class TransactionTestBase
         }
 
         return Result.Success;
+    }
+
+    /// <summary>
+    /// Every check Nethermind applies to a raw transaction before accepting it off the wire, as one error.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TxValidator.IsWellFormed"/> alone is not that set for EIP-8141: a frame transaction names
+    /// its sender explicitly, so it never goes through the sender recovery that rejects a bad signature on
+    /// every other type, and its <c>validate_signature</c> step lives in the pool's own ingress filter and
+    /// in the processor instead. Running the same static validator those two call keeps this harness's
+    /// notion of raw-transaction validity aligned with the client's, without a spec or processor context.
+    /// </remarks>
+    private static string? ValidateRawTransaction(Transaction tx, IReleaseSpec spec)
+    {
+        string? error = s_mainnetTxValidator.IsWellFormed(tx, spec).Error;
+        if (error is not null || !tx.SupportsFrames)
+        {
+            return error;
+        }
+
+        // Same availability test the pool filter and the processor make.
+        IPrecompile? p256Precompile = spec.IsPrecompile(FrameTxSignatureValidator.P256VerifyPrecompileAddress)
+            ? SecP256r1Precompile.Instance
+            : null;
+        return FrameTxSignatureValidator.Validate(tx, s_mainnetEcdsa, p256Precompile, spec, out string? signatureError)
+            ? null
+            : signatureError;
     }
 
     private static bool TryDecode(string txBytesHex, out Transaction? tx, out string? error)
@@ -171,6 +202,12 @@ public abstract class TransactionTestBase
         // Not s_rlpDecodeFragments: its "Invalid signature" fragment also matches the frame
         // signature failures, which the fixtures file under a separate label.
         ["TransactionException.TYPE_6_INVALID_FRAME_FORMAT"] = [.. FrameExceptionFragments.Format, .. FrameExceptionFragments.Decode],
+        ["TransactionException.TYPE_6_INVALID_SIGNATURE"] = [.. FrameExceptionFragments.Signature],
+        ["TransactionException.TYPE_3_TX_BLOB_COUNT_EXCEEDED"] = ["BlobTxGasLimitExceeded"],
+        ["TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS"] = ["InvalidMaxPriorityFeePerGas"],
+        // A fee field wider than its type: the decoder's length guard names neither field nor type.
+        ["TransactionException.GASPRICE_OVERFLOW"] = [.. FrameExceptionFragments.FeeOverflow],
+        ["TransactionException.PRIORITY_OVERFLOW"] = [.. FrameExceptionFragments.FeeOverflow],
         // EIP-7825's per-transaction gas cap under both wordings: a frame transaction reports it
         // against its own budget, every other type against its envelope gas limit.
         ["TransactionException.GAS_LIMIT_EXCEEDS_MAXIMUM"] = ["exceeds the transaction gas cap of", "TxGasLimitCapExceeded"],

--- a/src/Nethermind/Ethereum.Transaction.Test/FrameTxSignatureTransactionTestTests.cs
+++ b/src/Nethermind/Ethereum.Transaction.Test/FrameTxSignatureTransactionTestTests.cs
@@ -27,7 +27,7 @@ namespace Ethereum.Transaction.Test;
 public class FrameTxSignatureTransactionTestTests : TransactionTestBase
 {
     private const string Fork = "Eip8141Prototype";
-    private static readonly Ecdsa s_ecdsa = new();
+    private static readonly Ecdsa _ecdsa = new();
 
     [Test]
     public void ValidFrameSignatureIsAccepted()
@@ -81,7 +81,7 @@ public class FrameTxSignatureTransactionTestTests : TransactionTestBase
         // entry must be installed before hashing.
         TxFrameSignature entry = new(TxFrameSignature.SchemeSecp256k1, signer, default, default);
         tx.FrameSignatures = [entry];
-        Signature signature = s_ecdsa.Sign(TestItem.PrivateKeyB, FrameTxSigHash.ComputeValue(tx));
+        Signature signature = _ecdsa.Sign(TestItem.PrivateKeyB, FrameTxSigHash.ComputeValue(tx));
 
         byte[] raw = new byte[TxFrameSignature.Secp256k1SignatureLength];
         raw[0] = signature.RecoveryId; // strict yParity encoding (0/1)

--- a/src/Nethermind/Ethereum.Transaction.Test/FrameTxSignatureTransactionTestTests.cs
+++ b/src/Nethermind/Ethereum.Transaction.Test/FrameTxSignatureTransactionTestTests.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Ethereum.Test.Base;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Int256;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Specs;
+using NUnit.Framework;
+
+namespace Ethereum.Transaction.Test;
+
+/// <summary>
+/// Guards that the <c>transaction_tests</c> harness applies EIP-8141 <c>validate_signature</c>.
+/// </summary>
+/// <remarks>
+/// The rule is stateless but sits outside <c>TxValidator</c>, so a harness stopping there accepts every
+/// frame transaction whose only defect is a signature — silently passing the reject-shaped fixtures. Each
+/// case perturbs only the signature entry of one otherwise valid transaction, so the control below fails
+/// with them if the shared payload stops validating for an unrelated reason.
+/// </remarks>
+public class FrameTxSignatureTransactionTestTests : TransactionTestBase
+{
+    private const string Fork = "Eip8141Prototype";
+    private static readonly Ecdsa s_ecdsa = new();
+
+    [Test]
+    public void ValidFrameSignatureIsAccepted()
+    {
+        Result result = RunTest(TestFor(SignedFrameTx(), expectedException: null));
+
+        Assert.That((bool)result, Is.True, result.Error);
+    }
+
+    [Test]
+    public void HighSFrameSignatureIsRejectedAsInvalidSignature()
+    {
+        // EIP-2 low-s: the malleable complement of an otherwise verifying signature.
+        Nethermind.Core.Transaction tx = SignedFrameTx();
+        byte[] raw = tx.FrameSignatures![0].Signature.ToArray();
+        UInt256 s = new(raw.AsSpan(33, 32), isBigEndian: true);
+        (SecP256k1Curve.N - s).ToBigEndian(raw.AsSpan(33, 32));
+        tx.FrameSignatures = [WithSignature(tx.FrameSignatures[0], raw)];
+
+        Result result = RunTest(TestFor(tx, "TransactionException.TYPE_6_INVALID_SIGNATURE"));
+
+        Assert.That((bool)result, Is.True, result.Error);
+    }
+
+    [Test]
+    public void FrameSignatureFromAnotherKeyIsRejectedAsInvalidFrameFormat()
+    {
+        // The fixtures file a signer that does not match the recovered address as a format failure.
+        Nethermind.Core.Transaction tx = SignedFrameTx(signer: TestItem.PrivateKeyC.Address);
+
+        Result result = RunTest(TestFor(tx, "TransactionException.TYPE_6_INVALID_FRAME_FORMAT"));
+
+        Assert.That((bool)result, Is.True, result.Error);
+    }
+
+    /// <summary>A frame transaction that <c>TxValidator</c> accepts, signed over its canonical sig hash.</summary>
+    private static Nethermind.Core.Transaction SignedFrameTx(Address signer = null)
+    {
+        Nethermind.Core.Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = MainnetSpecProvider.Instance.ChainId,
+            Nonce = 0,
+            SenderAddress = TestItem.PrivateKeyB.Address,
+            Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, null, 100_000, default, default)],
+            GasPrice = 1,
+            DecodedMaxFeePerGas = 100,
+        };
+
+        // compute_sig_hash covers the entry's metadata and elides only its raw bytes, so the placeholder
+        // entry must be installed before hashing.
+        TxFrameSignature entry = new(TxFrameSignature.SchemeSecp256k1, signer, default, default);
+        tx.FrameSignatures = [entry];
+        Signature signature = s_ecdsa.Sign(TestItem.PrivateKeyB, FrameTxSigHash.ComputeValue(tx));
+
+        byte[] raw = new byte[TxFrameSignature.Secp256k1SignatureLength];
+        raw[0] = signature.RecoveryId; // strict yParity encoding (0/1)
+        signature.Bytes.CopyTo(raw.AsSpan(1));
+        tx.FrameSignatures = [WithSignature(entry, raw)];
+        return tx;
+    }
+
+    private static TxFrameSignature WithSignature(TxFrameSignature entry, byte[] raw) =>
+        new(entry.Scheme, entry.Signer, entry.Msg, raw);
+
+    private static TransactionTest TestFor(Nethermind.Core.Transaction tx, string expectedException) =>
+        new()
+        {
+            Name = TestContext.CurrentContext.Test.Name,
+            Fork = Fork,
+            TxBytes = Rlp.Encode(tx, RlpBehaviors.SkipTypedWrapping).Bytes.ToHexString(true),
+            ExpectedException = expectedException,
+        };
+}


### PR DESCRIPTION
## Changes

- Add `frameTxTest` to `run-nethtest.yml`: the frames archive's `transaction_tests` subtree, run through `--txTest` under the existing `frames` scope and the `Bogota=Eip8141Prototype` fork alias, and included in the `nethermind-tests.yml` matrix.
- Add `FRAME_TX_MIN_CASES` (74, against 78 shipped) and generalise the existing case-count floor to pick the right floor per lane, so a scope that resolves to nothing fails instead of reporting a clean run of no tests.
- `TransactionTestBase` now runs frame signature verification after `TxValidator.IsWellFormed`.
- Add four fixture labels to the transaction-test exception table that `BlockchainTestBase` already maps: `TYPE_6_INVALID_SIGNATURE`, `TYPE_3_TX_BLOB_COUNT_EXCEEDED`, `PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS`, and the `GASPRICE_OVERFLOW` / `PRIORITY_OVERFLOW` pair.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The lane itself is the test. Run end to end locally against the pinned `tests-frames-devnet@v0.3.0` archive:

| lane | executed | passed | failed |
|---|---|---|---|
| `frameTxTest` (new) | 78 | 78 | 0 |
| `frameTest` | 218 | 218 | 0 |
| `frameBlockTest` | 218 | 218 | 0 |

**No exclusions.** The lane gates on all 78 cases the release ships.

Before the `TransactionTestBase` change the new lane was 54/78 with 24 failures, in two groups:

- **20 accept-versus-reject** (`test_signature_constraints_transaction`, expecting `TYPE_6_INVALID_SIGNATURE` or `TYPE_6_INVALID_FRAME_FORMAT`) — the harness stopped at `TxValidator.IsWellFormed`, which is not the whole of what a raw frame transaction must clear. A frame transaction names its sender explicitly, so it never goes through the sender recovery that rejects a bad signature on every other type; its `validate_signature` step lives in `FrameTxSignatureFilter` (pool ingress) and in the processor instead. The client already rejects all 20 off the wire — only the harness was accepting them. Running the same static `FrameTxSignatureValidator` those two call fixes it in test infrastructure, with no client change.
- **4 exception-name mapping gaps** where the rejection was right and the label did not match. All four already have mappings in `BlockchainTestBase`; they were simply absent from the transaction table.

Controls run:

- **Case-count floor.** An empty scope makes the runner exit 0 with 0 cases — a silent green is a real possibility here — and the floor turns that into a failure. Verified as a red/green pair, and that the 214 and 74 floors are applied to the right lanes.
- **No regression outside the frames subtree.** The full 890-case `transaction_tests` tree, before and after, has an identical failure set except for two additional passes. Non-frame transactions short-circuit the new path.
- **P256 verification really runs.** `p256_valid_entry` expects success and passes, so the secp256r1 precompile is available and the negative P256 cases are not passing via `P256NotSupported`.
- Full Release build of `Nethermind.slnx`: 0 errors, 0 warnings. `dotnet format whitespace --verify-no-changes` clean. `Ethereum.Transaction.Test`: 20/20.
- The lint gate targets `Nethermind.slnx`, which does not contain `Ethereum.Test.Base`, so it was run against that project directly with the enforce flags. It caught a real unnecessary `using` in this change, which is fixed — positive control for the gate.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
