### PR TITLE
test(merge): deflake the FCU ancestry-walk assertion

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeCallSpy.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeCallSpy.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Concurrent;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
@@ -9,13 +11,23 @@ using Nethermind.Core.Test.Builders;
 namespace Nethermind.Merge.Plugin.Test;
 
 /// <summary>
-/// Counts <see cref="IBlockFinder.FindHeader"/> calls on a real block tree.
+/// Records the parent-header probes made against a real block tree, i.e. the lookups
+/// <see cref="IBlockFinderExtensions.FindParentHeader"/> issues with the parent's height.
 /// </summary>
+/// <remarks>
+/// The spy decorates the container's singleton block tree, which background components share and probe on
+/// their own threads - under the flat layout the persistence pipeline resolves the finalized state root that
+/// way. Recording is therefore thread-safe, and assertions have to key on the specific lookup under test
+/// rather than on a total call count that any of those threads can bump at any moment.
+/// </remarks>
 internal sealed class BlockTreeCallSpy(IBlockTree inner) : BlockTreeTestDouble(inner)
 {
-    public int FindHeaderCalls { get; private set; }
+    private readonly ConcurrentDictionary<(ValueHash256 Hash, ulong Number), byte> _parentProbes = new();
 
-    public void ResetCounters() => FindHeaderCalls = 0;
+    public void Reset() => _parentProbes.Clear();
+
+    public bool WasProbedAsParent(Hash256 blockHash, ulong blockNumber) =>
+        _parentProbes.ContainsKey((blockHash.ValueHash256, blockNumber));
 
     public static (IBlockTree Proxy, BlockTreeCallSpy Spy) Wrap(IBlockTree inner)
     {
@@ -25,13 +37,11 @@ internal sealed class BlockTreeCallSpy(IBlockTree inner) : BlockTreeTestDouble(i
 
     public override BlockHeader? FindHeader(Hash256 blockHash, BlockTreeLookupOptions options, ulong? blockNumber = null)
     {
-        FindHeaderCalls++;
-        return base.FindHeader(blockHash, options, blockNumber);
-    }
+        if (blockNumber is not null)
+        {
+            _parentProbes.TryAdd((blockHash.ValueHash256, blockNumber.Value), 0);
+        }
 
-    public override BlockHeader? FindHeader(ulong blockNumber, BlockTreeLookupOptions options)
-    {
-        FindHeaderCalls++;
-        return base.FindHeader(blockNumber, options);
+        return base.FindHeader(blockHash, options, blockNumber);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeCallSpy.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeCallSpy.cs
@@ -11,8 +11,8 @@ using Nethermind.Core.Test.Builders;
 namespace Nethermind.Merge.Plugin.Test;
 
 /// <summary>
-/// Records the parent-header probes made against a real block tree, i.e. the lookups
-/// <see cref="IBlockFinderExtensions.FindParentHeader"/> issues with the parent's height.
+/// Records every height-hinted header lookup made against a real block tree, the shape
+/// <see cref="IBlockFinderExtensions.FindParentHeader"/> issues when it passes the parent's height.
 /// </summary>
 /// <remarks>
 /// The spy decorates the container's singleton block tree, which background components share and probe on

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1710,16 +1710,20 @@ public partial class EngineModuleTests
             Assert.That(chain.BlockTree.IsMainChain(a3.BlockHash), Is.False, "precondition: a3's marker was flipped to b3");
         }
 
-        // Count FindHeader calls made by the repeated FCU only. Safe=Keccak.Zero skips its
-        // ValidateBlockHash lookup. Baseline: 1 to resolve head, 1 for finalized validation,
-        // 1 for IsOnMainChainBehindFinalized (FindFinalizedHeader), plus the IsInconsistent walk
-        // (1 under the optimization, 2 without).
-        spy!.ResetCounters();
+        // Watch the parent probes of the repeated FCU only. The walk steps a3 -> a2 and has to stop
+        // there; continuing would step a2 -> a1. Only the walk passes a height, so a probe of a1 at
+        // H=1 is its unambiguous signature - the finalized hash a1 is resolved without one.
+        spy!.Reset();
         ForkchoiceStateV1 repeated = new(headBlockHash: a3.BlockHash, finalizedBlockHash: a1.BlockHash, safeBlockHash: Keccak.Zero);
         ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(repeated);
         Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
 
-        Assert.That(spy.FindHeaderCalls, Is.EqualTo(4), "walk must stop at the first main-chain ancestor (a2) rather than continue to a1");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(spy.WasProbedAsParent(a2.BlockHash, a2.BlockNumber), Is.True, "the walk has to step a3 -> a2");
+            Assert.That(spy.WasProbedAsParent(a1.BlockHash, a1.BlockNumber), Is.False,
+                "walk must stop at the first main-chain ancestor (a2) rather than continue to a1");
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Changes

`forkchoiceUpdated_isInconsistent_takes_fast_path_when_candidate_is_on_main_chain` asserted an exact
`FindHeader` call total of 4. `BlockTreeCallSpy` decorates the container's **singleton** `IBlockTree`, so that
counter sees every lookup any component makes on any thread — one extra probe landing between
`ResetCounters()` and the assert turns 4 into 5, which is what CI reports:

```
failed forkchoiceUpdated_isInconsistent_takes_fast_path_when_candidate_is_on_main_chain
  walk must stop at the first main-chain ancestor (a2) rather than continue to a1
  Assert.That(spy.FindHeaderCalls, Is.EqualTo(4))
    Expected: 4
    But was:  5
```

Seen on two unrelated PRs, both in the Flat DB job: [run 34038549237](https://github.com/NethermindEth/nethermind/actions/runs/34038549237)
and [run 34129154486](https://github.com/NethermindEth/nethermind/actions/runs/34129154486).

- The assertion now names the lookup it actually guards: the walk has to step a3 -> a2 and must not step
  a2 -> a1. Only the walk passes a height hint (the finalized hash a1 is resolved without one), so a probe
  of a1 at H=1 is its unambiguous signature, and no unrelated lookup can forge or mask it.
- `BlockTreeCallSpy` records those probes in a `ConcurrentDictionary`-backed set instead of a non-atomic
  `int++`. Off-thread callers reach the same instance, so the increments were racy as well as over-counting.
- The `FindHeader(ulong, options)` override existed only to feed the counter and is gone.

The extra probe is not hypothetical. Instrumenting the spy with stack traces under `TEST_USE_FLAT=1` catches
it: the flat layout's persistence pipeline (`FlatDbManager`'s channel-driven `_persistenceTask` ->
`PersistenceManager.DetermineSnapshotAction` -> `ReorgDepthFinalizedStateProvider.GetFinalizedStateRootAt`)
resolves the finalized state root through `blockTree.FindHeader(blockNumber, RequireCanonical)` on its own
thread, once per state commit:

```
tid=34 :: ReorgDepthFinalizedStateProvider.GetFinalizedStateRootAt
          <- MergeFinalizedStateProvider.GetFinalizedStateRootAt :: byNumber(0, RequireCanonical)
```

The test enqueues five such jobs (genesis, a1, a2, a3, b3). On an idle box the pipeline always drains before
the counted window opens; on a loaded 2-core runner (`DOTNET_GCConserveMemory=9`, 1857 tests in parallel) one
job drains inside it. Under patricia there is no equivalent off-thread `IBlockTree` consumer, which is why
only the Flat DB job flakes.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Test fix — deflakes a test without touching production code

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.Merge.Plugin.Test` 1855/0 (2 skipped) with `TEST_USE_FLAT=1 DOTNET_GCConserveMemory=9`, matching
the job that flakes; the two `forkchoiceUpdated_isInconsistent_*` tests also pass under patricia.

The new assertion keeps the teeth of the old one: with the `candidateIsMain && IsMainChain(parent)` early exit
in `ForkchoiceUpdatedHandler.IsInconsistent` temporarily removed, the test fails on the a1 probe —

```
walk must stop at the first main-chain ancestor (a2) rather than continue to a1
  Expected: False
  But was:  True
```

so a regression that lets the walk run to the bottom of the chain is still caught, and the `a3 -> a2` leg is
asserted positively so a walk that never runs cannot pass silently either.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
