### PR TITLE
ci(nethtest): raise the frame lane case floors to the pinned release

### DIFF
--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -137,11 +137,11 @@ env:
   # means Amsterdam plus EIP-7805; nothing inside a fixture separates the two, so the lane names the
   # fork it means through the runner's --forkAlias.
   FRAMES_VERSION: ${{ inputs.frames_version || 'tests-frames-devnet@v0.3.0' }}
-  # Minimum cases the pinned release ships across the frame lanes. Asserted so a scope resolving to
-  # nothing fails rather than reporting a clean run of no tests.
-  FRAME_MIN_CASES: '214'
+  # Cases the pinned release ships across the frame lanes. Asserted so a scope resolving to nothing,
+  # or to less than the release holds, fails rather than reporting a clean run of too few tests.
+  FRAME_MIN_CASES: '218'
   # The same floor for the frame transaction-test lane, whose subtree is a much smaller fixture set.
-  FRAME_TX_MIN_CASES: '74'
+  FRAME_TX_MIN_CASES: '78'
   # ubuntu-latest runners have 16 GB of RAM. The runner ships with server GC
   # (throughput-oriented, collects lazily), which previously ballooned past the
   # runner limit on the full fixture set. Workstation GC keeps the heap tight,


### PR DESCRIPTION
## Changes

`FRAMES_VERSION` moved to `tests-frames-devnet@v0.3.0` in #13184, but the case floors the frame
lanes assert against kept the counts of the release before it. Each lane would therefore pass while
running four fewer cases than the pinned archive holds — a scope that quietly narrows is exactly
what the floors exist to catch.

- `FRAME_MIN_CASES` 214 → 218 (`frameTest`, `frameBlockTest`)
- `FRAME_TX_MIN_CASES` 74 → 78 (`frameTxTest`)

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Each lane's scope run locally against `tests-frames-devnet@v0.3.0`, at this branch's head:

| lane | fixtures | cases | pass | fail |
|---|---|---|---:|---:|
| `frameTest` | `blockchain_tests_engine/for_bogota/amsterdam/eip8141_frame_transactions` | 218 | 218 | 0 |
| `frameBlockTest` | `blockchain_tests/for_bogota/amsterdam/eip8141_frame_transactions` | 218 | 218 | 0 |
| `frameTxTest` | `transaction_tests/for_bogota/amsterdam/eip8141_frame_transactions` | 78 | 78 | 0 |

The scope expression the lanes use still resolves at v0.3.0, so the new floors are the counts the
lanes actually reach. No lane is newly red, so nothing is excluded here.

## Remarks

The four extra cases are the whole frame-subtree delta from `v0.1.0` to `v0.3.0`, read off the two
archives' `.meta/index.json`: `test_storage_refund_settlement` gained three parameterisations in
place of one unparameterised case, and `test_batch_unroll_refill_restores_spent_gas` and
`test_frame_revert_refill_restores_spent_gas` are new. Those are the cases #13184 was written
against, which is why it bumped the pin.

For scale, the archive as a whole went from 427,900 to 448,054 cases, and its `for_bogota`
engine tree from 25,045 to 30,412 (+5,839 / -472). The frame lanes deliberately run only the
EIP-8141 subtree of that; the remainder duplicates the Amsterdam corpus the other lanes already
cover against their own pin.
