### PR TITLE
fix(jsonrpc): frame a malformed chunked body as an invalid request

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
@@ -14,6 +14,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Nethermind.Core;
@@ -174,6 +175,54 @@ public class StartupTests
         Assert.That(statusCode, Is.EqualTo(StatusCodes.Status413PayloadTooLarge));
         AssertErrorCodeResponse(response, ErrorCodes.LimitExceeded);
     }
+
+    [Test]
+    public async Task ProcessJsonRpcRequest_OverMaxRequestBodySizeWithoutContentLength_ReturnsPayloadTooLarge()
+    {
+        (string response, int statusCode) = await ProcessJsonRpcRequestWithStatus(
+            CreateJsonRpcRequest(),
+            setContentLength: false,
+            maxRequestBodySize: 1);
+
+        Assert.That(statusCode, Is.EqualTo(StatusCodes.Status413PayloadTooLarge));
+        AssertErrorCodeResponse(response, ErrorCodes.LimitExceeded);
+    }
+
+    [Test]
+    public async Task ProcessJsonRpcRequest_BodyReadFailsWithIOException_ReturnsInvalidRequestBadRequest([Values] bool withInnerException)
+    {
+        IOException failure = withInnerException
+            ? new IOException("Bad chunk size data.", new OverflowException())
+            : new IOException("Bad chunk size data.");
+
+        (string response, int statusCode) = await ProcessJsonRpcRequestWithStatus(
+            CreateJsonRpcRequest(),
+            setContentLength: false,
+            body: new ThrowOnReadStream(failure));
+
+        Assert.That(statusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        AssertErrorCodeResponse(response, ErrorCodes.InvalidRequest);
+        AssertJsonResponse(response, static root =>
+            Assert.That(root.GetProperty("error").GetProperty("message").GetString(), Is.EqualTo("Could not read request body.")));
+    }
+
+    [Test]
+    public async Task ProcessJsonRpcRequest_BodyReadFailsWithWrappedCancellation_ReturnsTimeout()
+    {
+        (string response, _) = await ProcessJsonRpcRequestWithStatus(
+            CreateJsonRpcRequest(),
+            setContentLength: false,
+            body: new ThrowOnReadStream(new IOException("Unable to read data from the transport connection.", new OperationCanceledException())));
+
+        AssertErrorCodeResponse(response, ErrorCodes.Timeout);
+    }
+
+    [Test]
+    public void ProcessJsonRpcRequest_BodyReadFailsWithConnectionReset_Rethrows() =>
+        Assert.ThrowsAsync<ConnectionResetException>(async () => await ProcessJsonRpcRequestWithStatus(
+            CreateJsonRpcRequest(),
+            setContentLength: false,
+            body: new ThrowOnReadStream(new ConnectionResetException("Connection reset."))));
 
     [Test]
     public async Task ProcessJsonRpcRequest_AuthFailure_ReturnsUnauthorizedError()
@@ -477,7 +526,8 @@ public class StartupTests
         bool setContentLength = true,
         long? maxRequestBodySize = null,
         Startup? startup = null,
-        bool isAuthenticated = false)
+        bool isAuthenticated = false,
+        Stream? body = null)
     {
         byte[] requestBytes = Encoding.UTF8.GetBytes(request);
 
@@ -487,7 +537,7 @@ public class StartupTests
             {
                 Method = "POST",
                 ContentType = "application/json",
-                Body = new MemoryStream(requestBytes)
+                Body = body ?? new MemoryStream(requestBytes)
             }
         };
         if (setContentLength) ctx.Request.ContentLength = requestBytes.Length;
@@ -583,6 +633,22 @@ public class StartupTests
             Stopwatch.GetTimestamp());
 
         return new(sink, ctx, responseBody, jsonRpcLocalStats);
+    }
+
+    private sealed class ThrowOnReadStream(Exception exception) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => throw exception;
+        public override int Read(byte[] buffer, int offset, int count) => throw exception;
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 
     private readonly record struct HttpJsonRpcResponseSinkFixture(HttpJsonRpcResponseSink Sink, DefaultHttpContext Context, MemoryStream ResponseBody, IJsonRpcLocalStats LocalStats);

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -580,6 +580,12 @@ public class Startup : IStartup
                 }
             }
         }
+        catch (IOException e) when (e is not Microsoft.AspNetCore.Http.BadHttpRequestException
+            and not Microsoft.AspNetCore.Connections.ConnectionResetException
+            and { InnerException: not OperationCanceledException })
+        {
+            throw new Microsoft.AspNetCore.Http.BadHttpRequestException("Could not read request body.", StatusCodes.Status400BadRequest, e);
+        }
         finally
         {
             await bodyReader.CompleteAsync();


### PR DESCRIPTION
Fixes #13195

## Changes

Kestrel reports a chunk-size line `>= 0x80000000` as a bare `IOException("Bad chunk size data.")` rather than `BadHttpRequestException` — it catches the `OverflowException` from its checked accumulator and rethrows. `CollectHttpRequestBodyAsync`'s read loop has only a `finally`, and its caller catches `OperationCanceledException` and `BadHttpRequestException`, so the `IOException` unwinds into Kestrel: HTTP 500 with `Content-Length: 0`, an unhandled-exception count, and no JSON-RPC envelope. A minimal unauthenticated request triggers it, and `MaxRequestBodySize` does not apply because Kestrel counts bytes consumed rather than the declared chunk size.

Rethrow it as a 400 `BadHttpRequestException` so the existing handler writes the framed `-32600` and Debug-logs the chain, which stays complete because the original is kept as the inner exception. The message is constructed rather than taken from the exception: `SslStream` wraps transport failures as `IOException`, and that text should not be echoed to an anonymous caller.

Three shapes keep their current handling, and each is pinned by a test:

- `BadHttpRequestException` — carries the 413 that `ThrowRequestBodyTooLarge` raises inside the same `try`.
- `ConnectionResetException` — a client disconnect must not be answered on a closed connection.
- an `IOException` wrapping an `OperationCanceledException` — `SslStream` produces this for a cancelled read, and the caller already maps it to a timeout.

`SocketException` does not derive from `IOException`, so genuine socket failures are unaffected.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Added to the existing `StartupTests` fixture, using a `Stream` that throws on read — `DefaultHttpContext.Request.BodyReader` wraps `Request.Body`, which is how the existing `MemoryStream` cases already work.

Every behaviour is mutation-verified, each mutation killing exactly the matching test:

| mutation | fails |
|---|---|
| remove the `catch` | `..._BodyReadFailsWithIOException_...` |
| drop `not BadHttpRequestException` | `..._OverMaxRequestBodySizeWithoutContentLength_...` |
| drop `not ConnectionResetException` | `..._BodyReadFailsWithConnectionReset_Rethrows` |
| drop `InnerException: not OperationCanceledException` | `..._BodyReadFailsWithWrappedCancellation_...` |
| use `e.Message` instead of the constant | both `..._BodyReadFailsWithIOException_...` cases |

The pre-existing `..._OverMaxRequestBodySize_...` test does not cover the `BadHttpRequestException` exclusion: its `Content-Length` check runs before the `try`, so the 413 never reaches the new catch. `..._WithoutContentLength_...` was added to exercise the in-loop size check, which does.

`Nethermind.Runner.Test`: 774 passed / 2 pre-existing skips.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

A chunked JSON-RPC request with a chunk-size line `>= 0x80000000` now returns HTTP 400 with a framed `-32600` instead of HTTP 500 with an empty body.

## Remarks

Two deliberate omissions, both open to being overruled.

**No log level above Debug.** Previously this shape produced Kestrel's `An unhandled exception was thrown by the application` at Error plus an unhandled-exception count; it now takes `LogBadRequest` at Debug. Operators alerting on that line or that counter lose the signal. A Warn would restore it, but the condition is reachable at will by an unauthenticated caller, so one line per request reintroduces the amplification reported in #13156. Debug seems right for a caller-controlled condition, and the framed 400 is the caller-visible signal.

**`SszMiddleware` is untouched.** `SszRest/SszMiddleware.cs` reads `ctx.Request.BodyReader` in its own loop and has the same gap, falling through to a generic `catch` that logs at Error and returns 500. It is JWT-gated, so unlike this path it is not reachable pre-auth, and it lives in a different plugin — worth a follow-up rather than widening this change.
