### PR TITLE
feat(xdc): reject transactions under the minimum gas price on pool admission

### DIFF
--- a/src/Nethermind/Nethermind.Runner/configs/xdc-testnet.json
+++ b/src/Nethermind/Nethermind.Runner/configs/xdc-testnet.json
@@ -17,7 +17,8 @@
     "PruningBoundary": 4096
   },
   "Blocks": {
-    "TargetBlockGasLimit": 420000000
+    "TargetBlockGasLimit": 420000000,
+    "MinGasPrice": 0
   },
   "TxPool": {
     "BlobsSupport": "Disabled"

--- a/src/Nethermind/Nethermind.Runner/configs/xdc.json
+++ b/src/Nethermind/Nethermind.Runner/configs/xdc.json
@@ -17,7 +17,8 @@
     "PruningBoundary": 4096
   },
   "Blocks": {
-    "TargetBlockGasLimit": 420000000
+    "TargetBlockGasLimit": 420000000,
+    "MinGasPrice": 0
   },
   "TxPool": {
     "BlobsSupport": "Disabled"

--- a/src/Nethermind/Nethermind.Xdc.Test/BlackListedAddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/BlackListedAddressFilterTests.cs
@@ -113,7 +113,7 @@ internal class BlackListedAddressFilterTests
             .WithTo(TestItem.AddressC)
             .WithValue(1)
             .WithType(TxType.Legacy)
-            .WithGasPrice(XdcConstants.MinGasPrice)
+            .WithGasPrice(XdcConstants.DefaultMinGasPrice * XdcConstants.Gas50xMultiplier)
             .WithNonce(chain.TxPool.GetLatestPendingNonce(TestItem.AddressB))
             .TestObject;
         new Signer(chain.SpecProvider.ChainId, TestItem.PrivateKeyB, NullLogManager.Instance).TrySign(tx);

--- a/src/Nethermind/Nethermind.Xdc.Test/BlackListedAddressFilterTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/BlackListedAddressFilterTests.cs
@@ -113,6 +113,7 @@ internal class BlackListedAddressFilterTests
             .WithTo(TestItem.AddressC)
             .WithValue(1)
             .WithType(TxType.Legacy)
+            .WithGasPrice(XdcConstants.MinGasPrice)
             .WithNonce(chain.TxPool.GetLatestPendingNonce(TestItem.AddressB))
             .TestObject;
         new Signer(chain.SpecProvider.ChainId, TestItem.PrivateKeyB, NullLogManager.Instance).TrySign(tx);

--- a/src/Nethermind/Nethermind.Xdc.Test/BlockProductionMinGasPriceTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/BlockProductionMinGasPriceTests.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Config;
+using Nethermind.Consensus.Transactions;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.TxPool;
+using Nethermind.Xdc.Spec;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test;
+
+/// <summary>
+/// Pins why the shipped XDC configs set <c>Blocks.MinGasPrice</c> to zero.
+/// </summary>
+/// <remarks>
+/// XDC's base fee is a constant equal to the gas price floor its reference client demands, so a transaction paying
+/// exactly that floor - the reference's minimum, and what its gas price oracle suggests - has no priority fee left.
+/// <see cref="MinGasPriceTxFilter"/> compares the priority fee, so any non-zero <c>Blocks.MinGasPrice</c> makes the
+/// block producer skip transactions the reference client both accepts and mines.
+/// </remarks>
+[Parallelizable(ParallelScope.All)]
+internal class BlockProductionMinGasPriceTests
+{
+    [TestCase(0ul, true, TestName = "Zero floor includes a transaction paying the chain minimum")]
+    [TestCase(1ul, false, TestName = "Default one wei floor skips a transaction paying the chain minimum")]
+    public void MinGasPriceTxFilter_TxAtChainMinimum_WithXdcBaseFee(ulong configuredFloor, bool expectedAllowed)
+    {
+        XdcReleaseSpec spec = new() { IsEip1559Enabled = true, BaseFeeCalculator = new XdcBaseFeeCalculator() };
+        MinGasPriceTxFilter filter = new(new BlocksConfig { MinGasPrice = configuredFloor });
+
+        Transaction tx = Build.A.Transaction
+            .WithType(TxType.Legacy)
+            .WithGasPrice(XdcConstants.MinGasPrice)
+            .WithTo(TestItem.AddressC)
+            .TestObject;
+
+        AcceptTxResult result = filter.IsAllowed(tx, Build.A.BlockHeader.TestObject, spec);
+
+        Assert.That((bool)result, Is.EqualTo(expectedAllowed), result.ToString());
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc.Test/BlockProductionMinGasPriceTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/BlockProductionMinGasPriceTests.cs
@@ -18,7 +18,9 @@ namespace Nethermind.Xdc.Test;
 /// XDC's base fee is a constant equal to the gas price floor its reference client demands, so a transaction paying
 /// exactly that floor - the reference's minimum, and what its gas price oracle suggests - has no priority fee left.
 /// <see cref="MinGasPriceTxFilter"/> compares the priority fee, so any non-zero <c>Blocks.MinGasPrice</c> makes the
-/// block producer skip transactions the reference client both accepts and mines.
+/// block producer skip transactions the reference client both accepts and mines. The reference has no equivalent
+/// floor to match: its <c>NewTransactionsByPriceAndNonce</c> takes no base fee and orders on the raw gas price, so
+/// nothing in its block building converts to an effective tip.
 /// </remarks>
 [Parallelizable(ParallelScope.All)]
 internal class BlockProductionMinGasPriceTests
@@ -32,7 +34,7 @@ internal class BlockProductionMinGasPriceTests
 
         Transaction tx = Build.A.Transaction
             .WithType(TxType.Legacy)
-            .WithGasPrice(XdcConstants.MinGasPrice)
+            .WithGasPrice(XdcConstants.DefaultMinGasPrice * XdcConstants.Gas50xMultiplier)
             .WithTo(TestItem.AddressC)
             .TestObject;
 

--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
@@ -189,7 +189,8 @@ public class XdcTestBlockchain : TestBlockchain
                     ctx.Resolve<ITxGossipPolicy>(),
                     [
                         new SignTransactionFilter(ctx.Resolve<ISnapshotManager>(), ctx.Resolve<IBlockTree>(), ctx.Resolve<ISpecProvider>()),
-                        new BlackListedAddressFilter(ctx.Resolve<IChainHeadInfoProvider>(), ctx.Resolve<ISpecProvider>(), ctx.Resolve<ILogManager>())
+                        new BlackListedAddressFilter(ctx.Resolve<IChainHeadInfoProvider>(), ctx.Resolve<ISpecProvider>(), ctx.Resolve<ILogManager>()),
+                        new MinGasPriceFilter(ctx.Resolve<IChainHeadInfoProvider>(), ctx.Resolve<ISpecProvider>(), ctx.Resolve<ILogManager>())
                     ]);
 
                 return txPool;

--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
@@ -605,7 +605,9 @@ public class XdcTestBlockchain : TestBlockchain
 
     public TransactionBuilder<Transaction> CreateTransactionBuilder()
     {
-        TransactionBuilder<Transaction> txBuilder = BuildSimpleTransaction;
+        // MinGasPriceFilter keeps anything cheaper out of the pool, so a transaction below the floor would never
+        // reach a block.
+        TransactionBuilder<Transaction> txBuilder = BuildSimpleTransaction.WithGasPrice(XdcConstants.MinGasPrice);
 
         Block? head = BlockFinder.Head;
         if (head is not null)

--- a/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/Helpers/XdcTestBlockchain.cs
@@ -607,7 +607,7 @@ public class XdcTestBlockchain : TestBlockchain
     {
         // MinGasPriceFilter keeps anything cheaper out of the pool, so a transaction below the floor would never
         // reach a block.
-        TransactionBuilder<Transaction> txBuilder = BuildSimpleTransaction.WithGasPrice(XdcConstants.MinGasPrice);
+        TransactionBuilder<Transaction> txBuilder = BuildSimpleTransaction.WithGasPrice(XdcConstants.DefaultMinGasPrice * XdcConstants.Gas50xMultiplier);
 
         Block? head = BlockFinder.Head;
         if (head is not null)

--- a/src/Nethermind/Nethermind.Xdc.Test/MinGasPriceFilterTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/MinGasPriceFilterTests.cs
@@ -7,6 +7,7 @@ using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
+using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.TxPool;
 using Nethermind.Xdc.Spec;
@@ -20,16 +21,17 @@ namespace Nethermind.Xdc.Test;
 [Parallelizable(ParallelScope.All)]
 internal class MinGasPriceFilterTests
 {
-    private const ulong MinGasPrice = XdcConstants.MinGasPrice;
+    private const ulong MinGasPrice = XdcConstants.DefaultMinGasPrice * XdcConstants.Gas50xMultiplier;
     private static readonly Address BlockSigner = TestItem.AddressA;
     private static readonly Address Randomize = TestItem.AddressB;
 
-    private static MinGasPriceFilter CreateFilter(ulong headNumber = 100, ISpecProvider? specProvider = null)
+    private static MinGasPriceFilter CreateFilter(UInt256? minimumGasPrice = null, ulong headNumber = 100, ISpecProvider? specProvider = null)
     {
         IChainHeadInfoProvider chainHeadInfoProvider = Substitute.For<IChainHeadInfoProvider>();
         chainHeadInfoProvider.HeadNumber.Returns(headNumber);
 
         IXdcReleaseSpec xdcSpec = Substitute.For<IXdcReleaseSpec>();
+        xdcSpec.MinimumGasPrice.Returns(minimumGasPrice ?? MinGasPrice);
         xdcSpec.BlockSignerContract.Returns(BlockSigner);
         xdcSpec.RandomizeSMCBinary.Returns(Randomize);
 
@@ -45,16 +47,31 @@ internal class MinGasPriceFilterTests
         return filter.Accept(tx, ref state, options);
     }
 
-    [TestCase(MinGasPrice, true, TestName = "Exactly at the minimum accepted")]
-    [TestCase(MinGasPrice + 1, true, TestName = "Above the minimum accepted")]
-    [TestCase(MinGasPrice - 1, false, TestName = "Below the minimum rejected")]
-    [TestCase(0ul, false, TestName = "Zero gas price rejected")]
-    public void Accept_ComparesLegacyGasPriceWithMinimum(ulong gasPrice, bool expectedAccepted)
+    [TestCase(MinGasPrice, true, null, TestName = "Exactly at the minimum accepted")]
+    [TestCase(MinGasPrice + 1, true, null, TestName = "Above the minimum accepted")]
+    [TestCase(MinGasPrice - 1, false, "under min gas price", TestName = "Below the minimum rejected")]
+    [TestCase(0ul, false, "zero gas price", TestName = "Zero gas price reported separately")]
+    public void Accept_ComparesLegacyGasPriceWithMinimum(ulong gasPrice, bool expectedAccepted, string? expectedMessage)
     {
         MinGasPriceFilter filter = CreateFilter();
         Transaction tx = Build.A.Transaction.WithType(TxType.Legacy).WithGasPrice(gasPrice).WithTo(TestItem.AddressC).TestObject;
 
-        Assert.That((bool)Accept(filter, tx), Is.EqualTo(expectedAccepted));
+        AcceptTxResult result = Accept(filter, tx);
+
+        Assert.That((bool)result, Is.EqualTo(expectedAccepted));
+        if (expectedMessage is not null)
+            Assert.That(result.ToString(), Does.Contain(expectedMessage));
+    }
+
+    // A gasless subnet states a zero floor, which disables both checks as common.Gasless does in the reference.
+    [TestCase(0ul, TestName = "Gasless accepts a zero gas price")]
+    [TestCase(1ul, TestName = "Gasless accepts one wei")]
+    public void Accept_ZeroFloor_AcceptsAnything(ulong gasPrice)
+    {
+        MinGasPriceFilter filter = CreateFilter(UInt256.Zero);
+        Transaction tx = Build.A.Transaction.WithType(TxType.Legacy).WithGasPrice(gasPrice).WithTo(TestItem.AddressC).TestObject;
+
+        Assert.That(Accept(filter, tx), Is.EqualTo(AcceptTxResult.Accepted));
     }
 
     // The reference client compares tx.GasPrice(), which is the fee cap for a dynamic fee transaction. XDC's base fee
@@ -108,6 +125,7 @@ internal class MinGasPriceFilterTests
     public async Task SubmitTx_UnderMinGasPrice_IsRejectedOnPoolAdmission(ulong gasPrice, bool expectedAccepted)
     {
         using XdcTestBlockchain chain = await XdcTestBlockchain.Create(5, false);
+        chain.ChangeReleaseSpec(spec => spec.MinimumGasPrice = MinGasPrice);
 
         Transaction tx = Build.A.Transaction
             .WithSenderAddress(TestItem.AddressB)

--- a/src/Nethermind/Nethermind.Xdc.Test/MinGasPriceFilterTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/MinGasPriceFilterTests.cs
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Nethermind.Consensus;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.TxPool;
+using Nethermind.Xdc.Spec;
+using Nethermind.Xdc.Test.Helpers;
+using Nethermind.Xdc.TxPool;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test;
+
+[Parallelizable(ParallelScope.All)]
+internal class MinGasPriceFilterTests
+{
+    private const ulong MinGasPrice = XdcConstants.DefaultMinGasPrice;
+    private static readonly Address BlockSigner = new("0x00000000000000000000000000000000b000089");
+
+    private static MinGasPriceFilter CreateFilter(UInt256 minimumGasPrice, ulong headNumber = 100, ISpecProvider? specProvider = null)
+    {
+        IChainHeadInfoProvider chainHeadInfoProvider = Substitute.For<IChainHeadInfoProvider>();
+        chainHeadInfoProvider.HeadNumber.Returns(headNumber);
+
+        IXdcReleaseSpec xdcSpec = Substitute.For<IXdcReleaseSpec>();
+        xdcSpec.MinimumGasPrice.Returns(minimumGasPrice);
+        xdcSpec.BlockSignerContract.Returns(BlockSigner);
+
+        specProvider ??= Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(xdcSpec);
+
+        return new MinGasPriceFilter(chainHeadInfoProvider, specProvider, LimboLogs.Instance);
+    }
+
+    private static AcceptTxResult Accept(MinGasPriceFilter filter, Transaction tx)
+    {
+        TxFilteringState state = default;
+        return filter.Accept(tx, ref state, TxHandlingOptions.None);
+    }
+
+    [TestCase(MinGasPrice, true, TestName = "Exactly at the minimum accepted")]
+    [TestCase(MinGasPrice + 1, true, TestName = "Above the minimum accepted")]
+    [TestCase(MinGasPrice - 1, false, TestName = "Below the minimum rejected")]
+    [TestCase(0ul, false, TestName = "Zero gas price rejected")]
+    public void Accept_ComparesLegacyGasPriceWithMinimum(ulong gasPrice, bool expectedAccepted)
+    {
+        MinGasPriceFilter filter = CreateFilter(MinGasPrice);
+        Transaction tx = Build.A.Transaction.WithType(TxType.Legacy).WithGasPrice(gasPrice).WithTo(TestItem.AddressC).TestObject;
+
+        Assert.That((bool)Accept(filter, tx), Is.EqualTo(expectedAccepted));
+    }
+
+    // The reference client compares tx.GasPrice(), which is the fee cap for a dynamic fee transaction, so a low
+    // priority fee alone is not a reason to reject.
+    [TestCase(MinGasPrice, 1ul, true, TestName = "Fee cap at the minimum accepted regardless of priority fee")]
+    [TestCase(MinGasPrice - 1, MinGasPrice - 1, false, TestName = "Fee cap below the minimum rejected")]
+    public void Accept_Uses1559FeeCap(ulong maxFeePerGas, ulong maxPriorityFeePerGas, bool expectedAccepted)
+    {
+        MinGasPriceFilter filter = CreateFilter(MinGasPrice);
+        Transaction tx = Build.A.Transaction
+            .WithType(TxType.EIP1559)
+            .WithMaxFeePerGas(maxFeePerGas)
+            .WithMaxPriorityFeePerGas(maxPriorityFeePerGas)
+            .WithTo(TestItem.AddressC)
+            .TestObject;
+
+        Assert.That((bool)Accept(filter, tx), Is.EqualTo(expectedAccepted));
+    }
+
+    [Test]
+    public void Accept_SpecialTransaction_IsAcceptedWithoutPayingAnything()
+    {
+        MinGasPriceFilter filter = CreateFilter(MinGasPrice);
+        Transaction tx = Build.A.Transaction.WithGasPrice(0).WithTo(BlockSigner).TestObject;
+
+        Assert.That(Accept(filter, tx), Is.EqualTo(AcceptTxResult.Accepted));
+    }
+
+    [Test]
+    public void Accept_MinimumNotConfigured_IsInert()
+    {
+        MinGasPriceFilter filter = CreateFilter(UInt256.Zero);
+        Transaction tx = Build.A.Transaction.WithGasPrice(0).WithTo(TestItem.AddressC).TestObject;
+
+        Assert.That(Accept(filter, tx), Is.EqualTo(AcceptTxResult.Accepted));
+    }
+
+    [Test]
+    public void Accept_UnderpricedLocalTransaction_IsRejected()
+    {
+        MinGasPriceFilter filter = CreateFilter(MinGasPrice);
+        Transaction tx = Build.A.Transaction.WithGasPrice(1).WithTo(TestItem.AddressC).TestObject;
+        TxFilteringState state = default;
+
+        AcceptTxResult result = filter.Accept(tx, ref state, TxHandlingOptions.PersistentBroadcast);
+
+        Assert.That(result, Is.EqualTo(AcceptTxResult.FeeTooLow));
+    }
+
+    [Test]
+    public void Accept_UsesSpecOfHead()
+    {
+        const ulong headNumber = 1234;
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        MinGasPriceFilter filter = CreateFilter(MinGasPrice, headNumber, specProvider);
+
+        Accept(filter, Build.A.Transaction.WithGasPrice(MinGasPrice).WithTo(TestItem.AddressC).TestObject);
+
+        specProvider.Received().GetSpec(Arg.Is<ForkActivation>(f => f.BlockNumber == headNumber));
+    }
+
+    [TestCase(1ul, false, TestName = "Pool rejects underpriced transaction")]
+    [TestCase(MinGasPrice, true, TestName = "Pool accepts transaction at the minimum")]
+    public async Task SubmitTx_UnderMinGasPrice_IsRejectedOnPoolAdmission(ulong gasPrice, bool expectedAccepted)
+    {
+        using XdcTestBlockchain chain = await XdcTestBlockchain.Create(5, false);
+        chain.ChangeReleaseSpec(spec => spec.MinimumGasPrice = MinGasPrice);
+
+        Transaction tx = Build.A.Transaction
+            .WithSenderAddress(TestItem.AddressB)
+            .WithTo(TestItem.AddressC)
+            .WithValue(1)
+            .WithGasPrice(gasPrice)
+            .WithType(TxType.Legacy)
+            .WithNonce(chain.TxPool.GetLatestPendingNonce(TestItem.AddressB))
+            .TestObject;
+        new Signer(chain.SpecProvider.ChainId, TestItem.PrivateKeyB, NullLogManager.Instance).TrySign(tx);
+        tx.Hash = tx.CalculateHash();
+
+        AcceptTxResult result = chain.TxPool.SubmitTx(tx, TxHandlingOptions.None);
+
+        Assert.That((bool)result, Is.EqualTo(expectedAccepted), result.ToString());
+        if (!expectedAccepted)
+            Assert.That(result, Is.EqualTo(AcceptTxResult.FeeTooLow));
+        Assert.That(chain.TxPool.GetPendingTransactions(), Has.Length.EqualTo(expectedAccepted ? 1 : 0));
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc.Test/MinGasPriceFilterTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/MinGasPriceFilterTests.cs
@@ -7,7 +7,6 @@ using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
-using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.TxPool;
 using Nethermind.Xdc.Spec;
@@ -21,17 +20,18 @@ namespace Nethermind.Xdc.Test;
 [Parallelizable(ParallelScope.All)]
 internal class MinGasPriceFilterTests
 {
-    private const ulong MinGasPrice = XdcConstants.DefaultMinGasPrice;
-    private static readonly Address BlockSigner = new("0x00000000000000000000000000000000b000089");
+    private const ulong MinGasPrice = XdcConstants.MinGasPrice;
+    private static readonly Address BlockSigner = TestItem.AddressA;
+    private static readonly Address Randomize = TestItem.AddressB;
 
-    private static MinGasPriceFilter CreateFilter(UInt256 minimumGasPrice, ulong headNumber = 100, ISpecProvider? specProvider = null)
+    private static MinGasPriceFilter CreateFilter(ulong headNumber = 100, ISpecProvider? specProvider = null)
     {
         IChainHeadInfoProvider chainHeadInfoProvider = Substitute.For<IChainHeadInfoProvider>();
         chainHeadInfoProvider.HeadNumber.Returns(headNumber);
 
         IXdcReleaseSpec xdcSpec = Substitute.For<IXdcReleaseSpec>();
-        xdcSpec.MinimumGasPrice.Returns(minimumGasPrice);
         xdcSpec.BlockSignerContract.Returns(BlockSigner);
+        xdcSpec.RandomizeSMCBinary.Returns(Randomize);
 
         specProvider ??= Substitute.For<ISpecProvider>();
         specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(xdcSpec);
@@ -39,10 +39,10 @@ internal class MinGasPriceFilterTests
         return new MinGasPriceFilter(chainHeadInfoProvider, specProvider, LimboLogs.Instance);
     }
 
-    private static AcceptTxResult Accept(MinGasPriceFilter filter, Transaction tx)
+    private static AcceptTxResult Accept(MinGasPriceFilter filter, Transaction tx, TxHandlingOptions options = TxHandlingOptions.None)
     {
         TxFilteringState state = default;
-        return filter.Accept(tx, ref state, TxHandlingOptions.None);
+        return filter.Accept(tx, ref state, options);
     }
 
     [TestCase(MinGasPrice, true, TestName = "Exactly at the minimum accepted")]
@@ -51,19 +51,19 @@ internal class MinGasPriceFilterTests
     [TestCase(0ul, false, TestName = "Zero gas price rejected")]
     public void Accept_ComparesLegacyGasPriceWithMinimum(ulong gasPrice, bool expectedAccepted)
     {
-        MinGasPriceFilter filter = CreateFilter(MinGasPrice);
+        MinGasPriceFilter filter = CreateFilter();
         Transaction tx = Build.A.Transaction.WithType(TxType.Legacy).WithGasPrice(gasPrice).WithTo(TestItem.AddressC).TestObject;
 
         Assert.That((bool)Accept(filter, tx), Is.EqualTo(expectedAccepted));
     }
 
-    // The reference client compares tx.GasPrice(), which is the fee cap for a dynamic fee transaction, so a low
-    // priority fee alone is not a reason to reject.
+    // The reference client compares tx.GasPrice(), which is the fee cap for a dynamic fee transaction. XDC's base fee
+    // equals the floor, so comparing the priority fee instead would reject everything the reference accepts.
     [TestCase(MinGasPrice, 1ul, true, TestName = "Fee cap at the minimum accepted regardless of priority fee")]
     [TestCase(MinGasPrice - 1, MinGasPrice - 1, false, TestName = "Fee cap below the minimum rejected")]
     public void Accept_Uses1559FeeCap(ulong maxFeePerGas, ulong maxPriorityFeePerGas, bool expectedAccepted)
     {
-        MinGasPriceFilter filter = CreateFilter(MinGasPrice);
+        MinGasPriceFilter filter = CreateFilter();
         Transaction tx = Build.A.Transaction
             .WithType(TxType.EIP1559)
             .WithMaxFeePerGas(maxFeePerGas)
@@ -75,45 +75,32 @@ internal class MinGasPriceFilterTests
     }
 
     [Test]
-    public void Accept_SpecialTransaction_IsAcceptedWithoutPayingAnything()
+    public void Accept_SpecialTransactions_AreAcceptedWithoutPayingAnything()
     {
-        MinGasPriceFilter filter = CreateFilter(MinGasPrice);
-        Transaction tx = Build.A.Transaction.WithGasPrice(0).WithTo(BlockSigner).TestObject;
+        MinGasPriceFilter filter = CreateFilter();
 
-        Assert.That(Accept(filter, tx), Is.EqualTo(AcceptTxResult.Accepted));
-    }
-
-    [Test]
-    public void Accept_MinimumNotConfigured_IsInert()
-    {
-        MinGasPriceFilter filter = CreateFilter(UInt256.Zero);
-        Transaction tx = Build.A.Transaction.WithGasPrice(0).WithTo(TestItem.AddressC).TestObject;
-
-        Assert.That(Accept(filter, tx), Is.EqualTo(AcceptTxResult.Accepted));
+        Assert.Multiple(() =>
+        {
+            Assert.That(Accept(filter, Build.A.Transaction.WithGasPrice(0).WithTo(BlockSigner).TestObject), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(Accept(filter, Build.A.Transaction.WithGasPrice(0).WithTo(Randomize).TestObject), Is.EqualTo(AcceptTxResult.Accepted));
+        });
     }
 
     [Test]
     public void Accept_UnderpricedLocalTransaction_IsRejected()
     {
-        MinGasPriceFilter filter = CreateFilter(MinGasPrice);
+        MinGasPriceFilter filter = CreateFilter();
         Transaction tx = Build.A.Transaction.WithGasPrice(1).WithTo(TestItem.AddressC).TestObject;
-        TxFilteringState state = default;
 
-        AcceptTxResult result = filter.Accept(tx, ref state, TxHandlingOptions.PersistentBroadcast);
-
-        Assert.That(result, Is.EqualTo(AcceptTxResult.FeeTooLow));
+        Assert.That(Accept(filter, tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.FeeTooLow));
     }
 
     [Test]
-    public void Accept_UsesSpecOfHead()
+    public void Accept_ContractCreation_IsSubjectToTheMinimum()
     {
-        const ulong headNumber = 1234;
-        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        MinGasPriceFilter filter = CreateFilter(MinGasPrice, headNumber, specProvider);
+        MinGasPriceFilter filter = CreateFilter();
 
-        Accept(filter, Build.A.Transaction.WithGasPrice(MinGasPrice).WithTo(TestItem.AddressC).TestObject);
-
-        specProvider.Received().GetSpec(Arg.Is<ForkActivation>(f => f.BlockNumber == headNumber));
+        Assert.That(Accept(filter, Build.A.Transaction.WithGasPrice(1).WithTo(null).TestObject), Is.EqualTo(AcceptTxResult.FeeTooLow));
     }
 
     [TestCase(1ul, false, TestName = "Pool rejects underpriced transaction")]
@@ -121,7 +108,6 @@ internal class MinGasPriceFilterTests
     public async Task SubmitTx_UnderMinGasPrice_IsRejectedOnPoolAdmission(ulong gasPrice, bool expectedAccepted)
     {
         using XdcTestBlockchain chain = await XdcTestBlockchain.Create(5, false);
-        chain.ChangeReleaseSpec(spec => spec.MinimumGasPrice = MinGasPrice);
 
         Transaction tx = Build.A.Transaction
             .WithSenderAddress(TestItem.AddressB)

--- a/src/Nethermind/Nethermind.Xdc.Test/MinGasPriceFilterTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/MinGasPriceFilterTests.cs
@@ -63,7 +63,6 @@ internal class MinGasPriceFilterTests
             Assert.That(result.ToString(), Does.Contain(expectedMessage));
     }
 
-    // A gasless subnet states a zero floor, which disables both checks as common.Gasless does in the reference.
     [TestCase(0ul, TestName = "Gasless accepts a zero gas price")]
     [TestCase(1ul, TestName = "Gasless accepts one wei")]
     public void Accept_ZeroFloor_AcceptsAnything(ulong gasPrice)
@@ -74,8 +73,6 @@ internal class MinGasPriceFilterTests
         Assert.That(Accept(filter, tx), Is.EqualTo(AcceptTxResult.Accepted));
     }
 
-    // The reference client compares tx.GasPrice(), which is the fee cap for a dynamic fee transaction. XDC's base fee
-    // equals the floor, so comparing the priority fee instead would reject everything the reference accepts.
     [TestCase(MinGasPrice, 1ul, true, TestName = "Fee cap at the minimum accepted regardless of priority fee")]
     [TestCase(MinGasPrice - 1, MinGasPrice - 1, false, TestName = "Fee cap below the minimum rejected")]
     public void Accept_Uses1559FeeCap(ulong maxFeePerGas, ulong maxPriorityFeePerGas, bool expectedAccepted)

--- a/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
@@ -58,6 +58,7 @@ internal class SpecialTransactionsTests
             .WithTo(destination.Address)
             .WithValue(amount)
             .WithType(TxType.Legacy)
+            .WithGasPrice(XdcConstants.MinGasPrice)
             .WithNonce(nonce)
             .TestObject;
 

--- a/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/SpecialTransactionsTests.cs
@@ -58,7 +58,7 @@ internal class SpecialTransactionsTests
             .WithTo(destination.Address)
             .WithValue(amount)
             .WithType(TxType.Legacy)
-            .WithGasPrice(XdcConstants.MinGasPrice)
+            .WithGasPrice(XdcConstants.DefaultMinGasPrice * XdcConstants.Gas50xMultiplier)
             .WithNonce(nonce)
             .TestObject;
 

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcSpecProviderTests.cs
@@ -5,6 +5,7 @@ using Nethermind.Xdc.Spec;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
+using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs.ChainSpecStyle;
 using NSubstitute;
@@ -141,6 +142,75 @@ public class XdcSpecProviderTests
 
         Assert.That(specProvider.GetXdcSpec(dynamicGasLimitBlock - 1).IsDynamicGasLimitBlock, Is.False);
         Assert.That(specProvider.GetXdcSpec(dynamicGasLimitBlock).IsDynamicGasLimitBlock, Is.True);
+    }
+
+    private static XdcChainSpecBasedSpecProvider BuildProvider(XdcChainSpecEngineParameters parameters)
+    {
+        parameters.V2Configs = [new V2ConfigParams { SwitchRound = 0 }];
+        IChainSpecParametersProvider parametersProvider = Substitute.For<IChainSpecParametersProvider>();
+        parametersProvider.AllChainSpecParameters.Returns([parameters]);
+        ChainSpec chainSpec = new()
+        {
+            Parameters = new ChainParameters { Eip1559Transition = 5 },
+            EngineChainSpecParametersProvider = parametersProvider,
+        };
+        return new XdcChainSpecBasedSpecProvider(chainSpec, parameters, Substitute.For<ILogManager>());
+    }
+
+    private const ulong Raised = XdcConstants.DefaultMinGasPrice * XdcConstants.Gas50xMultiplier;
+
+    [Test]
+    public void MinimumGasPrice_is_raised_50x_on_Gas50xBlock()
+    {
+        const ulong gas50xBlock = 1000;
+        XdcChainSpecBasedSpecProvider specProvider =
+            BuildProvider(new XdcChainSpecEngineParameters { SwitchBlock = 1, Gas50xBlock = gas50xBlock });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(specProvider.GetXdcSpec(gas50xBlock - 1).MinimumGasPrice, Is.EqualTo((UInt256)XdcConstants.DefaultMinGasPrice));
+            Assert.That(specProvider.GetXdcSpec(gas50xBlock).MinimumGasPrice, Is.EqualTo((UInt256)Raised));
+        }
+    }
+
+    // Mirrors the reference client's --miner-gasprice: a stated floor is used when it is above the default and
+    // raised to the default when it is below, so the network floor can never be weakened.
+    [TestCase(null, XdcConstants.DefaultMinGasPrice, TestName = "Unset uses the reference default")]
+    [TestCase(1ul, XdcConstants.DefaultMinGasPrice, TestName = "Below the default is raised to it")]
+    [TestCase(0ul, XdcConstants.DefaultMinGasPrice, TestName = "Zero is not gasless outside a subnet")]
+    [TestCase(XdcConstants.DefaultMinGasPrice * 2, XdcConstants.DefaultMinGasPrice * 2, TestName = "Above the default is used")]
+    public void MinimumGasPrice_follows_the_stated_floor(ulong? stated, ulong expectedBeforeGas50x)
+    {
+        XdcChainSpecBasedSpecProvider specProvider = BuildProvider(new XdcChainSpecEngineParameters
+        {
+            SwitchBlock = 1,
+            Gas50xBlock = 1000,
+            MinGasPrice = stated is null ? null : (UInt256)stated.Value,
+        });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(specProvider.GetXdcSpec(999).MinimumGasPrice, Is.EqualTo((UInt256)expectedBeforeGas50x));
+            Assert.That(specProvider.GetXdcSpec(1000).MinimumGasPrice,
+                Is.EqualTo((UInt256)expectedBeforeGas50x * XdcConstants.Gas50xMultiplier));
+        }
+    }
+
+    // The subnet fork's GetMinGasPrice has no 50x transition and honours a gasless node.
+    [Test]
+    public void MinimumGasPrice_on_a_subnet_is_raised_from_genesis_and_zero_means_gasless()
+    {
+        XdcChainSpecBasedSpecProvider raised =
+            BuildProvider(new XdcSubnetChainSpecEngineParameters { SwitchBlock = 1 });
+        XdcChainSpecBasedSpecProvider gasless =
+            BuildProvider(new XdcSubnetChainSpecEngineParameters { SwitchBlock = 1, MinGasPrice = UInt256.Zero });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(raised.GetXdcSpec(0).MinimumGasPrice, Is.EqualTo((UInt256)Raised), "no 50x transition on a subnet");
+            Assert.That(raised.GetXdcSpec(1_000_000).MinimumGasPrice, Is.EqualTo((UInt256)Raised));
+            Assert.That(gasless.GetXdcSpec(0).MinimumGasPrice, Is.EqualTo(UInt256.Zero), "gasless disables the check");
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcSpecProviderTests.cs
@@ -173,8 +173,6 @@ public class XdcSpecProviderTests
         }
     }
 
-    // Mirrors the reference client's --miner-gasprice: a stated floor is used when it is above the default and
-    // raised to the default when it is below, so the network floor can never be weakened.
     [TestCase(null, XdcConstants.DefaultMinGasPrice, TestName = "Unset uses the reference default")]
     [TestCase(1ul, XdcConstants.DefaultMinGasPrice, TestName = "Below the default is raised to it")]
     [TestCase(0ul, XdcConstants.DefaultMinGasPrice, TestName = "Zero is not gasless outside a subnet")]
@@ -196,7 +194,6 @@ public class XdcSpecProviderTests
         }
     }
 
-    // The subnet fork's GetMinGasPrice has no 50x transition and honours a gasless node.
     [Test]
     public void MinimumGasPrice_on_a_subnet_is_raised_from_genesis_and_zero_means_gasless()
     {

--- a/src/Nethermind/Nethermind.Xdc/InitializeBlockchainXdc.cs
+++ b/src/Nethermind/Nethermind.Xdc/InitializeBlockchainXdc.cs
@@ -48,7 +48,8 @@ internal class InitializeBlockchainXdc(
                 _txGossipPolicy,
                 [
                     new SignTransactionFilter(snapshotManager, _api.BlockTree, XdcSpecProvider),
-                    new BlackListedAddressFilter(chainHeadInfoProvider, XdcSpecProvider, _api.LogManager)
+                    new BlackListedAddressFilter(chainHeadInfoProvider, XdcSpecProvider, _api.LogManager),
+                    new MinGasPriceFilter(chainHeadInfoProvider, XdcSpecProvider, _api.LogManager)
                 ],
                 true
             );

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecBasedSpecProvider.cs
@@ -81,6 +81,9 @@ public class XdcChainSpecBasedSpecProvider(ChainSpec chainSpec,
         releaseSpec.IsTIPXDCXMiner = (chainSpecEngineParameters.TipXDCX ?? ulong.MaxValue) <= releaseStartBlock && releaseStartBlock < (chainSpecEngineParameters.TIPXDCXMinerDisable ?? ulong.MaxValue);
         releaseSpec.IsTIPXDCXReceiver = (chainSpecEngineParameters.TipXDCX ?? ulong.MaxValue) <= releaseStartBlock && releaseStartBlock < (chainSpecEngineParameters.TIPXDCXReceiverDisable ?? ulong.MaxValue);
         releaseSpec.IsDynamicGasLimitBlock = (chainSpecEngineParameters.DynamicGasLimitBlock ?? ulong.MaxValue) <= releaseStartBlock;
+        releaseSpec.MinimumGasPrice = (chainSpecEngineParameters.Gas50xBlock ?? ulong.MaxValue) <= releaseStartBlock
+            ? XdcConstants.DefaultMinGasPrice * XdcConstants.Gas50xMultiplier
+            : XdcConstants.DefaultMinGasPrice;
         // Fall back to ulong.MaxValue so that a null TipUpgradeReward/Penalty means "never enabled".
         releaseSpec.IsTipUpgradeRewardEnabled = (chainSpecEngineParameters.TipUpgradeReward ?? ulong.MaxValue) <= releaseStartBlock;
         releaseSpec.IsTipUpgradePenaltyEnabled = (chainSpecEngineParameters.TipUpgradePenalty ?? ulong.MaxValue) <= releaseStartBlock;

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecBasedSpecProvider.cs
@@ -81,6 +81,7 @@ public class XdcChainSpecBasedSpecProvider(ChainSpec chainSpec,
         releaseSpec.IsTIPXDCXMiner = (chainSpecEngineParameters.TipXDCX ?? ulong.MaxValue) <= releaseStartBlock && releaseStartBlock < (chainSpecEngineParameters.TIPXDCXMinerDisable ?? ulong.MaxValue);
         releaseSpec.IsTIPXDCXReceiver = (chainSpecEngineParameters.TipXDCX ?? ulong.MaxValue) <= releaseStartBlock && releaseStartBlock < (chainSpecEngineParameters.TIPXDCXReceiverDisable ?? ulong.MaxValue);
         releaseSpec.IsDynamicGasLimitBlock = (chainSpecEngineParameters.DynamicGasLimitBlock ?? ulong.MaxValue) <= releaseStartBlock;
+        releaseSpec.MinimumGasPrice = chainSpecEngineParameters.ResolveMinGasPrice(releaseStartBlock);
         // Fall back to ulong.MaxValue so that a null TipUpgradeReward/Penalty means "never enabled".
         releaseSpec.IsTipUpgradeRewardEnabled = (chainSpecEngineParameters.TipUpgradeReward ?? ulong.MaxValue) <= releaseStartBlock;
         releaseSpec.IsTipUpgradePenaltyEnabled = (chainSpecEngineParameters.TipUpgradePenalty ?? ulong.MaxValue) <= releaseStartBlock;

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecBasedSpecProvider.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecBasedSpecProvider.cs
@@ -81,9 +81,6 @@ public class XdcChainSpecBasedSpecProvider(ChainSpec chainSpec,
         releaseSpec.IsTIPXDCXMiner = (chainSpecEngineParameters.TipXDCX ?? ulong.MaxValue) <= releaseStartBlock && releaseStartBlock < (chainSpecEngineParameters.TIPXDCXMinerDisable ?? ulong.MaxValue);
         releaseSpec.IsTIPXDCXReceiver = (chainSpecEngineParameters.TipXDCX ?? ulong.MaxValue) <= releaseStartBlock && releaseStartBlock < (chainSpecEngineParameters.TIPXDCXReceiverDisable ?? ulong.MaxValue);
         releaseSpec.IsDynamicGasLimitBlock = (chainSpecEngineParameters.DynamicGasLimitBlock ?? ulong.MaxValue) <= releaseStartBlock;
-        releaseSpec.MinimumGasPrice = (chainSpecEngineParameters.Gas50xBlock ?? ulong.MaxValue) <= releaseStartBlock
-            ? XdcConstants.DefaultMinGasPrice * XdcConstants.Gas50xMultiplier
-            : XdcConstants.DefaultMinGasPrice;
         // Fall back to ulong.MaxValue so that a null TipUpgradeReward/Penalty means "never enabled".
         releaseSpec.IsTipUpgradeRewardEnabled = (chainSpecEngineParameters.TipUpgradeReward ?? ulong.MaxValue) <= releaseStartBlock;
         releaseSpec.IsTipUpgradePenaltyEnabled = (chainSpecEngineParameters.TipUpgradePenalty ?? ulong.MaxValue) <= releaseStartBlock;

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
@@ -130,7 +130,6 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
         // Without its own release spec boundary the flag would only flip on whichever transition encloses it.
         if (DynamicGasLimitBlock is not null)
             blockNumbers.Add(DynamicGasLimitBlock.Value);
-        // The transaction pool's gas price floor changes here.
         if (Gas50xBlock is not null)
             blockNumbers.Add(Gas50xBlock.Value);
         if (TipXDCX is not null)

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
@@ -106,9 +106,6 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
         // Without its own release spec boundary the flag would only flip on whichever transition encloses it.
         if (DynamicGasLimitBlock is not null)
             blockNumbers.Add(DynamicGasLimitBlock.Value);
-        // The gas price floor of the transaction pool changes here, so it needs its own release spec boundary.
-        if (Gas50xBlock is not null)
-            blockNumbers.Add(Gas50xBlock.Value);
         if (TipXDCX is not null)
             blockNumbers.Add(TipXDCX.Value);
         if (TIPXDCXMinerDisable is not null)

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
@@ -106,6 +106,9 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
         // Without its own release spec boundary the flag would only flip on whichever transition encloses it.
         if (DynamicGasLimitBlock is not null)
             blockNumbers.Add(DynamicGasLimitBlock.Value);
+        // The gas price floor of the transaction pool changes here, so it needs its own release spec boundary.
+        if (Gas50xBlock is not null)
+            blockNumbers.Add(Gas50xBlock.Value);
         if (TipXDCX is not null)
             blockNumbers.Add(TipXDCX.Value);
         if (TIPXDCXMinerDisable is not null)

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcChainSpecEngineParameters.cs
@@ -60,6 +60,18 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
     public ulong? TipXDCXCancellationFeeBlock { get; set; }
     public ulong? Gas50xBlock { get; set; }
 
+    /// <summary>
+    /// Gas price floor, in wei, that the transaction pool applies before <see cref="Gas50xBlock"/>; from that block it
+    /// is multiplied by <see cref="XdcConstants.Gas50xMultiplier"/>. Defaults to
+    /// <see cref="XdcConstants.DefaultMinGasPrice"/> (0.25 gwei, so 12.5 gwei once raised).
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the reference client's <c>--miner-gasprice</c>: a value below the default is raised to it, so the floor
+    /// can never be weakened below what the network expects. Zero means the same as unset here; only a subnet can
+    /// disable the check, via <see cref="XdcSubnetChainSpecEngineParameters"/>.
+    /// </remarks>
+    public UInt256? MinGasPrice { get; set; }
+
     public ulong? TipUpgradePenalty { get; set; }
     public ulong? TipUpgradeReward { get; set; }
     [JsonConverter(typeof(XdcToWeiConverter))]
@@ -75,6 +87,18 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
     public ulong? TIPXDCXMinerDisable { get; set; }
     public ulong? TIPXDCXReceiverDisable { get; set; }
     public ulong? DynamicGasLimitBlock { get; set; }
+
+    /// <summary>The transaction pool's gas price floor, in wei, at <paramref name="blockNumber"/>.</summary>
+    /// <remarks>Mirrors <c>common.GetMinGasPrice</c> of XDPoSChain: the configured floor below
+    /// <see cref="Gas50xBlock"/>, raised 50x from it.</remarks>
+    internal virtual UInt256 ResolveMinGasPrice(ulong blockNumber) =>
+        (Gas50xBlock ?? ulong.MaxValue) <= blockNumber
+            ? ConfiguredMinGasPrice * XdcConstants.Gas50xMultiplier
+            : ConfiguredMinGasPrice;
+
+    /// <summary>The stated floor, never below <see cref="XdcConstants.DefaultMinGasPrice"/>.</summary>
+    protected UInt256 ConfiguredMinGasPrice =>
+        UInt256.Max(MinGasPrice.GetValueOrDefault(), XdcConstants.DefaultMinGasPrice);
 
     private readonly struct V2ConfigBySwitchRoundComparer : IComparer<V2ConfigParams>
     {
@@ -106,6 +130,9 @@ public class XdcChainSpecEngineParameters : IChainSpecEngineParameters
         // Without its own release spec boundary the flag would only flip on whichever transition encloses it.
         if (DynamicGasLimitBlock is not null)
             blockNumbers.Add(DynamicGasLimitBlock.Value);
+        // The transaction pool's gas price floor changes here.
+        if (Gas50xBlock is not null)
+            blockNumbers.Add(Gas50xBlock.Value);
         if (TipXDCX is not null)
             blockNumbers.Add(TipXDCX.Value);
         if (TIPXDCXMinerDisable is not null)

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcReleaseSpec.cs
@@ -53,7 +53,6 @@ public class XdcReleaseSpec : ReleaseSpec, IXdcReleaseSpec
     public bool IsTIPXDCXMiner { get; set; }
     public bool IsTIPXDCXReceiver { get; set; }
     public bool IsDynamicGasLimitBlock { get; set; }
-    public UInt256 MinimumGasPrice { get; set; }
     public ulong RangeReturnSigner { get; set; }
 
     public void ApplyV2Config(ulong round)
@@ -149,9 +148,5 @@ public interface IXdcReleaseSpec : IReleaseSpec
     public bool IsTIPXDCXReceiver { get; set; }
     public bool IsTipUpgradePenaltyEnabled { get; set; }
     public bool IsDynamicGasLimitBlock { get; set; }
-
-    /// <summary>Gas price, in wei, below which the transaction pool rejects a non-special transaction. Zero disables the check.</summary>
-    /// <remarks>A mempool-admission rule rather than a consensus rule, so only the pool reads it.</remarks>
-    public UInt256 MinimumGasPrice { get; set; }
     public void ApplyV2Config(ulong round);
 }

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcReleaseSpec.cs
@@ -53,6 +53,7 @@ public class XdcReleaseSpec : ReleaseSpec, IXdcReleaseSpec
     public bool IsTIPXDCXMiner { get; set; }
     public bool IsTIPXDCXReceiver { get; set; }
     public bool IsDynamicGasLimitBlock { get; set; }
+    public UInt256 MinimumGasPrice { get; set; }
     public ulong RangeReturnSigner { get; set; }
 
     public void ApplyV2Config(ulong round)
@@ -148,5 +149,12 @@ public interface IXdcReleaseSpec : IReleaseSpec
     public bool IsTIPXDCXReceiver { get; set; }
     public bool IsTipUpgradePenaltyEnabled { get; set; }
     public bool IsDynamicGasLimitBlock { get; set; }
+
+    /// <summary>Gas price, in wei, below which the transaction pool rejects a non-special transaction. Zero disables the check.</summary>
+    /// <remarks>
+    /// A mempool-admission rule rather than a consensus rule, so only the pool reads it. Resolved from the chainspec by
+    /// <see cref="XdcChainSpecEngineParameters.ResolveMinGasPrice"/>.
+    /// </remarks>
+    public UInt256 MinimumGasPrice { get; set; }
     public void ApplyV2Config(ulong round);
 }

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcReleaseSpec.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcReleaseSpec.cs
@@ -53,6 +53,7 @@ public class XdcReleaseSpec : ReleaseSpec, IXdcReleaseSpec
     public bool IsTIPXDCXMiner { get; set; }
     public bool IsTIPXDCXReceiver { get; set; }
     public bool IsDynamicGasLimitBlock { get; set; }
+    public UInt256 MinimumGasPrice { get; set; }
     public ulong RangeReturnSigner { get; set; }
 
     public void ApplyV2Config(ulong round)
@@ -148,5 +149,9 @@ public interface IXdcReleaseSpec : IReleaseSpec
     public bool IsTIPXDCXReceiver { get; set; }
     public bool IsTipUpgradePenaltyEnabled { get; set; }
     public bool IsDynamicGasLimitBlock { get; set; }
+
+    /// <summary>Gas price, in wei, below which the transaction pool rejects a non-special transaction. Zero disables the check.</summary>
+    /// <remarks>A mempool-admission rule rather than a consensus rule, so only the pool reads it.</remarks>
+    public UInt256 MinimumGasPrice { get; set; }
     public void ApplyV2Config(ulong round);
 }

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcSubnetChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcSubnetChainSpecEngineParameters.cs
@@ -5,9 +5,5 @@ namespace Nethermind.Xdc.Spec;
 
 public class XdcSubnetChainSpecEngineParameters : XdcChainSpecEngineParameters
 {
-    // The subnet reference client has no 50x transition - its GetMinGasPrice always returns MinGasPrice50x - so the
-    // raised gas price floor applies from genesis. A chainspec that states Gas50xBlock still overrides this.
-    public XdcSubnetChainSpecEngineParameters() => Gas50xBlock = 0;
-
     public override string SealEngineType => XdcConstants.XDPoSSubnet;
 }

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcSubnetChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcSubnetChainSpecEngineParameters.cs
@@ -5,5 +5,9 @@ namespace Nethermind.Xdc.Spec;
 
 public class XdcSubnetChainSpecEngineParameters : XdcChainSpecEngineParameters
 {
+    // The subnet reference client has no 50x transition - its GetMinGasPrice always returns MinGasPrice50x - so the
+    // raised gas price floor applies from genesis. A chainspec that states Gas50xBlock still overrides this.
+    public XdcSubnetChainSpecEngineParameters() => Gas50xBlock = 0;
+
     public override string SealEngineType => XdcConstants.XDPoSSubnet;
 }

--- a/src/Nethermind/Nethermind.Xdc/Spec/XdcSubnetChainSpecEngineParameters.cs
+++ b/src/Nethermind/Nethermind.Xdc/Spec/XdcSubnetChainSpecEngineParameters.cs
@@ -1,9 +1,23 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Int256;
+
 namespace Nethermind.Xdc.Spec;
 
 public class XdcSubnetChainSpecEngineParameters : XdcChainSpecEngineParameters
 {
     public override string SealEngineType => XdcConstants.XDPoSSubnet;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// The subnet fork's <c>common.GetMinGasPrice</c> has no 50x transition - it always returns the raised floor - and
+    /// honours a gasless node, which its <c>--gasprice 0</c> enables. A subnet chainspec therefore states
+    /// <see cref="XdcChainSpecEngineParameters.MinGasPrice"/> as zero to run gasless, and
+    /// <see cref="Gas50xBlock"/> is not consulted at all.
+    /// </remarks>
+    internal override UInt256 ResolveMinGasPrice(ulong blockNumber) =>
+        MinGasPrice == UInt256.Zero
+            ? UInt256.Zero
+            : ConfiguredMinGasPrice * XdcConstants.Gas50xMultiplier;
 }

--- a/src/Nethermind/Nethermind.Xdc/TxPool/MinGasPriceFilter.cs
+++ b/src/Nethermind/Nethermind.Xdc/TxPool/MinGasPriceFilter.cs
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.TxPool;
+using Nethermind.TxPool.Filters;
+using Nethermind.Xdc.Spec;
+
+namespace Nethermind.Xdc.TxPool;
+
+/// <summary>
+/// Rejects transactions paying less than <see cref="IXdcReleaseSpec.MinimumGasPrice"/>, keeping them out of the pool
+/// and out of gossip.
+/// </summary>
+/// <remarks>
+/// This is a mempool-admission rule of the reference client (<c>ErrZeroGasPrice</c> and <c>ErrUnderMinGasPrice</c> in
+/// its <c>core/txpool/txpool.go</c>), not a consensus rule: a block carrying an underpriced transaction is still
+/// valid, so nothing outside the pool enforces the minimum. Special transactions - the free block-signing and
+/// randomize calls - are exempt there and here.
+/// <para>
+/// Two deliberate differences from Nethermind's <c>FeeTooLowFilter</c>, both to follow the reference client:
+/// locally submitted transactions are not exempt, and the value compared is the transaction's fee cap rather than its
+/// effective priority fee. The minimum is read from the spec of the current head, which is the header the reference
+/// client reads it from.
+/// </para>
+/// </remarks>
+internal sealed class MinGasPriceFilter(
+    IChainHeadInfoProvider chainHeadInfoProvider,
+    ISpecProvider specProvider,
+    ILogManager logManager) : IIncomingTxFilter
+{
+    private readonly ILogger _logger = logManager.GetClassLogger<MinGasPriceFilter>();
+
+    public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
+    {
+        IXdcReleaseSpec spec = specProvider.GetXdcSpec(chainHeadInfoProvider.HeadNumber);
+        UInt256 minimum = spec.MinimumGasPrice;
+
+        if (minimum.IsZero || tx.IsSpecialTransaction(spec))
+            return AcceptTxResult.Accepted;
+
+        // MaxFeePerGas is the fee cap of a 1559 transaction and the gas price of a legacy one, matching what the
+        // reference client compares - its tx.GasPrice() returns GasFeeCap for dynamic fee transactions.
+        if (tx.MaxFeePerGas < minimum)
+        {
+            AcceptTxResult result = AcceptTxResult.FeeTooLow.WithMessage($"Gas price below the chain minimum {tx.MaxFeePerGas} < {minimum}");
+            if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, {result}.");
+            return result;
+        }
+
+        return AcceptTxResult.Accepted;
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc/TxPool/MinGasPriceFilter.cs
+++ b/src/Nethermind/Nethermind.Xdc/TxPool/MinGasPriceFilter.cs
@@ -3,7 +3,6 @@
 
 using Nethermind.Core;
 using Nethermind.Core.Specs;
-using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.TxPool;
 using Nethermind.TxPool.Filters;
@@ -12,19 +11,31 @@ using Nethermind.Xdc.Spec;
 namespace Nethermind.Xdc.TxPool;
 
 /// <summary>
-/// Rejects transactions paying less than <see cref="IXdcReleaseSpec.MinimumGasPrice"/>, keeping them out of the pool
-/// and out of gossip.
+/// Rejects transactions paying less than <see cref="XdcConstants.MinGasPrice"/>, keeping them out of the pool and out
+/// of gossip.
 /// </summary>
 /// <remarks>
 /// This is a mempool-admission rule of the reference client (<c>ErrZeroGasPrice</c> and <c>ErrUnderMinGasPrice</c> in
 /// its <c>core/txpool/txpool.go</c>), not a consensus rule: a block carrying an underpriced transaction is still
-/// valid, so nothing outside the pool enforces the minimum. Special transactions - the free block-signing and
-/// randomize calls - are exempt there and here.
+/// valid, so nothing outside the pool enforces the floor. Special transactions - the free block-signing and randomize
+/// calls - are exempt there and here.
 /// <para>
-/// Two deliberate differences from Nethermind's <c>FeeTooLowFilter</c>, both to follow the reference client:
-/// locally submitted transactions are not exempt, and the value compared is the transaction's fee cap rather than its
-/// effective priority fee. The minimum is read from the spec of the current head, which is the header the reference
-/// client reads it from.
+/// Three things differ from what a reader of the neighbouring filters might expect, all of them to follow the
+/// reference client:
+/// <list type="bullet">
+/// <item>Locally submitted transactions are not exempt. The reference exempts them only from its separate
+/// <c>pool.gasPrice</c>/base fee check, not from this floor, so neither does this filter - unlike Nethermind's
+/// <c>FeeTooLowFilter</c>.</item>
+/// <item>The value compared is the fee cap rather than the effective priority fee, because the reference compares
+/// <c>tx.GasPrice()</c>, which returns <c>GasFeeCap</c> for a dynamic fee transaction. XDC's base fee is a constant
+/// equal to this floor, so comparing the priority fee would demand twice the price the reference asks for. That is
+/// also why <c>Blocks.MinGasPrice</c> cannot carry this value - it drives the block production filter off the
+/// priority fee, and the shipped XDC configs set it to zero for that reason.</item>
+/// <item>The exemption is <see cref="XdcExtensions.IsSpecialTransaction"/>, narrower than the
+/// <see cref="XdcExtensions.RequiresSpecialHandling"/> set that <see cref="XdcTransactionProcessor.BuyGas"/> gives
+/// free gas to. The reference keeps XDCX order and lending traffic in its own pools, so those transactions never
+/// reach this one.</item>
+/// </list>
 /// </para>
 /// </remarks>
 internal sealed class MinGasPriceFilter(
@@ -32,25 +43,24 @@ internal sealed class MinGasPriceFilter(
     ISpecProvider specProvider,
     ILogManager logManager) : IIncomingTxFilter
 {
+    // Built once: the floor is a constant, and the rejection path is reachable by any peer flooding underpriced
+    // transactions.
+    private static readonly AcceptTxResult Underpriced =
+        AcceptTxResult.FeeTooLow.WithMessage($"Gas price below the {XdcConstants.MinGasPrice} wei chain minimum");
+
     private readonly ILogger _logger = logManager.GetClassLogger<MinGasPriceFilter>();
 
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        IXdcReleaseSpec spec = specProvider.GetXdcSpec(chainHeadInfoProvider.HeadNumber);
-        UInt256 minimum = spec.MinimumGasPrice;
+        // The spec is only consulted for the special transaction addresses, so the block it is read for does not
+        // matter; head + 1 matches the sibling XDC filters.
+        IXdcReleaseSpec spec = specProvider.GetXdcSpec(chainHeadInfoProvider.HeadNumber + 1);
 
-        if (minimum.IsZero || tx.IsSpecialTransaction(spec))
+        if (tx.IsSpecialTransaction(spec) || tx.MaxFeePerGas >= XdcConstants.MinGasPrice)
             return AcceptTxResult.Accepted;
 
-        // MaxFeePerGas is the fee cap of a 1559 transaction and the gas price of a legacy one, matching what the
-        // reference client compares - its tx.GasPrice() returns GasFeeCap for dynamic fee transactions.
-        if (tx.MaxFeePerGas < minimum)
-        {
-            AcceptTxResult result = AcceptTxResult.FeeTooLow.WithMessage($"Gas price below the chain minimum {tx.MaxFeePerGas} < {minimum}");
-            if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, {result}.");
-            return result;
-        }
-
-        return AcceptTxResult.Accepted;
+        Metrics.PendingTransactionsTooLowFee++;
+        if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, {Underpriced}.");
+        return Underpriced;
     }
 }

--- a/src/Nethermind/Nethermind.Xdc/TxPool/MinGasPriceFilter.cs
+++ b/src/Nethermind/Nethermind.Xdc/TxPool/MinGasPriceFilter.cs
@@ -60,7 +60,6 @@ internal sealed class MinGasPriceFilter(
         if (minimum.IsZero || tx.IsSpecialTransaction(spec))
             return AcceptTxResult.Accepted;
 
-        // MaxFeePerGas is the fee cap of a 1559 transaction and the gas price of a legacy one.
         UInt256 gasPrice = tx.MaxFeePerGas;
         if (gasPrice.IsZero)
             return Reject(tx, ZeroGasPrice, minimum);

--- a/src/Nethermind/Nethermind.Xdc/TxPool/MinGasPriceFilter.cs
+++ b/src/Nethermind/Nethermind.Xdc/TxPool/MinGasPriceFilter.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Core;
 using Nethermind.Core.Specs;
+using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.TxPool;
 using Nethermind.TxPool.Filters;
@@ -11,14 +12,15 @@ using Nethermind.Xdc.Spec;
 namespace Nethermind.Xdc.TxPool;
 
 /// <summary>
-/// Rejects transactions paying less than <see cref="XdcConstants.MinGasPrice"/>, keeping them out of the pool and out
-/// of gossip.
+/// Rejects transactions paying less than <see cref="IXdcReleaseSpec.MinimumGasPrice"/>, keeping them out of the pool
+/// and out of gossip.
 /// </summary>
 /// <remarks>
-/// This is a mempool-admission rule of the reference client (<c>ErrZeroGasPrice</c> and <c>ErrUnderMinGasPrice</c> in
-/// its <c>core/txpool/txpool.go</c>), not a consensus rule: a block carrying an underpriced transaction is still
-/// valid, so nothing outside the pool enforces the floor. Special transactions - the free block-signing and randomize
-/// calls - are exempt there and here.
+/// Mirrors the two gas price checks of the reference client's <c>validateTx</c>: <c>ErrZeroGasPrice</c> and
+/// <c>ErrUnderMinGasPrice</c>, both applied only to transactions that are not special ones - the free block-signing
+/// and randomize calls. Neither is a consensus rule, so a block carrying an underpriced transaction is still valid
+/// and nothing outside the pool enforces the floor. A zero floor - a gasless subnet - disables both, as
+/// <c>common.Gasless</c> does there.
 /// <para>
 /// Three things differ from what a reader of the neighbouring filters might expect, all of them to follow the
 /// reference client:
@@ -27,14 +29,15 @@ namespace Nethermind.Xdc.TxPool;
 /// <c>pool.gasPrice</c>/base fee check, not from this floor, so neither does this filter - unlike Nethermind's
 /// <c>FeeTooLowFilter</c>.</item>
 /// <item>The value compared is the fee cap rather than the effective priority fee, because the reference compares
-/// <c>tx.GasPrice()</c>, which returns <c>GasFeeCap</c> for a dynamic fee transaction. XDC's base fee is a constant
-/// equal to this floor, so comparing the priority fee would demand twice the price the reference asks for. That is
-/// also why <c>Blocks.MinGasPrice</c> cannot carry this value - it drives the block production filter off the
-/// priority fee, and the shipped XDC configs set it to zero for that reason.</item>
+/// <c>tx.GasPrice()</c>, which returns <c>GasFeeCap</c> for a dynamic fee transaction. The reference reserves the
+/// tip for replacement bumps and overflow eviction and never gates admission or block building on it. Since XDC's
+/// base fee equals the raised floor, comparing the priority fee here would demand twice the price the reference asks
+/// for; that is also why <c>Blocks.MinGasPrice</c> cannot carry this value, and why the shipped XDC configs set it
+/// to zero.</item>
 /// <item>The exemption is <see cref="XdcExtensions.IsSpecialTransaction"/>, narrower than the
 /// <see cref="XdcExtensions.RequiresSpecialHandling"/> set that <see cref="XdcTransactionProcessor.BuyGas"/> gives
-/// free gas to. The reference keeps XDCX order and lending traffic in its own pools, so those transactions never
-/// reach this one.</item>
+/// free gas to. The reference keeps XDCX order and lending traffic in its own pools, and both shipped chainspecs
+/// disable it outright, so those transactions never reach this one.</item>
 /// </list>
 /// </para>
 /// </remarks>
@@ -43,24 +46,32 @@ internal sealed class MinGasPriceFilter(
     ISpecProvider specProvider,
     ILogManager logManager) : IIncomingTxFilter
 {
-    // Built once: the floor is a constant, and the rejection path is reachable by any peer flooding underpriced
-    // transactions.
-    private static readonly AcceptTxResult Underpriced =
-        AcceptTxResult.FeeTooLow.WithMessage($"Gas price below the {XdcConstants.MinGasPrice} wei chain minimum");
+    // The reference client's own errors carry no numbers, so these are static and the floor is logged instead.
+    private static readonly AcceptTxResult ZeroGasPrice = AcceptTxResult.FeeTooLow.WithMessage("zero gas price");
+    private static readonly AcceptTxResult UnderMinGasPrice = AcceptTxResult.FeeTooLow.WithMessage("under min gas price");
 
     private readonly ILogger _logger = logManager.GetClassLogger<MinGasPriceFilter>();
 
     public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
     {
-        // The spec is only consulted for the special transaction addresses, so the block it is read for does not
-        // matter; head + 1 matches the sibling XDC filters.
         IXdcReleaseSpec spec = specProvider.GetXdcSpec(chainHeadInfoProvider.HeadNumber + 1);
+        UInt256 minimum = spec.MinimumGasPrice;
 
-        if (tx.IsSpecialTransaction(spec) || tx.MaxFeePerGas >= XdcConstants.MinGasPrice)
+        if (minimum.IsZero || tx.IsSpecialTransaction(spec))
             return AcceptTxResult.Accepted;
 
+        // MaxFeePerGas is the fee cap of a 1559 transaction and the gas price of a legacy one.
+        UInt256 gasPrice = tx.MaxFeePerGas;
+        if (gasPrice.IsZero)
+            return Reject(tx, ZeroGasPrice, minimum);
+
+        return gasPrice < minimum ? Reject(tx, UnderMinGasPrice, minimum) : AcceptTxResult.Accepted;
+    }
+
+    private AcceptTxResult Reject(Transaction tx, AcceptTxResult result, in UInt256 minimum)
+    {
         Metrics.PendingTransactionsTooLowFee++;
-        if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, {Underpriced}.");
-        return Underpriced;
+        if (_logger.IsTrace) _logger.Trace($"Skipped adding transaction {tx.ToString("  ")}, {result}, minimum is {minimum}.");
+        return result;
     }
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
@@ -28,6 +28,11 @@ internal static class XdcConstants
     // XDC default gas limit per block https://github.com/XinFinOrg/XDPoSChain/blob/dev-upgrade/cicd/mainnet/start.sh#L120
     public const long DefaultTargetGasLimit = 420_000_000;
 
+    // Gas price floor of the reference client's transaction pool, in wei (0.25 gwei), and the factor by which
+    // Gas50xBlock raises it to 12.5 gwei. See common.DefaultMinGasPrice and common.MinGasPrice50x in XDPoSChain.
+    public const ulong DefaultMinGasPrice = 250_000_000;
+    public const uint Gas50xMultiplier = 50;
+
     public const byte ConsensusVersion = 0x02;
 
     public const int GasLimitBoundDivisor = 1024; // The bound divisor of gas limit adjustment per block

--- a/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
@@ -28,10 +28,10 @@ internal static class XdcConstants
     // XDC default gas limit per block https://github.com/XinFinOrg/XDPoSChain/blob/dev-upgrade/cicd/mainnet/start.sh#L120
     public const long DefaultTargetGasLimit = 420_000_000;
 
-    // Gas price floor of the reference client's transaction pool, in wei (0.25 gwei), and the factor by which
-    // Gas50xBlock raises it to 12.5 gwei. See common.DefaultMinGasPrice and common.MinGasPrice50x in XDPoSChain.
-    public const ulong DefaultMinGasPrice = 250_000_000;
-    public const uint Gas50xMultiplier = 50;
+    // Gas price floor of the reference client's transaction pool, in wei (12.5 gwei) - common.MinGasPrice50x in
+    // XDPoSChain. Its earlier 0.25 gwei floor is unreachable here: Gas50xBlock coincides with the XDPoS 2.0 switch
+    // block on both networks (mainnet 80370000, testnet 56828700) and only 2.0 is supported.
+    public const ulong MinGasPrice = 12_500_000_000;
 
     public const byte ConsensusVersion = 0x02;
 

--- a/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcConstants.cs
@@ -28,10 +28,10 @@ internal static class XdcConstants
     // XDC default gas limit per block https://github.com/XinFinOrg/XDPoSChain/blob/dev-upgrade/cicd/mainnet/start.sh#L120
     public const long DefaultTargetGasLimit = 420_000_000;
 
-    // Gas price floor of the reference client's transaction pool, in wei (12.5 gwei) - common.MinGasPrice50x in
-    // XDPoSChain. Its earlier 0.25 gwei floor is unreachable here: Gas50xBlock coincides with the XDPoS 2.0 switch
-    // block on both networks (mainnet 80370000, testnet 56828700) and only 2.0 is supported.
-    public const ulong MinGasPrice = 12_500_000_000;
+    // Inputs of the reference client's transaction pool gas price floor: common.DefaultMinGasPrice, in wei
+    // (0.25 gwei), and the factor by which Gas50xBlock raises it (common.MinGasPrice50x = 50x, 12.5 gwei).
+    public const ulong DefaultMinGasPrice = 250_000_000;
+    public const uint Gas50xMultiplier = 50;
 
     public const byte ConsensusVersion = 0x02;
 


### PR DESCRIPTION
## Changes

- Add `MinGasPriceFilter`, an XDC `IIncomingTxFilter` that rejects transactions below the chain's gas price floor, so they stay out of the pool and out of gossip instead of being stored and relayed to peers that drop them.
- Resolve that floor from the chainspec via a new optional `MinGasPrice` engine parameter, mirroring the reference client's two `GetMinGasPrice` variants — subnets and gasless subnets included.
- Set `Blocks.MinGasPrice` to `0` in the XDC mainnet and testnet configs — a **separate live bug**, see below.

### The pool floor

The reference enforces the floor on pool admission only: `ErrZeroGasPrice` and `ErrUnderMinGasPrice` in `core/txpool/txpool.go`. It is **not** a consensus rule — block validation never looks at gas price, so a block carrying an underpriced transaction is still valid and nothing outside the pool checks it. Special transactions (the free block-signing and randomize calls) are exempt. Nethermind had no equivalent, so an XDC node accepted, stored and gossiped transactions every Go peer drops.

The floor is chainspec-resolved rather than hardcoded because a subnet can be configured with a different gas price. `ResolveMinGasPrice` mirrors the reference per fork:

| | `XdcChainSpecEngineParameters` (XDPoSChain) | `XdcSubnetChainSpecEngineParameters` |
|---|---|---|
| floor | stated value below `Gas50xBlock`, `50 ×` it from that block | `50 ×` the stated value, always — the subnet fork has no 50x transition |
| gasless | not available, as in the reference | stated `0` disables the check, as `--gasprice 0` → `common.Gasless` does |
| below the default | raised to `DefaultMinGasPrice`, mirroring the reference's clamp on `--miner-gasprice` so the network floor can't be weakened | same |

Unset means the default, so both shipped chainspecs keep today's 12.5 gwei floor and need no new key. The reference's 50x multiplication is worth knowing about: `--gasprice 1000000000` yields a **50 gwei** floor, not 1 gwei.

### Why `Blocks.MinGasPrice: 0`

Found while testing the above, and worse than it. XDC's base fee is a **constant equal to the floor** (`XdcBaseFeeCalculator`), and EIP-1559 is already active on both networks (`eip1559Transition` 98,800,200 mainnet / 71,550,000 testnet, both behind the shipped pivots). `MinGasPriceTxFilter`, in the XDC block-production pipeline, compares the effective **priority fee**:

```
premiumPerGas = min(gasPrice, feeCap - baseFee) = min(12.5 gwei, 12.5 - 12.5) = 0
```

So with the 1 wei default, a Nethermind validator **skips every transaction paying exactly 12.5 gwei** — the reference's minimum, and what its gas price oracle suggests. There is no equivalent floor in the reference to match: its `NewTransactionsByPriceAndNonce` takes no base fee and orders on the raw gas price, so nothing in its block building converts to an effective tip. It reserves the tip for replacement bumps and overflow eviction only.

That is also why this key cannot carry the pool floor: it is a priority-fee comparison, whereas the reference compares the gas price / fee cap. One key cannot be both.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`MinGasPriceFilterTests` covers boundary values, the two distinct errors, fee-cap-vs-priority-fee for 1559 transactions, both special-transaction targets, contract creation, a zero (gasless) floor, that locals are not exempt, and end-to-end rejection on `TxPool.SubmitTx`. `XdcSpecProviderTests` covers the resolution: the 50x flip landing on its own release-spec boundary, the clamp, unset, zero outside a subnet, and the subnet's always-raised and gasless cases. `BlockProductionMinGasPriceTests` pins the `Blocks.MinGasPrice` behaviour. Full `Nethermind.Xdc.Test` (735) and `Nethermind.Runner.Test` (769) suites pass.

Four existing tests failed once the floor applied and now use a realistic gas price, which models a live node better.

### Verified on live nodes, before and after

A four-validator chain: two Nethermind validators and two `xinfinorg/devnet:latest` Go validators, round-robin proposers, EIP-1559 active with base fee exactly 12.5 gwei. Each case is an independent throwaway sender submitting one transaction.

**Pool admission.** Before, on `nethermindeth/nethermind:master`; after, on an image built from this branch:

| gas price | master | **this branch** | go devnet |
|---|---|---|---|
| 0 | ACCEPTED | **REJECTED** — `zero gas price` | REJECTED — `zero gas price` |
| 1 wei | ACCEPTED | **REJECTED** — `under min gas price` | REJECTED — `under min gas price` |
| 0.25 gwei | ACCEPTED | **REJECTED** — `under min gas price` | REJECTED — `under min gas price` |
| 12.5 gwei - 1 | ACCEPTED | **REJECTED** — `under min gas price` | REJECTED — `under min gas price` |
| 12.5 gwei | ACCEPTED | ACCEPTED | ACCEPTED |
| 13.75 gwei | ACCEPTED | ACCEPTED | ACCEPTED |

Four of six diverged before; all six agree after, with the reference's own error wording. On master, the four that Go refused were **still pending 190 blocks later**, 95 of them Nethermind-proposed — unmineable by any validator on the network, which is the pool pollution this filter removes. The 12.5 gwei floor was resolved from that chain's chainspec (`Gas50xBlock = 0`, `XDPoS` engine → `DefaultMinGasPrice × 50`), so the new resolution path is exercised on a real chain rather than only in unit tests.

**Block production**, isolating the config value on otherwise identical nodes — same image, same chain, same moment, masternode1 with `--Blocks.MinGasPrice=0` and masternode2 with the 1 wei default. Eight senders, one transaction each at exactly the floor, all submitted to Nethermind; all eight mined:

| proposer | took |
|---|---|
| **NM-mn1** (`MinGasPrice=0`) | 2 |
| **NM-mn2** (1 wei default) | **0** |
| GO-mn3 | 6 |

Across that window masternode2 proposed 35 blocks and included 12 transactions — sign transactions and above-floor ones — but not one of the eight at the floor. The config value alone separates the two nodes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

### One decision for reviewers

Setting `Blocks.MinGasPrice: 0` in the two shipped configs reaches **only operators who use those configs**. The live chain above runs its own config file, and the block-production bug reproduced on it with the branch image — so every subnet deployment and any operator with a custom config still runs a validator that silently skips minimum-price transactions.

Defaulting the key from the XDC plugin instead would reach them, but I did not find an established pattern for a plugin overriding another module's config default, and "did the operator set it explicitly" is not cleanly detectable from `IBlocksConfig`. Flagging it rather than guessing: happy to implement whichever way you prefer.

### Deliberate deviations

Three things about the filter differ from what a reader of the neighbouring XDC filters might expect, all to follow the reference, and all documented on the type: locals are not exempt; the fee cap is compared rather than the priority fee; and the exemption is `IsSpecialTransaction`, narrower than the `RequiresSpecialHandling` set `BuyGas` gives free gas to — the reference keeps XDCX order and lending traffic in separate pools, and both shipped chainspecs disable it outright via `TIPXDCXReceiverDisable`, so it never reaches this filter.

The spec is read at `HeadNumber + 1`, matching `BlackListedAddressFilter` and `SignTransactionFilter`, where the reference reads its current header. The two differ only for the single block at `Gas50xBlock`, which coincides with the XDPoS 2.0 switch block on both networks and is long past.

### Remaining divergences in the pool's gas and priority handling, not in scope

- **`MaxPendingTxsPerSender`** defaults to 0 (unlimited) against the reference's `LimitThresholdNonceInQueue = 10`, and measures from the confirmed rather than the pending nonce. One config line; the cheapest remaining convergence.
- **Pool capacity** — `TxPoolConfig.Size` 2048 against the reference's 5120 slots, and no per-account cap against its `AccountSlots = 16`. Different drop thresholds under load, same eviction semantics.
- **Special-transaction replacement** — the reference refuses to replace a pending special transaction and lets one force-replace a non-special transaction, bypassing the price bump; Nethermind does the opposite in both directions. Only reachable from the validator's own key, and `SignTransactionManager` takes its nonce from `GetLatestPendingNonce` so it queues rather than colliding. Fixing it needs a new injection point in `Nethermind.TxPool` for a custom replacement comparer.
- **`eth_gasPrice`** — the reference clamps its oracle up to `GetMinGasPrice` on non-1559 heads; Nethermind's clamps to `Blocks.MinGasPrice`, now 0 on XDC. On the live chain Nethermind suggests 13,750,000,001 against Go's 12,500,000,000, so it stays above the floor either way, but it's worth its own issue.

No change is needed for the reference's non-local underpriced check: once 1559 is active it compares the fee cap against the base fee, which on XDC is arithmetically the floor this filter already enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
