### PR TITLE
fix(txpool): stop revalidation recreating an evicted frame tx's index entry

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -3977,6 +3977,42 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
+        public async Task Revalidation_does_not_reindex_a_transaction_evicted_while_its_prefix_simulated()
+        {
+            // Block production evicts without the head lock, so the removal can land while the head loop is
+            // inside the simulation. Re-indexing the accepted result would leave a dependency entry behind a
+            // transaction the pool no longer holds, and no later head removes it.
+            IFrameTxPrefixSimulator simulator = Substitute.For<IFrameTxPrefixSimulator>();
+            simulator.Simulate(Arg.Any<Transaction>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<bool>()).Returns(FrameTxSimulationResult.Accept(TestItem.AddressD));
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance), frameTxPrefixSimulator: simulator);
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressD, UInt256.MaxValue);
+
+            Transaction tx = SponsoredFrameTx(TestItem.PrivateKeyA, TestItem.PrivateKeyD);
+            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+
+            // Stands in for the concurrent eviction, pinned to the one interleaving that matters: it lands
+            // after the sweep read the transaction and before the accepted result is indexed.
+            simulator.Simulate(Arg.Any<Transaction>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<bool>())
+                .Returns(_ =>
+                {
+                    _txPool.EvictTransaction(tx);
+                    return FrameTxSimulationResult.Accept(TestItem.AddressD);
+                });
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).TestObject);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero, "the eviction must have taken, or nothing was raced");
+                Assert.That(TrackedFrameTxDependencies(), Is.Zero, "the finished simulation must not recreate the removed entry");
+            }
+        }
+
+        private int TrackedFrameTxDependencies() => ((FrameTxDependencyIndex)typeof(TxPool)
+            .GetField("_frameDependencies", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(_txPool)!).Count;
+
+        [Test]
         public async Task Revalidation_eviction_leaves_the_transaction_resubmittable()
         {
             // Unlike expiry, invalidity against a head reverses, so the hash must not stay in the cache.

--- a/src/Nethermind/Nethermind.TxPool/FrameTxDependencyIndex.cs
+++ b/src/Nethermind/Nethermind.TxPool/FrameTxDependencyIndex.cs
@@ -28,21 +28,21 @@ internal sealed class FrameTxDependencyIndex
     /// <summary>Indexes <paramref name="hash"/> under each of <paramref name="accounts"/>, replacing any earlier entry.</summary>
     public void Set(ValueHash256 hash, AddressAsKey[] accounts)
     {
+        lock (_lock) SetLocked(hash, accounts);
+    }
+
+    /// <summary>Re-indexes <paramref name="hash"/> under <paramref name="accounts"/>, doing nothing if it is no longer tracked.</summary>
+    /// <remarks>The membership test and the write share this index's lock, so a removal racing a caller that read
+    /// the transaction earlier — block production evicting while its prefix re-simulates — either lands first and
+    /// leaves nothing to re-index, or lands after and clears what was written. A recreated entry would leak: later
+    /// heads skip the absent transaction without cleaning up after it, and no removal is left to run.</remarks>
+    public void Update(ValueHash256 hash, AddressAsKey[] accounts)
+    {
         lock (_lock)
         {
-            RemoveLocked(hash);
-            if (accounts.Length == 0) return;
+            if (!_byTx.ContainsKey(hash)) return;
 
-            _byTx[hash] = accounts;
-            foreach (AddressAsKey account in accounts)
-            {
-                if (!_byAccount.TryGetValue(account, out HashSet<ValueHash256>? hashes))
-                {
-                    _byAccount[account] = hashes = [];
-                }
-
-                hashes.Add(hash);
-            }
+            SetLocked(hash, accounts);
         }
     }
 
@@ -67,6 +67,23 @@ internal sealed class FrameTxDependencyIndex
     public void CollectAll(HashSet<ValueHash256> into)
     {
         lock (_lock) into.UnionWith(_byTx.Keys);
+    }
+
+    private void SetLocked(ValueHash256 hash, AddressAsKey[] accounts)
+    {
+        RemoveLocked(hash);
+        if (accounts.Length == 0) return;
+
+        _byTx[hash] = accounts;
+        foreach (AddressAsKey account in accounts)
+        {
+            if (!_byAccount.TryGetValue(account, out HashSet<ValueHash256>? hashes))
+            {
+                _byAccount[account] = hashes = [];
+            }
+
+            hashes.Add(hash);
+        }
     }
 
     private void RemoveLocked(ValueHash256 hash)

--- a/src/Nethermind/Nethermind.TxPool/FrameTxDependencyIndex.cs
+++ b/src/Nethermind/Nethermind.TxPool/FrameTxDependencyIndex.cs
@@ -35,7 +35,9 @@ internal sealed class FrameTxDependencyIndex
     /// <remarks>The membership test and the write share this index's lock, so a removal racing a caller that read
     /// the transaction earlier — block production evicting while its prefix re-simulates — either lands first and
     /// leaves nothing to re-index, or lands after and clears what was written. A recreated entry would leak: later
-    /// heads skip the absent transaction without cleaning up after it, and no removal is left to run.</remarks>
+    /// heads skip the absent transaction without cleaning up after it, and no removal is left to run.
+    /// Membership stands in for entry identity because admission takes the pool's head read lock and revalidation
+    /// its write lock, so the same hash cannot be re-admitted between a caller's read and its update.</remarks>
     public void Update(ValueHash256 hash, AddressAsKey[] accounts)
     {
         lock (_lock)

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -77,6 +77,24 @@ namespace Nethermind.TxPool
         /// </summary>
         void ForgetRejectedBlobTransaction(Hash256 hash);
         bool RemoveTransaction(Hash256? hash);
+
+        /// <summary>
+        /// Drops <paramref name="tx"/> as unbuildable, so later blocks stop re-burning its validation prefix.
+        /// </summary>
+        /// <remarks>
+        /// Everything <see cref="RemoveTransaction"/> does, plus: <see cref="EvictedPending"/> is raised after
+        /// <see cref="RemovedPending"/>, and the hash leaves the long-term known-hash cache so the same
+        /// transaction may be resubmitted. That last part is what makes this a drop rather than a verdict —
+        /// the reasons block production evicts for turn on head state and can reverse — so callers must not
+        /// use it to blacklist a transaction.
+        /// Removal is atomic and the rest of the work follows it, so repeated calls are idempotent: only the
+        /// call that removes the transaction reports <see langword="true"/>, raises the events and counts the
+        /// eviction, and a call for a transaction the pool does not hold changes nothing.
+        /// Runs without the pool's head lock, so it may land at any point of a concurrent head update.
+        /// </remarks>
+        /// <param name="tx">The transaction to drop. The instance is what the events carry, so it must be the
+        /// pooled one rather than a re-decoded copy sharing its hash.</param>
+        /// <returns><see langword="true"/> if this call removed the transaction from the pool.</returns>
         bool EvictTransaction(Transaction tx);
         Transaction? GetBestTx();
         IEnumerable<Transaction> GetBestTxOfEachSender();

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -457,7 +457,9 @@ namespace Nethermind.TxPool
         /// reads (<c>TIMESTAMP</c>, <c>NUMBER</c>), which no change list can describe.
         /// </remarks>
         /// <param name="resolvedPayer">A payer the sweep resolved but did not record, so it is still tracked.</param>
-        private void IndexFrameTxDependencies(Transaction tx, Address? resolvedPayer = null)
+        /// <param name="onlyIfTracked">Set by revalidation, which re-indexes a transaction the pool already holds
+        /// rather than admitting one, so an eviction that landed meanwhile is not undone.</param>
+        private void IndexFrameTxDependencies(Transaction tx, Address? resolvedPayer = null, bool onlyIfTracked = false)
         {
             // Under persistent blob storage the pool holds a frameless light record. There is no prefix left
             // to re-resolve, so indexing it would only queue a revalidation that must reject it.
@@ -474,7 +476,8 @@ namespace Nethermind.TxPool
             if (hasDistinctPayer) accounts[next++] = payer!;
             if (delegated is not null) accounts[next] = delegated;
 
-            _frameDependencies.Set(tx.Hash!.ValueHash256, accounts);
+            if (onlyIfTracked) _frameDependencies.Update(tx.Hash!.ValueHash256, accounts);
+            else _frameDependencies.Set(tx.Hash!.ValueHash256, accounts);
         }
 
         private static bool HasExpiryDeadline(Transaction tx) => tx.SupportsFrames && FrameTxValidation.TryGetExpiryDeadline(tx, out _);
@@ -1115,12 +1118,14 @@ namespace Nethermind.TxPool
         /// <em>Which</em> of that payer's transactions survive follows index iteration order, not the spec's
         /// nearest-expiry-then-lowest-fee order.
         /// A transaction that stays pending is re-indexed for the sender's delegation target, a head-state
-        /// snapshot that can move while the payer does not, since a payer that moves evicts instead.
+        /// snapshot that can move while the payer does not, since a payer that moves evicts instead. The
+        /// re-index is update-only: block production evicts without the head lock, so it can drop the
+        /// transaction while the prefix simulates, and recreating the entry here would leak it.
         /// </remarks>
         private bool TryRevalidateFrameTransaction(Transaction tx, IReadOnlyStateProvider state)
         {
             bool stillValid = ResolveFrameTxAgainstHead(tx, state, out Address? resolvedPayer);
-            if (stillValid) IndexFrameTxDependencies(tx, resolvedPayer);
+            if (stillValid) IndexFrameTxDependencies(tx, resolvedPayer, onlyIfTracked: true);
             return stillValid;
         }
 
@@ -2289,7 +2294,7 @@ namespace Nethermind.TxPool
             return true;
         }
 
-        /// <summary>Removes a frame transaction that block production dropped because its frames did not approve payment.</summary>
+        /// <inheritdoc/>
         /// <remarks>The long-term cache is cleared, unlike in <see cref="RemoveExpiredFrameTransactions"/>: a payment failure turns on chain state that can change.</remarks>
         public bool EvictTransaction(Transaction tx)
         {


### PR DESCRIPTION
Addresses two P2 review threads from @benaadams on #12526.

## Changes

**Revalidation no longer recreates the dependency index entry of an evicted frame transaction.**

`RevalidateFrameTransactions` runs on the head loop under the `_newHeadLock` write lock, and the
prefix simulation it calls per transaction runs inside that lock. `EvictTransaction` (and
`RemoveTransaction`) take no such lock — block production calls it straight from
`BlockProductionTransactionsExecutor`. So the interleaving is:

1. the head loop reads the pooled transaction and enters `IFrameTxPrefixSimulator.Simulate`;
2. block production evicts it — `SortedPool` removal fires `OnRemovedTx`, which removes the
   transaction's `FrameTxDependencyIndex` entry;
3. the simulation returns `Accepted`, and `TryRevalidateFrameTransaction` re-indexes
   unconditionally through `FrameTxDependencyIndex.Set`, recreating the entry.

Nothing removes that entry afterwards. Later heads collect the hash out of the index, fail the
`_transactions` / `_blobTransactions` lookup, and `continue` without cleaning it up, so the index
retains the accounts indefinitely and grows past pool capacity.

Revalidation now re-indexes update-only, through a new `FrameTxDependencyIndex.Update` that tests
membership and writes under the index's own lock. That is what makes it a fix rather than a
narrower window: a re-check against `_transactions` from `TxPool` would be a check-then-act with the
removal still free to land in between, whereas here the removal and the update contend for the same
lock, so whichever lands second sees the other's effect. Insertion (`OnInsertedTx`) still uses
`Set` — it is the operation that legitimately creates entries.

**`ITxPool.EvictTransaction` is documented.** Its difference from `RemoveTransaction` (the extra
`EvictedPending` event and the long-term hash-cache delete that makes it a drop rather than a
verdict), the meaning of the return value, the idempotence of repeated calls, and that it runs
without the head lock. The implementation's summary becomes `<inheritdoc/>`, keeping its own
`<remarks>`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Revalidation_does_not_reindex_a_transaction_evicted_while_its_prefix_simulated` pins the
interleaving deterministically rather than racing threads: the simulator substitute calls
`EvictTransaction` from inside `Simulate`, which places the removal exactly between the sweep's read
of the transaction and the index write, then returns `Accepted`. It asserts both that the eviction
took (so the case is not vacuous) and that the index tracks nothing afterwards.

Red/green pair, `Nethermind.TxPool.Test` in release:

- with `onlyIfTracked: true` reverted to the original call: `failed: 1` — `Expected: 0, But was: 1`,
  the leaked entry;
- with the fix: `succeeded: 1`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
