### PR TITLE
test(specs): pin each geth genesis fork label to the fork it names

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadV4Tests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadV4Tests.cs
@@ -3,12 +3,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Merge.Plugin.Data;
+using Nethermind.Serialization.Json;
 using Nethermind.Serialization.Rlp.Eip7928;
+using Nethermind.Specs.ChainSpecStyle;
 using NUnit.Framework;
 
 namespace Nethermind.Merge.Plugin.Test;
@@ -66,6 +70,45 @@ public class ExecutionPayloadV4Tests
         Hash256 expected = new(ValueKeccak.Compute(encoded).Bytes);
         Assert.That(block.Header.BlockAccessListHash, Is.EqualTo(expected));
         Assert.That(block.Header.BlockAccessListHash, Is.EqualTo(block.BlockAccessList!.WireHash));
+    }
+
+    // Two devnet fixture lines both call their Amsterdam successor Bogota while meaning different
+    // things by it, so the label a genesis carries has to decide which newPayload version the node
+    // accepts: inclusion lists move it to V6, frame transactions leave it on Amsterdam's V5.
+    [TestCase("bogotaTime", EngineApiVersions.NewPayload.V6)]
+    [TestCase("eip8141PrototypeTime", EngineApiVersions.NewPayload.V5)]
+    public void ValidateForkOnNewPayload_accepts_the_version_the_genesis_fork_label_selects(string label, int accepted)
+    {
+        string genesis = $$"""
+            {
+              "config": { "chainId": 1, "homesteadBlock": 0, "amsterdamTime": 15, "{{label}}": 15 },
+              "difficulty": "0x1",
+              "gasLimit": "0x8000000",
+              "alloc": {}
+            }
+            """;
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(genesis));
+        ChainSpec chainSpec = new GethGenesisLoader(new EthereumJsonSerializer()).Load(stream);
+        ChainSpecBasedSpecProvider specProvider = new(chainSpec);
+
+        ExecutionPayloadV4 payload = new()
+        {
+            BlockAccessList = [],
+            SlotNumber = 0,
+            BlockNumber = 1,
+            Timestamp = 15,
+            GasLimit = 30_000_000,
+            ReceiptsRoot = Keccak.EmptyTreeHash,
+            StateRoot = Keccak.EmptyTreeHash,
+        };
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(payload.ValidateForkOnNewPayload(specProvider, EngineApiVersions.NewPayload.V5),
+                Is.EqualTo(accepted == EngineApiVersions.NewPayload.V5));
+            Assert.That(payload.ValidateForkOnNewPayload(specProvider, EngineApiVersions.NewPayload.V6),
+                Is.EqualTo(accepted == EngineApiVersions.NewPayload.V6));
+        }
     }
 
     private static IEnumerable<TestCaseData> MalformedBlockAccessLists()

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -44,12 +44,9 @@ public class GethGenesisLoaderTests
     // Config properties whose name doesn't match any fork class (legacy aliases or special transitions)
     private static readonly HashSet<string> ConfigPropsWithoutForkClass =
     [
-        "DaoForkBlock",       // fork class is "Dao", not "DaoFork"
         "Eip150Block",        // alias for TangerineWhistleBlock
         "Eip155Block",        // alias for SpuriousDragonBlock
         "Eip158Block",        // alias for SpuriousDragonBlock
-        "PetersburgBlock",    // fork class is "ConstantinopleFix"
-        "MergeNetsplitBlock", // fork ID transition, not a fork class
     ];
 
     // Fork classes that are not real Geth fork names and therefore have no genesis config property
@@ -304,47 +301,31 @@ public class GethGenesisLoaderTests
         }
     }
 
-    [Test]
-    public void Can_load_genesis_with_bogota_time()
+    // Two devnet fixture lines both call their fork Bogota while meaning different things by it, so a
+    // genesis says which it means by the label it carries: bogotaTime is inclusion lists, and frame
+    // transactions have their own. Neither may drag the other's EIP in — they sit on different
+    // engine_newPayload versions, and the frame-transaction predeploy shifts every EIP-7928 access list.
+    [TestCase("bogotaTime", true, false)]
+    [TestCase("eip8141PrototypeTime", false, true)]
+    public void Genesis_fork_label_picks_one_of_the_two_amsterdam_successors(string label, bool eip7805, bool eip8141)
     {
-        ChainSpec chainSpec = LoadStandardGethGenesis(configExtra: "\"bogotaTime\": 15");
+        ChainSpec chainSpec = LoadStandardGethGenesis(configExtra: $"\"{label}\": 15");
 
-        // bogotaTime carries inclusion lists alone. Frame transactions keep their own transition, so a
-        // genesis scheduling Bogota does not silently pull in the predeploy that shifts the fixtures.
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(chainSpec.Parameters.Eip7805TransitionTimestamp, Is.EqualTo(15));
-            Assert.That(chainSpec.Parameters.Eip8141TransitionTimestamp, Is.Null);
+            Assert.That(chainSpec.Parameters.Eip7805TransitionTimestamp, Is.EqualTo(eip7805 ? (ulong?)15 : null));
+            Assert.That(chainSpec.Parameters.Eip8141TransitionTimestamp, Is.EqualTo(eip8141 ? (ulong?)15 : null));
         }
 
         ChainSpecBasedSpecProvider provider = new(chainSpec);
+        IReleaseSpec before = provider.GetSpec(ForkActivation.TimestampOnly(14));
+        IReleaseSpec after = provider.GetSpec(ForkActivation.TimestampOnly(15));
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(14)).IsEip7805Enabled, Is.False);
-            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(15)).IsEip7805Enabled, Is.True);
-            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(15)).IsEip8141Enabled, Is.False);
-        }
-    }
-
-    // The other half of the split: frame transactions must stay activatable from the format the devnet
-    // genesis files are generated in, without dragging inclusion lists along.
-    [Test]
-    public void Can_load_genesis_with_eip8141_prototype_time()
-    {
-        ChainSpec chainSpec = LoadStandardGethGenesis(configExtra: "\"eip8141PrototypeTime\": 15");
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(chainSpec.Parameters.Eip8141TransitionTimestamp, Is.EqualTo(15));
-            Assert.That(chainSpec.Parameters.Eip7805TransitionTimestamp, Is.Null);
-        }
-
-        ChainSpecBasedSpecProvider provider = new(chainSpec);
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(14)).IsEip8141Enabled, Is.False);
-            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(15)).IsEip8141Enabled, Is.True);
-            Assert.That(provider.GetSpec(ForkActivation.TimestampOnly(15)).IsEip7805Enabled, Is.False);
+            Assert.That(before.IsEip7805Enabled, Is.False);
+            Assert.That(before.IsEip8141Enabled, Is.False);
+            Assert.That(after.IsEip7805Enabled, Is.EqualTo(eip7805));
+            Assert.That(after.IsEip8141Enabled, Is.EqualTo(eip8141));
         }
     }
 
@@ -707,10 +688,30 @@ public class GethGenesisLoaderTests
         }
     }
 
+    /// <summary>Whether <paramref name="prop"/> has the shape of a <c>{Name}{suffix}</c> fork label.</summary>
+    private static bool IsForkLabel(PropertyInfo prop, string suffix) =>
+        prop.PropertyType == typeof(ulong?) && prop.Name.EndsWith(suffix, StringComparison.Ordinal);
+
+    /// <summary>Returns the fork class <paramref name="prop"/> actually labels, or <c>null</c> for none.</summary>
+    /// <remarks>Read back from the key the property writes, because a property may route to a fork class
+    /// its own name doesn't spell (<c>petersburgBlock</c>, <c>daoForkBlock</c>).</remarks>
+    private static string? RoutedForkName(PropertyInfo prop, bool isTime)
+    {
+        GethGenesisConfigJson probe = new();
+        prop.SetValue(probe, (ulong?)1);
+        IHasNamedForks named = probe;
+        IReadOnlyDictionary<string, ulong>? written = isTime ? named.NamedForkTimestamps : named.NamedForkBlocks;
+        return written?.Keys.SingleOrDefault();
+    }
+
     /// <summary>
     /// Discovers all forks with matching activation properties on <see cref="GethGenesisConfigJson"/>:
-    /// <c>{Name}Time</c> (ulong?) for timestamp forks, <c>{Name}Block</c> (long?) for block forks.
+    /// <c>{Name}Time</c> for timestamp forks, <c>{Name}Block</c> for block forks, both <c>ulong?</c>.
     /// </summary>
+    /// <remarks>
+    /// A property may route to a fork class its own name doesn't spell, so the fork is read back from the
+    /// key the property writes rather than from its name.
+    /// </remarks>
     private static List<ForkActivationInfo> DiscoverGethForks()
     {
         static (Type type, NamedReleaseSpec instance) FindFork((Type type, NamedReleaseSpec instance)[] forks, string name) =>
@@ -723,14 +724,13 @@ public class GethGenesisLoaderTests
 
         foreach (PropertyInfo prop in configType.GetProperties())
         {
-            bool isTime = prop.PropertyType == typeof(ulong?) && prop.Name.EndsWith("Time");
-            bool isBlock = prop.PropertyType == typeof(long?) && prop.Name.EndsWith("Block");
+            bool isTime = IsForkLabel(prop, "Time");
 
-            if (isTime || isBlock)
+            if (isTime || IsForkLabel(prop, "Block"))
             {
-                (string suffix, string transitionSuffix) = isTime ? ("Time", "TransitionTimestamp") : ("Block", "Transition");
-                string forkName = prop.Name[..^suffix.Length];
-                (Type type, NamedReleaseSpec instance) match = FindFork(allForks, forkName);
+                string transitionSuffix = isTime ? "TransitionTimestamp" : "Transition";
+                string? forkName = RoutedForkName(prop, isTime);
+                (Type type, NamedReleaseSpec instance) match = forkName is null ? default : FindFork(allForks, forkName);
                 if (match.instance?.Parent is not null)
                 {
                     string gethConfigName = char.ToLowerInvariant(prop.Name[0]) + prop.Name[1..];
@@ -752,39 +752,36 @@ public class GethGenesisLoaderTests
         int configPropsChecked = 0;
         int forkClassesChecked = 0;
 
-        // Every *Time and *Block property must have a matching fork class
+        // Every *Time and *Block property must label a fork class
+        HashSet<string> forksWithLabel = new(StringComparer.OrdinalIgnoreCase);
         foreach (PropertyInfo prop in configType.GetProperties())
         {
-            bool isTime = prop.PropertyType == typeof(ulong?) && prop.Name.EndsWith("Time");
-            bool isBlock = prop.PropertyType == typeof(long?) && prop.Name.EndsWith("Block");
+            bool isTime = IsForkLabel(prop, "Time");
+            if (!isTime && !IsForkLabel(prop, "Block")) continue;
 
-            if (isTime || isBlock)
+            configPropsChecked++;
+            if (ConfigPropsWithoutForkClass.Contains(prop.Name)) continue;
+
+            string? forkName = RoutedForkName(prop, isTime);
+            if (forkName is not null && allForks.Any(f => f.type.Name.Equals(forkName, StringComparison.OrdinalIgnoreCase)))
             {
-                configPropsChecked++;
-                string suffix = isTime ? "Time" : "Block";
-                if (!ConfigPropsWithoutForkClass.Contains(prop.Name))
-                {
-                    string forkName = prop.Name[..^suffix.Length];
-                    if (!allForks.Any(f => f.type.Name.Equals(forkName, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        mismatches.Add($"GethGenesisConfigJson.{prop.Name} has no matching fork class");
-                    }
-                }
+                forksWithLabel.Add(forkName);
+            }
+            else
+            {
+                mismatches.Add($"GethGenesisConfigJson.{prop.Name} has no matching fork class");
             }
         }
 
-        // Every fork class that introduces EIPs must have a *Time or *Block property
+        // Every fork class that introduces EIPs must carry one of those labels
         foreach ((Type type, NamedReleaseSpec instance) in allForks)
         {
             if (instance.Parent is not null && !ForkClassesWithoutConfigProp.Contains(type.Name) && GetNewlyEnabledEips(instance, instance.Parent).Any())
             {
                 forkClassesChecked++;
-                bool hasBlockProp = configType.GetProperties().Any(p => p.Name.Equals($"{type.Name}Block", StringComparison.OrdinalIgnoreCase));
-                bool hasTimeProp = configType.GetProperties().Any(p => p.Name.Equals($"{type.Name}Time", StringComparison.OrdinalIgnoreCase));
-
-                if (!hasBlockProp && !hasTimeProp)
+                if (!forksWithLabel.Contains(type.Name))
                 {
-                    mismatches.Add($"Fork class {type.Name} introduces EIPs but has no {type.Name}Block or {type.Name}Time in GethGenesisConfigJson");
+                    mismatches.Add($"Fork class {type.Name} introduces EIPs but no GethGenesisConfigJson property labels it");
                 }
             }
         }


### PR DESCRIPTION
## Changes

The frame-transaction devnet's fixture line labels its fork `Bogota` meaning Amsterdam plus
EIP-8141, and the genesis generated from those fixtures carries the activation as `bogotaTime`.
Nethermind resolves that label to the fork class of the same name, which is Amsterdam plus
EIP-7805 and moves `engine_newPayload` from V5 to V6, so every payload the devnet sends is refused
with `-38005 Unsupported fork` before it is validated.

An earlier revision of this PR pointed `bogotaTime` at the frame-transaction fork. That is not
shippable: `Bogota` is a mainnet fork name here (`MainnetSpecProvider` maps it, `SpecNameParser`
resolves it, engine `newPayload` V6 and `forkchoiceUpdated` V5 are pinned to it), so the route
would merge to master and, once Bogota is actually scheduled, a genesis saying `bogotaTime` would
activate a prototype fork. It also breaks the mirror case today — see below.

So the labels keep their meanings, and this PR pins them:

- `bogotaTime` selects EIP-7805 inclusion lists and `newPayload` V6.
- `eip8141PrototypeTime` selects EIP-8141 frame transactions and `newPayload` V5.

Both assertions run through `GethGenesisLoader`, so they cover the genesis routing itself rather
than the fork classes.

The reflective genesis guards paired a config property with a fork class by its own name, which
`petersburgBlock`, `daoForkBlock` and `mergeNetsplitBlock` never satisfied, and typed the block half
`long?` where every `*Block` property on `GethGenesisConfigJson` is `ulong?` — so no block fork was
discovered at all. They now read back the key a property actually writes.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Test coverage only — no production code changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Both directions are pinned twice, at the chainspec layer and at the engine gate that produced the
`-38005`, each with a red control that isolates one variable (the routing of a single property).

| genesis label | assertion | with the routing this PR keeps | with `bogotaTime` re-pointed at frame transactions | with `eip8141PrototypeTime` re-pointed at inclusion lists |
|---|---|---|---|---|
| `bogotaTime` | EIP-7805 on, EIP-8141 off | pass | **fail** | pass |
| `eip8141PrototypeTime` | EIP-8141 on, EIP-7805 off | pass | pass | **fail** |
| `bogotaTime` | `newPayload` V6 accepted, V5 refused | pass | **fail** | — |
| `eip8141PrototypeTime` | `newPayload` V5 accepted, V6 refused | pass | pass | — |

The middle column is the state of the earlier revision of this PR: a genesis scheduling inclusion
lists refuses `newPayload` V6 and accepts V5 — the exact mirror of the devnet failure, aimed at the
other devnet instead.

The reflective guards go from 12 forks / 39 EIP mappings to 26 forks / 64, covering every `*Block`
property for the first time; no newly discovered fork surfaces a mismatch.

- `Nethermind.Specs.Test`: 306/306
- `Nethermind.Merge.Plugin.Test`: 1876 total, 1873 passed, 3 skipped, 0 failed
- Lint gate (`EnforceCodeStyleInBuild` + `GenerateDocumentationFile`) clean on both, verified against
  a deliberately unused `using` so the check is not vacuous
- `dotnet format whitespace --verify-no-changes` clean

## Remarks

**Scheduling both devnets off one build.** The two fixture lines give one name two meanings, and a
generated genesis carries only the name — so one build cannot answer both for the same key. It does
not have to: the two forks already have distinct Geth-genesis labels, and a genesis says which fork
it means by which label it carries. What has to change is the producer of that label, not the reader.

For the hive suites, that producer is `clients/nethermind/mapper.jq`, which turns
`HIVE_BOGOTA_TIMESTAMP` into `"bogotaTime"`. A frame-transaction deployment emits
`"eip8141PrototypeTime"` from the same variable instead, and the two suites then run side by side
against one image. The permanent fix is upstream: give the frame-transaction fixture line a fork
name of its own so the two stop colliding at the source.

A node-side option selecting what the label means was considered and rejected. It is unreachable
from hive — hive deletes every environment variable without a `HIVE_` prefix before the container
starts, `build_args` reach only `docker build`, and the client entrypoint ends in a fixed
`--config` invocation with no flag pass-through — and a knob that relabels forks at load time lets
an operator silently run a fork the genesis does not name.

Inferring the fork from the genesis instead was also rejected: the only frame-transaction artefact
in a genesis is the expiry-verifier predeploy, which the node installs itself at activation, so it
is absent whenever the fork is scheduled after block 0.
