### PR TITLE
frames devnet genesis fork-label alias (Don't merge)

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadV4Tests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/ExecutionPayloadV4Tests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Serialization.Json;
@@ -72,12 +73,11 @@ public class ExecutionPayloadV4Tests
         Assert.That(block.Header.BlockAccessListHash, Is.EqualTo(block.BlockAccessList!.WireHash));
     }
 
-    // Two devnet fixture lines both call their Amsterdam successor Bogota while meaning different
-    // things by it, so the label a genesis carries has to decide which newPayload version the node
-    // accepts: inclusion lists move it to V6, frame transactions leave it on Amsterdam's V5.
-    [TestCase("bogotaTime", EngineApiVersions.NewPayload.V6)]
-    [TestCase("eip8141PrototypeTime", EngineApiVersions.NewPayload.V5)]
-    public void ValidateForkOnNewPayload_accepts_the_version_the_genesis_fork_label_selects(string label, int accepted)
+    // On this deployment image bogotaTime is the frame-transaction devnet's label and selects frame
+    // transactions, which leaves newPayload on Amsterdam's V5; inclusion lists would move it to V6.
+    [TestCase("bogotaTime", true)]
+    [TestCase("eip8141PrototypeTime", false)]
+    public void ValidateForkOnNewPayload_accepts_V5_for_a_bogota_labelled_genesis(string label, bool selectsFrames)
     {
         string genesis = $$"""
             {
@@ -102,12 +102,13 @@ public class ExecutionPayloadV4Tests
             StateRoot = Keccak.EmptyTreeHash,
         };
 
+        IReleaseSpec spec = specProvider.GetSpec(ForkActivation.TimestampOnly(15));
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(payload.ValidateForkOnNewPayload(specProvider, EngineApiVersions.NewPayload.V5),
-                Is.EqualTo(accepted == EngineApiVersions.NewPayload.V5));
-            Assert.That(payload.ValidateForkOnNewPayload(specProvider, EngineApiVersions.NewPayload.V6),
-                Is.EqualTo(accepted == EngineApiVersions.NewPayload.V6));
+            Assert.That(spec.IsEip8141Enabled, Is.EqualTo(selectsFrames));
+            Assert.That(spec.IsEip7805Enabled, Is.False);
+            Assert.That(payload.ValidateForkOnNewPayload(specProvider, EngineApiVersions.NewPayload.V5), Is.True);
+            Assert.That(payload.ValidateForkOnNewPayload(specProvider, EngineApiVersions.NewPayload.V6), Is.False);
         }
     }
 

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/GethGenesisLoaderTests.cs
@@ -50,7 +50,12 @@ public class GethGenesisLoaderTests
     ];
 
     // Fork classes that are not real Geth fork names and therefore have no genesis config property
-    private static readonly HashSet<string> ForkClassesWithoutConfigProp = [];
+    private static readonly HashSet<string> ForkClassesWithoutConfigProp =
+    [
+        // This image spends the bogotaTime label on EIP-8141, so inclusion lists are scheduled through
+        // the chainspec's eip7805TransitionTimestamp instead.
+        "Bogota",
+    ];
 
     private static readonly string[] AmsterdamEipNumbers = ["7708", "7778", "7843", "7928", "7954", "8024", "8037"];
 
@@ -301,20 +306,19 @@ public class GethGenesisLoaderTests
         }
     }
 
-    // Two devnet fixture lines both call their fork Bogota while meaning different things by it, so a
-    // genesis says which it means by the label it carries: bogotaTime is inclusion lists, and frame
-    // transactions have their own. Neither may drag the other's EIP in — they sit on different
+    // This image's genesis generator emits bogotaTime for the fork carrying EIP-8141, so that is the one
+    // label that schedules anything here and it must not drag EIP-7805 in: the two sit on different
     // engine_newPayload versions, and the frame-transaction predeploy shifts every EIP-7928 access list.
-    [TestCase("bogotaTime", true, false)]
-    [TestCase("eip8141PrototypeTime", false, true)]
-    public void Genesis_fork_label_picks_one_of_the_two_amsterdam_successors(string label, bool eip7805, bool eip8141)
+    [TestCase("bogotaTime", true)]
+    [TestCase("eip8141PrototypeTime", false)]
+    public void Genesis_bogota_label_schedules_frame_transactions_alone(string label, bool eip8141)
     {
         ChainSpec chainSpec = LoadStandardGethGenesis(configExtra: $"\"{label}\": 15");
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(chainSpec.Parameters.Eip7805TransitionTimestamp, Is.EqualTo(eip7805 ? (ulong?)15 : null));
             Assert.That(chainSpec.Parameters.Eip8141TransitionTimestamp, Is.EqualTo(eip8141 ? (ulong?)15 : null));
+            Assert.That(chainSpec.Parameters.Eip7805TransitionTimestamp, Is.Null);
         }
 
         ChainSpecBasedSpecProvider provider = new(chainSpec);
@@ -324,8 +328,8 @@ public class GethGenesisLoaderTests
         {
             Assert.That(before.IsEip7805Enabled, Is.False);
             Assert.That(before.IsEip8141Enabled, Is.False);
-            Assert.That(after.IsEip7805Enabled, Is.EqualTo(eip7805));
             Assert.That(after.IsEip8141Enabled, Is.EqualTo(eip8141));
+            Assert.That(after.IsEip7805Enabled, Is.False);
         }
     }
 

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/GethGenesisConfigJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/GethGenesisConfigJson.cs
@@ -22,7 +22,8 @@ namespace Nethermind.Specs.ChainSpecStyle.Json;
 /// <c>&lt;ForkClass&gt;Block</c> or <c>&lt;ForkClass&gt;Time</c> and the helper strips that suffix
 /// from <see cref="CallerMemberNameAttribute"/> to derive the dict key — properties whose
 /// Geth-wire name doesn't match the Nethermind fork-class name (Petersburg / Constantinople-fix,
-/// merge-netsplit / Paris, Dao-fork / Dao, Bpo / BPO casing) pass an explicit override.
+/// merge-netsplit / Paris, Dao-fork / Dao, Bpo / BPO casing, Bogota / Eip8141Prototype) pass an
+/// explicit override.
 /// Per-EIP overrides (<c>Eip150Block</c>, <c>Eip155Block</c>, <c>Eip158Block</c>) are NOT routed —
 /// they're EIP-level fallbacks consumed inline by <c>GethGenesisLoader</c>.
 /// </remarks>
@@ -60,15 +61,14 @@ public class GethGenesisConfigJson : IHasNamedForks
     public ulong? PragueTime { get => GetTime(); set => SetTime(value); }
     public ulong? OsakaTime { get => GetTime(); set => SetTime(value); }
     public ulong? AmsterdamTime { get => GetTime(); set => SetTime(value); }
-    // Devnet fork on top of Amsterdam. The genesis generator emits this as bogotaTime; the fork
-    // class is Bogota.
-    public ulong? BogotaTime { get => GetTime(); set => SetTime(value); }
     /// <summary>Activation time for EIP-8141 frame transactions, in Unix timestamp seconds; <c>null</c> leaves them unscheduled.</summary>
     /// <remarks>
-    /// They schedule on their own rather than with Bogota: the expiry-verifier predeploy they install shifts
-    /// every block's EIP-7928 access list, which the Bogota consensus fixtures pin.
+    /// The frame-transaction devnet's genesis generator emits this label for Amsterdam plus EIP-8141, which
+    /// is <see cref="Eip8141Prototype"/> here, so it routes there rather than to the <see cref="Bogota"/>
+    /// fork class of the same name. A genesis wanting EIP-7805 inclusion lists instead schedules them
+    /// through the chainspec's <c>eip7805TransitionTimestamp</c>.
     /// </remarks>
-    public ulong? Eip8141PrototypeTime { get => GetTime(); set => SetTime(value); }
+    public ulong? BogotaTime { get => GetTime(nameof(Eip8141Prototype)); set => SetTime(value, nameof(Eip8141Prototype)); }
 
     // OIC dict matches "Bpo1" (from CallerMemberName-strip) against the BPO1 fork class.
     public ulong? Bpo1Time { get => GetTime(); set => SetTime(value); }


### PR DESCRIPTION
**REVIEW ONLY — DO NOT MERGE.** This PR exists so the deployment-only commit on
`feature/frames-devnet-0` can be read and reviewed. It will be closed, not merged.

## What this is

`feature/frames-devnet-0` is the frames devnet deployment branch. It is kept as
**base + exactly one commit**, so every refresh is a reset onto the base plus one
cherry-pick.

- Base: `eip8141-frame-txs-devnet7` @ `6ff3f884af`
- Head: `da586a98ae` — `DEPLOYMENT-ONLY: route the genesis bogotaTime label to frame transactions`

## The change

The devnet's fixture line labels its fork Bogota meaning Amsterdam plus EIP-8141,
and its generated genesis carries that as `bogotaTime`. Nethermind read the label
as the fork class of the same name — Amsterdam plus EIP-7805, which moves
`engine_newPayload` one version on — so every payload the devnet sent was rejected
with `-38005` before it was ever validated.

`GethGenesisConfigJson.BogotaTime` is therefore re-pointed at `Eip8141Prototype` on
this branch. Only one property carries the label, so no two can write the same fork
key and erase each other. A genesis wanting inclusion lists schedules them through
the chainspec's `eip7805TransitionTimestamp` instead.

## Why it must never land on the base or master

`Bogota` is a mainnet fork name here and maps to EIP-7805. On
`eip8141-frame-txs-devnet7` or `master` this alias would mean a genesis saying
`bogotaTime` activates a prototype fork once Bogota actually schedules. The commit
is re-applied on top of the base after every refresh instead.

## Reconciliation with #13227

The base gained #13227, which pins the *opposite* routing — `bogotaTime` → `Bogota`
→ EIP-7805 → newPayload V6 — plus the reflective `RoutedForkName` / `IsForkLabel`
genesis guards. #13227's read-back guards are the better version of what the
previous deployment commit carried, so they are taken from the base unchanged and
only the routing expectations are inverted. **No assertion was deleted or weakened:**

- `GethGenesisLoaderTests.Genesis_fork_label_picks_one_of_the_two_amsterdam_successors`
  → `Genesis_bogota_label_schedules_frame_transactions_alone`. Still parameterised over
  both labels. `bogotaTime` now pins EIP-8141 scheduled at 15 and EIP-7805 `null`;
  `eip8141PrototypeTime` — no longer a property on this branch — pins that the label is
  inert and schedules nothing. The before/after spec-provider assertions are kept, with
  `IsEip7805Enabled` now pinned false for both labels.
- `ExecutionPayloadV4Tests.ValidateForkOnNewPayload_accepts_the_version_the_genesis_fork_label_selects`
  → `ValidateForkOnNewPayload_accepts_V5_for_a_bogota_labelled_genesis`. Both labels kept.
  The V5/V6 pair is still asserted in both directions on both cases — V5 accepted, V6
  rejected — and the cases are told apart by `IsEip8141Enabled`, which follows the label.
- `ForkClassesWithoutConfigProp` gains `Bogota`, since no genesis property labels it here.

One assertion could not be preserved as-is: #13227's `bogotaTime` → EIP-7805 / V6
direction. That is exactly the behaviour this branch inverts, so it is asserted in the
opposite sense rather than dropped. The surviving coverage that inclusion lists still
activate from their own transition timestamp is
`ChainSpecBasedSpecProviderTests.Frame_family_eips_activate_only_at_their_own_transition_timestamp`
on the base, which this branch does not touch.

## Verification

- Full `Nethermind.slnx` Release build: **0 warnings, 0 errors**
- `Nethermind.Specs.Test`: **347/347 passed**
- `Nethermind.Merge.Plugin.Test`: **1873 passed, 3 skipped, 0 failed** (1876 total)
- Red control — perturbing only the routing expression back to `GetTime()` / `SetTime(value)`,
  changing nothing else, fails both routing proofs on the `bogotaTime` case
  (`IsEip8141Enabled` False, `IsEip7805Enabled` True, V5 rejected, V6 accepted;
  `Eip8141TransitionTimestamp` null, `Eip7805TransitionTimestamp` 15). Reverted and green again.
