### PR TITLE
fix(eip8141): stage empty return data when APPROVE is rejected

### DIFF
--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -37,27 +37,27 @@ public static unsafe partial class EvmInstructions
 
         // Only the resolved target (or a DELEGATECALL from it, which preserves ADDRESS) may approve.
         if (!vm.VmState.Env.ExecutingAccount.Equals(resolvedTarget))
-            return EvmExceptionType.Revert;
+            goto Reject;
 
         byte scopeByte = (byte)scope.u0;
         byte allowed = frame.AllowedApproveScope;
         if (scope > TxFrame.ApproveScopeMask || scopeByte == 0 || (scopeByte & ~allowed) != 0)
-            return EvmExceptionType.Revert;
+            goto Reject;
 
         bool approvesExecution = (scopeByte & TxFrame.ApproveExecution) != 0;
         bool approvesPayment = (scopeByte & TxFrame.ApprovePayment) != 0;
 
         if (approvesExecution)
         {
-            if (ctx.SenderApproved || resolvedTarget != ctx.Sender) return EvmExceptionType.Revert;
+            if (ctx.SenderApproved || resolvedTarget != ctx.Sender) goto Reject;
         }
 
         if (approvesPayment)
         {
-            if (ctx.Payer is not null) return EvmExceptionType.Revert;
+            if (ctx.Payer is not null) goto Reject;
             // EIP-8141 ordering: payment may not be approved before execution, unless this same APPROVE grants both.
-            if (!approvesExecution && !ctx.SenderApproved) return EvmExceptionType.Revert;
-            if (vm.WorldState.GetBalance(resolvedTarget) < ctx.MaxCost) return EvmExceptionType.Revert;
+            if (!approvesExecution && !ctx.SenderApproved) goto Reject;
+            if (vm.WorldState.GetBalance(resolvedTarget) < ctx.MaxCost) goto Reject;
 
             // Consumption happens at payment approval, so first use is charged against this frame's gas.
             if (ctx.NonceKeys is { } nonceKeys
@@ -79,6 +79,11 @@ public static unsafe partial class EvmInstructions
         // Stop (not None): APPROVE exits the current call frame successfully, and dispatch requires
         // a non-None status from any handler that stages ReturnData.
         return EvmExceptionType.Stop;
+
+    Reject:
+        // A rejected approval reverts with no data; Revert status requires staged return data.
+        vm.ReturnData = Array.Empty<byte>();
+        return EvmExceptionType.Revert;
     }
 
     /// <summary>TXPARAM (0xb0): read a transaction-scoped field.</summary>


### PR DESCRIPTION
## Changes

- `InstructionApprove` returned `EvmExceptionType.Revert` from its six rejection paths without staging return data. The VM contract is that a `Revert` status carries a `byte[]` return buffer (`RunByteCode` casts `ReturnData` to `byte[]` and asserts it), so the rejection paths now funnel through a single `Reject:` label that stages an empty buffer.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

`FrameTxApproveAuthorizationTests` already covers both scope-zero rejections and is the regression guard: without this change the checked lane terminates the `Nethermind.Evm.Test` process on the `REVERT must provide return data.` assert. No new test is added because the failure only manifests under the checked build.

Behaviour is unchanged in a release build: `(byte[])null` widens to a default `ReadOnlyMemory<byte>`, which is already empty, so the rejected frame reverted with empty output before and after.

Counts on `Nethermind.Evm.Test`:

| configuration | before | after |
|---|---|---|
| checked (`-c release -p:DefineConstants=TRACE%3BDEBUG`) | process terminated on the assert | 6380 total, 6361 passed, 19 skipped, 0 failed |
| release | 6382 total, 6363 passed, 19 skipped, 0 failed | 6382 total, 6363 passed, 19 skipped, 0 failed |

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
