### PR TITLE
fix(rlp): close the receipt logs sequence on both decode paths

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptMessageDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/ReceiptMessageDecoderTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core.Test.Builders;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
@@ -8,10 +9,79 @@ namespace Nethermind.Core.Test.Encoding;
 
 public class ReceiptMessageDecoderTests
 {
+    private const byte ShortSequenceHeaderBase = 0xc0;
+
     [Test]
     public void TestGlobalReceiptEncoderMustBeReceiptMessageDecoder()
     {
         Rlp.Decoders[typeof(TxReceipt)].Equals(typeof(ReceiptMessageDecoder));
         Rlp.Decoders[typeof(LogEntry)].Equals(typeof(LogEntryDecoder));
+    }
+
+    // The item count only requires a log to start before the declared end, so an under-declared logs header
+    // consumes the same bytes as the canonical one and every checkpoint one level out still holds.
+    [TestCase(TxType.Legacy, false, TestName = "Decode_CanonicalLogsHeader_IsAccepted")]
+    [TestCase(TxType.Legacy, true, TestName = "Decode_UnderDeclaredLogsHeader_Throws")]
+    [TestCase(TxType.FrameTx, false, TestName = "Decode_CanonicalFrameLogsHeader_IsAccepted")]
+    [TestCase(TxType.FrameTx, true, TestName = "Decode_UnderDeclaredFrameLogsHeader_Throws")]
+    public void Decode_LogsHeaderMustMatchItsContent(TxType txType, bool underDeclare)
+    {
+        LogEntry log = new(TestItem.AddressB, [], []);
+        TxReceipt receipt = txType == TxType.FrameTx
+            ? new TxReceipt
+            {
+                TxType = TxType.FrameTx,
+                GasUsedTotal = 21_000,
+                Payer = TestItem.AddressA,
+                FrameReceipts = [new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, [log])],
+            }
+            : new TxReceipt
+            {
+                TxType = TxType.Legacy,
+                StatusCode = 1,
+                GasUsedTotal = 21_000,
+                Bloom = new Bloom(),
+                Logs = [log],
+            };
+
+        ReceiptMessageDecoder decoder = new();
+        byte[] encoded = decoder.EncodeNew(receipt, RlpBehaviors.Eip658Receipts);
+        int headerIndex = LogsHeaderIndex(encoded, txType, Rlp.LengthOf(log));
+
+        if (underDeclare)
+        {
+            encoded[headerIndex]--;
+            Assert.That(() => Decode(decoder, encoded), Throws.InstanceOf<RlpException>());
+        }
+        else
+        {
+            Assert.That(Decode(decoder, encoded).Logs, Has.Length.EqualTo(1));
+        }
+    }
+
+    /// <summary>Locates the header of the logs list holding the single log both paths encode.</summary>
+    /// <remarks>The logs are the last item of the payload on either path, so the declared payload end places
+    /// their header exactly. A byte scan could instead hit an unrelated field and still throw, passing for the
+    /// wrong reason; the header assertion catches any drift in that layout.</remarks>
+    private static int LogsHeaderIndex(byte[] encoded, TxType txType, int logsContentLength)
+    {
+        RlpReader locator = new(encoded);
+        if (txType != TxType.Legacy)
+        {
+            locator.SkipLength();
+            locator.ReadByte();
+        }
+
+        int payloadEnd = locator.ReadSequenceLength() + locator.Position;
+        int headerIndex = payloadEnd - logsContentLength - 1;
+        Assert.That(encoded[headerIndex], Is.EqualTo((byte)(ShortSequenceHeaderBase + logsContentLength)),
+            "the logs list header is not where the payload layout puts it");
+        return headerIndex;
+    }
+
+    private static TxReceipt Decode(ReceiptMessageDecoder decoder, byte[] encoded)
+    {
+        RlpReader reader = new(encoded);
+        return decoder.Decode(ref reader)!;
     }
 }

--- a/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/ReceiptMessageDecoder69Tests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/Subprotocols/Eth/V69/ReceiptMessageDecoder69Tests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Network.P2P.Subprotocols.Eth.V69.Messages;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
@@ -11,6 +12,8 @@ namespace Nethermind.Network.Test.P2P.Subprotocols.Eth.V69;
 [TestFixture]
 public class ReceiptMessageDecoder69Tests
 {
+    private const byte ShortSequenceHeaderBase = 0xc0;
+
     [Test]
     public void Can_roundtrip_receipt()
     {
@@ -73,6 +76,59 @@ public class ReceiptMessageDecoder69Tests
             RlpWriter writer = new(new byte[64]);
             decoder.Encode(ref writer, receipt);
         }
+    }
+
+    // The item count only requires a log to start before the declared end, so an under-declared logs header
+    // consumes the same bytes as the canonical one and every checkpoint one level out still holds.
+    [TestCase(false, TestName = "Decode_CanonicalLogsHeader_IsAccepted")]
+    [TestCase(true, TestName = "Decode_UnderDeclaredLogsHeader_Throws")]
+    public void Decode_LogsHeaderMustMatchItsContent(bool underDeclare)
+    {
+        LogEntry log = new(TestItem.AddressB, [], []);
+        TxReceipt receipt = new()
+        {
+            TxType = TxType.EIP1559,
+            StatusCode = 1,
+            GasUsedTotal = 21000,
+            Bloom = new Bloom(),
+            Logs = [log]
+        };
+
+        ReceiptMessageDecoder69 decoder = new();
+        byte[] encoded = new byte[decoder.GetLength(receipt, RlpBehaviors.Eip658Receipts)];
+        RlpWriter writer = new(encoded);
+        decoder.Encode(ref writer, receipt, RlpBehaviors.Eip658Receipts);
+        int headerIndex = LogsHeaderIndex(encoded, Rlp.LengthOf(log));
+
+        if (underDeclare)
+        {
+            encoded[headerIndex]--;
+            Assert.That(() => Decode(decoder, encoded), Throws.InstanceOf<RlpException>());
+        }
+        else
+        {
+            Assert.That(Decode(decoder, encoded).Logs, Has.Length.EqualTo(1));
+        }
+    }
+
+    /// <summary>Locates the header of the logs list holding the single log the receipt carries.</summary>
+    /// <remarks>The logs are the last item of the payload, so the declared payload end places their header
+    /// exactly. A byte scan could instead hit an unrelated field and still throw, passing for the wrong
+    /// reason; the header assertion catches any drift in that layout.</remarks>
+    private static int LogsHeaderIndex(byte[] encoded, int logsContentLength)
+    {
+        RlpReader locator = new(encoded);
+        int payloadEnd = locator.ReadSequenceLength() + locator.Position;
+        int headerIndex = payloadEnd - logsContentLength - 1;
+        Assert.That(encoded[headerIndex], Is.EqualTo((byte)(ShortSequenceHeaderBase + logsContentLength)),
+            "the logs list header is not where the payload layout puts it");
+        return headerIndex;
+    }
+
+    private static TxReceipt Decode(ReceiptMessageDecoder69 decoder, byte[] encoded)
+    {
+        RlpReader reader = new(encoded);
+        return decoder.Decode(ref reader, RlpBehaviors.Eip658Receipts)!;
     }
 
     private static byte[] EncodeReceiptWithNullLogEntry()

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Messages/ReceiptMessageDecoder69.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Messages/ReceiptMessageDecoder69.cs
@@ -57,6 +57,9 @@ public sealed class ReceiptMessageDecoder69(bool skipStateAndStatus = false) : R
             entries[i] = LogEntryDecoder.Instance.DecodeGuardNotNull(ref ctx, RlpBehaviors.AllowExtraBytes);
         }
 
+        // The item count only requires each log to start before the declared end, so without this the last
+        // one may overrun it: an under-declared header consumes the same bytes and the receipt checkpoint holds.
+        ctx.Check(lastCheck);
         txReceipt.Logs = entries;
 
         // Handle any remaining extra bytes

--- a/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Messages/ReceiptMessageDecoder69.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/Subprotocols/Eth/V69/Messages/ReceiptMessageDecoder69.cs
@@ -57,8 +57,6 @@ public sealed class ReceiptMessageDecoder69(bool skipStateAndStatus = false) : R
             entries[i] = LogEntryDecoder.Instance.DecodeGuardNotNull(ref ctx, RlpBehaviors.AllowExtraBytes);
         }
 
-        // The item count only requires each log to start before the declared end, so without this the last
-        // one may overrun it: an under-declared header consumes the same bytes and the receipt checkpoint holds.
         ctx.Check(lastCheck);
         txReceipt.Logs = entries;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -72,6 +72,10 @@ namespace Nethermind.Serialization.Rlp
             {
                 entries[i] = LogEntryDecoder.Instance.DecodeGuardNotNull(ref ctx, RlpBehaviors.AllowExtraBytes);
             }
+
+            // The item count only requires each log to start before the declared end, so without this the last
+            // one may overrun it: an under-declared header consumes the same bytes and the receipt checkpoint holds.
+            ctx.Check(lastCheck);
             txReceipt.Logs = entries;
 
             // Handle any remaining extra bytes
@@ -148,6 +152,10 @@ namespace Nethermind.Serialization.Rlp
                 {
                     logs[j] = LogEntryDecoder.Instance.DecodeGuardNotNull(ref ctx, RlpBehaviors.AllowExtraBytes);
                 }
+
+                // Closes the logs sequence the same way as the regular path: the frame checkpoint below sits one
+                // level out, so on its own it accepts a last log that overruns the logs header.
+                ctx.Check(logsEnd);
 
                 frameReceipts[i] = new TxFrameReceipt(status, executionGasUsed, stateGasUsed, logs);
                 ctx.Check(frameEnd);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -73,8 +73,6 @@ namespace Nethermind.Serialization.Rlp
                 entries[i] = LogEntryDecoder.Instance.DecodeGuardNotNull(ref ctx, RlpBehaviors.AllowExtraBytes);
             }
 
-            // The item count only requires each log to start before the declared end, so without this the last
-            // one may overrun it: an under-declared header consumes the same bytes and the receipt checkpoint holds.
             ctx.Check(lastCheck);
             txReceipt.Logs = entries;
 
@@ -153,8 +151,6 @@ namespace Nethermind.Serialization.Rlp
                     logs[j] = LogEntryDecoder.Instance.DecodeGuardNotNull(ref ctx, RlpBehaviors.AllowExtraBytes);
                 }
 
-                // Closes the logs sequence the same way as the regular path: the frame checkpoint below sits one
-                // level out, so on its own it accepts a last log that overruns the logs header.
                 ctx.Check(logsEnd);
 
                 frameReceipts[i] = new TxFrameReceipt(status, executionGasUsed, stateGasUsed, logs);


### PR DESCRIPTION
## Changes

The receipt decoders count the logs in a receipt with an item walk that only
requires each element to **start** before the list's declared end — it never checks
that the last one **ends** there. Three decode paths did not close the logs sequence
afterwards:

- `ReceiptMessageDecoder`, **frame path** — `logsEnd` was computed and used only for the
  peek. `Check(frameEnd)` and `Check(receiptEnd)` sit one and two levels out.
- `ReceiptMessageDecoder`, **regular path** — the same shape with `lastCheck`; the
  `receiptEnd` handling is the outer boundary, not the logs sequence.
- `ReceiptMessageDecoder69` — byte-identical to the regular path above, and the decoder
  actually on the wire for eth/69+.

So an under-declared logs header consumes exactly the same bytes as the canonical one,
the decode lands where the canonical form would, and every outer checkpoint passes:
one receipt, two accepted wire forms. This adds `ctx.Check(...)` on all three, matching what
`ReceiptStorageDecoder` / `CompactReceiptStorageDecoder` already do on their regular path
and what #13212 did for `nonce_keys`.

All three are fixed deliberately. The two regular paths are inherited from master rather than
introduced by the frames work, but they are the same defect in the same shape, and closing
only some of them would leave their siblings open — least of all the eth/69 one, which is the
most-used of the three.

## Severity: nil consequence today

Receipts are validated by re-encoding the decoded objects into the receipts root
(`ReceiptsRootCalculator` → `ReceiptTrie.CalculateRoot`), and **no receipt hash is taken
over the received bytes** anywhere — not on the wire paths, and not in the Era1 archive
path, which also verifies via a re-encoded receipts root. A malleated wire form therefore
yields a byte-identical object and a byte-identical root. This is defence in depth closing
a bug class, not a live defect, and it is deliberately not being labelled higher.

## Wire compatibility

This tightens two P2P-facing decodes, so the compatibility question was checked before the
consistency one:

- Our encoders write every logs header from the exact content length
  (`GetLogsLength` / `GetFrameLogsLength` → `StartSequence`), so they can never emit the
  rejected form.
- **Over**-declaring was already rejected: the item walk would run past the list into the
  next field and the existing outer checkpoint would fail. Only **under**-declaring slipped
  through, and an under-declared length prefix is not canonical RLP under any encoder.
- The item-count cap (`LogsRlpLimit.Limit + 1`) can truncate the walk, but `GuardLimit`
  throws on that count before the new checkpoint is reached, so it cannot fire spuriously.
- `RlpBehaviors.AllowExtraBytes` is unaffected: it governs trailing fields *after* the logs
  list within the receipt, and the peek already bounds log decoding at the list's end, so
  the new checkpoint sits before that handling and passes.

The new checkpoints only reject streams that are already non-canonical RLP.

## Notes on scope

The other receipt decoders were then re-audited line by line rather than pattern-matched, and
two of them turned out not to belong on the list at all. What is actually left open:

| decoder | path | status |
|---|---|---|
| `ReceiptStorageDecoder` | frame | **open** — only `Check(frameEnd)`, one level out |
| `CompactReceiptStorageDecoder` | frame | **open** — same shape |
| `OptimismReceiptMessageDecoder` | regular | **open** — the logs end feeds the peek only; the file has no `Check` at all |
| `OptimismCompactReceiptStorageDecoder` | regular | **open** — only the outer receipt end is checked |
| `ReceiptStorageDecoder` | regular | closed, but gated on `!allowExtraBytes` |
| `CompactReceiptStorageDecoder` | regular | closed, same gate |
| `EraSlimReceiptDecoder` | regular | **already closed** — it throws explicitly when the logs list is not fully consumed, before its receipt-level check |
| `ReceiptArrayStorageDecoder` | — | **not applicable** — no logs loop of its own; it reads the receipts-array sequence and delegates each element to the two storage decoders, so it inherits their behaviour |

The four open ones are left out rather than swept in: the storage ones read our own database,
and the rest are separate decoders in separate domains. Flagging them here so they can be
picked up deliberately. Worth noting alongside them that the two storage regular paths gate
their close on `!allowExtraBytes`, where the paths fixed here check unconditionally.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Decode_LogsHeaderMustMatchItsContent` covers one canonical / under-declared pair per path —
in `ReceiptMessageDecoderTests` for the two paths of `ReceiptMessageDecoder`, and mirrored in
`ReceiptMessageDecoder69Tests` for the eth/69 decoder, which lives in `Nethermind.Network` and
so is not reachable from `Nethermind.Core.Test`.

The header is located **structurally** — the logs list is the last item of the payload on
every path, so the payload's own declared end places it, with an assertion on the header
byte to catch layout drift. No byte-pattern scan, which could hit an unrelated field,
corrupt it, and still throw, passing for the wrong reason.

Red/green, each with only its own checkpoint reverted:

| reverted | failing case | observed |
|---|---|---|
| frame `Check(logsEnd)` | `Decode_UnderDeclaredFrameLogsHeader_Throws` (1 of 5) | no exception thrown |
| regular `Check(lastCheck)` | `Decode_UnderDeclaredLogsHeader_Throws` (1 of 5) | no exception thrown |
| eth/69 `Check(lastCheck)` | `Decode_UnderDeclaredLogsHeader_Throws` (1 of 6 in that fixture) | no exception thrown |

None of the three co-fire, and every canonical case passes in all configurations.

Also run green: Release build of the changed projects (0 errors, 0 warnings);
`Nethermind.Network.Test` in full (1674, up from 1672 with the two new cases);
`dotnet format whitespace src/Nethermind --folder --verify-no-changes` clean; the CI lint gate
over both changed projects, positive-controlled with an injected IDE0005 in the changed file.
From the earlier revision, unaffected by this one: `Nethermind.Core.Test` (6389 Release, 6390
Debug), `Nethermind.Blockchain.Test` (2012), `Nethermind.Evm.Test` (6370), frame `blockTest`
218/218 and `engineTest` 218/218.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
