### PR TITLE
fix(rpc): reject a missing-argument marker on a required parameter

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -513,6 +513,22 @@ public class JsonRpcServiceTests
     }
 
     [Test]
+    public void Missing_marker_on_an_optional_argument_binds_its_default([Values(false, true)] bool rawUtf8)
+    {
+        IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        ethRpcModule
+            .eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())
+            .ReturnsForAnyArgs(_ => ResultWrapper<BlockForRpc>.Success(new BlockForRpc(Build.A.Block.WithNumber(2).TestObject, true, specProvider)));
+
+        RpcTest.AssertSuccess<BlockForRpc>(rawUtf8
+            ? TestRawRequest(ethRpcModule, "eth_getBlockByNumber", """["0x1b4",""]""")
+            : TestRequest(ethRpcModule, "eth_getBlockByNumber", "0x1b4", ""));
+
+        ethRpcModule.Received().eth_getBlockByNumber(Arg.Any<BlockParameter>(), false);
+    }
+
+    [Test]
     public void Eth_getTransactionReceipt_properly_fails_given_wrong_parameters()
     {
         IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
@@ -525,6 +541,8 @@ public class JsonRpcServiceTests
     [TestCase("eth_getBlockByNumber", new object?[] { "", false }, "missing value for required argument 0", TestName = "FirstArgMarkedMissingBeforeAnother")]
     [TestCase("eth_getProof", new object?[] { "0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842", "", "latest" }, "missing value for required argument 1", TestName = "LaterArgMarkedMissingBeforeAnother")]
     [TestCase("eth_feeHistory", new object?[] { "", "latest" }, "missing value for required argument 0", TestName = "MarkedMissingArgIsNamedAheadOfOmittedTrailingOnes")]
+    [TestCase("eth_getBlockByNumber", new object?[] { "", false, "" }, "Invalid params", TestName = "ExtraArgumentWinsOverAMarkedMissingOne")]
+    [TestCase("eth_getBlockByNumber", new object?[] { "0x1", false, "" }, "Invalid params", TestName = "ExtraTrailingMarkerIsAnExtraArgument")]
     public void MissingRequiredArgument_ReturnsGethStyleError(string method, object?[] parameters, string expectedMessage)
     {
         IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -106,6 +106,18 @@ public class JsonRpcServiceTests
             (Action<IEthRpcModule>)(static module => module.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())))
             .SetName("Extra argument");
         yield return new TestCaseData(
+            nameof(IEthRpcModule.eth_getBlockByNumber),
+            """["",false]""",
+            "missing value for required argument 0",
+            (Action<IEthRpcModule>)(static module => module.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())))
+            .SetName("Required argument marked missing before another");
+        yield return new TestCaseData(
+            nameof(IEthRpcModule.eth_getBlockByNumber),
+            """["",false,"extra"]""",
+            "Invalid params",
+            (Action<IEthRpcModule>)(static module => module.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())))
+            .SetName("Extra argument alongside a missing marker");
+        yield return new TestCaseData(
             nameof(IEthRpcModule.eth_getBalance),
             """["cf1dc766fc2c62bef0b67a8de666c8e67acf35f6","0x1036640"]""",
             "hex string without 0x prefix",
@@ -510,6 +522,9 @@ public class JsonRpcServiceTests
 
     [TestCase("eth_getBlockByNumber", new object?[] { }, "missing value for required argument 0", TestName = "FirstArgOmitted")]
     [TestCase("eth_feeHistory", new object?[] { "0x1", "latest" }, "missing value for required argument 2", TestName = "LaterArgOmitted")]
+    [TestCase("eth_getBlockByNumber", new object?[] { "", false }, "missing value for required argument 0", TestName = "FirstArgMarkedMissingBeforeAnother")]
+    [TestCase("eth_getProof", new object?[] { "0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842", "", "latest" }, "missing value for required argument 1", TestName = "LaterArgMarkedMissingBeforeAnother")]
+    [TestCase("eth_feeHistory", new object?[] { "", "latest" }, "missing value for required argument 0", TestName = "MarkedMissingArgIsNamedAheadOfOmittedTrailingOnes")]
     public void MissingRequiredArgument_ReturnsGethStyleError(string method, object?[] parameters, string expectedMessage)
     {
         IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -317,6 +317,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             providedParametersUtf8,
             out int providedParametersLength,
             out int missingParamsCount,
+            out int missingRequiredParameterIndex,
             out ExceptionDispatchInfo? parameterDeserializationException,
             out returnParametersToPool);
 
@@ -325,6 +326,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             methodName,
             in requestId,
             providedParametersLength,
+            missingRequiredParameterIndex,
             ref missingParamsCount);
         if (validationError is not null)
         {
@@ -356,13 +358,14 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         returnParametersToPool = false;
 
         int providedParametersLength = providedParameters.ValueKind == JsonValueKind.Array ? providedParameters.GetArrayLength() : 0;
-        int missingParamsCount = CountMissingJsonElementParameters(expectedParameters, providedParameters, providedParametersLength);
+        int missingParamsCount = CountMissingJsonElementParameters(expectedParameters, providedParameters, providedParametersLength, out int missingRequiredParameterIndex);
 
         JsonRpcErrorResponse? validationError = ValidateMissingParameters(
             expectedParameters,
             methodName,
             in requestId,
             providedParametersLength,
+            missingRequiredParameterIndex,
             ref missingParamsCount);
         if (validationError is not null)
         {
@@ -383,16 +386,29 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
     private static int CountMissingJsonElementParameters(
         ExpectedParameter[] expectedParameters,
         JsonElement providedParameters,
-        int providedParametersLength)
+        int providedParametersLength,
+        out int missingRequiredParameterIndex)
     {
         int missingParamsCount = expectedParameters.Length - providedParametersLength;
         int initialMissingParamsCount = missingParamsCount;
+        missingRequiredParameterIndex = -1;
 
         if (providedParametersLength > 0)
         {
+            int index = 0;
             foreach (JsonElement item in providedParameters.EnumerateArray())
             {
-                UpdateMissingParamsCount(item, ref missingParamsCount, initialMissingParamsCount);
+                bool isMissing = IsMissingParameterMarker(item);
+                missingParamsCount = isMissing ? missingParamsCount + 1 : initialMissingParamsCount;
+                if (isMissing
+                    && missingRequiredParameterIndex < 0
+                    && index < expectedParameters.Length
+                    && RequiresExplicitValue(in expectedParameters[index]))
+                {
+                    missingRequiredParameterIndex = index;
+                }
+
+                index++;
             }
         }
 
@@ -448,8 +464,15 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         string methodName,
         in JsonRpcId requestId,
         int providedParametersLength,
+        int missingRequiredParameterIndex,
         ref int missingParamsCount)
     {
+        if (missingParamsCount >= 0 && missingRequiredParameterIndex >= 0)
+        {
+            return GetErrorResponse(methodName, ErrorCodes.InvalidParams,
+                $"missing value for required argument {missingRequiredParameterIndex}", null, in requestId);
+        }
+
         int explicitNullableParamsCount = 0;
 
         if (missingParamsCount != 0)
@@ -515,17 +538,12 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         reader.TokenType == JsonTokenType.Null
         || (reader.TokenType == JsonTokenType.String && reader.ValueTextEquals(ReadOnlySpan<byte>.Empty));
 
-    private static void UpdateMissingParamsCount(JsonElement item, ref int missingParamsCount, int initialMissingParamsCount)
-    {
-        if (item.ValueKind == JsonValueKind.Null || (item.ValueKind == JsonValueKind.String && item.ValueEquals(ReadOnlySpan<byte>.Empty)))
-        {
-            missingParamsCount++;
-        }
-        else
-        {
-            missingParamsCount = initialMissingParamsCount;
-        }
-    }
+    private static bool IsMissingParameterMarker(JsonElement item) =>
+        item.ValueKind == JsonValueKind.Null
+        || (item.ValueKind == JsonValueKind.String && item.ValueEquals(ReadOnlySpan<byte>.Empty));
+
+    private static bool RequiresExplicitValue(in ExpectedParameter parameter) =>
+        !parameter.IsOptional && !parameter.IsNullable;
 
     private JsonRpcErrorResponse HandleInvocationException(Exception ex, string methodName, JsonRpcRequest request, Action? returnAction)
     {
@@ -799,11 +817,13 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         ReadOnlyMemory<byte> providedParametersUtf8,
         out int providedParametersLength,
         out int missingParamsCount,
+        out int missingRequiredParameterIndex,
         out ExceptionDispatchInfo? parameterDeserializationException,
         out bool returnParametersToPool)
     {
         providedParametersLength = 0;
         missingParamsCount = 0;
+        missingRequiredParameterIndex = -1;
         parameterDeserializationException = null;
         returnParametersToPool = false;
 
@@ -832,6 +852,14 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
 
             bool isMissing = IsMissingParameterMarker(in reader);
             trailingMissingParamsCount = isMissing ? trailingMissingParamsCount + 1 : 0;
+            if (isMissing
+                && missingRequiredParameterIndex < 0
+                && providedParametersLength < expectedParameters.Length
+                && RequiresExplicitValue(in expectedParameters[providedParametersLength]))
+            {
+                missingRequiredParameterIndex = providedParametersLength;
+            }
+
             Utf8JsonReader parameterReader = reader;
             try
             {

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -400,12 +400,9 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             {
                 bool isMissing = IsMissingParameterMarker(item);
                 missingParamsCount = isMissing ? missingParamsCount + 1 : initialMissingParamsCount;
-                if (isMissing
-                    && missingRequiredParameterIndex < 0
-                    && index < expectedParameters.Length
-                    && RequiresExplicitValue(in expectedParameters[index]))
+                if (isMissing)
                 {
-                    missingRequiredParameterIndex = index;
+                    TrackMissingRequiredParameter(expectedParameters, index, ref missingRequiredParameterIndex);
                 }
 
                 index++;
@@ -467,7 +464,14 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         int missingRequiredParameterIndex,
         ref int missingParamsCount)
     {
-        if (missingParamsCount >= 0 && missingRequiredParameterIndex >= 0)
+        // The JSON element deserializer walks every provided element against expectedParameters, so an
+        // over-long request has to be rejected here rather than indexing past the end.
+        if (providedParametersLength > expectedParameters.Length || missingParamsCount < 0)
+        {
+            return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", null, in requestId);
+        }
+
+        if (missingRequiredParameterIndex >= 0)
         {
             return GetErrorResponse(methodName, ErrorCodes.InvalidParams,
                 $"missing value for required argument {missingRequiredParameterIndex}", null, in requestId);
@@ -475,40 +479,21 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
 
         int explicitNullableParamsCount = 0;
 
-        if (missingParamsCount != 0)
+        for (int i = 0; i < missingParamsCount; i++)
         {
-            bool hasIncorrectParameters = true;
-            int firstMissingRequiredIndex = -1;
-            if (missingParamsCount > 0)
+            int parameterIndex = expectedParameters.Length - missingParamsCount + i;
+
+            // Preserve compatibility for calls that pass trailing nullable defaults as null or "".
+            bool isExplicit = providedParametersLength >= parameterIndex + 1;
+            if (expectedParameters[parameterIndex].IsNullable && isExplicit)
             {
-                hasIncorrectParameters = false;
-                for (int i = 0; i < missingParamsCount; i++)
-                {
-                    int parameterIndex = expectedParameters.Length - missingParamsCount + i;
-                    bool nullable = expectedParameters[parameterIndex].IsNullable;
-
-                    // Preserve compatibility for calls that pass trailing nullable defaults as null or "".
-                    bool isExplicit = providedParametersLength >= parameterIndex + 1;
-                    if (nullable && isExplicit)
-                    {
-                        explicitNullableParamsCount += 1;
-                    }
-
-                    if (!expectedParameters[parameterIndex].IsOptional && !nullable)
-                    {
-                        hasIncorrectParameters = true;
-                        firstMissingRequiredIndex = parameterIndex;
-                        break;
-                    }
-                }
+                explicitNullableParamsCount += 1;
             }
 
-            if (hasIncorrectParameters)
+            if (RequiresExplicitValue(in expectedParameters[parameterIndex]))
             {
-                string message = firstMissingRequiredIndex >= 0
-                    ? $"missing value for required argument {firstMissingRequiredIndex}"
-                    : "Invalid params";
-                return GetErrorResponse(methodName, ErrorCodes.InvalidParams, message, null, in requestId);
+                return GetErrorResponse(methodName, ErrorCodes.InvalidParams,
+                    $"missing value for required argument {parameterIndex}", null, in requestId);
             }
         }
 
@@ -544,6 +529,20 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
 
     private static bool RequiresExplicitValue(in ExpectedParameter parameter) =>
         !parameter.IsOptional && !parameter.IsNullable;
+
+    /// <summary>
+    /// Records <paramref name="index"/> as the first argument where a missing-argument marker landed on a
+    /// parameter that requires an explicit value, leaving an already recorded index untouched.
+    /// </summary>
+    private static void TrackMissingRequiredParameter(ExpectedParameter[] expectedParameters, int index, ref int missingRequiredParameterIndex)
+    {
+        if (missingRequiredParameterIndex < 0
+            && index < expectedParameters.Length
+            && RequiresExplicitValue(in expectedParameters[index]))
+        {
+            missingRequiredParameterIndex = index;
+        }
+    }
 
     private JsonRpcErrorResponse HandleInvocationException(Exception ex, string methodName, JsonRpcRequest request, Action? returnAction)
     {
@@ -852,12 +851,9 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
 
             bool isMissing = IsMissingParameterMarker(in reader);
             trailingMissingParamsCount = isMissing ? trailingMissingParamsCount + 1 : 0;
-            if (isMissing
-                && missingRequiredParameterIndex < 0
-                && providedParametersLength < expectedParameters.Length
-                && RequiresExplicitValue(in expectedParameters[providedParametersLength]))
+            if (isMissing)
             {
-                missingRequiredParameterIndex = providedParametersLength;
+                TrackMissingRequiredParameter(expectedParameters, providedParametersLength, ref missingRequiredParameterIndex);
             }
 
             Utf8JsonReader parameterReader = reader;


### PR DESCRIPTION
Fixes #13196

## Changes

`""` and `null` mark an argument as omitted, but both parameter paths reset their marker count on the next non-marker argument, so a marker anywhere but the tail is forgotten. `ValidateMissingParameters` then sees a zero count and passes, and `DeserializeParameter` binds `expectedParameter.DefaultValue` — `null` for a required parameter — which the module dereferences. `eth_getBlockByNumber ["",false]` answers `-32603` with a stack trace where `-32602` is correct. It applies to every required parameter of every module, and to required value types at unboxing.

Both paths now record, through one shared helper, the first index where a marker lands on a parameter that is neither optional nor nullable, and `ValidateMissingParameters` rejects it. That predicate is the one the existing trailing scan already applies — it just never saw non-trailing markers — so the scan now calls the same `RequiresExplicitValue` instead of spelling it out a second time.

`ValidateMissingParameters` rejects an over-long request first, so a request that is both over-long and carries a marker keeps answering `Invalid params`, identically on both paths. That also closes an older hole on the `JsonElement` path: `eth_getBlockByNumber ["0x1",false,""]` indexed past `expectedParameters` and only the broad `catch` turned the `IndexOutOfRangeException` into the same `Invalid params`, with a stack trace in the Warn log. With over-long requests rejected up front `missingParamsCount` can no longer be negative, so the trailing scan's `hasIncorrectParameters` bookkeeping collapses into a direct return.

`""` on an optional nullable argument still means omitted: `eth_call` and `eth_getBalance` declare `BlockParameter? blockParameter = null` and are unchanged.

`UpdateMissingParamsCount` had one caller and collapsed to a single conditional once the marker test was hoisted out of it, so it is removed.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Cases added to the existing sources in `JsonRpcServiceTests` — `MissingRequiredArgument_ReturnsGethStyleError` covers the `JsonElement` path, `InvalidRawUtf8ParamCases` the utf8 path.

Failing against `master`: the marker at index 0 on both paths, a marker at index 1 (`eth_getProof [addr,"","latest"]`), the `eth_feeHistory` index change, and `eth_getBlockByNumber ["",false,""]` — which the first revision of this branch answered with `missing value for required argument 0` on the `JsonElement` path while the utf8 path said `Invalid params`.

Two more pin behaviour the rework must not change and so pass on `master` as well: `["0x1",false,""]` is the `IndexOutOfRangeException` hole (same response, no stack trace now), and `Missing_marker_on_an_optional_argument_binds_its_default` is `""` on an optional non-nullable argument still binding its default, on both paths.

`Nethermind.JsonRpc.Test` 1986 passed / 22 pre-existing skips, `Nethermind.Merge.Plugin.Test` 1855 passed / 2 skipped, `Nethermind.Optimism.Test` 724 passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

An empty string or `null` for a required non-nullable JSON-RPC argument now returns `-32602 Invalid params` instead of `-32603 Internal error` with a stack trace.

## Remarks

Two behaviour notes:

- `eth_feeHistory ["","latest"]` now names argument 0 instead of the omitted argument 2.
- Required **nullable** parameters are out of scope and still coerce `""` to `null` — `parentBeaconBlockRoot` on `engine_newPayloadV3` is the notable one, where the CL gets `Parent beacon block root must be set` rather than an invalid-params rejection.

