### PR TITLE
fix(flatdb): release compacted snapshots after base conversion

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotCompactorTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotCompactorTests.cs
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
@@ -14,6 +19,7 @@ using Nethermind.State.Flat.PersistedSnapshots;
 using Nethermind.State.Flat.Persistence.BloomFilter;
 using Nethermind.State.Flat.PersistedSnapshots.Storage;
 using Nethermind.Trie;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
@@ -38,6 +44,27 @@ public class PersistedSnapshotCompactorTests
     {
         _memArena.Dispose();
         try { Directory.Delete(_memArenaDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task EnqueueAsync_FailedHandoff_ReturnsBatchToPool(bool channelClosed)
+    {
+        using FlatTestContainer tier = new();
+        using CancellationTokenSource cancellation = new();
+        ArrayPool<StateId> pool = Substitute.For<ArrayPool<StateId>>();
+        StateId[] rented = new StateId[1];
+        pool.Rent(1).Returns(rented);
+        using ArrayPoolList<StateId> batch = new(pool, 1) { new StateId(1, Keccak.EmptyTreeHash) };
+
+        if (channelClosed)
+            await tier.Compactor.DisposeAsync();
+        else
+            await cancellation.CancelAsync();
+
+        Type exceptionType = channelClosed ? typeof(ChannelClosedException) : typeof(OperationCanceledException);
+        Assert.That(async () => await tier.Compactor.EnqueueAsync(batch, 0, cancellation.Token), Throws.InstanceOf(exceptionType));
+        pool.Received(1).Return(rented, Arg.Any<bool>());
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotCompactorTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotCompactorTests.cs
@@ -6,7 +6,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -48,7 +47,7 @@ public class PersistedSnapshotCompactorTests
 
     [TestCase(false)]
     [TestCase(true)]
-    public async Task EnqueueAsync_FailedHandoff_ReturnsBatchToPool(bool channelClosed)
+    public async Task EnqueueAsync_FailedHandoff_ReturnsBatchToPool(bool disposed)
     {
         using FlatTestContainer tier = new();
         using CancellationTokenSource cancellation = new();
@@ -57,12 +56,12 @@ public class PersistedSnapshotCompactorTests
         pool.Rent(1).Returns(rented);
         using ArrayPoolList<StateId> batch = new(pool, 1) { new StateId(1, Keccak.EmptyTreeHash) };
 
-        if (channelClosed)
+        if (disposed)
             await tier.Compactor.DisposeAsync();
         else
             await cancellation.CancelAsync();
 
-        Type exceptionType = channelClosed ? typeof(ChannelClosedException) : typeof(OperationCanceledException);
+        Type exceptionType = disposed ? typeof(ObjectDisposedException) : typeof(OperationCanceledException);
         Assert.That(async () => await tier.Compactor.EnqueueAsync(batch, 0, cancellation.Token), Throws.InstanceOf(exceptionType));
         pool.Received(1).Return(rented, Arg.Any<bool>());
     }

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -66,7 +66,7 @@ public class PersistenceManagerTests
 
         _persistenceManager = new PersistenceManager(
             _config,
-            ScheduleHelper.CreateWithOffset(_config, 0),
+            _tier.Resolve<ICompactionSchedule>(),
             _finalizedStateProvider,
             _persistence,
             _snapshotRepository,

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
@@ -39,6 +41,7 @@ public class PersistenceManagerTests
         _config = new FlatDbConfig
         {
             CompactSize = 16,
+            CompactionOffset = 0,
             MinReorgDepth = 64,
             MaxInMemoryBaseSnapshotCount = 128 + 32,
             MaxReorgDepth = 256,
@@ -51,7 +54,7 @@ public class PersistenceManagerTests
         // SnapshotRepository owns both tiers over a real temp-dir-backed persisted store, wired the
         // production way through FlatWorldStateModule; the container pairs it with its loader (load on
         // build, teardown on dispose).
-        _tier = new FlatTestContainer();
+        _tier = new FlatTestContainer(_config);
         _snapshotRepository = _tier.Repository;
         _persistence = Substitute.For<IPersistence>();
 
@@ -89,10 +92,11 @@ public class PersistenceManagerTests
         return new StateId(blockNumber, new ValueHash256(bytes));
     }
 
-    private Snapshot CreateSnapshot(StateId from, StateId to, bool compacted = false)
+    private Snapshot CreateSnapshot(StateId from, StateId to, bool compacted = false, Action<Snapshot>? populate = null)
     {
         Snapshot snapshot = _resourcePool.CreateSnapshot(from, to, ResourcePool.Usage.ReadOnlyProcessingEnv);
         snapshot.Content.Accounts[TestItem.AddressA] = new Account(1, 100);
+        populate?.Invoke(snapshot);
 
         if (compacted)
         {
@@ -477,22 +481,30 @@ public class PersistenceManagerTests
     [TestCase(8)]
     public async Task AddToPersistence_RepeatedForks_ReleasesConvertedCompactedSnapshots(int forkCount)
     {
-        _tier.Config.CompactionOffset = 0;
-
         // Keep the conversion threshold reached while each fork stays below a full compaction boundary.
         for (int i = 0; i < _config.MaxInMemoryBaseSnapshotCount; i++)
             CreateSnapshot(Block0, CreateStateId(3, (byte)i));
 
         ISnapshotCompactor compactor = _tier.Resolve<ISnapshotCompactor>();
         List<Snapshot> convertedCompacts = [];
+        List<int> compactedCountsAtHandoff = [];
         StateId latest = Block0;
+        _persistedSnapshotCompactor
+            .EnqueueAsync(Arg.Any<ArrayPoolList<StateId>>(), Arg.Any<ulong>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                using ArrayPoolList<StateId> batch = call.Arg<ArrayPoolList<StateId>>();
+                if (batch[0] == latest)
+                    compactedCountsAtHandoff.Add(_snapshotRepository.CompactedSnapshotCount);
+                return ValueTask.CompletedTask;
+            });
+
         for (int i = 1; i <= forkCount; i++)
         {
             StateId setup = CreateStateId(1, (byte)i);
             latest = CreateStateId(2, (byte)i);
-            Snapshot setupSnapshot = CreateSnapshot(Block0, setup);
             Account setupAccount = new(1, (UInt256)i);
-            setupSnapshot.Content.Accounts[TestItem.AddressB] = setupAccount;
+            CreateSnapshot(Block0, setup, populate: snapshot => snapshot.Content.Accounts[TestItem.AddressB] = setupAccount);
             CreateSnapshot(setup, latest);
 
             Assert.That(compactor.DoCompactSnapshot(latest), Is.True);
@@ -512,6 +524,8 @@ public class PersistenceManagerTests
         {
             Assert.That(_snapshotRepository.SnapshotCount, Is.EqualTo(_config.MaxInMemoryBaseSnapshotCount));
             Assert.That(_snapshotRepository.CompactedSnapshotCount, Is.Zero, "converted forks must not retain compacted snapshots");
+            Assert.That(compactedCountsAtHandoff, Has.Count.EqualTo(forkCount));
+            Assert.That(compactedCountsAtHandoff, Is.All.Zero, "compacted snapshots must be released before the potentially blocking handoff");
             Assert.That(assembled.InMemory.Count, Is.Zero);
             Assert.That(assembled.Persisted.Count, Is.EqualTo(2), "the persisted bases must still cover the fork");
             foreach (Snapshot compacted in convertedCompacts)

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -473,6 +473,56 @@ public class PersistenceManagerTests
         });
     }
 
+    [TestCase(1)]
+    [TestCase(8)]
+    public async Task AddToPersistence_RepeatedForks_ReleasesConvertedCompactedSnapshots(int forkCount)
+    {
+        _tier.Config.CompactionOffset = 0;
+
+        // Keep the conversion threshold reached while each fork stays below a full compaction boundary.
+        for (int i = 0; i < _config.MaxInMemoryBaseSnapshotCount; i++)
+            CreateSnapshot(Block0, CreateStateId(3, (byte)i));
+
+        ISnapshotCompactor compactor = _tier.Resolve<ISnapshotCompactor>();
+        List<Snapshot> convertedCompacts = [];
+        StateId latest = Block0;
+        for (int i = 1; i <= forkCount; i++)
+        {
+            StateId setup = CreateStateId(1, (byte)i);
+            latest = CreateStateId(2, (byte)i);
+            Snapshot setupSnapshot = CreateSnapshot(Block0, setup);
+            Account setupAccount = new(1, (UInt256)i);
+            setupSnapshot.Content.Accounts[TestItem.AddressB] = setupAccount;
+            CreateSnapshot(setup, latest);
+
+            Assert.That(compactor.DoCompactSnapshot(latest), Is.True);
+            Assert.That(_snapshotRepository.TryLeaseInMemoryState(latest, SnapshotTier.InMemoryCompacted, out Snapshot? compacted), Is.True);
+            using (compacted)
+            {
+                convertedCompacts.Add(compacted!);
+                await _persistenceManager.AddToPersistence(latest);
+
+                Assert.That(compacted!.TryGetAccount(TestItem.AddressB, out Account? account), Is.True);
+                Assert.That(account, Is.EqualTo(setupAccount), "an active reader must survive conversion");
+            }
+        }
+
+        using AssembledSnapshotResult assembled = _snapshotRepository.AssembleSnapshots(latest, Block0, 2);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_snapshotRepository.SnapshotCount, Is.EqualTo(_config.MaxInMemoryBaseSnapshotCount));
+            Assert.That(_snapshotRepository.CompactedSnapshotCount, Is.Zero, "converted forks must not retain compacted snapshots");
+            Assert.That(assembled.InMemory.Count, Is.Zero);
+            Assert.That(assembled.Persisted.Count, Is.EqualTo(2), "the persisted bases must still cover the fork");
+            foreach (Snapshot compacted in convertedCompacts)
+            {
+                bool retained = compacted.TryAcquire();
+                if (retained) compacted.Dispose();
+                Assert.That(retained, Is.False, "compacted data must be released after the last reader exits");
+            }
+        }
+    }
+
     [Test]
     public async Task AddToPersistence_InMemoryPersist_PrunesPersistedTier()
     {

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/IPersistedSnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/IPersistedSnapshotCompactor.cs
@@ -22,5 +22,9 @@ public interface IPersistedSnapshotCompactor : IAsyncDisposable
     /// Compaction windows are clamped to not reach below it — snapshots below are already in RocksDB,
     /// so merging them would be wasted work.</param>
     /// <param name="cancellationToken">Releases the backpressure wait when the producer is shutting down.</param>
+    /// <exception cref="ObjectDisposedException">The compactor has been disposed. This check precedes cancellation;
+    /// <paramref name="batch"/> is returned to its pool before the exception is propagated.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was canceled before or while
+    /// waiting to enqueue; <paramref name="batch"/> is returned to its pool before the exception is propagated.</exception>
     ValueTask EnqueueAsync(ArrayPoolList<StateId> batch, ulong persistedBlockNumber, CancellationToken cancellationToken);
 }

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/IPersistedSnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/IPersistedSnapshotCompactor.cs
@@ -13,9 +13,9 @@ public interface IPersistedSnapshotCompactor : IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// Takes ownership of <paramref name="batch"/> and disposes it once the batch has been
-    /// processed (or drained on cancellation). Asynchronously awaits a free slot when the internal
-    /// queue is full, providing backpressure to the block-processing pipeline without blocking a
-    /// thread.
+    /// processed, rejected during enqueue, or drained on cancellation. Asynchronously awaits a free
+    /// slot when the internal queue is full, providing backpressure to the block-processing pipeline
+    /// without blocking a thread.
     /// </remarks>
     /// <param name="batch">The converted states to compact; ownership transfers to the compactor.</param>
     /// <param name="persistedBlockNumber">The current persistence point (RocksDB persisted state block).

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotCompactor.cs
@@ -87,6 +87,8 @@ public class PersistedSnapshotCompactor(
         // Guard against concurrent EnqueueAsync callers spawning duplicate worker sets.
         lock (_startLock)
         {
+            ObjectDisposedException.ThrowIf(_disposed != 0, this);
+
             _compactPersistedTask ??= RunPersistedCompactor(_shutdownToken);
             if (_boundaryCompactorTasks is null)
             {
@@ -214,7 +216,11 @@ public class PersistedSnapshotCompactor(
 
     public async ValueTask DisposeAsync()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        lock (_startLock)
+        {
+            if (_disposed != 0) return;
+            _disposed = 1;
+        }
         // Complete and drain the persisted stage first so any boundary jobs it produces are written
         // before the boundary channel is completed; on process exit the shared token has already
         // cancelled both stages, so these awaits return promptly instead of draining.

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotCompactor.cs
@@ -66,15 +66,15 @@ public class PersistedSnapshotCompactor(
     /// <inheritdoc/>
     public async ValueTask EnqueueAsync(ArrayPoolList<StateId> batch, ulong persistedBlockNumber, CancellationToken cancellationToken)
     {
-        // Fire-and-forget: EnsureStarted returns the long-running compactor task, which must not be awaited.
-        _ = EnsureStarted();
         try
         {
+            // Fire-and-forget: EnsureStarted returns the long-running compactor task, which must not be awaited.
+            _ = EnsureStarted();
             // Awaits a free slot on the bounded queue, providing backpressure without blocking a thread;
             // the caller's token releases the wait on shutdown.
             await _compactPersistedJobs.Writer.WriteAsync((batch, persistedBlockNumber), cancellationToken);
         }
-        catch (OperationCanceledException)
+        catch
         {
             // The batch never entered the channel, so dispose the handoff we still own.
             batch.Dispose();

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -364,11 +364,10 @@ public class PersistenceManager(
             loader.ConvertAndRegister(baseSnap);
             Metrics.PersistedSnapshotConvertTime.Observe(Stopwatch.GetTimestamp() - sw);
 
-            ArrayPoolList<StateId> single = new(1) { baseSnap.To };
-
             snapshotRepository.RemoveAndReleaseInMemoryKnownState(baseSnap.To, SnapshotTier.InMemoryCompacted);
             snapshotRepository.RemoveAndReleaseInMemoryKnownState(baseSnap.To, SnapshotTier.InMemoryBase);
 
+            ArrayPoolList<StateId> single = new(1) { baseSnap.To };
             await compactor.EnqueueAsync(single, GetCurrentPersistedStateId().BlockNumber, _cts.Token);
         }
         finally

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -367,6 +367,7 @@ public class PersistenceManager(
             ArrayPoolList<StateId> single = new(1) { baseSnap.To };
             await compactor.EnqueueAsync(single, GetCurrentPersistedStateId().BlockNumber, _cts.Token);
 
+            snapshotRepository.RemoveAndReleaseInMemoryKnownState(baseSnap.To, SnapshotTier.InMemoryCompacted);
             snapshotRepository.RemoveAndReleaseInMemoryKnownState(baseSnap.To, SnapshotTier.InMemoryBase);
         }
         finally

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -365,10 +365,11 @@ public class PersistenceManager(
             Metrics.PersistedSnapshotConvertTime.Observe(Stopwatch.GetTimestamp() - sw);
 
             ArrayPoolList<StateId> single = new(1) { baseSnap.To };
-            await compactor.EnqueueAsync(single, GetCurrentPersistedStateId().BlockNumber, _cts.Token);
 
             snapshotRepository.RemoveAndReleaseInMemoryKnownState(baseSnap.To, SnapshotTier.InMemoryCompacted);
             snapshotRepository.RemoveAndReleaseInMemoryKnownState(baseSnap.To, SnapshotTier.InMemoryBase);
+
+            await compactor.EnqueueAsync(single, GetCurrentPersistedStateId().BlockNumber, _cts.Token);
         }
         finally
         {


### PR DESCRIPTION
## Changes

- Release the matching in-memory compacted snapshot when converting a single base snapshot to the persisted tier. Previously, base removal also deleted its StateId from the pruning index, leaving the compacted snapshot and its account/storage/trie data retained outside normal cleanup. Release compacted ownership before base ownership and before the potentially blocking compactor handoff; active readers retain their own leases.
- Return the compaction batch to its pool if worker startup or enqueue fails, including a closed channel during shutdown. Cleanup belongs to `EnqueueAsync`, which takes batch ownership for both conversion branches.
- Serialize worker startup and disposal under the same lock. Reject enqueue after disposal with `ObjectDisposedException.ThrowIf` before starting workers, while still returning the rejected batch to its pool.
- Add regressions covering one and eight two-block forks, release before handoff, active-reader validity, persisted ancestry, and pooled-array return on canceled or disposed enqueue attempts. Populate test snapshots before registration seals their counts.
- Align the entire `PersistenceManagerTests` fixture with its existing manager configuration: the container now receives `CompactSize = 16` (previously 32), `MinReorgDepth = 64` (previously 128), and `CompactionOffset = 0` (previously random). The manager uses the same container-resolved schedule. This changes the configuration of all 49 fixture tests, not only the new regression; the container still applies its usual test arena/cache overrides.

Investigated after [benchmarkoor run 34104257992](https://github.com/ethpandaops/benchmarkoor-tests/actions/runs/34104257992) encountered managed OOMs. This fixes a reproduced retention defect. Its contribution to the benchmark OOM is unquantified, and the benchmark has not been rerun with the fix. The original OOM remains unresolved.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Retention regression run before the production fix: both cases failed, retaining one and eight compacted snapshots respectively. Both pass with the fix. The handoff assertions also failed before moving cleanup ahead of enqueue and pass afterwards.
- Closed-channel enqueue regression failed before the receiver cleanup fix: no return to the array pool. The cancellation and disposed cases verify exactly one return. The disposed case also failed before the startup guard (expected `ObjectDisposedException`, received `ChannelClosedException`) and passes with it.
- Release build and all 49 persistence tests plus the two failed-handoff cases pass (51 tests).
- Full `Nethermind.State.Flat.Test` suite on Windows: 1,037 passed, 10 skipped, 14 failed during arena/blob file cleanup with sharing violations. The failure names match the 14 failures reproduced on the baseline without the retention fix.
- `dotnet format whitespace` verification for all five changed files and `git diff --check` pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Fixed FlatDb retaining compacted snapshots after their base snapshots were converted to disk, which could increase memory use during repeated forks.

