### PR TITLE
fix(jsonrpc): do not format the request when logging an OutOfMemoryException

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -646,6 +647,36 @@ public class JsonRpcServiceTests
         JsonRpcResponse response = await service.SendRequestAsync(request, _context);
 
         AssertJsonRpcError(response, ErrorCodes.InternalError);
+    }
+
+    [Test]
+    public void OutOfMemory_during_invocation_logs_without_request_parameters()
+    {
+        const string marker = "0x00000000000000000000000000000000deadbeef";
+        IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
+        ethRpcModule.eth_getBalance(Arg.Any<Address>(), Arg.Any<BlockParameter>()).Throws(new OutOfMemoryException());
+        TestErrorLogManager logManager = new();
+        _logManager = logManager;
+
+        AssertJsonRpcError(TestRequest(ethRpcModule, "eth_getBalance", marker, "latest"), ErrorCodes.InternalError);
+
+        TestErrorLogManager.Error logged = logManager.Errors.Single(e => e.Exception is OutOfMemoryException);
+        Assert.That(logged.Text, Does.Contain("eth_getBalance").And.Not.Contain(marker));
+    }
+
+    [Test]
+    public void OutOfMemory_before_invocation_logs_without_request_parameters()
+    {
+        const string marker = "0x00000000000000000000000000000000deadbeef";
+        IRpcModulePool<IEthRpcModule> pool = Substitute.For<IRpcModulePool<IEthRpcModule>>();
+        pool.GetModule(Arg.Any<bool>()).Returns(Task.FromException<IEthRpcModule>(new OutOfMemoryException()));
+        TestErrorLogManager logManager = new();
+        _logManager = logManager;
+
+        AssertJsonRpcError(TestRequestWithPool(pool, "eth_getBalance", marker, "latest"), ErrorCodes.InternalError);
+
+        TestErrorLogManager.Error logged = logManager.Errors.Single(e => e.Exception is OutOfMemoryException);
+        Assert.That(logged.Text, Does.Contain("eth_getBalance").And.Not.Contain(marker));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -649,33 +650,37 @@ public class JsonRpcServiceTests
         AssertJsonRpcError(response, ErrorCodes.InternalError);
     }
 
-    [Test]
-    public void OutOfMemory_during_invocation_logs_without_request_parameters()
+    private static IEnumerable<TestCaseData> OutOfMemoryPools()
     {
-        const string marker = "0x00000000000000000000000000000000deadbeef";
-        IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
-        ethRpcModule.eth_getBalance(Arg.Any<Address>(), Arg.Any<BlockParameter>()).Throws(new OutOfMemoryException());
-        TestErrorLogManager logManager = new();
-        _logManager = logManager;
+        static IRpcModulePool<IEthRpcModule> Throwing(Exception ex)
+        {
+            IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
+            ethRpcModule.eth_getBalance(Arg.Any<Address>(), Arg.Any<BlockParameter>()).Throws(ex);
+            return new SingletonModulePool<IEthRpcModule>(new SingletonFactory<IEthRpcModule>(ethRpcModule), true);
+        }
 
-        AssertJsonRpcError(TestRequest(ethRpcModule, "eth_getBalance", marker, "latest"), ErrorCodes.InternalError);
+        static IRpcModulePool<IEthRpcModule> FaultedRental()
+        {
+            IRpcModulePool<IEthRpcModule> pool = Substitute.For<IRpcModulePool<IEthRpcModule>>();
+            pool.GetModule(Arg.Any<bool>()).Returns(Task.FromException<IEthRpcModule>(new OutOfMemoryException()));
+            return pool;
+        }
 
-        TestErrorLogManager.Error logged = logManager.Errors.Single(e => e.Exception is OutOfMemoryException);
-        Assert.That(logged.Text, Does.Contain("eth_getBalance").And.Not.Contain(marker));
+        yield return new TestCaseData(Throwing(new OutOfMemoryException())).SetName("{m}(module throws)");
+        yield return new TestCaseData(Throwing(new TargetInvocationException(new OutOfMemoryException()))).SetName("{m}(module throws wrapped)");
+        yield return new TestCaseData(FaultedRental()).SetName("{m}(module rental faults)");
     }
 
-    [Test]
-    public void OutOfMemory_before_invocation_logs_without_request_parameters()
+    [TestCaseSource(nameof(OutOfMemoryPools))]
+    public void OutOfMemory_logs_without_request_parameters(IRpcModulePool<IEthRpcModule> pool)
     {
         const string marker = "0x00000000000000000000000000000000deadbeef";
-        IRpcModulePool<IEthRpcModule> pool = Substitute.For<IRpcModulePool<IEthRpcModule>>();
-        pool.GetModule(Arg.Any<bool>()).Returns(Task.FromException<IEthRpcModule>(new OutOfMemoryException()));
         TestErrorLogManager logManager = new();
         _logManager = logManager;
 
         AssertJsonRpcError(TestRequestWithPool(pool, "eth_getBalance", marker, "latest"), ErrorCodes.InternalError);
 
-        TestErrorLogManager.Error logged = logManager.Errors.Single(e => e.Exception is OutOfMemoryException);
+        TestErrorLogManager.Error logged = logManager.Errors.Single(e => e.Exception is OutOfMemoryException or { InnerException: OutOfMemoryException });
         Assert.That(logged.Text, Does.Contain("eth_getBalance").And.Not.Contain(marker));
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -94,7 +94,9 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
     // Formatting the request parses and stringifies its params, which for engine_newPayload is a
     // multi-megabyte payload. When the heap is already exhausted that would just throw again.
     private static string DescribeForErrorLog(JsonRpcRequest request, Exception ex) =>
-        ex is OutOfMemoryException ? $"Id:{request.Id}, {request.Method}(params omitted)" : request.ToString();
+        ex is OutOfMemoryException or { InnerException: OutOfMemoryException }
+            ? $"Id:{request.Id}, {request.Method}(params omitted)"
+            : request.ToString();
 
     private async ValueTask<JsonRpcResponse> ExecuteAsync(JsonRpcRequest request, string methodName, ResolvedMethodInfo method, JsonRpcContext context)
     {

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -87,9 +87,14 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             _ => (ErrorCodes.InternalError, "Internal error", false),
         };
 
-        if (!suppressWarning && _logger.IsError) _logger.Error($"Error during method execution, request: {rpcRequest}", ex);
+        if (!suppressWarning && _logger.IsError) _logger.Error($"Error during method execution, request: {DescribeForErrorLog(rpcRequest, ex)}", ex);
         return GetErrorResponse(rpcRequest.Method, errorCode, errorText, suppressWarning ? null : ex.ToString(), in rpcRequest.IdRef, suppressWarning: suppressWarning);
     }
+
+    // Formatting the request parses and stringifies its params, which for engine_newPayload is a
+    // multi-megabyte payload. When the heap is already exhausted that would just throw again.
+    private static string DescribeForErrorLog(JsonRpcRequest request, Exception ex) =>
+        ex is OutOfMemoryException ? $"Id:{request.Id}, {request.Method}(params omitted)" : request.ToString();
 
     private async ValueTask<JsonRpcResponse> ExecuteAsync(JsonRpcRequest request, string methodName, ResolvedMethodInfo method, JsonRpcContext context)
     {
@@ -568,7 +573,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
 
         JsonRpcErrorResponse HandleException(Exception ex, string methodName, JsonRpcRequest request, Action? returnAction)
         {
-            if (_logger.IsError) _logger.Error($"Error during method execution, request: {request}", ex);
+            if (_logger.IsError) _logger.Error($"Error during method execution, request: {DescribeForErrorLog(request, ex)}", ex);
             return GetErrorResponse(methodName, ErrorCodes.InternalError, "Internal error", ex.ToString(), in request.IdRef, returnAction);
         }
 


### PR DESCRIPTION
## Changes

- When the exception being reported is an `OutOfMemoryException`, the two error-log sites in `JsonRpcService` now log only the request id and method instead of interpolating the whole request. Formatting the request parses and stringifies its params, which for `engine_newPayload` is a multi-megabyte payload, so with the heap already exhausted the log line itself threw again (visible as `DefaultInterpolatedStringHandler.GrowThenCopyString` under `JsonRpcRequest.ToString()` in the stack traces of [benchmarkoor run 34104257992](https://github.com/ethpandaops/benchmarkoor-tests/actions/runs/34104257992)).
- All other exceptions keep the full request in the log; the JSON-RPC error response is unchanged.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `OutOfMemory_during_invocation_logs_without_request_parameters` (module method throws) and `OutOfMemory_before_invocation_logs_without_request_parameters` (module rental throws) assert the logged text names the method but not a marker parameter. Both fail without the production change and pass with it.
- `JsonRpcServiceTests` release run: 58 passed. `dotnet format whitespace --verify-no-changes` and `git diff --check` pass on the changed files.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
