### PR TITLE
EIP-8141: apply APPROVE during execution and journal its context

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1186,6 +1186,31 @@ public class FrameTxProcessorTests
     }
 
     /// <summary>
+    /// A payment approval discarded with a reverted nested call leaves no payer behind, so a later
+    /// approval still collects <c>max_cost</c> from the sender.
+    /// </summary>
+    /// <remarks>
+    /// The world state restored on the nested revert takes the collection and the nonce with it, so a
+    /// payer that outlived the revert would name an account nothing had been taken from.
+    /// </remarks>
+    [Test]
+    public void Execute_PaymentApprovalInsideARevertedNestedCall_IsRetriedAndCollectsMaxCost()
+    {
+        DeploySmartSender(RetriesPaymentApprovalAfterDiscard(Observer));
+        DeployContract(Observer, ApprovesPaymentThroughSenderThenReverts());
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient));
+
+        TransactionResult result = Process(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True, result.ErrorDescription);
+            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL), "the retried approval collected the payment");
+        }
+    }
+
+    /// <summary>
     /// <c>APPROVE</c>'s payment effects are visible to its caller as soon as the approving call returns,
     /// not only once the frame ends.
     /// </summary>
@@ -1201,6 +1226,32 @@ public class FrameTxProcessorTests
         TransactionResult result = Process(tx);
 
         Assert.That(result.TransactionExecuted, Is.True);
+    }
+
+    /// <summary>
+    /// The default code approves payment through the same balance guard as the <c>APPROVE</c> opcode, so a
+    /// target that cannot cover <c>max_cost</c> reverts the <c>VERIFY</c> frame rather than approving.
+    /// </summary>
+    /// <remarks>Reporting success after the signature checks alone approved execution and left payment to a
+    /// later frame, admitting a transaction with no account able to cover it.</remarks>
+    [Test]
+    public void Execute_DefaultCodeVerify_WithTargetBelowMaxCost_InvalidatesTheTransaction()
+    {
+        _stateProvider.CreateAccount(Sender, 1000);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, new byte[TxFrameSignature.Secp256k1SignatureLength])];
+        SignCanonicalHash(tx, index: 0, TestItem.PrivateKeyA, signer: null);
+
+        TransactionResult result = Process(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False);
+            Assert.That(result.ErrorDescription, Does.Contain("VERIFY frame reverted"));
+        }
     }
 
     /// <summary>
@@ -2837,6 +2888,22 @@ public class FrameTxProcessorTests
 
     private static byte[] ApprovesThroughSenderThenReverts() =>
         Prepare.EvmCode.CallWithInput(Sender, 60_000, [1]).Op(Instruction.POP).Revert(0, 0).Done;
+
+    /// <summary>Approves the scope named by the calldata length when re-entered, and otherwise approves
+    /// execution, has <paramref name="helper"/> discard a payment approval, then approves payment again.</summary>
+    private static byte[] RetriesPaymentApprovalAfterDiscard(Address helper) =>
+        BranchOnStackTop(
+            Prepare.EvmCode.Op(Instruction.CALLDATASIZE).Done,
+            // APPROVE stack order (top to bottom): offset, length, scope; the scope is the calldata length.
+            [(byte)Instruction.CALLDATASIZE, (byte)Instruction.PUSH1, 0, (byte)Instruction.PUSH1, 0, (byte)Instruction.APPROVE],
+            Prepare.EvmCode
+                .CallWithInput(Sender, 40_000, [1, 1]).Op(Instruction.POP)
+                .Call(helper, 60_000).Op(Instruction.POP)
+                .CallWithInput(Sender, 40_000, [1]).Op(Instruction.POP)
+                .Op(Instruction.STOP).Done);
+
+    private static byte[] ApprovesPaymentThroughSenderThenReverts() =>
+        Prepare.EvmCode.CallWithInput(Sender, 30_000, [1]).Op(Instruction.POP).Revert(0, 0).Done;
 
     /// <summary>Approves in a nested self-call, then fails unless that call already collected <c>max_cost</c>.</summary>
     /// <remarks>The nested call returns nothing, so copying one byte of its return data halts the frame

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1101,6 +1101,79 @@ public class FrameTxProcessorTests
         Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL));
     }
 
+    /// <summary>
+    /// EIP-8141 <c>APPROVE</c> updates the approval context during execution, so an approval made inside a
+    /// nested call is discarded with that call's state changes when it reverts.
+    /// </summary>
+    /// <remarks>
+    /// The sender calls a helper, the helper calls back into the sender to approve and then reverts, and
+    /// the sender swallows the failure and returns. Staging the approval for the end of the frame let it
+    /// outlive the reverted call and authorize the transaction.
+    /// </remarks>
+    [Test]
+    public void Execute_ApprovalInsideARevertedNestedCall_IsDiscarded()
+    {
+        DeploySmartSender(ApproveWhenReentered(Observer));
+        DeployContract(Observer, ApprovesThroughSenderThenReverts());
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient, value: 5));
+
+        TransactionResult result = Process(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False);
+            Assert.That(result.ErrorDescription, Does.Contain("SENDER frame before execution approval"));
+            Assert.That(_stateProvider.GetBalance(Recipient), Is.EqualTo(UInt256.Zero));
+        }
+    }
+
+    /// <summary>
+    /// <c>APPROVE</c>'s payment effects are visible to its caller as soon as the approving call returns,
+    /// not only once the frame ends.
+    /// </summary>
+    /// <remarks>The sender approves in a nested call and then fails its frame unless its own balance
+    /// already shows the collected <c>max_cost</c>.</remarks>
+    [Test]
+    public void Execute_ApprovalInsideANestedCall_CollectsTheMaxCostBeforeItReturns()
+    {
+        DeploySmartSender(ApproveInNestedCallThenRequireCharged());
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient));
+
+        TransactionResult result = Process(tx);
+
+        Assert.That(result.TransactionExecuted, Is.True);
+    }
+
+    /// <summary>
+    /// The default code approves through the same guards as the <c>APPROVE</c> opcode, so a second
+    /// self-targeted <c>VERIFY</c> frame is refused instead of approving execution twice.
+    /// </summary>
+    /// <remarks>
+    /// Reporting success after the signature checks alone let the second frame re-approve execution and
+    /// silently skip payment because a payer already existed, admitting a transaction the opcode rejects.
+    /// </remarks>
+    [Test]
+    public void Execute_SecondSelfTargetedDefaultCodeVerify_InvalidatesTheTransaction()
+    {
+        _stateProvider.CreateAccount(Sender, 1.Ether);
+        _stateProvider.Commit(Spec);
+        _stateProvider.CommitTree(0);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, new byte[TxFrameSignature.Secp256k1SignatureLength])];
+        SignCanonicalHash(tx, index: 0, TestItem.PrivateKeyA, signer: null);
+
+        TransactionResult result = Process(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.False);
+            Assert.That(result.ErrorDescription, Does.Contain("VERIFY frame reverted"));
+        }
+    }
+
     [Test]
     public void Execute_CodelessEoaSponsor_ReadsPaymentSignatureAtIndexOne()
     {
@@ -2685,6 +2758,49 @@ public class FrameTxProcessorTests
     private static byte[] ApproveCode(byte scope) =>
         // APPROVE stack order (top to bottom): offset, length, scope.
         Prepare.EvmCode.PushData(scope).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+
+    /// <summary>Runs <paramref name="whenTrue"/> if the stack top is non-zero, otherwise <paramref name="whenFalse"/>,
+    /// which must terminate rather than fall through.</summary>
+    private static byte[] BranchOnStackTop(byte[] condition, byte[] whenTrue, byte[] whenFalse)
+    {
+        byte destination = checked((byte)(condition.Length + 3 + whenFalse.Length));
+        return
+        [
+            .. condition, (byte)Instruction.PUSH1, destination, (byte)Instruction.JUMPI,
+            .. whenFalse, (byte)Instruction.JUMPDEST, .. whenTrue,
+        ];
+    }
+
+    /// <summary>Approves when called with data, and otherwise calls <paramref name="helper"/> and ignores its outcome.</summary>
+    private static byte[] ApproveWhenReentered(Address helper) =>
+        BranchOnStackTop(
+            Prepare.EvmCode.Op(Instruction.CALLDATASIZE).Done,
+            ApproveCode(TxFrame.ApproveExecutionAndPayment),
+            Prepare.EvmCode.Call(helper, 100_000).Op(Instruction.POP).Op(Instruction.STOP).Done);
+
+    private static byte[] ApprovesThroughSenderThenReverts() =>
+        Prepare.EvmCode.CallWithInput(Sender, 60_000, [1]).Op(Instruction.POP).Revert(0, 0).Done;
+
+    /// <summary>Approves in a nested self-call, then fails unless that call already collected <c>max_cost</c>.</summary>
+    /// <remarks>The nested call returns nothing, so copying one byte of its return data halts the frame
+    /// exceptionally; copying none of it continues.</remarks>
+    private static byte[] ApproveInNestedCallThenRequireCharged() =>
+        BranchOnStackTop(
+            Prepare.EvmCode.Op(Instruction.CALLDATASIZE).Done,
+            ApproveCode(TxFrame.ApproveExecutionAndPayment),
+            Prepare.EvmCode
+                .CallWithInput(Sender, 100_000, [1]).Op(Instruction.POP)
+                // balance + max_cost matches the funded balance only once APPROVE has collected it.
+                .PushData(0x06).Op(Instruction.TXPARAM)
+                .Op(Instruction.ADDRESS).Op(Instruction.BALANCE)
+                .Op(Instruction.ADD)
+                .PushData(1.Ether)
+                .Op(Instruction.EQ)
+                .Op(Instruction.ISZERO)
+                .PushData(0).PushData(0)
+                .Op(Instruction.RETURNDATACOPY)
+                .Op(Instruction.STOP)
+                .Done);
 
     // EIP-8272: only the commitment the predeploy holds satisfies a reference. The committed case also
     // proves the intrinsic gas is charged, the transaction paying more than one declaring nothing.

--- a/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
@@ -143,7 +143,7 @@ public sealed class FrameTxContext(
     /// a charge that cannot be met must not leave a half-applied approval behind.</remarks>
     /// <param name="plan">The effects an admitted approval will apply; meaningless unless the outcome is
     /// <see cref="FrameApprovalOutcome.Approved"/>.</param>
-    public FrameApprovalOutcome PlanApproval(byte scope, Address resolvedTarget, IWorldState worldState, out FrameApprovalPlan plan)
+    internal FrameApprovalOutcome PlanApproval(byte scope, Address resolvedTarget, IWorldState worldState, out FrameApprovalPlan plan)
     {
         plan = default;
         if (scope == 0 || (scope & ~CurrentFrame.AllowedApproveScope) != 0) return FrameApprovalOutcome.Rejected;
@@ -177,7 +177,7 @@ public sealed class FrameTxContext(
     /// world state on a nested revert or halt restores the approval context with it.
     /// </summary>
     /// <remarks>The sender's account creation, when the plan calls for one, must already have been charged.</remarks>
-    public void ApplyApproval(in FrameApprovalPlan plan, Address resolvedTarget, IWorldState worldState, IReleaseSpec spec, in StackAccessTracker accessTracker)
+    internal void ApplyApproval(in FrameApprovalPlan plan, Address resolvedTarget, IWorldState worldState, IReleaseSpec spec, in StackAccessTracker accessTracker)
     {
         _frameJournal.Add(new FrameJournalEntry(FrameJournalKind.ApprovalAdvanced, default, ApprovalStage, 0));
 
@@ -308,7 +308,7 @@ public sealed class FrameTxContext(
 }
 
 /// <summary>Outcome of evaluating an EIP-8141 <c>APPROVE</c> against a transaction's approval context.</summary>
-public enum FrameApprovalOutcome : byte
+internal enum FrameApprovalOutcome : byte
 {
     /// <summary>The approval is admissible.</summary>
     Approved,
@@ -321,4 +321,4 @@ public enum FrameApprovalOutcome : byte
 }
 
 /// <summary>The effects an admitted <c>APPROVE</c> will apply, so its caller can charge for them beforehand.</summary>
-public readonly record struct FrameApprovalPlan(bool ApprovesExecution, bool ApprovesPayment, bool CreatesSender);
+internal readonly record struct FrameApprovalPlan(bool ApprovesExecution, bool ApprovesPayment, bool CreatesSender);

--- a/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.State;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 
 namespace Nethermind.Evm;
@@ -80,10 +83,6 @@ public sealed class FrameTxContext(
     public bool SenderApproved { get; set; }
     public Address? Payer { get; set; }
 
-    /// <summary>Scope deposited by a successful <c>APPROVE</c> in the current frame; 0 means no signal.
-    /// The outer loop reads and clears it after the frame terminates.</summary>
-    public byte ApprovalScopeSignal { get; set; }
-
     public TxFrame CurrentFrame => Frames[CurrentFrameIndex];
 
     /// <summary>EIP-7906: lazily-built, sorted view of this transaction's state diff and logs, shared by its POST_TX frames.</summary>
@@ -99,7 +98,7 @@ public sealed class FrameTxContext(
     private readonly long[] _frameStateGasCorrection = new long[frames.Length];
     private readonly ulong[] _frameExecutionGasUsed = new ulong[frames.Length];
     private readonly ulong[] _frameStateGasUsed = new ulong[frames.Length];
-    private readonly List<StateGasJournalEntry> _stateGasJournal = [];
+    private readonly List<FrameJournalEntry> _frameJournal = [];
 
     /// <summary>
     /// Records a completed frame's attributed <c>gas_used</c> so a later frame can read it through
@@ -125,8 +124,80 @@ public sealed class FrameTxContext(
         return net > 0 ? (ulong)net : 0;
     }
 
-    /// <summary>Journal position captured when an EVM call frame begins, so the rollback boundary that restores world state also restores the SSTORE-charge ownership map and per-frame <c>gas_used.state</c> corrections (EIP-8141 Gas Accounting).</summary>
-    public int StateGasJournalCheckpoint => _stateGasJournal.Count;
+    /// <summary>Journal position captured when an EVM call frame begins, so the rollback boundary that restores world state also restores the approval context, the SSTORE-charge ownership map and per-frame <c>gas_used.state</c> corrections (EIP-8141 Gas Accounting).</summary>
+    public int FrameJournalCheckpoint => _frameJournal.Count;
+
+    // Approval only advances, none -> sender approved -> paid, and Payer is write-once, so the stage
+    // number the journal keeps is a complete undo record.
+    private const int NoApproval = 0;
+    private const int SenderApprovedStage = 1;
+    private const int PaidStage = 2;
+
+    private int ApprovalStage => Payer is not null ? PaidStage : SenderApproved ? SenderApprovedStage : NoApproval;
+
+    /// <summary>
+    /// Evaluates an <c>APPROVE</c> of <paramref name="scope"/> by <paramref name="resolvedTarget"/> against
+    /// the transaction's approval context, changing nothing.
+    /// </summary>
+    /// <remarks>Split from <see cref="ApplyApproval"/> so a caller can charge the approval's gas in between:
+    /// a charge that cannot be met must not leave a half-applied approval behind.</remarks>
+    /// <param name="plan">The effects an admitted approval will apply; meaningless unless the outcome is
+    /// <see cref="FrameApprovalOutcome.Approved"/>.</param>
+    public FrameApprovalOutcome PlanApproval(byte scope, Address resolvedTarget, IWorldState worldState, out FrameApprovalPlan plan)
+    {
+        plan = default;
+        if (scope == 0 || (scope & ~CurrentFrame.AllowedApproveScope) != 0) return FrameApprovalOutcome.Rejected;
+
+        bool approvesExecution = (scope & TxFrame.ApproveExecution) != 0;
+        bool approvesPayment = (scope & TxFrame.ApprovePayment) != 0;
+
+        if (approvesExecution && (SenderApproved || resolvedTarget != Sender)) return FrameApprovalOutcome.Rejected;
+
+        bool createsSender = false;
+        if (approvesPayment)
+        {
+            if (Payer is not null) return FrameApprovalOutcome.Rejected;
+            // EIP-8141 ordering: payment may not be approved before execution, unless this same APPROVE grants both.
+            if (!approvesExecution && !SenderApproved) return FrameApprovalOutcome.Rejected;
+            if (worldState.GetBalance(resolvedTarget) < MaxCost) return FrameApprovalOutcome.Rejected;
+
+            if (NonceKeys is not { } keys || !KeyedNonceManager.UsesKeyedDomain(keys))
+            {
+                if (worldState.GetNonce(Sender) >= Eip8250Constants.MaxNonceSeq) return FrameApprovalOutcome.NonceExhausted;
+                createsSender = !worldState.AccountExists(Sender);
+            }
+        }
+
+        plan = new FrameApprovalPlan(approvesExecution, approvesPayment, createsSender);
+        return FrameApprovalOutcome.Approved;
+    }
+
+    /// <summary>
+    /// Applies an approval admitted by <see cref="PlanApproval"/>, journaled so the boundary that restores
+    /// world state on a nested revert or halt restores the approval context with it.
+    /// </summary>
+    /// <remarks>The sender's account creation, when the plan calls for one, must already have been charged.</remarks>
+    public void ApplyApproval(in FrameApprovalPlan plan, Address resolvedTarget, IWorldState worldState, IReleaseSpec spec, in StackAccessTracker accessTracker)
+    {
+        _frameJournal.Add(new FrameJournalEntry(FrameJournalKind.ApprovalAdvanced, default, ApprovalStage, 0));
+
+        if (plan.ApprovesExecution) SenderApproved = true;
+        if (!plan.ApprovesPayment) return;
+
+        if (plan.CreatesSender) worldState.CreateAccountIfNotExists(Sender, UInt256.Zero);
+        worldState.SubtractFromBalance(resolvedTarget, MaxCost, spec);
+        if (NonceKeys is { } nonceKeys)
+        {
+            KeyedNonceManager.ConsumeNonceSet(worldState, Sender, nonceKeys, Nonce);
+        }
+        else
+        {
+            worldState.IncrementNonce(Sender);
+        }
+
+        Payer = resolvedTarget;
+        if (spec.UseHotAndColdStorage) accessTracker.WarmUp(resolvedTarget);
+    }
 
     /// <summary>
     /// Records the frame that paid an <c>SSTORE</c> state charge as the outstanding-charge owner
@@ -138,7 +209,7 @@ public sealed class FrameTxContext(
         ref int owner = ref CollectionsMarshal.GetValueRefOrAddDefault(_stateChargeOwner, slot, out bool existed);
         int previousOwner = existed ? owner : NoOwner;
         owner = frame;
-        _stateGasJournal.Add(new StateGasJournalEntry(StateGasJournalKind.OwnerSet, slot, previousOwner, 0));
+        _frameJournal.Add(new FrameJournalEntry(FrameJournalKind.OwnerSet, slot, previousOwner, 0));
     }
 
     /// <summary>
@@ -153,7 +224,7 @@ public sealed class FrameTxContext(
             return false;
         }
 
-        _stateGasJournal.Add(new StateGasJournalEntry(StateGasJournalKind.OwnerCleared, slot, owner, 0));
+        _frameJournal.Add(new FrameJournalEntry(FrameJournalKind.OwnerCleared, slot, owner, 0));
         return true;
     }
 
@@ -164,57 +235,64 @@ public sealed class FrameTxContext(
     public void ReduceFrameStateGas(int owner, long amount)
     {
         _frameStateGasCorrection[owner] += amount;
-        _stateGasJournal.Add(new StateGasJournalEntry(StateGasJournalKind.ReceiptReduced, default, owner, amount));
+        _frameJournal.Add(new FrameJournalEntry(FrameJournalKind.ReceiptReduced, default, owner, amount));
     }
 
     /// <summary>
-    /// Undoes ownership and receipt-correction journal entries recorded after
+    /// Undoes approval, ownership and receipt-correction journal entries recorded after
     /// <paramref name="checkpoint"/>, at the same boundary that restores world state.
     /// </summary>
-    public void RestoreStateGasJournal(int checkpoint)
+    public void RestoreFrameJournal(int checkpoint)
     {
-        int count = _stateGasJournal.Count;
+        int count = _frameJournal.Count;
         if (count == checkpoint) return;
 
-        Span<StateGasJournalEntry> entries = CollectionsMarshal.AsSpan(_stateGasJournal);
+        Span<FrameJournalEntry> entries = CollectionsMarshal.AsSpan(_frameJournal);
         for (int k = count - 1; k >= checkpoint; k--)
         {
-            ref StateGasJournalEntry entry = ref entries[k];
+            ref FrameJournalEntry entry = ref entries[k];
             switch (entry.Kind)
             {
-                case StateGasJournalKind.OwnerSet:
-                    if (entry.Owner == NoOwner)
+                case FrameJournalKind.OwnerSet:
+                    if (entry.Value == NoOwner)
                     {
                         _stateChargeOwner.Remove(entry.Slot);
                     }
                     else
                     {
-                        _stateChargeOwner[entry.Slot] = entry.Owner;
+                        _stateChargeOwner[entry.Slot] = entry.Value;
                     }
                     break;
-                case StateGasJournalKind.OwnerCleared:
-                    _stateChargeOwner[entry.Slot] = entry.Owner;
+                case FrameJournalKind.OwnerCleared:
+                    _stateChargeOwner[entry.Slot] = entry.Value;
                     break;
-                case StateGasJournalKind.ReceiptReduced:
-                    _frameStateGasCorrection[entry.Owner] -= entry.Amount;
+                case FrameJournalKind.ReceiptReduced:
+                    _frameStateGasCorrection[entry.Value] -= entry.Amount;
+                    break;
+                case FrameJournalKind.ApprovalAdvanced:
+                    SenderApproved = entry.Value >= SenderApprovedStage;
+                    if (entry.Value < PaidStage) Payer = null;
                     break;
             }
         }
 
-        _stateGasJournal.RemoveRange(checkpoint, count - checkpoint);
+        _frameJournal.RemoveRange(checkpoint, count - checkpoint);
     }
 
     /// <summary>The refill-driven reduction of <paramref name="frame"/>'s <c>gas_used.state</c>.</summary>
     public long StateGasCorrectionFor(int frame) => _frameStateGasCorrection[frame];
 
-    private enum StateGasJournalKind : byte
+    private enum FrameJournalKind : byte
     {
         OwnerSet,
         OwnerCleared,
         ReceiptReduced,
+        ApprovalAdvanced,
     }
 
-    private readonly record struct StateGasJournalEntry(StateGasJournalKind Kind, StorageCell Slot, int Owner, long Amount);
+    /// <summary><see cref="Value"/> carries the entry's undo target: a frame index for the ownership and
+    /// receipt kinds, the previous approval stage for <see cref="FrameJournalKind.ApprovalAdvanced"/>.</summary>
+    private readonly record struct FrameJournalEntry(FrameJournalKind Kind, StorageCell Slot, int Value, long Amount);
 
     private static ValueHash256 ComputeNonceKeysHash(UInt256[] nonceKeys)
     {
@@ -228,3 +306,19 @@ public sealed class FrameTxContext(
         return ValueKeccak.Compute(input[..((nonceKeys.Length + 1) * 32)]);
     }
 }
+
+/// <summary>Outcome of evaluating an EIP-8141 <c>APPROVE</c> against a transaction's approval context.</summary>
+public enum FrameApprovalOutcome : byte
+{
+    /// <summary>The approval is admissible.</summary>
+    Approved,
+
+    /// <summary>A guard refused the approval; the requesting call frame reverts.</summary>
+    Rejected,
+
+    /// <summary>The sender's nonce sequence is exhausted; the requesting call frame halts exceptionally.</summary>
+    NonceExhausted,
+}
+
+/// <summary>The effects an admitted <c>APPROVE</c> will apply, so its caller can charge for them beforehand.</summary>
+public readonly record struct FrameApprovalPlan(bool ApprovesExecution, bool ApprovesPayment, bool CreatesSender);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -369,7 +369,7 @@ public static partial class EvmInstructions
             stateForAccessLists: in vm.VmState.AccessTracker,
             snapshot: in snapshot,
             newAccountCharged: newAccountCharged,
-            stateGasJournalCheckpoint: vm.TxExecutionContext.FrameTxContext?.StateGasJournalCheckpoint ?? 0);
+            frameJournalCheckpoint: vm.TxExecutionContext.FrameTxContext?.FrameJournalCheckpoint ?? 0);
 
         return EvmExceptionType.Suspend;
     }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
@@ -233,7 +233,7 @@ public static partial class EvmInstructions
             stateForAccessLists: in vm.VmState.AccessTracker,
             snapshot: in snapshot,
             isCreateStateGasCharged: chargeCreateStateGas,
-            stateGasJournalCheckpoint: vm.TxExecutionContext.FrameTxContext?.StateGasJournalCheckpoint ?? 0);
+            frameJournalCheckpoint: vm.TxExecutionContext.FrameTxContext?.FrameJournalCheckpoint ?? 0);
 
         return EvmExceptionType.Suspend;
         // Jump forward to be unpredicted by the branch predictor.

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -15,7 +15,7 @@ namespace Nethermind.Evm;
 /// Each exceptional-halts outside a frame transaction, where <see cref="FrameTxContext"/> is absent.</summary>
 public static unsafe partial class EvmInstructions
 {
-    /// <summary>APPROVE (0xaa): terminate the frame successfully and record the approval scope for the outer loop.</summary>
+    /// <summary>APPROVE (0xaa): apply the approval scope to the transaction context and exit the call frame successfully.</summary>
     [SkipLocalsInit]
     public static EvmExceptionType InstructionApprove<TGasPolicy>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
@@ -39,32 +39,20 @@ public static unsafe partial class EvmInstructions
         if (!vm.VmState.Env.ExecutingAccount.Equals(resolvedTarget))
             goto Reject;
 
-        byte scopeByte = (byte)scope.u0;
-        byte allowed = frame.AllowedApproveScope;
-        if (scope > TxFrame.ApproveScopeMask || scopeByte == 0 || (scopeByte & ~allowed) != 0)
-            goto Reject;
+        if (scope > TxFrame.ApproveScopeMask) goto Reject;
 
-        bool approvesExecution = (scopeByte & TxFrame.ApproveExecution) != 0;
-        bool approvesPayment = (scopeByte & TxFrame.ApprovePayment) != 0;
-
-        if (approvesExecution)
+        FrameApprovalOutcome outcome = ctx.PlanApproval((byte)scope.u0, resolvedTarget, vm.WorldState, out FrameApprovalPlan plan);
+        if (outcome != FrameApprovalOutcome.Approved)
         {
-            if (ctx.SenderApproved || resolvedTarget != ctx.Sender) goto Reject;
+            if (outcome == FrameApprovalOutcome.Rejected) goto Reject;
+            return EvmExceptionType.OutOfGas;
         }
 
-        if (approvesPayment)
+        // Consumption happens at payment approval, so first use is charged against this frame's gas.
+        if (plan.ApprovesPayment && ctx.NonceKeys is { } nonceKeys
+            && !TGasPolicy.TryConsume(ref gas, KeyedNonceManager.FirstUseSurcharge(vm.WorldState, ctx.Sender, nonceKeys)))
         {
-            if (ctx.Payer is not null) goto Reject;
-            // EIP-8141 ordering: payment may not be approved before execution, unless this same APPROVE grants both.
-            if (!approvesExecution && !ctx.SenderApproved) goto Reject;
-            if (vm.WorldState.GetBalance(resolvedTarget) < ctx.MaxCost) goto Reject;
-
-            // Consumption happens at payment approval, so first use is charged against this frame's gas.
-            if (ctx.NonceKeys is { } nonceKeys
-                && !TGasPolicy.TryConsume(ref gas, KeyedNonceManager.FirstUseSurcharge(vm.WorldState, ctx.Sender, nonceKeys)))
-            {
-                return EvmExceptionType.OutOfGas;
-            }
+            return EvmExceptionType.OutOfGas;
         }
 
         // EIP-8141 APPROVE: the memory region becomes the frame's return data, following RETURN semantics.
@@ -74,8 +62,17 @@ public static unsafe partial class EvmInstructions
             return EvmExceptionType.OutOfGas;
         }
 
+        // Charged immediately before the nonce increment that would create the sender.
+        if (plan.CreatesSender && !TGasPolicy.ConsumeStateGas(ref gas, TGasPolicy.GetNewAccountStateCost()))
+        {
+            return EvmExceptionType.OutOfGas;
+        }
+
+        // EIP-8141: the approval takes effect here, journaled with the world-state writes it makes, so a
+        // nested revert between this and the end of the frame discards both together.
+        ctx.ApplyApproval(in plan, resolvedTarget, vm.WorldState, vm.Spec, in vm.VmState.AccessTracker);
+
         vm.ReturnData = returnData.ToArray();
-        ctx.ApprovalScopeSignal = scopeByte;
         // Stop (not None): APPROVE exits the current call frame successfully, and dispatch requires
         // a non-None status from any handler that stages ReturnData.
         return EvmExceptionType.Stop;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -258,7 +258,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 batchStartIndex = i;
                 batchStartRefund = refundCounter;
                 batchStartStateGas = totalFrameStateGasUsed;
-                batchStartJournal = frameContext.StateGasJournalCheckpoint;
+                batchStartJournal = frameContext.FrameJournalCheckpoint;
                 batchStartDestroys = accessTracker.DestroyList.TakeSnapshot();
             }
 
@@ -282,23 +282,12 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
             // The shared journal accumulates logs across frames; this frame's own logs start here.
             int frameLogStart = accessTracker.Logs.Count;
-            int frameStartJournal = frameContext.StateGasJournalCheckpoint;
+            int frameStartJournal = frameContext.FrameJournalCheckpoint;
             bool payerWasSet = frameContext.Payer is not null;
             TransactionSubstate substate = ExecuteFrame(frame, resolvedTarget, caller, isStatic, frameContext, in accessTracker, spec, tracer, out ulong frameGasUsed, out long frameStateGas);
             shouldRestoreRipemdTouch |= substate.ShouldRestoreRipemdTouch;
 
             bool frameSucceeded = !substate.ShouldRevert && !substate.IsError;
-            if (frameSucceeded && frameContext.ApprovalScopeSignal != 0)
-            {
-                if (!TryApplyPostFrameApproval(frameContext, frame, resolvedTarget, spec, in accessTracker, tracer, ref substate, ref frameGasUsed, ref frameStateGas))
-                {
-                    frameSucceeded = false;
-                }
-            }
-            else if (!frameSucceeded)
-            {
-                frameContext.ApprovalScopeSignal = 0;
-            }
 
             totalFrameGasUsed += frameGasUsed;
             if (frameSucceeded)
@@ -368,7 +357,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
                 totalFrameGasUsed -= (ulong)(totalFrameStateGasUsed - prefixEndStateGas);
                 totalFrameStateGasUsed = prefixEndStateGas;
-                frameContext.RestoreStateGasJournal(prefixEndJournal);
+                frameContext.RestoreFrameJournal(prefixEndJournal);
 
                 for (int s = i + 1; s < frames.Length; s++)
                 {
@@ -389,13 +378,13 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     prefixEndIndex = i;
                     prefixEndRefund = refundCounter;
                     prefixEndStateGas = totalFrameStateGasUsed;
-                    prefixEndJournal = frameContext.StateGasJournalCheckpoint;
+                    prefixEndJournal = frameContext.FrameJournalCheckpoint;
                     prefixEndDestroys = accessTracker.DestroyList.TakeSnapshot();
                 }
             }
             else if (!inBatch)
             {
-                frameContext.RestoreStateGasJournal(frameStartJournal);
+                frameContext.RestoreFrameJournal(frameStartJournal);
             }
 
             if (inBatch)
@@ -423,7 +412,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     // are not owed either; the counter only grows, so the batch-start value undoes them.
                     totalFrameGasUsed -= (ulong)(totalFrameStateGasUsed - batchStartStateGas);
                     totalFrameStateGasUsed = batchStartStateGas;
-                    frameContext.RestoreStateGasJournal(batchStartJournal);
+                    frameContext.RestoreFrameJournal(batchStartJournal);
                     // Refunds from the reverted batch are discarded with its state, so roll the counter back.
                     // No payer/sender_approved rollback is needed: EIP-8141 forbids approval scope on batch frames.
                     refundCounter = batchStartRefund;
@@ -634,11 +623,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 // A deploy frame runs in DEFAULT mode, so unlike a VERIFY frame it may write state.
                 TransactionSubstate substate = ExecuteFrame(boundedFrame, resolvedTarget, caller, isStatic: !isDeployFrame, frameContext, in accessTracker, spec, tracer, out ulong frameGasUsed, out long frameStateGas);
 
-                if (!substate.ShouldRevert && !substate.IsError && frameContext.ApprovalScopeSignal != 0)
-                {
-                    TryApplyPostFrameApproval(frameContext, boundedFrame, resolvedTarget, spec, in accessTracker, tracer, ref substate, ref frameGasUsed, ref frameStateGas);
-                }
-
                 verifyGasUsed += frameGasUsed - (ulong)frameStateGas;
 
                 if (substate.ShouldRevert || substate.IsError)
@@ -765,28 +749,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         && FrameTxValidation.IsDeployFrame(frames[i])
         && frames[i + 1].Mode == TxFrame.ModeVerify;
 
-    /// <summary>Applies a succeeded frame's pending approval scope, charging its state gas or, on failure,
-    /// replacing the substate with an out-of-gas halt.</summary>
-    private bool TryApplyPostFrameApproval(FrameTxContext frameContext, TxFrame frame, Address resolvedTarget, IReleaseSpec spec, in StackAccessTracker accessTracker, ITxTracer tracer, ref TransactionSubstate substate, ref ulong frameGasUsed, ref long frameStateGas)
-    {
-        long stateLimit = frame.StateGasLimit > long.MaxValue ? long.MaxValue : (long)frame.StateGasLimit;
-        long remainingStateGas = stateLimit - frameStateGas;
-        if (!TryApplyApproval(frameContext, resolvedTarget, spec, in accessTracker, remainingStateGas, out long approvalStateGas))
-        {
-            substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions)
-            {
-                ShouldRestoreRipemdTouch = substate.ShouldRestoreRipemdTouch,
-            };
-            frameGasUsed = frame.ExecutionGasLimit;
-            frameStateGas = 0;
-            return false;
-        }
-
-        frameGasUsed += (ulong)approvalStateGas;
-        frameStateGas += approvalStateGas;
-        return true;
-    }
-
     private TransactionSubstate ExecuteFrame(TxFrame frame, Address resolvedTarget, Address caller, bool isStatic, FrameTxContext frameContext, in StackAccessTracker accessTracker, IReleaseSpec spec, ITxTracer tracer, out ulong gasUsed, out long stateGasUsed)
     {
         stateGasUsed = 0;
@@ -827,7 +789,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             && _codeInfoRepository.GetPrecompile(resolvedTarget, spec) is null
             && WorldState.GetCodeHash(resolvedTarget) == Keccak.OfAnEmptyString)
         {
-            TransactionSubstate defaultCode = ExecuteDefaultVerifyCode(frame, resolvedTarget, frameContext, tracer, entryExecution, out gasUsed);
+            TransactionSubstate defaultCode = ExecuteDefaultVerifyCode(frame, resolvedTarget, frameContext, spec, in accessTracker, tracer, entryExecution, out gasUsed, out stateGasUsed);
             // The entry charge warms the target on this path too; a failing default-code frame is a failing
             // VERIFY frame, which invalidates the transaction, so there is nothing to unwind.
             if (spec.UseHotAndColdStorage && !defaultCode.IsError && !defaultCode.ShouldRevert)
@@ -928,11 +890,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             : TGasPolicy.GetPreRefundGas(in state.Gas, combinedLimit);
         stateGasUsed = Math.Max(0, TGasPolicy.GetStateGasUsed(in state.Gas));
 
-        if (!substate.ShouldRevert && !substate.IsError && frameContext.ApprovalScopeSignal != 0)
-        {
-            TryApplyPostFrameApproval(frameContext, frame, resolvedTarget, spec, in accessTracker, tracer, ref substate, ref gasUsed, ref stateGasUsed);
-        }
-
         if (substate.ShouldRevert || substate.IsError)
         {
             WorldState.Restore(snapshot);
@@ -952,13 +909,16 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     /// The signature's cryptographic validity is already checked in pre-flight; default code checks
     /// only the structural conditions the spec pins.
     /// </summary>
+    /// <remarks>The approval runs the same guards and effects as the <c>APPROVE</c> opcode, so a default-code
+    /// frame the approval context refuses fails exactly as an opcode approval would.</remarks>
     /// <param name="entryExecution">
     /// Execution gas the frame already owes for its target's access, charged before dispatch and known to
     /// fit within <see cref="TxFrame.ExecutionGasLimit"/>.
     /// </param>
-    private TransactionSubstate ExecuteDefaultVerifyCode(TxFrame frame, Address resolvedTarget, FrameTxContext frameContext, ITxTracer tracer, ulong entryExecution, out ulong gasUsed)
+    private TransactionSubstate ExecuteDefaultVerifyCode(TxFrame frame, Address resolvedTarget, FrameTxContext frameContext, IReleaseSpec spec, in StackAccessTracker accessTracker, ITxTracer tracer, ulong entryExecution, out ulong gasUsed, out long stateGasUsed)
     {
         gasUsed = entryExecution;
+        stateGasUsed = 0;
 
         byte allowedScope = frame.AllowedApproveScope;
         if (allowedScope == 0)
@@ -976,13 +936,20 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return new TransactionSubstate(EvmExceptionType.Revert, tracer.IsTracingInstructions);
         }
 
-        // Owes APPROVE's surcharge, but only past the guards ApplyApproval discards on — charging ahead
-        // of them would bill a consumption that never happens.
-        if ((allowedScope & TxFrame.ApprovePayment) != 0
-            && frameContext.Payer is null
-            && ((allowedScope & TxFrame.ApproveExecution) != 0 || frameContext.SenderApproved)
-            && WorldState.GetBalance(resolvedTarget) >= frameContext.MaxCost
-            && frameContext.NonceKeys is { } nonceKeys)
+        FrameApprovalOutcome outcome = frameContext.PlanApproval(allowedScope, resolvedTarget, WorldState, out FrameApprovalPlan plan);
+        if (outcome != FrameApprovalOutcome.Approved)
+        {
+            if (outcome == FrameApprovalOutcome.Rejected)
+            {
+                return new TransactionSubstate(EvmExceptionType.Revert, tracer.IsTracingInstructions);
+            }
+
+            gasUsed = frame.ExecutionGasLimit;
+            return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+        }
+
+        // Owes APPROVE's charges out of the frame's declared limits, which the default code never draws on otherwise.
+        if (plan.ApprovesPayment && frameContext.NonceKeys is { } nonceKeys)
         {
             ulong surcharge = KeyedNonceManager.FirstUseSurcharge(WorldState, frameContext.Sender, nonceKeys);
             if (surcharge > frame.ExecutionGasLimit - entryExecution)
@@ -994,76 +961,23 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             gasUsed = entryExecution + surcharge;
         }
 
-        frameContext.ApprovalScopeSignal = allowedScope;
+        if (plan.CreatesSender)
+        {
+            long newAccountCost = TGasPolicy.GetNewAccountStateCost();
+            if ((ulong)newAccountCost > frame.StateGasLimit)
+            {
+                gasUsed = frame.ExecutionGasLimit;
+                return new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracingInstructions);
+            }
+
+            stateGasUsed = newAccountCost;
+            gasUsed += (ulong)newAccountCost;
+        }
+
+        frameContext.ApplyApproval(in plan, resolvedTarget, WorldState, spec, in accessTracker);
         return DefaultCodeSuccess();
     }
 
     private static TransactionSubstate DefaultCodeSuccess() =>
         new(ReadOnlyMemory<byte>.Empty, refund: 0, destroyList: null, logs: null, shouldRevert: false);
-
-    private bool TryApplyApproval(FrameTxContext frameContext, Address resolvedTarget, IReleaseSpec spec, in StackAccessTracker accessTracker, long availableStateGas, out long stateGasCharged)
-    {
-        stateGasCharged = 0;
-        byte scope = frameContext.ApprovalScopeSignal;
-        if (scope == 0) return true;
-        frameContext.ApprovalScopeSignal = 0;
-
-        bool approvesExecution = (scope & TxFrame.ApproveExecution) != 0;
-        bool approvesPayment = (scope & TxFrame.ApprovePayment) != 0;
-        bool applyPayment = false;
-        bool usesAccountNonce = false;
-        long newAccountCost = 0;
-
-        if (approvesPayment)
-        {
-            UInt256[]? keys = frameContext.NonceKeys;
-            usesAccountNonce = keys is null || !KeyedNonceManager.UsesKeyedDomain(keys);
-            if (usesAccountNonce && WorldState.GetNonce(frameContext.Sender) >= Eip8250Constants.MaxNonceSeq)
-            {
-                return false;
-            }
-
-            bool executionApproved = frameContext.SenderApproved || approvesExecution;
-            if (frameContext.Payer is null
-                && executionApproved
-                && WorldState.GetBalance(resolvedTarget) >= frameContext.MaxCost)
-            {
-                applyPayment = true;
-                if (usesAccountNonce && !WorldState.AccountExists(frameContext.Sender))
-                {
-                    newAccountCost = TGasPolicy.GetNewAccountStateCost();
-                    if (availableStateGas < newAccountCost) return false;
-                }
-            }
-        }
-
-        if (approvesExecution)
-        {
-            frameContext.SenderApproved = true;
-        }
-
-        if (applyPayment)
-        {
-            if (newAccountCost > 0)
-            {
-                stateGasCharged = newAccountCost;
-                WorldState.CreateAccountIfNotExists(frameContext.Sender, UInt256.Zero);
-            }
-
-            WorldState.SubtractFromBalance(resolvedTarget, frameContext.MaxCost, spec);
-            if (frameContext.NonceKeys is { } nonceKeys)
-            {
-                KeyedNonceManager.ConsumeNonceSet(WorldState, frameContext.Sender, nonceKeys, frameContext.Nonce);
-            }
-            else
-            {
-                WorldState.IncrementNonce(frameContext.Sender);
-            }
-
-            frameContext.Payer = resolvedTarget;
-            if (spec.UseHotAndColdStorage) accessTracker.WarmUp(resolvedTarget);
-        }
-
-        return true;
-    }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -414,7 +414,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                     totalFrameStateGasUsed = batchStartStateGas;
                     frameContext.RestoreFrameJournal(batchStartJournal);
                     // Refunds from the reverted batch are discarded with its state, so roll the counter back.
-                    // No payer/sender_approved rollback is needed: EIP-8141 forbids approval scope on batch frames.
                     refundCounter = batchStartRefund;
 
                     if (prefixEndIndex >= batchStartIndex)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -556,7 +556,7 @@ public partial class VirtualMachine<TGasPolicy>(
             }
             RemoveAdvancedStateGasRefund(previousState, ref _currentState.Gas);
             _worldState.Restore(previousState.Snapshot);
-            _txExecutionContext.FrameTxContext?.RestoreStateGasJournal(previousState.StateGasJournalCheckpoint);
+            _txExecutionContext.FrameTxContext?.RestoreFrameJournal(previousState.FrameJournalCheckpoint);
             if (!previousState.IsCreateOnPreExistingAccount)
             {
                 _worldState.DeleteAccount(callCodeOwner);
@@ -597,7 +597,7 @@ public partial class VirtualMachine<TGasPolicy>(
     {
         // Restore the world state to the snapshot taken before the execution of the call.
         _worldState.Restore(previousState.Snapshot);
-        _txExecutionContext.FrameTxContext?.RestoreStateGasJournal(previousState.StateGasJournalCheckpoint);
+        _txExecutionContext.FrameTxContext?.RestoreFrameJournal(previousState.FrameJournalCheckpoint);
         RestoreRipemdTouch(_worldState, BlockExecutionContext.Spec, _shouldRestoreRipemdTouch);
 
         // Cache the output bytes from the call result to avoid multiple property accesses.
@@ -719,7 +719,7 @@ public partial class VirtualMachine<TGasPolicy>(
     private void PopAndRestoreParentState()
     {
         VmState<TGasPolicy> childState = _currentState;
-        _txExecutionContext.FrameTxContext?.RestoreStateGasJournal(childState.StateGasJournalCheckpoint);
+        _txExecutionContext.FrameTxContext?.RestoreFrameJournal(childState.FrameJournalCheckpoint);
         _currentState = _stateStack.Pop();
         RemoveAdvancedStateGasRefund(childState, ref childState.Gas);
         TGasPolicy.RestoreChildStateGasOnHalt(ref _currentState.Gas, in childState.Gas);

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -30,10 +30,10 @@ public class VmState<TGasPolicy> : IDisposable
     // still has to reach the ancestor frame that originally paid the state gas.
     public long StateGasRefundAdvanced;
     /// <summary>
-    /// EIP-8141 outstanding-charge/receipt journal position at this call frame's entry; the same
-    /// boundary that restores world state on revert/halt restores the journal to here.
+    /// EIP-8141 approval/outstanding-charge/receipt journal position at this call frame's entry; the
+    /// same boundary that restores world state on revert/halt restores the journal to here.
     /// </summary>
-    public int StateGasJournalCheckpoint;
+    public int FrameJournalCheckpoint;
     internal long OutputDestination { get; private set; } // TODO: move to CallEnv
     internal long OutputLength { get; private set; } // TODO: move to CallEnv
     public long Refund { get; set; }
@@ -106,7 +106,7 @@ public class VmState<TGasPolicy> : IDisposable
         bool isTopLevel = false,
         bool newAccountCharged = false,
         bool isCreateStateGasCharged = false,
-        int stateGasJournalCheckpoint = 0)
+        int frameJournalCheckpoint = 0)
     {
         VmState<TGasPolicy> state = Rent();
         state.Initialize(
@@ -122,7 +122,7 @@ public class VmState<TGasPolicy> : IDisposable
             env: env,
             stateForAccessLists: stateForAccessLists,
             snapshot: snapshot,
-            stateGasJournalCheckpoint: stateGasJournalCheckpoint);
+            frameJournalCheckpoint: frameJournalCheckpoint);
         return state;
     }
 
@@ -146,7 +146,7 @@ public class VmState<TGasPolicy> : IDisposable
         ExecutionEnvironment env,
         in StackAccessTracker stateForAccessLists,
         in Snapshot snapshot,
-        int stateGasJournalCheckpoint = 0)
+        int frameJournalCheckpoint = 0)
     {
         _env = env;
         _snapshot = snapshot;
@@ -166,7 +166,7 @@ public class VmState<TGasPolicy> : IDisposable
         Gas = gas;
         InitialStateGasUsed = TGasPolicy.GetStateGasUsed(in gas);
         StateGasRefundAdvanced = 0;
-        StateGasJournalCheckpoint = stateGasJournalCheckpoint;
+        FrameJournalCheckpoint = frameJournalCheckpoint;
         OutputDestination = outputDestination;
         OutputLength = outputLength;
         Refund = 0;


### PR DESCRIPTION
Addresses two P1 consensus threads on #12526, both about `APPROVE` semantics:

- [Journal approval at the nested call boundary](https://github.com/NethermindEth/nethermind/pull/12526#discussion_r3951659446)
- [Apply APPROVE rejection checks to default code](https://github.com/NethermindEth/nethermind/pull/12526#discussion_r3951659450)

## Changes

**`APPROVE` applies during execution and is journaled.** The opcode staged a transaction-global scope that the frame loop applied only after the outer VM returned. An approval made in a nested call therefore outlived that call's revert, and its balance and nonce effects were invisible to the approving call's caller. `APPROVE` now performs the effects where it runs, and records the previous approval stage in the frame journal that the boundaries restoring world state already unwind, so a nested revert or exceptional halt discards the approval with the state writes it made.

Spec basis: EIP-8141's [`APPROVE` behavior](https://eips.ethereum.org/EIPS/eip-8141#behavior-2) lists setting `sender_approved`, incrementing the sender's nonce, setting `payer` and collecting `max_cost` as effects of the instruction, and the [calling-convention rationale](https://eips.ethereum.org/EIPS/eip-8141#approve-calling-convention) says it "actually updates the transaction scoped values `sender_approved` and `payer` during execution". The frame behavior section pairs the two rollback units directly: "If a frame's execution reverts, its state changes and approval context (`payer`, `sender_approved`) are discarded."

*Where the spec is not explicit:* it states the discard rule for a **frame** revert and does not spell out a **nested call** revert inside a frame. I read it as journaled with world state, and implemented that, for three reasons: the nonce increment and the `max_cost` collection are ordinary state writes that a nested revert already undoes, so leaving `payer` set would record a payer from whom nothing was collected; the spec treats approval context and state changes as one unit; and the reference implementation on `execution-specs` `devnets/frames/0` pairs `copy_frame_context`/`restore_frame_context` with every transaction-state snapshot the interpreter takes.

**Default code shares the instruction's guards.** `ExecuteDefaultVerifyCode` reported success after its signature checks and left approval to a lenient post-frame pass, so a second self-targeted `VERIFY` frame re-approved execution and silently skipped payment because a payer already existed. It now runs the same guard-and-apply routine as the opcode, and a refusal fails the frame — which, for a `VERIFY` frame, invalidates the transaction.

Spec basis: [default code](https://eips.ethereum.org/EIPS/eip-8141#default-code) says the `VERIFY` path, after its signature check, "Call[s] `APPROVE(allowed_scope)`", so every guard in `APPROVE`'s behavior applies and a refusal reverts the frame. The reference implementation's default code calls the same `attempt_approval` as the opcode and returns a frame failure when it refuses.

**Shape of the change.** The guards and the effects move to `FrameTxContext.PlanApproval` / `ApplyApproval`, called by both the opcode and the default code. `PlanApproval` changes nothing, so each caller can charge the approval's gas between the guards and the effects; a charge that cannot be met leaves no partial approval. The deferred `ApprovalScopeSignal` field and its two post-frame appliers are gone. The state-gas journal in `FrameTxContext` now also carries approval, so it is named for the frame context rather than for state gas alone.

Two ordering notes. The sender-creation state charge is taken immediately before the effects, after the `RETURN`-style memory-expansion charge; the two draw from separate pools, so the order only decides which one halts first when both are short. Charging it inside the instruction also means an exhausted state pool now halts the executing call frame rather than the whole frame, which is what the spec asks for.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Three regressions in `FrameTxProcessorTests`, each red on the base commit and green here:

- `Execute_ApprovalInsideARevertedNestedCall_IsDiscarded` — the sender calls a helper, the helper calls back into the sender to approve and then reverts, and the sender swallows the failure. Base: the transaction executes. Here: the following `SENDER` frame has no execution approval.
- `Execute_ApprovalInsideANestedCall_CollectsTheMaxCostBeforeItReturns` — the sender approves in a nested self-call and then fails the frame unless its own balance already shows the collected `max_cost`. Base: the balance is untouched until the frame ends.
- `Execute_SecondSelfTargetedDefaultCodeVerify_InvalidatesTheTransaction` — two self-targeted `VERIFY` frames at scope `0x3` from a funded codeless sender. Base: both succeed.

Ran locally: `Nethermind.Evm.Test` 6385/6385 in release and 6383/6383 in the checked configuration; frame fixtures at `tests-frames-devnet@v0.3.0` 218/218 on both `blockTest` and `engineTest`; the frame tests of `Nethermind.TxPool.Test` and `Nethermind.Blockchain.Test`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
