### PR TITLE
fix(eip8141): bound the frame-tx gas estimate per gas dimension

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -101,7 +101,9 @@ public class GasEstimator(
 
     /// <summary>The gas an EIP-8141 frame transaction reserves, or a failure when that budget is unestimable.</summary>
     /// <remarks>There is nothing to binary-search: the budget is fixed by the signed per-frame limits. The
-    /// sender's balance is not gated on either, since the payer is frame-chosen rather than the sender.</remarks>
+    /// sender's balance is not gated on either, since the payer is frame-chosen rather than the sender.
+    /// The reported budget is the combined reservation, but admission bounds the execution and state
+    /// dimensions separately, so the combined figure is not what either limit is tested against.</remarks>
     private static EstimationResult EstimateFrameTx(Transaction tx, BlockHeader header, IReleaseSpec spec)
     {
         // The budget below is computable from an empty or oversized frame list, so a count no valid
@@ -109,10 +111,12 @@ public class GasEstimator(
         if (tx.Frames is not { Length: > 0 and <= Eip8141Constants.MaxFrames })
             return EstimationResult.Failure(FrameTxValidation.MissingFrames);
 
-        if (!FrameTxValidation.TryCalculateGasBudget(tx, spec, out _, out _, out ulong maxGas))
+        if (!FrameTxValidation.TryCalculateGasBudget(tx, spec, out _, out _, out ulong maxGas)
+            || !FrameTxValidation.TryCalculateBlockGasReservations(tx, spec, out ulong executionReservation, out ulong stateReservation))
             return EstimationResult.Failure(FrameTxGasLimitOverflows);
 
-        return maxGas > Math.Min(header.GasLimit, spec.GetTxGasLimitCap())
+        // EIP-8037: each dimension gets its own block budget, and only execution carries the per-tx cap.
+        return executionReservation > Math.Min(header.GasLimit, spec.GetTxGasLimitCap()) || stateReservation > header.GasLimit
             ? EstimationResult.Failure(CannotEstimateGasExceeded)
             : EstimationResult.Success(maxGas);
     }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -980,6 +980,37 @@ public class FrameTxProcessorTests
         Assert.That(error, Is.EqualTo(GasEstimator.CannotEstimateGasExceeded));
     }
 
+    /// <remarks>EIP-8037 gives execution and state a block budget each, so a transaction whose combined
+    /// reservation exceeds the block gas limit is still includable while neither dimension does.</remarks>
+    [Test]
+    public void EstimateGas_FrameTxWhoseDimensionsFitTheBlockButWhoseCombinedBudgetDoesNot_IsEstimable()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        const ulong blockGasLimit = 30_000_000;
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(),
+            new TxFrame(TxFrame.ModeSender, 0, Recipient,
+                executionGasLimit: 200_000, stateGasLimit: 29_900_000, UInt256.Zero, default));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(blockGasLimit).TestObject;
+
+        Assert.That(FrameTxValidation.TryCalculateBlockGasReservations(tx, Spec, out ulong execution, out ulong state), Is.True);
+        Assert.That(FrameTxValidation.TryCalculateGasBudget(tx, Spec, out _, out _, out ulong maxGas), Is.True);
+
+        GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
+        ulong estimate = estimator.Estimate(tx, header, new EstimateGasTracer(), out string? error);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(execution, Is.LessThanOrEqualTo(blockGasLimit), "the execution dimension fits the block");
+            Assert.That(state, Is.LessThanOrEqualTo(blockGasLimit), "the state dimension fits the block");
+            Assert.That(maxGas, Is.GreaterThan(blockGasLimit), "only the combined budget exceeds it");
+            Assert.That(error, Is.Null);
+            Assert.That(estimate, Is.EqualTo(maxGas));
+        }
+    }
+
     /// <remarks>
     /// A type-6 transaction reaches the frame estimator on its type alone, so a frame count EIP-8141 never
     /// admits must be reported as such: an absent list is not the gas-limit overflow the estimator blamed,

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -989,8 +989,7 @@ public class FrameTxProcessorTests
 
         const ulong blockGasLimit = 30_000_000;
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(),
-            new TxFrame(TxFrame.ModeSender, 0, Recipient,
-                executionGasLimit: 200_000, stateGasLimit: 29_900_000, UInt256.Zero, default));
+            Frame(TxFrame.ModeSender, target: Recipient, stateGasLimit: 29_900_000));
         BlockHeader header = Build.A.BlockHeader.WithNumber(1)
             .WithBeneficiary(Beneficiary)
             .WithGasLimit(blockGasLimit).TestObject;
@@ -1008,6 +1007,33 @@ public class FrameTxProcessorTests
             Assert.That(maxGas, Is.GreaterThan(blockGasLimit), "only the combined budget exceeds it");
             Assert.That(error, Is.Null);
             Assert.That(estimate, Is.EqualTo(maxGas));
+        }
+    }
+
+    /// <remarks>The state dimension carries a block budget of its own, so a reservation no block can hold in
+    /// that dimension alone is unestimable however small the execution dimension is.</remarks>
+    [Test]
+    public void EstimateGas_FrameTxWhoseStateBudgetAloneExceedsTheBlock_ReportsTheBudgetAsUnestimable()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        const ulong blockGasLimit = 30_000_000;
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, target: Recipient, stateGasLimit: 40_000_000));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(blockGasLimit).TestObject;
+
+        Assert.That(FrameTxValidation.TryCalculateBlockGasReservations(tx, Spec, out ulong execution, out ulong state), Is.True);
+
+        GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
+        estimator.Estimate(tx, header, new EstimateGasTracer(), out string? error);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(execution, Is.LessThanOrEqualTo(blockGasLimit), "the execution dimension fits the block");
+            Assert.That(state, Is.GreaterThan(blockGasLimit), "only the state dimension exceeds it");
+            Assert.That(error, Is.EqualTo(GasEstimator.CannotEstimateGasExceeded));
         }
     }
 


### PR DESCRIPTION
## Changes

`GasEstimator.EstimateFrameTx` tested the *combined* budget (`maxGas`) against a single limit, `Math.Min(header.GasLimit, spec.GetTxGasLimitCap())`. Under EIP-8037 a frame transaction reserves two independent dimensions, and admission bounds them separately:

- **Execution** — `FrameTxFieldsTxValidator` caps `executionReservation` at the per-transaction gas cap, and `GasLimitTxFilter` / `Eip8037BlockGasInclusionCheck` bound it by the block gas limit.
- **State** — `stateReservation` is bounded by the block gas limit only; no per-transaction cap applies to it.

The combined budget is what the payer escrows, so it is the right figure to *report*, but it is not what either limit is tested against. A transaction with a small execution budget and a large state budget was reported `CannotEstimateGasExceeded` as soon as the two together crossed the block gas limit, even though every validator on the admission path accepts it and a block can include it.

The estimate now reads `TryCalculateBlockGasReservations` — the same accessor the field validator and the pool filter use — and bounds execution and state independently, still returning the combined `maxGas` on success.

Surfaced by a review of #12526 (P2, gas estimation).

## Relation to #13191

Orthogonal, and they compose. #13191 changes the *source* of the execution cap (`spec.GetTxGasLimitCap()`, which is unbounded on any fork enabling frame transactions, to the raw per-transaction cap the field validator enforces). This PR changes the *dimensioning*: which reservation each limit applies to. Neither subsumes the other, and this PR deliberately leaves the cap accessor alone so #13191 stays the single place that call is made.

They touch the same expression, so whichever lands second is a small textual rebase; the composed result applies the per-transaction cap to `executionReservation` and the block gas limit to each dimension separately.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `EstimateGas_FrameTxWhoseDimensionsFitTheBlockButWhoseCombinedBudgetDoesNot_IsEstimable`: a frame transaction reserving 200k execution and 29.9M state in a 30M block, whose combined budget is 30,312,950. Each dimension fits the block, only the sum does not, and the estimate now succeeds and returns the combined budget.

Red/green pair — with the dimension split neutered back to the combined comparison, the new test fails (`Expected: null, But was: "Cannot estimate gas..."`) and the other six frame estimate tests stay green (7 total, 1 failed / 6 passed). With the fix, 7/7 pass. The pre-existing `EstimateGas_FrameTxReservingMoreThanTheBlock_ReportsTheBudgetAsUnestimable` stays red-on-purpose under both, so the block bound is still enforced per dimension.

Suites, all green on release builds with 0 warnings:

- `Nethermind.Evm.Test` `FrameTx*` — 367/367
- `Nethermind.Blockchain.Test` — 2018 total, 1867 passed, 151 skipped, 0 failed
- `Nethermind.JsonRpc.Test` — 2041 total, 2019 passed, 22 skipped, 0 failed
- `Nethermind.Facade.Test` — 139/139

## Documentation

Requires documentation update: no
