### PR TITLE
fix(rpc): stop unauthenticated input causing unhandled exceptions, empty 500s, leaked traces and WARN floods (#13194, #13195, #13197, #13198, #13156)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Tracing/EstimateGasTracerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Tracing/EstimateGasTracerTests.cs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain.Tracing;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test.Tracing;
+
+[Parallelizable(ParallelScope.All)]
+public class EstimateGasTracerTests
+{
+    // #13197. The EIP-150 64/63 rule is applied once per nesting level to an already-scaled figure, so the advisory
+    // MaxGasNeeded compounds with call depth and saturates a few hundred frames down. Everything on the way to
+    // GasEstimator.CheckFunds saturates for that reason - this pins the last step, where an unchecked add would wrap
+    // a saturated figure back to a small number and report it as a plausible-looking estimate.
+    [Test]
+    public void CalculateAdditionalGasRequired_saturates_instead_of_wrapping_past_a_saturated_child_total()
+    {
+        const ulong rootGas = 1UL;
+        const ulong claimableRefund = 600_000UL;
+
+        EstimateGasTracer tracer = new();
+
+        // Root frame. IntrinsicGasAt is taken from this call, so keep it small: the wrap only shows when the
+        // additional gas is nearer ulong.MaxValue than the refund that is added to it.
+        tracer.ReportAction(rootGas, UInt256.Zero, TestItem.AddressA, TestItem.AddressB, default, ExecutionType.TRANSACTION);
+
+        // One child whose own figure is already saturated, which is what a deep call chain produces.
+        tracer.ReportAction(0UL, UInt256.Zero, TestItem.AddressB, TestItem.AddressB, default, ExecutionType.CALL);
+        tracer.ReportExtraGasPressure(ulong.MaxValue);
+        tracer.ReportActionEnd(0UL, default);
+
+        // MaxRefundQuotientEIP3529 is 5, so the claimable refund is capped at a fifth of the non-intrinsic gas.
+        tracer.ReportRefund((long)claimableRefund);
+        Transaction tx = Build.A.Transaction.WithGasLimit(claimableRefund * 5UL + rootGas).TestObject;
+
+        Assert.That(tracer.CalculateAdditionalGasRequired(tx, Cancun.Instance), Is.EqualTo(ulong.MaxValue),
+            "an unchecked add wraps ulong.MaxValue - 1 + 600000 round to a small, plausible-looking estimate");
+    }
+}

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/EstimateGasTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/EstimateGasTracer.cs
@@ -99,9 +99,11 @@ public class EstimateGasTracer : TxTracer
     internal ulong CalculateAdditionalGasRequired(Transaction tx, IReleaseSpec releaseSpec)
     {
         ulong intrinsicGas = tx.GasLimit - IntrinsicGasAt;
-        return _currentGasAndNesting.Peek().AdditionalGasRequired +
-               RefundHelper.CalculateClaimableRefund(intrinsicGas + NonIntrinsicGasSpentBeforeRefund, TotalRefund,
-                   releaseSpec);
+        // Saturating for the same reason as MaxGasNeeded: AdditionalGasRequired can legitimately be ulong.MaxValue,
+        // and an unchecked add would wrap it to a small number that GasEstimator.CheckFunds then reports as a
+        // successful estimate.
+        return _currentGasAndNesting.Peek().AdditionalGasRequired
+            .SaturatingAdd(RefundHelper.CalculateClaimableRefund(intrinsicGas + NonIntrinsicGasSpentBeforeRefund, TotalRefund, releaseSpec));
     }
 
     private int _currentNestingLevel = -1;

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/EstimateGasTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/EstimateGasTracer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.Tracing;
@@ -63,13 +64,27 @@ public class EstimateGasTracer : TxTracer
         public ulong GasLeft { get; set; }
         public int NestingLevel { get; set; } = nestingLevel;
 
+        // Above this the 64/63 step no longer fits in a ulong; the value is only advisory (GasEstimator.CheckFunds),
+        // so saturate instead of letting the (ulong) cast throw.
+        private const ulong MaxScalableGas = ulong.MaxValue / 64 * 63;
+
         private ulong MaxGasNeeded
         {
             get
             {
-                ulong maxGasNeeded = GasOnStart + ExtraGasPressure - GasLeft + GasUsageFromChildren;
+                // Saturating on purpose: the 64/63 factor is applied NestingLevel times per frame and the children's
+                // figure is already scaled, so it compounds with call depth and exceeds ulong a few hundred frames
+                // deep. This getter runs inside VirtualMachine.ExecuteTransaction's try block, where an
+                // OverflowException is treated as an EVM frame failure (HandleFailure -> ReportActionError) and
+                // unbalances the action stack ("Stack empty."). It must never throw.
+                ulong maxGasNeeded = GasOnStart.SaturatingAdd(ExtraGasPressure).SaturatingSub(GasLeft).SaturatingAdd(GasUsageFromChildren);
                 for (int i = 0; i < NestingLevel; i++)
                 {
+                    if (maxGasNeeded > MaxScalableGas)
+                    {
+                        return ulong.MaxValue;
+                    }
+
                     maxGasNeeded = (ulong)Math.Ceiling(maxGasNeeded * 64m / 63);
                 }
 
@@ -77,7 +92,7 @@ public class EstimateGasTracer : TxTracer
             }
         }
 
-        public ulong AdditionalGasRequired => MaxGasNeeded - (GasOnStart - GasLeft);
+        public ulong AdditionalGasRequired => MaxGasNeeded.SaturatingSub(GasOnStart - GasLeft);
         public ulong ExtraGasPressure { get; set; }
     }
 
@@ -165,7 +180,8 @@ public class EstimateGasTracer : TxTracer
                 current.GasLeft = gasLeft.Value;
             }
 
-            _currentGasAndNesting.Peek().GasUsageFromChildren += current.AdditionalGasRequired;
+            GasAndNesting parent = _currentGasAndNesting.Peek();
+            parent.GasUsageFromChildren = parent.GasUsageFromChildren.SaturatingAdd(current.AdditionalGasRequired);
             _currentNestingLevel--;
 
             if (_currentNestingLevel == -1)

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GasEstimationTests.cs
@@ -1391,5 +1391,33 @@ namespace Nethermind.Evm.Test.Tracing
 
             public void Dispose() => _closer.Dispose();
         }
+
+        [Test]
+        public void Estimates_self_recursive_call_until_exhaustion_without_throwing()
+        {
+            // PUSH0 x5, ADDRESS, GAS, CALL: recurse into self with all remaining gas until 63/64 or depth stops it.
+            using TestEnvironment testEnvironment = new();
+            Address recursive = TestItem.AddressB;
+            testEnvironment.InsertContract(recursive, Bytes.FromHexString("0x5f5f5f5f5f305af1"));
+
+            ulong gasLimit = 30_000_000ul;
+            Transaction tx = Build.A.Transaction
+                .WithGasLimit(gasLimit)
+                .WithTo(recursive)
+                .WithSenderAddress(TestItem.AddressA)
+                .TestObject;
+            Block block = Build.A.Block
+                .WithNumber(20_000_000)
+                .WithTimestamp(MainnetSpecProvider.CancunBlockTimestamp)
+                .WithGasLimit(gasLimit)
+                .WithTransactions(tx)
+                .TestObject;
+
+            ulong result = 0;
+            string? err = null;
+            Assert.DoesNotThrow(() => result = testEnvironment.estimator.Estimate(tx, block.Header, testEnvironment.tracer, out err));
+            Assert.That(err, Is.Null, err);
+            Assert.That(result, Is.GreaterThan(GasCostOf.Transaction));
+        }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -859,6 +859,45 @@ public class JsonRpcProcessorTests
         Assert.That(dispatched, Is.EqualTo(validItemIndex < 0 ? 0 : 1));
     }
 
+    private static IEnumerable<TestCaseData> ServerSideDecodeLookalikeExceptionCases()
+    {
+        (string name, Func<Exception> factory)[] cases =
+        [
+            ("InvalidOperationException", static () => new InvalidOperationException("module went away")),
+            ("ObjectDisposedException", static () => new ObjectDisposedException("RentedModule")),
+        ];
+
+        foreach ((string name, Func<Exception> factory) in cases)
+        {
+            foreach (RequestTransport transport in Enum.GetValues<RequestTransport>())
+            {
+                yield return new TestCaseData(factory, transport).SetName($"{name} ({transport})");
+            }
+        }
+    }
+
+    /// <remarks>
+    /// A server-side <see cref="InvalidOperationException"/> or <see cref="ObjectDisposedException"/> raised *after* a
+    /// well-formed request has decoded must never be reported to the caller as -32700 parse error: that hides a real
+    /// server fault behind a message blaming the client. Only the decode steps may treat those types as caller input
+    /// errors, which is why the guards sit inside the decode helpers rather than around request execution.
+    /// </remarks>
+    [TestCaseSource(nameof(ServerSideDecodeLookalikeExceptionCases))]
+    public void Server_side_exception_after_a_request_decodes_is_not_reported_as_a_parse_error(Func<Exception> factory, RequestTransport transport)
+    {
+        Exception expected = factory();
+        IJsonRpcService service = CreateService(_ => throw expected);
+        JsonRpcProcessor processor = CreateProcessor(service);
+        byte[] request = """{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}"""u8.ToArray();
+
+        Exception? thrown = Assert.CatchAsync(async () =>
+        {
+            using CollectedJsonRpcResponses ignored = await ProcessAsync(processor, request, transport);
+        });
+
+        Assert.That(thrown, Is.SameAs(expected), "the server fault must surface, not be reframed as a client parse error");
+    }
+
     private static async ValueTask<CollectedJsonRpcResponses> ProcessAsync(JsonRpcProcessor processor, byte[] request, RequestTransport transport)
     {
         if (transport == RequestTransport.HttpMemory)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -137,6 +137,35 @@ public class JsonRpcProcessorTests
             $"WARN/ERROR lines: {string.Join(" | ", warnLogger.LogList)}");
     }
 
+    // The two tests above cover errors a module produced. Bytes that never decode into a request never reach one, so
+    // -32700 is raised on the transport path instead, which had its own unconditional Error line. Same rule applies:
+    // undecodable bytes are the caller's fault, and the JWT endpoint keeps the operator's line.
+    [TestCase(false, TestName = "Parse error is not WARN for an unauthenticated caller")]
+    [TestCase(true, TestName = "Parse error keeps WARN when authenticated")]
+    public async Task Transport_parse_error_log_level_follows_authentication(bool isAuthenticated)
+    {
+        IJsonRpcService service = CreateService(request => new JsonRpcSuccessResponse { Id = request.Id });
+        const string request = "{ not json";
+        const string fragment = "Error during parsing/validation";
+
+        TestLogger warnLogger = new() { IsInfo = false, IsDebug = false, IsTrace = false };
+        TestLogger debugLogger = new();
+        foreach (TestLogger logger in (TestLogger[])[warnLogger, debugLogger])
+        {
+            using JsonRpcContext context = isAuthenticated ? CreateEngineContext() : CreateHttpContext();
+            using CollectedJsonRpcResponses result = await ProcessAsync(CreateProcessorWithLogger(service, logger), request, context);
+            Assert.That(((JsonRpcErrorResponse)AssertSingleResponse(result).Response!).Error!.Code, Is.EqualTo(ErrorCodes.ParseError));
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warnLogger.LogList.Where(l => l.Contains(fragment)), isAuthenticated ? Is.Not.Empty : Is.Empty,
+                $"WARN/ERROR lines: {string.Join(" | ", warnLogger.LogList)}");
+            Assert.That(debugLogger.LogList.Where(l => l.Contains(fragment)), Is.Not.Empty,
+                "the detail must stay recoverable at Debug");
+        }
+    }
+
     [Test]
     public async Task Http_engine_newPayloadV4_keeps_envelope_and_params_on_direct_utf8_path()
     {
@@ -929,6 +958,38 @@ public class JsonRpcProcessorTests
         Assert.That(dispatched, Is.EqualTo(validItemIndex < 0 ? 0 : 1));
     }
 
+    /// <summary>
+    /// An element that cannot be decoded still produces a response entry, so it still consumes response body.
+    /// Its <c>continue</c> must not skip the sink's stop signal: the next element would then be dispatched and
+    /// serialized in full after the response was already over <c>MaxBatchResponseBodySize</c>.
+    /// </summary>
+    [Test]
+    public async Task Batch_with_undecodable_element_does_not_bypass_the_response_limit(
+        [Values] RequestTransport transport)
+    {
+        int dispatched = 0;
+        IJsonRpcService service = CreateService(rpcRequest =>
+        {
+            dispatched++;
+            return new JsonRpcSuccessResponse { Id = rpcRequest.Id };
+        });
+        JsonRpcProcessor processor = CreateProcessor(service);
+        CollectingJsonRpcResponseSink sink = new() { StopAfterBatchItems = 1 };
+
+        using CollectedJsonRpcResponses result = await ProcessAsync(
+            processor,
+            "[null,{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_chainId\",\"params\":[]}]"u8.ToArray(),
+            transport,
+            sink);
+
+        IReadOnlyList<JsonRpcResponse> batchItems = AssertOnlyResult(result).BatchItems!;
+        Assert.That(batchItems, Has.Count.EqualTo(2));
+        Assert.That(((JsonRpcErrorResponse)batchItems[0]).Error!.Code, Is.EqualTo(ErrorCodes.InvalidRequest));
+        Assert.That(batchItems[1], Is.TypeOf<JsonRpcErrorResponse>(), "the element after the limit was reached must not be dispatched");
+        Assert.That(((JsonRpcErrorResponse)batchItems[1]).Error!.Code, Is.EqualTo(ErrorCodes.LimitExceeded));
+        Assert.That(dispatched, Is.Zero);
+    }
+
     private static IEnumerable<TestCaseData> ServerSideDecodeLookalikeExceptionCases()
     {
         (string name, Func<Exception> factory)[] cases =
@@ -968,17 +1029,21 @@ public class JsonRpcProcessorTests
         Assert.That(thrown, Is.SameAs(expected), "the server fault must surface, not be reframed as a client parse error");
     }
 
-    private static async ValueTask<CollectedJsonRpcResponses> ProcessAsync(JsonRpcProcessor processor, byte[] request, RequestTransport transport)
+    private static async ValueTask<CollectedJsonRpcResponses> ProcessAsync(
+        JsonRpcProcessor processor,
+        byte[] request,
+        RequestTransport transport,
+        CollectingJsonRpcResponseSink? sink = null)
     {
         if (transport == RequestTransport.HttpMemory)
         {
-            CollectingJsonRpcResponseSink sink = new();
+            sink ??= new CollectingJsonRpcResponseSink();
             await processor.ProcessAsync(request.AsMemory(), CreateHttpContext(), sink, new JsonRpcProcessingOptions(JsonRpcInputMode.SingleDocument));
             return sink.Responses;
         }
 
         JsonRpcContext context = transport == RequestTransport.HttpPipe ? CreateHttpContext() : new JsonRpcContext(RpcEndpoint.Ws);
-        return await ProcessAsync(processor, PipeReader.Create(new ReadOnlySequence<byte>(request)), context);
+        return await ProcessAsync(processor, PipeReader.Create(new ReadOnlySequence<byte>(request)), context, sink);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -68,11 +68,15 @@ public class JsonRpcProcessorTests
 
     private static JsonRpcContext CreateHttpContext() => new(RpcEndpoint.Http);
 
+    private static JsonRpcContext CreateEngineContext() =>
+        new(RpcEndpoint.Http, url: new JsonRpcUrl("http", "127.0.0.1", 8551, RpcEndpoint.Http, isAuthenticated: true, [ModuleType.Engine]));
+
     private static JsonRpcProcessor CreateProcessorWithLogger(IJsonRpcService service, TestLogger logger) =>
         new(service, new JsonRpcConfig(), Substitute.For<IFileSystem>(), new OneLoggerLogManager(new(logger)), null);
 
     // #13156: the JSON-RPC 2.0 request-error codes (-32700..-32600 and -32601/-32602) are the caller's fault and are
     // triggered by one unauthenticated request each, so they must not reach WARN; server-side codes keep their level.
+    // The demotion is scoped to unauthenticated callers - see Engine_api_request_errors_keep_warn below.
     [TestCase(ErrorCodes.ParseError, false, TestName = "ParseError (-32700) is not WARN")]
     [TestCase(ErrorCodes.InvalidRequest, false, TestName = "InvalidRequest (-32600) is not WARN")]
     [TestCase(ErrorCodes.MethodNotFound, false, TestName = "MethodNotFound (-32601) is not WARN")]
@@ -104,6 +108,33 @@ public class JsonRpcProcessorTests
                 $"WARN/ERROR lines: {string.Join(" | ", warnLogger.LogList)}");
             Assert.That(debugLogger.LogList.Where(l => l.Contains(expectedFragment)), Is.Not.Empty);
         }
+    }
+
+    // The #13156 rationale is that a client fault costs one unauthenticated request, so it must not dictate the
+    // operator's log volume. That does not hold for the JWT-authenticated Engine endpoint: -32601 is the canonical
+    // CL/EL version-mismatch signal and -32602 means the consensus client sent a payload this node could not bind.
+    // Both are the operator's problem and must stay visible at default level on a node running at Info.
+    [TestCase(ErrorCodes.MethodNotFound, TestName = "MethodNotFound (-32601) keeps WARN when authenticated")]
+    [TestCase(ErrorCodes.InvalidParams, TestName = "InvalidParams (-32602) keeps WARN when authenticated")]
+    [TestCase(ErrorCodes.InvalidRequest, TestName = "InvalidRequest (-32600) keeps WARN when authenticated")]
+    [TestCase(ErrorCodes.ParseError, TestName = "ParseError (-32700) keeps WARN when authenticated")]
+    public async Task Engine_api_request_errors_keep_warn(int errorCode)
+    {
+        IJsonRpcService service = CreateService(request => new JsonRpcErrorResponse
+        {
+            Id = request.Id,
+            Error = new Error { Code = errorCode, Message = "test message" }
+        });
+        string request = CreateRequest("1", "engine_newPayloadV4", "[]");
+
+        TestLogger warnLogger = new() { IsInfo = false, IsDebug = false, IsTrace = false };
+        using (JsonRpcContext engineContext = CreateEngineContext())
+        {
+            await ProcessAsync(CreateProcessorWithLogger(service, warnLogger), request, engineContext);
+        }
+
+        Assert.That(warnLogger.LogList.Where(l => l.Contains($"Code: {errorCode} Message: test message")), Is.Not.Empty,
+            $"WARN/ERROR lines: {string.Join(" | ", warnLogger.LogList)}");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -751,6 +751,127 @@ public class JsonRpcProcessorTests
         AssertBatchResponse(result, expectedBatchItems.Value);
     }
 
+    public enum RequestTransport
+    {
+        HttpMemory,
+        HttpPipe,
+        WsPipe
+    }
+
+    private static readonly byte[] _methodPrefixUtf8 = Encoding.UTF8.GetBytes("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_");
+    private static readonly byte[] _methodSuffixUtf8 = Encoding.UTF8.GetBytes("\",\"params\":[]}");
+
+    private static byte[] CreateRequestWithRawMethodTail(params byte[] rawMethodTail) =>
+        [.. _methodPrefixUtf8, .. rawMethodTail, .. _methodSuffixUtf8];
+
+    private static IEnumerable<TestCaseData> MalformedMethodTextCases()
+    {
+        (string name, byte[] tail)[] cases =
+        [
+            ("Invalid UTF-8 continuation byte", [0xC3]),
+            ("Overlong UTF-8 encoding", [0xC0, 0xAF]),
+            ("Truncated 4-byte UTF-8 sequence", [0xF0, 0x9F]),
+            ("Lone high surrogate escape", Encoding.ASCII.GetBytes("\\ud800")),
+            ("Lone low surrogate escape", Encoding.ASCII.GetBytes("\\udc00")),
+        ];
+
+        foreach ((string name, byte[] tail) in cases)
+        {
+            foreach (RequestTransport transport in Enum.GetValues<RequestTransport>())
+            {
+                yield return new TestCaseData(CreateRequestWithRawMethodTail(tail), transport).SetName($"{name} ({transport})");
+            }
+        }
+    }
+
+    [TestCaseSource(nameof(MalformedMethodTextCases))]
+    public async Task Malformed_utf8_or_utf16_in_method_name_is_a_parse_error(byte[] request, RequestTransport transport)
+    {
+        bool dispatched = false;
+        IJsonRpcService service = CreateService(rpcRequest =>
+        {
+            dispatched = true;
+            return new JsonRpcSuccessResponse { Id = rpcRequest.Id };
+        });
+        JsonRpcProcessor processor = CreateProcessor(service);
+
+        using CollectedJsonRpcResponses result = await ProcessAsync(processor, request, transport);
+
+        CollectedJsonRpcResult only = AssertOnlyResult(result);
+        Assert.That(only.BatchItems, Is.Null, "a malformed single request must produce a single framed error, not a batch");
+        Assert.That(only.Response, Is.TypeOf<JsonRpcErrorResponse>());
+        Assert.That(((JsonRpcErrorResponse)only.Response!).Error!.Code, Is.EqualTo(ErrorCodes.ParseError));
+        Assert.That(dispatched, Is.False, "a request that cannot be decoded must never reach the service");
+    }
+
+    private static IEnumerable<TestCaseData> NonObjectBatchElementCases()
+    {
+        (string name, byte[] request, int expectedItems, int validItemIndex)[] cases =
+        [
+            ("Null element", "[null]"u8.ToArray(), 1, -1),
+            ("Array element", "[[]]"u8.ToArray(), 1, -1),
+            ("Number element", "[1]"u8.ToArray(), 1, -1),
+            ("String element", "[\"x\"]"u8.ToArray(), 1, -1),
+            ("Null element followed by valid request", "[null,{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_chainId\",\"params\":[]}]"u8.ToArray(), 2, 1),
+            ("Object element with invalid UTF-8 method", [(byte)'[', .. CreateRequestWithRawMethodTail(0xC3), (byte)']'], 1, -1),
+            ("Object element with fractional id", "[{\"jsonrpc\":\"2.0\",\"id\":1.5,\"method\":\"eth_chainId\",\"params\":[]}]"u8.ToArray(), 1, -1),
+        ];
+
+        foreach ((string name, byte[] request, int expectedItems, int validItemIndex) in cases)
+        {
+            foreach (RequestTransport transport in Enum.GetValues<RequestTransport>())
+            {
+                yield return new TestCaseData(request, expectedItems, validItemIndex, transport).SetName($"{name} ({transport})");
+            }
+        }
+    }
+
+    [TestCaseSource(nameof(NonObjectBatchElementCases))]
+    public async Task Batch_with_undecodable_element_returns_invalid_request_for_that_element(byte[] request, int expectedItems, int validItemIndex, RequestTransport transport)
+    {
+        int dispatched = 0;
+        IJsonRpcService service = CreateService(rpcRequest =>
+        {
+            dispatched++;
+            return new JsonRpcSuccessResponse { Id = rpcRequest.Id };
+        });
+        JsonRpcProcessor processor = CreateProcessor(service);
+
+        using CollectedJsonRpcResponses result = await ProcessAsync(processor, request, transport);
+
+        CollectedJsonRpcResult only = AssertOnlyResult(result);
+        Assert.That(only.Response, Is.Null, "a syntactically valid JSON array must be answered with a batch response");
+        Assert.That(only.BatchItems, Has.Count.EqualTo(expectedItems));
+        for (int i = 0; i < expectedItems; i++)
+        {
+            JsonRpcResponse item = only.BatchItems![i];
+            if (i == validItemIndex)
+            {
+                Assert.That(item, Is.TypeOf<JsonRpcSuccessResponse>(), $"item {i} is a valid request and must be dispatched");
+                Assert.That(item.Id, Is.EqualTo(new JsonRpcId(1)));
+                continue;
+            }
+
+            Assert.That(item, Is.TypeOf<JsonRpcErrorResponse>(), $"item {i} is not a request object");
+            Assert.That(((JsonRpcErrorResponse)item).Error!.Code, Is.EqualTo(ErrorCodes.InvalidRequest));
+        }
+
+        Assert.That(dispatched, Is.EqualTo(validItemIndex < 0 ? 0 : 1));
+    }
+
+    private static async ValueTask<CollectedJsonRpcResponses> ProcessAsync(JsonRpcProcessor processor, byte[] request, RequestTransport transport)
+    {
+        if (transport == RequestTransport.HttpMemory)
+        {
+            CollectingJsonRpcResponseSink sink = new();
+            await processor.ProcessAsync(request.AsMemory(), CreateHttpContext(), sink, new JsonRpcProcessingOptions(JsonRpcInputMode.SingleDocument));
+            return sink.Responses;
+        }
+
+        JsonRpcContext context = transport == RequestTransport.HttpPipe ? CreateHttpContext() : new JsonRpcContext(RpcEndpoint.Ws);
+        return await ProcessAsync(processor, PipeReader.Create(new ReadOnlySequence<byte>(request)), context);
+    }
+
     [Test]
     public async Task Should_stop_processing_when_shutdown_requested()
     {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -14,6 +14,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Config;
+using Nethermind.Core.Test;
 using Nethermind.Logging;
 using Nethermind.JsonRpc.Modules;
 using NSubstitute;
@@ -66,6 +67,44 @@ public class JsonRpcProcessorTests
         new(service, config ?? new JsonRpcConfig(), fileSystem ?? Substitute.For<IFileSystem>(), LimboLogs.Instance, processExitSource);
 
     private static JsonRpcContext CreateHttpContext() => new(RpcEndpoint.Http);
+
+    private static JsonRpcProcessor CreateProcessorWithLogger(IJsonRpcService service, TestLogger logger) =>
+        new(service, new JsonRpcConfig(), Substitute.For<IFileSystem>(), new OneLoggerLogManager(new(logger)), null);
+
+    // #13156: the JSON-RPC 2.0 request-error codes (-32700..-32600 and -32601/-32602) are the caller's fault and are
+    // triggered by one unauthenticated request each, so they must not reach WARN; server-side codes keep their level.
+    [TestCase(ErrorCodes.ParseError, false, TestName = "ParseError (-32700) is not WARN")]
+    [TestCase(ErrorCodes.InvalidRequest, false, TestName = "InvalidRequest (-32600) is not WARN")]
+    [TestCase(ErrorCodes.MethodNotFound, false, TestName = "MethodNotFound (-32601) is not WARN")]
+    [TestCase(ErrorCodes.InvalidParams, false, TestName = "InvalidParams (-32602) is not WARN")]
+    [TestCase(ErrorCodes.InternalError, true, TestName = "InternalError (-32603) keeps WARN")]
+    [TestCase(ErrorCodes.Default, true, TestName = "Default (-32000) keeps WARN")]
+    [TestCase(ErrorCodes.LimitExceeded, true, TestName = "LimitExceeded (-32005) without suppression keeps WARN")]
+    public async Task Error_response_log_level_follows_error_class(int errorCode, bool expectWarn)
+    {
+        IJsonRpcService service = CreateService(request => new JsonRpcErrorResponse
+        {
+            Id = request.Id,
+            Error = new Error { Code = errorCode, Message = "test message" }
+        });
+        string request = CreateRequest("1", "eth_getBalance", """["0x1234","latest"]""");
+
+        // Warn/Error-only capture: anything recorded here would be one stdout line per request on a default node.
+        TestLogger warnLogger = new() { IsInfo = false, IsDebug = false, IsTrace = false };
+        await ProcessAsync(CreateProcessorWithLogger(service, warnLogger), request, CreateHttpContext());
+
+        // Full capture: the message must still be available at Debug for operators debugging a client.
+        TestLogger debugLogger = new();
+        await ProcessAsync(CreateProcessorWithLogger(service, debugLogger), request, CreateHttpContext());
+
+        string expectedFragment = $"Code: {errorCode} Message: test message";
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warnLogger.LogList.Where(l => l.Contains(expectedFragment)), expectWarn ? Is.Not.Empty : Is.Empty,
+                $"WARN/ERROR lines: {string.Join(" | ", warnLogger.LogList)}");
+            Assert.That(debugLogger.LogList.Where(l => l.Contains(expectedFragment)), Is.Not.Empty);
+        }
+    }
 
     [Test]
     public async Task Http_engine_newPayloadV4_keeps_envelope_and_params_on_direct_utf8_path()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -16,6 +16,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm;
 using Nethermind.Facade.Eth;
@@ -568,6 +569,30 @@ public class JsonRpcServiceTests
         IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
         AssertInvalidParamsWithoutData(TestRequest(ethRpcModule, method, parameters), expectedMessage);
         ethRpcModule.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>());
+    }
+
+    // #13156: a parameter the caller got wrong is answered with -32602; it must not also cost the operator a WARN line
+    // (with a stack trace) per request. The detail stays available at Debug.
+    [Test]
+    public void Invalid_params_are_not_logged_at_warn()
+    {
+        IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
+        const string rawParameters = """["0x1234","latest"]""";
+
+        TestLogger warnLogger = new() { IsInfo = false, IsDebug = false, IsTrace = false };
+        _logManager = new OneLoggerLogManager(new(warnLogger));
+        AssertJsonRpcError(TestRawRequest(ethRpcModule, nameof(IEthRpcModule.eth_getBalance), rawParameters), ErrorCodes.InvalidParams);
+
+        TestLogger debugLogger = new();
+        _logManager = new OneLoggerLogManager(new(debugLogger));
+        AssertJsonRpcError(TestRawRequest(ethRpcModule, nameof(IEthRpcModule.eth_getBalance), rawParameters), ErrorCodes.InvalidParams);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warnLogger.LogList, Is.Empty, $"WARN/ERROR lines: {string.Join(" | ", warnLogger.LogList)}");
+            Assert.That(debugLogger.LogList.Where(l => l.Contains("Incorrect JSON RPC parameters when calling eth_getBalance")), Is.Not.Empty);
+            ethRpcModule.DidNotReceive().eth_getBalance(Arg.Any<Address>(), Arg.Any<BlockParameter?>());
+        }
     }
 
     [TestCaseSource(nameof(InvalidRawUtf8ParamCases))]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain.Find;
@@ -595,6 +596,30 @@ public class JsonRpcServiceTests
         }
     }
 
+    // The counterpart to the test above: the catch around parameter binding is broad, so it also swallows faults
+    // the params cannot cause. Those are a condition of the node and must stay visible - at this site, and at the
+    // processor, which would otherwise demote every -32602 from an unauthenticated caller to Debug.
+    [Test]
+    public void Node_faults_during_binding_stay_visible_and_omit_the_params()
+    {
+        IMetadataTestRpcModule module = Substitute.For<IMetadataTestRpcModule>();
+        const string rawParameters = """[{"secret":"0x1234"}]""";
+
+        TestLogger logger = new() { IsInfo = false, IsDebug = false, IsTrace = false };
+        _logManager = new OneLoggerLogManager(new(logger));
+        using JsonRpcErrorResponse response = AssertJsonRpcError(
+            TestRawRequest(module, "test_node_fault", rawParameters),
+            ErrorCodes.InvalidParams);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response.Error!.OperatorActionable, Is.True, "the processor must not demote a node fault");
+            Assert.That(logger.LogList.Where(static l => l.Contains("Failed to bind JSON RPC parameters for test_node_fault")), Is.Not.Empty);
+            Assert.That(logger.LogList.Where(static l => l.Contains("secret")), Is.Empty, "the params must not be formatted on a fault that may be an exhausted heap");
+            module.DidNotReceive().test_node_fault(Arg.Any<NodeFaultPayload>());
+        }
+    }
+
     [TestCaseSource(nameof(InvalidRawUtf8ParamCases))]
     public void Raw_utf8_params_invalid_arguments_return_invalid_params_before_invocation(
         string method,
@@ -920,6 +945,22 @@ public class JsonRpcServiceTests
 
         [JsonRpcMethod(Description = "Test method used to verify JSON-RPC array parameter metadata handling.")]
         ResultWrapper<int> test_byte_arrays(byte[][] value);
+
+        [JsonRpcMethod(Description = "Test method used to verify JSON-RPC parameter binding faults.")]
+        ResultWrapper<string> test_node_fault(NodeFaultPayload value);
+    }
+
+    [JsonConverter(typeof(NodeFaultPayloadConverter))]
+    public sealed class NodeFaultPayload;
+
+    /// <summary>Stands in for a fault the caller's params cannot cause, arriving from inside parameter binding.</summary>
+    private sealed class NodeFaultPayloadConverter : JsonConverter<NodeFaultPayload>
+    {
+        public override NodeFaultPayload Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+            throw new ObjectDisposedException(nameof(NodeFaultPayloadConverter));
+
+        public override void Write(Utf8JsonWriter writer, NodeFaultPayload value, JsonSerializerOptions options) =>
+            throw new NotSupportedException();
     }
 
     private sealed class DisposableProbe : IDisposable

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -94,6 +94,18 @@ public class JsonRpcServiceTests
             (Action<IEthRpcModule>)(static module => module.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())))
             .SetName("Malformed typed argument");
         yield return new TestCaseData(
+            nameof(IEthRpcModule.eth_getBlockByNumber),
+            """["",false]""",
+            "missing value for required argument 0",
+            (Action<IEthRpcModule>)(static module => module.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())))
+            .SetName("Empty string for non-trailing required argument");
+        yield return new TestCaseData(
+            nameof(IEthRpcModule.eth_getBlockByNumber),
+            """[null,false]""",
+            "missing value for required argument 0",
+            (Action<IEthRpcModule>)(static module => module.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())))
+            .SetName("Null for non-trailing required argument");
+        yield return new TestCaseData(
             nameof(IEthRpcModule.eth_feeHistory),
             """[{},"latest"]""",
             "missing value for required argument 2",
@@ -549,6 +561,15 @@ public class JsonRpcServiceTests
         AssertInvalidParamsWithoutData(TestRequest(ethRpcModule, method, parameters), expectedMessage);
     }
 
+    [TestCase("eth_getBlockByNumber", new object?[] { "", false }, "missing value for required argument 0", TestName = "EmptyStringNonTrailing")]
+    [TestCase("eth_getBlockByNumber", new object?[] { null, false }, "missing value for required argument 0", TestName = "NullNonTrailing")]
+    public void MissingRequiredArgument_NonTrailingMarker_ReturnsInvalidParams(string method, object?[] parameters, string expectedMessage)
+    {
+        IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
+        AssertInvalidParamsWithoutData(TestRequest(ethRpcModule, method, parameters), expectedMessage);
+        ethRpcModule.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>());
+    }
+
     [TestCaseSource(nameof(InvalidRawUtf8ParamCases))]
     public void Raw_utf8_params_invalid_arguments_return_invalid_params_before_invocation(
         string method,
@@ -678,7 +699,43 @@ public class JsonRpcServiceTests
         JsonRpcRequest request = RpcTest.BuildJsonRequest("eth_test");
         JsonRpcResponse response = await service.SendRequestAsync(request, _context);
 
-        AssertJsonRpcError(response, ErrorCodes.InternalError);
+        JsonRpcErrorResponse errorResponse = AssertJsonRpcError(response, ErrorCodes.InternalError);
+        // Covers the second error.data producer, JsonRpcService.ReturnErrorResponse, which the module-invocation
+        // path in Error_data_does_not_leak_stack_trace_or_build_paths never reaches.
+        AssertErrorDataWithoutStackTrace(errorResponse);
+    }
+
+    // error.data reaches unauthenticated callers, so it must not carry the stack trace: our release builds
+    // render frames with the build machine's absolute source paths and expose the internal call graph.
+    [TestCase(ErrorCodes.InternalError, TestName = "InternalErrorArm")]
+    [TestCase(ErrorCodes.InvalidParams, TestName = "InvalidParamsArm")]
+    public void Error_data_does_not_leak_stack_trace_or_build_paths(int expectedCode)
+    {
+        Exception thrown = expectedCode == ErrorCodes.InternalError
+            ? new InvalidOperationException("Stack empty.")
+            : new ArgumentException("bad argument");
+
+        IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
+        ethRpcModule.eth_getLogs(Arg.Any<Filter>()).Throws(thrown);
+
+        using JsonRpcErrorResponse response = AssertJsonRpcError(TestRequest(ethRpcModule, "eth_getLogs", "{}"), expectedCode);
+
+        AssertErrorDataWithoutStackTrace(response, thrown.GetType(), thrown.Message);
+    }
+
+    private static void AssertErrorDataWithoutStackTrace(JsonRpcErrorResponse response, Type? expectedType = null, string? expectedMessage = null)
+    {
+        string data = response.Error!.Data?.ToString() ?? string.Empty;
+        Assert.Multiple(() =>
+        {
+            // Still actionable: the caller learns what went wrong.
+            if (expectedType is not null) Assert.That(data, Does.Contain(expectedType.FullName!), data);
+            if (expectedMessage is not null) Assert.That(data, Does.Contain(expectedMessage), data);
+            // But nothing about where our source lives or how the call got there.
+            Assert.That(data, Does.Not.Contain("   at "), data);
+            Assert.That(data, Does.Not.Contain(".cs:line"), data);
+            Assert.That(data, Does.Not.Contain("Nethermind.JsonRpc.JsonRpcService"), data);
+        });
     }
 
     private static IEnumerable<TestCaseData> OutOfMemoryPools()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -797,6 +797,32 @@ public class JsonRpcServiceTests
         Assert.That(logged.Text, Does.Contain("eth_getBalance").And.Not.Contain(marker));
     }
 
+    // #13156 follow-up: -32600 is overloaded. It is returned both for a request the caller got wrong ("Method is
+    // required") and for a namespace this node has disabled, whose message is a remediation instruction for the
+    // operator. Only the first may be demoted out of WARN, so the disabled cases carry OperatorActionable.
+    [TestCase(ModuleResolution.Disabled, true)]
+    [TestCase(ModuleResolution.EndpointDisabled, true)]
+    [TestCase(ModuleResolution.NotAuthenticated, false)]
+    public async Task Disabled_namespace_stays_operator_actionable(ModuleResolution resolution, bool expectedOperatorActionable)
+    {
+        IRpcModuleProvider moduleProvider = Substitute.For<IRpcModuleProvider>();
+        moduleProvider.Check(Arg.Any<string>(), Arg.Any<JsonRpcContext>(), out Arg.Any<string?>(), out Arg.Any<RpcModuleProvider.ResolvedMethodInfo?>())
+            .Returns(callInfo =>
+            {
+                callInfo[2] = "Debug";
+                callInfo[3] = null;
+                return resolution;
+            });
+
+        JsonRpcService service = new(moduleProvider, _logManager, _configurationProvider.GetConfig<IJsonRpcConfig>());
+        JsonRpcRequest request = RpcTest.BuildJsonRequest("debug_traceCall");
+        using JsonRpcErrorResponse response = (JsonRpcErrorResponse)await service.SendRequestAsync(request, _context);
+
+        Assert.That(response.Error!.Code, Is.EqualTo(ErrorCodes.InvalidRequest));
+        Assert.That(ErrorCodes.IsRequestError(response.Error.Code), Is.True, "guards the premise: the code alone would demote this");
+        Assert.That(response.Error.OperatorActionable, Is.EqualTo(expectedOperatorActionable));
+    }
+
     [Test]
     public void Invocation_limit_exceeded_suppresses_warning()
     {

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EstimateGas.cs
@@ -877,4 +877,21 @@ public partial class EthRpcModuleTests
         Assert.That(parsed["error"]!["code"]!.Value<int>(), Is.EqualTo(-32602));
     }
 
+    [Test]
+    public async Task Eth_estimateGas_self_recursive_call_until_exhaustion_does_not_return_internal_error()
+    {
+        // 0x5f5f5f5f5f305af1 = PUSH0 x5, ADDRESS, GAS, CALL: the contract CALLs itself with all remaining gas
+        // until the 63/64 rule or the depth limit stops the recursion. Every frame must be reported to the
+        // EstimateGasTracer in balance; a stray ReportActionError surfaced as -32603 "Stack empty." on 2.0.0-rc.
+        object? transaction = JsonSerializer.Deserialize<object>("""{"to":"0x00000000000000000000000000000000000000aa"}""");
+        object? stateOverride = JsonSerializer.Deserialize<object>("""{"0x00000000000000000000000000000000000000aa":{"code":"0x5f5f5f5f5f305af1"}}""");
+
+        TestSpecProvider specProvider = new(Prague.Instance);
+        using Context ctx = await Context.Create(specProvider);
+
+        string serialized = await ctx.Test.TestEthRpc("eth_estimateGas", transaction, "latest", stateOverride);
+
+        Assert.That(serialized, Does.Not.Contain("-32603"), serialized);
+        Assert.That(serialized, Does.Contain("\"result\":\"0x"), serialized);
+    }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.cs
@@ -3033,4 +3033,11 @@ public partial class EthRpcModuleTests
         }
     }
 
+    [Test]
+    public async Task Eth_getBlockByNumber_with_empty_string_block_parameter_returns_invalid_params()
+    {
+        using Context ctx = await Context.Create();
+        string serialized = await ctx.Test.TestEthRpc("eth_getBlockByNumber", "", false);
+        Assert.That(serialized, Is.EqualTo("""{"jsonrpc":"2.0","error":{"code":-32602,"message":"missing value for required argument 0"},"id":67}"""));
+    }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/Error.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Error.cs
@@ -18,5 +18,14 @@ namespace Nethermind.JsonRpc
 
         [JsonIgnore]
         public bool SuppressWarning { get; set; }
+
+        /// <summary>
+        /// Set when the error reports a condition of *this node* rather than a fault in the request, even though it
+        /// carries one of the JSON-RPC pre-defined request codes. A disabled namespace is the motivating case: the
+        /// caller asked for a legitimate method and the message is a remediation instruction for the operator, so it
+        /// must keep its WARN even though the code is <see cref="ErrorCodes.InvalidRequest"/>.
+        /// </summary>
+        [JsonIgnore]
+        public bool OperatorActionable { get; set; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/ErrorCodes.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ErrorCodes.cs
@@ -180,6 +180,11 @@ namespace Nethermind.JsonRpc
         /// True for the JSON-RPC 2.0 pre-defined request errors (<see cref="ParseError"/>, <see cref="InvalidRequest"/>,
         /// <see cref="MethodNotFound"/>, <see cref="InvalidParams"/>): the request itself was wrong, which is the
         /// caller's fault rather than a condition of this node.
+        /// <para>
+        /// The code alone is not always enough: <see cref="InvalidRequest"/> is also returned for a namespace that
+        /// is disabled for the requested URL or endpoint, which is a condition of this node. Those errors set
+        /// <c>Error.OperatorActionable</c> and callers of this helper must honour it.
+        /// </para>
         /// </summary>
         public static bool IsRequestError(int code) =>
             code is ParseError or InvalidRequest or MethodNotFound or InvalidParams;

--- a/src/Nethermind/Nethermind.JsonRpc/ErrorCodes.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/ErrorCodes.cs
@@ -175,5 +175,13 @@ namespace Nethermind.JsonRpc
         /// Error during EVM execution
         /// </summary>
         public const int VMError = -32015;
+
+        /// <summary>
+        /// True for the JSON-RPC 2.0 pre-defined request errors (<see cref="ParseError"/>, <see cref="InvalidRequest"/>,
+        /// <see cref="MethodNotFound"/>, <see cref="InvalidParams"/>): the request itself was wrong, which is the
+        /// caller's fault rather than a condition of this node.
+        /// </summary>
+        public static bool IsRequestError(int code) =>
+            code is ParseError or InvalidRequest or MethodNotFound or InvalidParams;
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -221,7 +221,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
 
                 if (buffer.IsEmpty && readResult.IsCompleted && options.InputMode == JsonRpcInputMode.SingleDocument)
                 {
-                    result = GetParsingError(startTime, in buffer, "Error during parsing/validation: empty request.");
+                    result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation: empty request.");
                     processingState.ShouldExit = true;
                 }
                 else if (!buffer.IsEmpty)
@@ -235,7 +235,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                             if (!TryDecodeSingleObjectRequest(buffer.First, out JsonRpcRequest? directRequest, out Exception? decodeException)
                                 && decodeException is not null)
                             {
-                                result = GetParsingError(startTime, in buffer, "Error during parsing/validation.", decodeException);
+                                result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation.", decodeException);
                                 processingState.ShouldExit = true;
                                 reader.AdvanceTo(buffer.End);
                                 advanced = true;
@@ -278,7 +278,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                         }
                         catch (Exception ex) when (IsRequestDecodingException(ex))
                         {
-                            result = GetParsingError(startTime, in buffer, "Error during parsing/validation.", ex);
+                            result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation.", ex);
                             processingState.ShouldExit = true;
                             undecodable = true;
                             if (!advanced)
@@ -313,7 +313,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                         }
                         else if (!undecodable && isCompleted && !buffer.IsEmpty)
                         {
-                            result = GetParsingError(startTime, in buffer, "Error during parsing/validation: incomplete request.");
+                            result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation: incomplete request.");
                             processingState.ShouldExit = true;
                         }
 
@@ -337,7 +337,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                     {
                         // Deliberately NOT IsRequestDecodingException: this catch wraps request *execution* as
                         // well as decoding. See IsRequestDecodingException.
-                        result = GetParsingError(startTime, in buffer, "Error during parsing/validation.", ex);
+                        result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation.", ex);
                         processingState.ShouldExit = true;
                     }
                 }
@@ -376,7 +376,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         {
             pendingSingleDocument.Dispose();
             processingState.ShouldExit = true;
-            return GetParsingError(processingState.PendingSingleDocumentStartTime, in trailingBuffer, "Error during parsing/validation: trailing data after JSON-RPC request.");
+            return GetParsingError(processingState.PendingSingleDocumentStartTime, in trailingBuffer, context, "Error during parsing/validation: trailing data after JSON-RPC request.");
         }
 
         if (isCompleted)
@@ -408,7 +408,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         {
             jsonDocument.Dispose();
             processingState.ShouldExit = true;
-            return GetParsingError(startTime, in trailingBuffer, "Error during parsing/validation: trailing data after JSON-RPC request.");
+            return GetParsingError(startTime, in trailingBuffer, context, "Error during parsing/validation: trailing data after JSON-RPC request.");
         }
 
         if (isCompleted)
@@ -442,7 +442,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
         catch (Exception ex) when (IsRequestDecodingException(ex))
         {
-            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
+            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), context, sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
             return;
         }
 
@@ -461,7 +461,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
         catch (JsonException ex)
         {
-            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
+            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), context, sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
             return;
         }
 
@@ -472,7 +472,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
         catch (JsonException ex)
         {
-            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
+            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), context, sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
         }
     }
 
@@ -692,7 +692,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                         // -32700, not -32600: the bytes never decoded into a request, so there is nothing to
                         // call invalid. The raw buffer is not available here (the document is already parsed),
                         // and GetParsingError only uses it to enrich the debug log.
-                        await WriteParsingErrorAsync(default, sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
+                        await WriteParsingErrorAsync(default, context, sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
                         break;
                     }
 
@@ -767,6 +767,9 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                 if (jsonRpcRequest is null)
                 {
                     await WriteBatchEntryAsync(CreateInvalidRequestEntry(startTime), sink, cancellationToken);
+                    // The entry still counts against the response body: skipping this read would let the next
+                    // valid element be dispatched in full after the sink already asked to stop.
+                    isStopped |= sink.StopRequested;
                     continue;
                 }
 
@@ -844,6 +847,9 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                 if (jsonRpcRequest is null)
                 {
                     await WriteBatchEntryAsync(CreateInvalidRequestEntry(startTime), sink, cancellationToken);
+                    // The entry still counts against the response body: skipping this read would let the next
+                    // valid element be dispatched in full after the sink already asked to stop.
+                    isStopped |= sink.StopRequested;
                     continue;
                 }
 
@@ -973,13 +979,14 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
 
     private async ValueTask WriteParsingErrorAsync(
         ReadOnlySequence<byte> buffer,
+        JsonRpcContext context,
         IJsonRpcResponseSink sink,
         long startTime,
         string error,
         CancellationToken cancellationToken,
         Exception? exception = null)
     {
-        JsonRpcResult.Entry result = GetParsingError(startTime, in buffer, error, exception);
+        JsonRpcResult.Entry result = GetParsingError(startTime, in buffer, context, error, exception);
         await WriteSingleEntryAsync(result, sink, cancellationToken);
     }
 
@@ -1029,10 +1036,20 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
     }
 
-    private JsonRpcResult.Entry GetParsingError(long startTime, ref readonly ReadOnlySequence<byte> buffer, string error, Exception? exception = null)
+    /// <remarks>
+    /// -32700 is a request error like any other (#13156): bytes this node could not parse are the caller's fault,
+    /// and one unauthenticated request must not put a line - let alone a stack trace - on the operator's console.
+    /// The detail is kept, at Debug, by the same rule <see cref="IsDemotableRequestError"/> applies to the response
+    /// path: a JWT-authenticated caller that cannot frame a JSON-RPC request is the operator's problem.
+    /// </remarks>
+    private JsonRpcResult.Entry GetParsingError(
+        long startTime,
+        ref readonly ReadOnlySequence<byte> buffer,
+        JsonRpcContext context,
+        string error,
+        Exception? exception = null)
     {
         Metrics.JsonRpcRequestDeserializationFailures++;
-        if (_logger.IsError) _logger.Error(error, exception);
 
         if (_logger.IsDebug)
         {
@@ -1042,9 +1059,18 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                 error = isFullString
                     ? $"{error} Data:\n{data}\n"
                     : $"{error} Data (first {sliceSize} chars):\n{data[..sliceSize]}\n";
-
-                _logger.Debug(error);
             }
+        }
+
+        // DebugError, not Debug, so the exception is still attached and a demoted line is still recognisable as
+        // an error once the operator turns Debug on.
+        if (context.IsAuthenticated)
+        {
+            if (_logger.IsError) _logger.Error(error, exception);
+        }
+        else
+        {
+            _logger.DebugError(error, exception);
         }
 
         JsonRpcErrorResponse response = _jsonRpcService.GetErrorResponse(ErrorCodes.ParseError, "parse error");

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -303,7 +303,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                         Handle(e);
                         processingState.ShouldExit = true;
                     }
-                    catch (JsonException ex)
+                    catch (Exception ex) when (IsRequestDecodingException(ex))
                     {
                         result = GetParsingError(startTime, in buffer, "Error during parsing/validation.", ex);
                         processingState.ShouldExit = true;
@@ -417,7 +417,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
             PipeReader reader = PipeReader.Create(new ReadOnlySequence<byte>(requestBody));
             await ProcessCoreAsync(reader, context, sink, options, timeoutSource: null, timeoutToken: CancellationToken.None, cancellationToken, recordRequest: false);
         }
-        catch (JsonException ex)
+        catch (Exception ex) when (IsRequestDecodingException(ex))
         {
             await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
         }
@@ -550,6 +550,16 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         if (_logger.IsDebug) _logger.Debug($"Couldn't read request.{Environment.NewLine}{e}");
     }
 
+    /// <summary>Tells whether <paramref name="exception"/> means the request text could not be decoded into a JSON-RPC envelope.</summary>
+    /// <remarks>
+    /// System.Text.Json reports malformed syntax as <see cref="JsonException"/>, but invalid UTF-8 bytes and lone UTF-16
+    /// surrogate escapes inside a string value, as well as reading a non-object element as an object, surface as a bare
+    /// <see cref="InvalidOperationException"/>. Both are caller input errors and must become a JSON-RPC error response
+    /// instead of escaping to the transport as an unhandled exception.
+    /// </remarks>
+    private static bool IsRequestDecodingException(Exception exception) =>
+        exception is JsonException or InvalidOperationException;
+
     private static bool TryParseJson(
         ref ReadOnlySequence<byte> buffer,
         bool isFinalBlock,
@@ -652,7 +662,13 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         {
             foreach (JsonElement item in rootElement.EnumerateArray())
             {
-                JsonRpcRequest jsonRpcRequest = CreateRequest(item);
+                JsonRpcRequest? jsonRpcRequest = TryCreateBatchItemRequest(item);
+                if (jsonRpcRequest is null)
+                {
+                    await WriteBatchEntryAsync(CreateInvalidRequestEntry(startTime), sink, cancellationToken);
+                    continue;
+                }
+
                 JsonRpcResult.Entry response = isStopped
                     ? CreateBatchResponseLimitEntry(jsonRpcRequest)
                     : await HandleSingleRequest(jsonRpcRequest, context);
@@ -723,7 +739,13 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
             while (JsonRpcArrayReader.TryReadNextItem(batchBody, ref offset, ref readerState, ref started, out ReadOnlyMemory<byte> itemBody))
             {
                 requestIndex++;
-                JsonRpcRequest jsonRpcRequest = DeserializeBatchItem(itemBody, out JsonDocument? ownedRequestDocument);
+                JsonRpcRequest? jsonRpcRequest = TryDeserializeBatchItem(itemBody, out JsonDocument? ownedRequestDocument);
+                if (jsonRpcRequest is null)
+                {
+                    await WriteBatchEntryAsync(CreateInvalidRequestEntry(startTime), sink, cancellationToken);
+                    continue;
+                }
+
                 batchRequestJsonLifetime.TrackUntilBatchEnd(jsonRpcRequest, ownedRequestDocument);
 
                 JsonRpcResult.Entry response = isStopped
@@ -756,31 +778,62 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
     }
 
-    private JsonRpcRequest DeserializeBatchItem(ReadOnlyMemory<byte> itemBody, out JsonDocument? requestDocument)
+    private JsonRpcRequest? TryDeserializeBatchItem(ReadOnlyMemory<byte> itemBody, out JsonDocument? requestDocument)
     {
-        if (TryReadObjectRequest(itemBody, out JsonRpcRequest? directRequest))
-        {
-            requestDocument = null;
-            return directRequest;
-        }
-
-        requestDocument = JsonDocument.Parse(itemBody);
+        requestDocument = null;
         try
         {
-            return CreateRequest(requestDocument.RootElement);
+            if (TryReadObjectRequest(itemBody, out JsonRpcRequest? directRequest))
+            {
+                return directRequest;
+            }
+
+            requestDocument = JsonDocument.Parse(itemBody);
+            if (requestDocument.RootElement.ValueKind == JsonValueKind.Object)
+            {
+                return CreateRequest(requestDocument.RootElement);
+            }
         }
-        catch
+        catch (Exception ex) when (IsRequestDecodingException(ex))
         {
-            requestDocument.Dispose();
-            requestDocument = null;
-            throw;
+            LogInvalidBatchItem(ex);
+        }
+
+        requestDocument?.Dispose();
+        requestDocument = null;
+        return null;
+    }
+
+    private JsonRpcRequest? TryCreateBatchItemRequest(JsonElement item)
+    {
+        if (item.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        try
+        {
+            return CreateRequest(item);
+        }
+        catch (Exception ex) when (IsRequestDecodingException(ex))
+        {
+            LogInvalidBatchItem(ex);
+            return null;
         }
     }
 
-    private async ValueTask WriteInvalidRequestAsync(
+    private void LogInvalidBatchItem(Exception exception)
+    {
+        if (_logger.IsDebug) _logger.Debug($"Invalid JSON-RPC batch item.{Environment.NewLine}{exception}");
+    }
+
+    private ValueTask WriteInvalidRequestAsync(
         IJsonRpcResponseSink sink,
         long startTime,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken) =>
+        WriteSingleEntryAsync(CreateInvalidRequestEntry(startTime), sink, cancellationToken);
+
+    private JsonRpcResult.Entry CreateInvalidRequestEntry(long startTime)
     {
         Metrics.JsonRpcInvalidRequests++;
         JsonRpcErrorResponse invalidResponse = _jsonRpcService.GetErrorResponse(ErrorCodes.InvalidRequest, "Invalid request");
@@ -791,8 +844,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
             _logger.Trace($"  Failed request handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
         }
 
-        JsonRpcResult.Entry result = new(invalidResponse, new RpcReport("# parsing error #", (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, false));
-        await WriteSingleEntryAsync(result, sink, cancellationToken);
+        return new(invalidResponse, new RpcReport("# parsing error #", (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, false));
     }
 
     private async ValueTask WriteShutdownResponseAsync(IJsonRpcResponseSink sink, CancellationToken cancellationToken)

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -1085,7 +1085,9 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                 // A request error is the caller's fault and costs one unauthenticated request, so it must not be able
                 // to dictate the operator's WARN volume (#13156); the line stays available at Debug. Server-side
                 // codes (-32603, -32000, timeouts, unsuppressed limits) keep WARN.
-                bool requestError = ErrorCodes.IsRequestError(responseError.Code);
+                // OperatorActionable overrides the code: -32600 also carries "namespace X is disabled for this URL",
+                // which is a statement about this node's configuration and must stay at WARN.
+                bool requestError = ErrorCodes.IsRequestError(responseError.Code) && !responseError.OperatorActionable;
                 if (requestError ? _logger.IsDebug : _logger.IsWarn)
                 {
                     string message = $"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {responseError.Code} Message: {responseError.Message}";

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -268,9 +268,8 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                             }
                         }
 
-                        // Only the decode is guarded here. The outer catch below wraps request execution too, so
-                        // widening that one would report a module-side InvalidOperationException or
-                        // ObjectDisposedException to the caller as -32700 parse error.
+                        // Decode only; see IsRequestDecodingException for why this cannot be folded into the
+                        // outer catch.
                         JsonDocument? jsonDocument = null;
                         bool undecodable = false;
                         try
@@ -336,10 +335,8 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                     }
                     catch (JsonException ex)
                     {
-                        // Deliberately NOT IsRequestDecodingException: this catch wraps request *execution* as well
-                        // as decoding, so widening it to InvalidOperationException swallows a module-side
-                        // InvalidOperationException or ObjectDisposedException and reports it to the caller as
-                        // -32700 parse error. The decode steps guard themselves instead.
+                        // Deliberately NOT IsRequestDecodingException: this catch wraps request *execution* as
+                        // well as decoding. See IsRequestDecodingException.
                         result = GetParsingError(startTime, in buffer, "Error during parsing/validation.", ex);
                         processingState.ShouldExit = true;
                     }
@@ -439,12 +436,9 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         JsonRpcRequest? directRequest;
         try
         {
-            // Only the decode is guarded. The rest of this method runs the request, and a module-side
-            // InvalidOperationException or ObjectDisposedException must not be reported as a parse error.
-            if (!TryReadSingleObjectRequest(requestBody, out directRequest))
-            {
-                directRequest = null;
-            }
+            // Decode only; see IsRequestDecodingException. TryReadSingleObjectRequest nulls the out param on
+            // entry, so the false path needs no assignment of its own.
+            _ = TryReadSingleObjectRequest(requestBody, out directRequest);
         }
         catch (Exception ex) when (IsRequestDecodingException(ex))
         {
@@ -487,10 +481,8 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
     /// <paramref name="decodeException"/> instead of being thrown.
     /// </summary>
     /// <remarks>
-    /// The guard has to sit here, around the decode alone. Wrapping the caller's whole block instead would also cover
-    /// request <em>execution</em>, and a module-side <see cref="InvalidOperationException"/> or
-    /// <see cref="ObjectDisposedException"/> would then be reported to the caller as -32700 parse error and swallowed.
-    /// This mirrors <see cref="TryDeserializeBatchItem"/> and <see cref="TryCreateBatchItemRequest"/>.
+    /// The guard has to sit around the decode alone; see <see cref="IsRequestDecodingException"/>. This mirrors
+    /// <see cref="TryDeserializeBatchItem"/> and <see cref="TryCreateBatchItemRequest"/>.
     /// </remarks>
     private static bool TryDecodeSingleObjectRequest(
         ReadOnlyMemory<byte> memory,
@@ -643,6 +635,14 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
     /// surrogate escapes inside a string value, as well as reading a non-object element as an object, surface as a bare
     /// <see cref="InvalidOperationException"/>. Both are caller input errors and must become a JSON-RPC error response
     /// instead of escaping to the transport as an unhandled exception.
+    /// <para>
+    /// Every use of this predicate wraps a <em>decode step</em> and nothing else, which is why the call sites look
+    /// repetitive. The outer catches in this file also cover request <em>execution</em>: widening one of those to
+    /// <see cref="InvalidOperationException"/> would swallow a module-side <see cref="InvalidOperationException"/> or
+    /// <see cref="ObjectDisposedException"/> and report it to the caller as -32700 parse error, hiding a real node
+    /// fault behind a client error. <see cref="ObjectDisposedException"/> derives from
+    /// <see cref="InvalidOperationException"/> and so matches here, which is correct within the decode-only scope.
+    /// </para>
     /// </remarks>
     private static bool IsRequestDecodingException(Exception exception) =>
         exception is JsonException or InvalidOperationException;
@@ -684,9 +684,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                     JsonRpcRequest request;
                     try
                     {
-                        // Invalid UTF-8 bytes and lone UTF-16 surrogate escapes inside a string value surface here as
-                        // a bare InvalidOperationException rather than a JsonException. Guard the decode, not the
-                        // execution that follows it.
+                        // Decode only; see IsRequestDecodingException.
                         request = CreateRequest(rootElement);
                     }
                     catch (Exception ex) when (IsRequestDecodingException(ex))
@@ -1061,20 +1059,44 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
 
         ValueTask<JsonRpcResponse> responseTask = _jsonRpcService.SendRequestAsync(request, context);
         return responseTask.IsCompletedSuccessfully
-            ? ValueTask.FromResult(CreateSingleRequestEntry(request, responseTask.Result, startTime))
-            : AwaitAndCreateEntryAsync(responseTask, request, startTime);
+            ? ValueTask.FromResult(CreateSingleRequestEntry(request, responseTask.Result, context, startTime))
+            : AwaitAndCreateEntryAsync(responseTask, request, context, startTime);
 
         async ValueTask<JsonRpcResult.Entry> AwaitAndCreateEntryAsync(
             ValueTask<JsonRpcResponse> responseTask,
             JsonRpcRequest request,
+            JsonRpcContext context,
             long startTime)
         {
             JsonRpcResponse response = await responseTask;
-            return CreateSingleRequestEntry(request, response, startTime);
+            return CreateSingleRequestEntry(request, response, context, startTime);
         }
     }
 
-    private JsonRpcResult.Entry CreateSingleRequestEntry(JsonRpcRequest request, JsonRpcResponse response, long startTime)
+    private static string DescribeErrorResponse(JsonRpcRequest request, Error responseError) =>
+        $"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {responseError.Code} Message: {responseError.Message}";
+
+    /// <summary>
+    /// Whether this error response describes a fault in the request rather than a condition of the node, and so must
+    /// not be able to dictate the operator's WARN volume (#13156). Demoted lines stay available at Debug.
+    /// </summary>
+    /// <remarks>
+    /// Only unauthenticated callers are demoted. The rationale for #13156 is that a client fault costs one
+    /// unauthenticated request, which does not hold for the JWT-authenticated Engine endpoint: there, -32601 is the
+    /// canonical consensus-client/execution-client version-mismatch signal and -32602 means the CL sent a payload
+    /// this node could not bind, both of which are the operator's problem and have to stay visible at default level.
+    /// <para>
+    /// Server-side codes (-32603, -32000, timeouts, unsuppressed limits) keep WARN for every caller, and
+    /// <see cref="Error.OperatorActionable"/> overrides the code: -32600 also carries "namespace X is disabled for
+    /// this URL", which is a statement about this node's configuration.
+    /// </para>
+    /// </remarks>
+    private static bool IsDemotableRequestError(Error responseError, JsonRpcContext context) =>
+        !context.IsAuthenticated
+        && ErrorCodes.IsRequestError(responseError.Code)
+        && !responseError.OperatorActionable;
+
+    private JsonRpcResult.Entry CreateSingleRequestEntry(JsonRpcRequest request, JsonRpcResponse response, JsonRpcContext context, long startTime)
     {
         bool isError = response.TryGetError(out Error? responseError);
         bool isSuccess = !isError;
@@ -1082,24 +1104,15 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         {
             if (responseError?.SuppressWarning == false)
             {
-                // A request error is the caller's fault and costs one unauthenticated request, so it must not be able
-                // to dictate the operator's WARN volume (#13156); the line stays available at Debug. Server-side
-                // codes (-32603, -32000, timeouts, unsuppressed limits) keep WARN.
-                // OperatorActionable overrides the code: -32600 also carries "namespace X is disabled for this URL",
-                // which is a statement about this node's configuration and must stay at WARN.
-                bool requestError = ErrorCodes.IsRequestError(responseError.Code) && !responseError.OperatorActionable;
-                if (requestError ? _logger.IsDebug : _logger.IsWarn)
+                if (IsDemotableRequestError(responseError, context))
                 {
-                    string message = $"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {responseError.Code} Message: {responseError.Message}";
-                    if (requestError)
-                    {
-                        _logger.Debug(message);
-                    }
-                    else
-                    {
-                        _logger.Warn(message);
-                    }
+                    if (_logger.IsDebug) _logger.Debug(DescribeErrorResponse(request, responseError));
                 }
+                else
+                {
+                    if (_logger.IsWarn) _logger.Warn(DescribeErrorResponse(request, responseError));
+                }
+
                 if (_logger.IsTrace) _logger.Trace($"Error when handling {request} | {SerializeResponseForDiagnostics(response)}");
             }
             Metrics.JsonRpcErrors++;

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -232,7 +232,18 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                             isCompleted &&
                             buffer.IsSingleSegment)
                         {
-                            if (TryReadSingleObjectRequest(buffer.First, out JsonRpcRequest? directRequest))
+                            if (!TryDecodeSingleObjectRequest(buffer.First, out JsonRpcRequest? directRequest, out Exception? decodeException)
+                                && decodeException is not null)
+                            {
+                                result = GetParsingError(startTime, in buffer, "Error during parsing/validation.", decodeException);
+                                processingState.ShouldExit = true;
+                                reader.AdvanceTo(buffer.End);
+                                advanced = true;
+                                await WriteSingleEntryAsync(result.Value, sink, cancellationToken);
+                                return;
+                            }
+
+                            if (directRequest is not null)
                             {
                                 processingState.ShouldExit = true;
 
@@ -257,8 +268,28 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                             }
                         }
 
-                        processingState.FreshState = TryParseJson(ref buffer, isCompleted, ref processingState.ReaderState, out JsonDocument? jsonDocument, options);
-                        if (processingState.FreshState)
+                        // Only the decode is guarded here. The outer catch below wraps request execution too, so
+                        // widening that one would report a module-side InvalidOperationException or
+                        // ObjectDisposedException to the caller as -32700 parse error.
+                        JsonDocument? jsonDocument = null;
+                        bool undecodable = false;
+                        try
+                        {
+                            processingState.FreshState = TryParseJson(ref buffer, isCompleted, ref processingState.ReaderState, out jsonDocument, options);
+                        }
+                        catch (Exception ex) when (IsRequestDecodingException(ex))
+                        {
+                            result = GetParsingError(startTime, in buffer, "Error during parsing/validation.", ex);
+                            processingState.ShouldExit = true;
+                            undecodable = true;
+                            if (!advanced)
+                            {
+                                reader.AdvanceTo(buffer.End);
+                                advanced = true;
+                            }
+                        }
+
+                        if (!undecodable && processingState.FreshState)
                         {
                             if (options.InputMode == JsonRpcInputMode.SingleDocument)
                             {
@@ -281,7 +312,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                                 await ProcessJsonDocumentToSink(jsonDocument, context, sink, options, startTime, cancellationToken);
                             }
                         }
-                        else if (isCompleted && !buffer.IsEmpty)
+                        else if (!undecodable && isCompleted && !buffer.IsEmpty)
                         {
                             result = GetParsingError(startTime, in buffer, "Error during parsing/validation: incomplete request.");
                             processingState.ShouldExit = true;
@@ -303,8 +334,12 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                         Handle(e);
                         processingState.ShouldExit = true;
                     }
-                    catch (Exception ex) when (IsRequestDecodingException(ex))
+                    catch (JsonException ex)
                     {
+                        // Deliberately NOT IsRequestDecodingException: this catch wraps request *execution* as well
+                        // as decoding, so widening it to InvalidOperationException swallows a module-side
+                        // InvalidOperationException or ObjectDisposedException and reports it to the caller as
+                        // -32700 parse error. The decode steps guard themselves instead.
                         result = GetParsingError(startTime, in buffer, "Error during parsing/validation.", ex);
                         processingState.ShouldExit = true;
                     }
@@ -401,25 +436,77 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         CancellationToken cancellationToken)
     {
         long startTime = Stopwatch.GetTimestamp();
+        JsonRpcRequest? directRequest;
         try
         {
-            if (TryReadSingleObjectRequest(requestBody, out JsonRpcRequest? directRequest))
+            // Only the decode is guarded. The rest of this method runs the request, and a module-side
+            // InvalidOperationException or ObjectDisposedException must not be reported as a parse error.
+            if (!TryReadSingleObjectRequest(requestBody, out directRequest))
             {
-                await ProcessSingleRequestToSink(directRequest, context, sink, cancellationToken);
-                return;
+                directRequest = null;
             }
-
-            if (await TryProcessBatchRequestDirectly(requestBody, context, sink, cancellationToken))
-            {
-                return;
-            }
-
-            PipeReader reader = PipeReader.Create(new ReadOnlySequence<byte>(requestBody));
-            await ProcessCoreAsync(reader, context, sink, options, timeoutSource: null, timeoutToken: CancellationToken.None, cancellationToken, recordRequest: false);
         }
         catch (Exception ex) when (IsRequestDecodingException(ex))
         {
             await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
+            return;
+        }
+
+        if (directRequest is not null)
+        {
+            await ProcessSingleRequestToSink(directRequest, context, sink, cancellationToken);
+            return;
+        }
+
+        try
+        {
+            if (await TryProcessBatchRequestDirectly(requestBody, context, sink, cancellationToken))
+            {
+                return;
+            }
+        }
+        catch (JsonException ex)
+        {
+            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
+            return;
+        }
+
+        try
+        {
+            PipeReader reader = PipeReader.Create(new ReadOnlySequence<byte>(requestBody));
+            await ProcessCoreAsync(reader, context, sink, options, timeoutSource: null, timeoutToken: CancellationToken.None, cancellationToken, recordRequest: false);
+        }
+        catch (JsonException ex)
+        {
+            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
+        }
+    }
+
+    /// <summary>
+    /// Decode-only wrapper around <see cref="TryReadSingleObjectRequest"/>: a decoding failure is reported through
+    /// <paramref name="decodeException"/> instead of being thrown.
+    /// </summary>
+    /// <remarks>
+    /// The guard has to sit here, around the decode alone. Wrapping the caller's whole block instead would also cover
+    /// request <em>execution</em>, and a module-side <see cref="InvalidOperationException"/> or
+    /// <see cref="ObjectDisposedException"/> would then be reported to the caller as -32700 parse error and swallowed.
+    /// This mirrors <see cref="TryDeserializeBatchItem"/> and <see cref="TryCreateBatchItemRequest"/>.
+    /// </remarks>
+    private static bool TryDecodeSingleObjectRequest(
+        ReadOnlyMemory<byte> memory,
+        out JsonRpcRequest? request,
+        out Exception? decodeException)
+    {
+        decodeException = null;
+        try
+        {
+            return TryReadSingleObjectRequest(memory, out request);
+        }
+        catch (Exception ex) when (IsRequestDecodingException(ex))
+        {
+            request = null;
+            decodeException = ex;
+            return false;
         }
     }
 
@@ -594,7 +681,23 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
             switch (rootElement.ValueKind)
             {
                 case JsonValueKind.Object:
-                    JsonRpcRequest request = CreateRequest(rootElement);
+                    JsonRpcRequest request;
+                    try
+                    {
+                        // Invalid UTF-8 bytes and lone UTF-16 surrogate escapes inside a string value surface here as
+                        // a bare InvalidOperationException rather than a JsonException. Guard the decode, not the
+                        // execution that follows it.
+                        request = CreateRequest(rootElement);
+                    }
+                    catch (Exception ex) when (IsRequestDecodingException(ex))
+                    {
+                        // -32700, not -32600: the bytes never decoded into a request, so there is nothing to
+                        // call invalid. The raw buffer is not available here (the document is already parsed),
+                        // and GetParsingError only uses it to enrich the debug log.
+                        await WriteParsingErrorAsync(default, sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
+                        break;
+                    }
+
                     if (_logger.IsDebug) DebugRequest(request);
 
                     JsonRpcResult.Entry singleResponse = await HandleSingleRequest(request, context);

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -1082,7 +1082,22 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         {
             if (responseError?.SuppressWarning == false)
             {
-                if (_logger.IsWarn) _logger.Warn($"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {responseError.Code} Message: {responseError.Message}");
+                // A request error is the caller's fault and costs one unauthenticated request, so it must not be able
+                // to dictate the operator's WARN volume (#13156); the line stays available at Debug. Server-side
+                // codes (-32603, -32000, timeouts, unsuppressed limits) keep WARN.
+                bool requestError = ErrorCodes.IsRequestError(responseError.Code);
+                if (requestError ? _logger.IsDebug : _logger.IsWarn)
+                {
+                    string message = $"Error response handling JsonRpc Id:{request.Id} Method:{request.Method} | Code: {responseError.Code} Message: {responseError.Message}";
+                    if (requestError)
+                    {
+                        _logger.Debug(message);
+                    }
+                    else
+                    {
+                        _logger.Warn(message);
+                    }
+                }
                 if (_logger.IsTrace) _logger.Trace($"Error when handling {request} | {SerializeResponseForDiagnostics(response)}");
             }
             Metrics.JsonRpcErrors++;

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -298,7 +298,9 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         catch (Exception e)
         {
             ReturnParameters(parameters, returnParametersToPool);
-            if (_logger.IsWarn) _logger.Warn($"Incorrect JSON RPC parameters when calling {methodName} with params [{GetParamsForLog(request)}] {e}");
+            // Caller-supplied params that fail to bind are answered with -32602; the echo of the params and the
+            // exception (with its stack trace) is Debug-only detail, not an operator warning (#13156).
+            if (_logger.IsDebug) _logger.Debug($"Incorrect JSON RPC parameters when calling {methodName} with params [{GetParamsForLog(request)}] {e}");
             string message = GetSafePublicMessage(e) ?? "Invalid params";
             return GetErrorResponse(methodName, ErrorCodes.InvalidParams, message, null, in request.IdRef);
         }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -39,11 +39,17 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
 
     public ValueTask<JsonRpcResponse> SendRequestAsync(JsonRpcRequest rpcRequest, JsonRpcContext context)
     {
-        (int? errorCode, string? errorMessage, string methodName, ResolvedMethodInfo? method) = Validate(rpcRequest, context);
+        (int? errorCode, string? errorMessage, string methodName, ResolvedMethodInfo? method, bool operatorActionable) = Validate(rpcRequest, context);
         if (errorCode.HasValue)
         {
             if (_logger.IsDebug) _logger.Debug($"Validation error when handling request: {rpcRequest}");
-            return ValueTask.FromResult<JsonRpcResponse>(GetErrorResponse(methodName, errorCode.Value, errorMessage, null, in rpcRequest.IdRef));
+            JsonRpcErrorResponse errorResponse = GetErrorResponse(methodName, errorCode.Value, errorMessage, null, in rpcRequest.IdRef);
+            if (operatorActionable && errorResponse.Error is not null)
+            {
+                errorResponse.Error.OperatorActionable = true;
+            }
+
+            return ValueTask.FromResult<JsonRpcResponse>(errorResponse);
         }
 
         try
@@ -1017,17 +1023,17 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         return response;
     }
 
-    private (int? ErrorType, string? ErrorMessage, string MethodName, ResolvedMethodInfo? Method) Validate(JsonRpcRequest? rpcRequest, JsonRpcContext context)
+    private (int? ErrorType, string? ErrorMessage, string MethodName, ResolvedMethodInfo? Method, bool OperatorActionable) Validate(JsonRpcRequest? rpcRequest, JsonRpcContext context)
     {
         if (rpcRequest is null)
         {
-            return (ErrorCodes.InvalidRequest, "Invalid request", string.Empty, null);
+            return (ErrorCodes.InvalidRequest, "Invalid request", string.Empty, null, false);
         }
 
         string methodName = rpcRequest.Method;
         if (string.IsNullOrWhiteSpace(methodName))
         {
-            return (ErrorCodes.InvalidRequest, "Method is required", methodName, null);
+            return (ErrorCodes.InvalidRequest, "Method is required", methodName, null, false);
         }
 
         string trimmedMethodName = methodName.Trim();
@@ -1035,22 +1041,26 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         ModuleResolution result = _rpcModuleProvider.Check(trimmedMethodName, context, out string? module, out ResolvedMethodInfo? method);
         if (result == ModuleResolution.Enabled)
         {
-            return (null, null, trimmedMethodName, method);
+            return (null, null, trimmedMethodName, method, false);
         }
 
-        (int? errorType, string errorMessage) = GetErrorResult(trimmedMethodName, context, result, module);
-        return (errorType, errorMessage, methodName, null);
+        (int? errorType, string errorMessage, bool operatorActionable) = GetErrorResult(trimmedMethodName, context, result, module);
+        return (errorType, errorMessage, methodName, null, operatorActionable);
 
+        // OperatorActionable is decided here, at the only place that knows *why* the request failed. A namespace
+        // that is disabled for this URL or this endpoint is a fact about the node's configuration, not about the
+        // request, and its message tells the operator how to fix it - so it must not be demoted with the rest of
+        // the -32600 traffic. Unknown methods and failed authentication are genuine caller faults.
         [MethodImpl(MethodImplOptions.NoInlining)]
-        static (int? ErrorType, string ErrorMessage) GetErrorResult(string methodName, JsonRpcContext context, ModuleResolution result, string module) => result switch
+        static (int? ErrorType, string ErrorMessage, bool OperatorActionable) GetErrorResult(string methodName, JsonRpcContext context, ModuleResolution result, string module) => result switch
         {
-            ModuleResolution.Unknown => (ErrorCodes.MethodNotFound, ErrorMessages.MethodNotFound(methodName)),
+            ModuleResolution.Unknown => (ErrorCodes.MethodNotFound, ErrorMessages.MethodNotFound(methodName), false),
             ModuleResolution.Disabled => (ErrorCodes.InvalidRequest,
-                $"The method '{methodName}' is found but the namespace '{module}' is disabled for {context.Url?.ToString() ?? "n/a"}. Consider adding the namespace '{module}' to JsonRpc.AdditionalRpcUrls for an additional URL, or to JsonRpc.EnabledModules for the default URL."),
+                $"The method '{methodName}' is found but the namespace '{module}' is disabled for {context.Url?.ToString() ?? "n/a"}. Consider adding the namespace '{module}' to JsonRpc.AdditionalRpcUrls for an additional URL, or to JsonRpc.EnabledModules for the default URL.", true),
             ModuleResolution.EndpointDisabled => (ErrorCodes.InvalidRequest,
-                $"The method '{methodName}' is found in namespace '{module}' for {context.Url?.ToString() ?? "n/a"}' but is disabled for {context.RpcEndpoint}."),
-            ModuleResolution.NotAuthenticated => (ErrorCodes.InvalidRequest, $"The method '{methodName}' must be authenticated."),
-            _ => (null, null)
+                $"The method '{methodName}' is found in namespace '{module}' for {context.Url?.ToString() ?? "n/a"}' but is disabled for {context.RpcEndpoint}.", true),
+            ModuleResolution.NotAuthenticated => (ErrorCodes.InvalidRequest, $"The method '{methodName}' must be authenticated.", false),
+            _ => (null, null, false)
         };
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -591,14 +591,14 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             // "invalid params" (or a generic internal error) for history the node does not hold reads as a
             // retry-forever signal to indexers. EIP-4444 defines the accurate code.
             ResourceNotFoundException or TargetInvocationException { InnerException: ResourceNotFoundException } =>
-                GetErrorResponse(methodName, ErrorCodes.PrunedHistoryUnavailable,
-                    ErrorMessages.PrunedHistoryUnavailable, GetExceptionText(ex), in request.IdRef, returnAction),
+                KeepTrace(ex, GetErrorResponse(methodName, ErrorCodes.PrunedHistoryUnavailable,
+                    ErrorMessages.PrunedHistoryUnavailable, GetExceptionText(ex), in request.IdRef, returnAction)),
 
             TargetParameterCountException or ArgumentException =>
-                GetErrorResponse(methodName, ErrorCodes.InvalidParams, ex.Message, GetExceptionText(ex), in request.IdRef, returnAction),
+                KeepTrace(ex, GetErrorResponse(methodName, ErrorCodes.InvalidParams, ex.Message, GetExceptionText(ex), in request.IdRef, returnAction)),
 
             JsonException or TargetInvocationException and { InnerException: JsonException } =>
-                GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", GetExceptionText(ex), in request.IdRef, returnAction),
+                KeepTrace(ex, GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", GetExceptionText(ex), in request.IdRef, returnAction)),
 
             OperationCanceledException or { InnerException: OperationCanceledException } =>
                 GetErrorResponse(methodName, ErrorCodes.Timeout,
@@ -612,7 +612,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
                 GetErrorResponse(methodName, ErrorCodes.LimitExceeded, "Too many requests", null, in request.IdRef, returnAction, suppressWarning: true),
 
             InsufficientBalanceException or { InnerException: InsufficientBalanceException } =>
-                GetErrorResponse(methodName, ErrorCodes.InvalidInput, GetInsufficientBalanceMessage(ex), GetExceptionText(ex), in request.IdRef, returnAction),
+                KeepTrace(ex, GetErrorResponse(methodName, ErrorCodes.InvalidInput, GetInsufficientBalanceMessage(ex), GetExceptionText(ex), in request.IdRef, returnAction)),
 
             InvalidTransactionException or { InnerException: InvalidTransactionException } when (ex as InvalidTransactionException ?? ex.InnerException as InvalidTransactionException) is { Reason.ErrorDescription: var description } =>
                 GetErrorResponse(methodName, ErrorCodes.Default, description, null, in request.IdRef, returnAction),
@@ -629,6 +629,16 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             _ => HandleException(ex, methodName, request, returnAction)
         };
 
+        // GetExceptionText drops the stack trace from error.data on purpose, so the arms that answer with it and log
+        // nothing else of their own would leave the trace recoverable nowhere - a diagnosis regression, not part of
+        // the leak fix. Debug, because those arms are the caller's fault (#13156). HandleException logs at Error for
+        // itself and is deliberately not routed through here: a second line would be duplicate, not detail.
+        JsonRpcErrorResponse KeepTrace(Exception ex, JsonRpcErrorResponse response)
+        {
+            _logger.DebugError($"Exception during {methodName} execution", ex);
+            return response;
+        }
+
         JsonRpcErrorResponse HandleException(Exception ex, string methodName, JsonRpcRequest request, Action? returnAction)
         {
             if (_logger.IsError) _logger.Error($"Error during method execution, request: {DescribeForErrorLog(request, ex)}", ex);
@@ -644,7 +654,8 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             // after a successful guard. Surface as -32000 (Geth wire parity) and warn so operators
             // can investigate whether it's a legitimate pruning gap or a deeper issue.
             if (_logger.IsWarn) _logger.Warn($"Missing trie node during {methodName}: {ex.Message}");
-            return GetErrorResponse(methodName, ErrorCodes.ResourceNotFound, ex.Message, GetExceptionText(ex), in request.IdRef, returnAction);
+            // The Warn above carries the message but not the exception, so the trace still needs KeepTrace.
+            return KeepTrace(ex, GetErrorResponse(methodName, ErrorCodes.ResourceNotFound, ex.Message, GetExceptionText(ex), in request.IdRef, returnAction));
         }
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -304,12 +304,42 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         catch (Exception e)
         {
             ReturnParameters(parameters, returnParametersToPool);
+            // A fault the params cannot cause is a condition of this node, and the catch is deliberately broad
+            // enough to swallow one. It keeps the operator's line, and marks the response so the processor does
+            // not demote it either - -32602 alone would otherwise read as the caller's fault at both sites.
+            if (IsNodeFault(e))
+            {
+                // Formatting the params would allocate on an already exhausted heap, so they are omitted and the
+                // exception is passed to the logger rather than interpolated (same reason as DescribeForErrorLog).
+                if (_logger.IsError) _logger.Error($"Failed to bind JSON RPC parameters for {methodName}", e);
+                JsonRpcErrorResponse nodeFault = GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", null, in request.IdRef);
+                if (nodeFault.Error is not null) nodeFault.Error.OperatorActionable = true;
+                return nodeFault;
+            }
+
             // Caller-supplied params that fail to bind are answered with -32602; the echo of the params and the
             // exception (with its stack trace) is Debug-only detail, not an operator warning (#13156).
             if (_logger.IsDebug) _logger.Debug($"Incorrect JSON RPC parameters when calling {methodName} with params [{GetParamsForLog(request)}] {e}");
             string message = GetSafePublicMessage(e) ?? "Invalid params";
             return GetErrorResponse(methodName, ErrorCodes.InvalidParams, message, null, in request.IdRef);
         }
+    }
+
+    /// <summary>
+    /// Whether the fault is a condition of this node rather than something the caller's params can cause.
+    /// </summary>
+    /// <remarks>
+    /// A deny-list of two, not an allow-list of expected binding failures: a converter can throw anything, and
+    /// promoting an unanticipated caller-fault type back into a per-request WARN is what #13156 was about.
+    /// </remarks>
+    private static bool IsNodeFault(Exception e)
+    {
+        for (Exception? ex = e; ex is not null; ex = ex.InnerException)
+        {
+            if (ex is OutOfMemoryException or ObjectDisposedException) return true;
+        }
+
+        return false;
     }
 
     private JsonRpcErrorResponse? PrepareUtf8Parameters(

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -30,6 +30,7 @@ namespace Nethermind.JsonRpc;
 public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogManager logManager, IJsonRpcConfig jsonRpcConfig) : IJsonRpcService
 {
     private const int MaxPooledParameterCount = 8;
+    private const int MaxReportedExceptionChainDepth = 8;
 
     private readonly ILogger _logger = logManager.GetClassLogger<JsonRpcService>();
     private readonly IRpcModuleProvider _rpcModuleProvider = rpcModuleProvider;
@@ -88,7 +89,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         };
 
         if (!suppressWarning && _logger.IsError) _logger.Error($"Error during method execution, request: {DescribeForErrorLog(rpcRequest, ex)}", ex);
-        return GetErrorResponse(rpcRequest.Method, errorCode, errorText, suppressWarning ? null : ex.ToString(), in rpcRequest.IdRef, suppressWarning: suppressWarning);
+        return GetErrorResponse(rpcRequest.Method, errorCode, errorText, suppressWarning ? null : GetExceptionText(ex), in rpcRequest.IdRef, suppressWarning: suppressWarning);
     }
 
     // Formatting the request parses and stringifies its params, which for engine_newPayload is a
@@ -556,7 +557,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
                     ErrorMessages.PrunedHistoryUnavailable, GetExceptionText(ex), in request.IdRef, returnAction),
 
             TargetParameterCountException or ArgumentException =>
-                GetErrorResponse(methodName, ErrorCodes.InvalidParams, ex.Message, ex.ToString(), in request.IdRef, returnAction),
+                GetErrorResponse(methodName, ErrorCodes.InvalidParams, ex.Message, GetExceptionText(ex), in request.IdRef, returnAction),
 
             JsonException or TargetInvocationException and { InnerException: JsonException } =>
                 GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", GetExceptionText(ex), in request.IdRef, returnAction),
@@ -573,7 +574,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
                 GetErrorResponse(methodName, ErrorCodes.LimitExceeded, "Too many requests", null, in request.IdRef, returnAction, suppressWarning: true),
 
             InsufficientBalanceException or { InnerException: InsufficientBalanceException } =>
-                GetErrorResponse(methodName, ErrorCodes.InvalidInput, GetInsufficientBalanceMessage(ex), ex.ToString(), in request.IdRef, returnAction),
+                GetErrorResponse(methodName, ErrorCodes.InvalidInput, GetInsufficientBalanceMessage(ex), GetExceptionText(ex), in request.IdRef, returnAction),
 
             InvalidTransactionException or { InnerException: InvalidTransactionException } when (ex as InvalidTransactionException ?? ex.InnerException as InvalidTransactionException) is { Reason.ErrorDescription: var description } =>
                 GetErrorResponse(methodName, ErrorCodes.Default, description, null, in request.IdRef, returnAction),
@@ -593,10 +594,8 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         JsonRpcErrorResponse HandleException(Exception ex, string methodName, JsonRpcRequest request, Action? returnAction)
         {
             if (_logger.IsError) _logger.Error($"Error during method execution, request: {DescribeForErrorLog(request, ex)}", ex);
-            return GetErrorResponse(methodName, ErrorCodes.InternalError, "Internal error", ex.ToString(), in request.IdRef, returnAction);
+            return GetErrorResponse(methodName, ErrorCodes.InternalError, "Internal error", GetExceptionText(ex), in request.IdRef, returnAction);
         }
-
-        static string GetExceptionText(Exception ex) => (ex as TargetInvocationException)?.InnerException?.ToString() ?? ex.ToString();
 
         static string GetInsufficientBalanceMessage(Exception ex) =>
             (ex as InsufficientBalanceException ?? ex.InnerException as InsufficientBalanceException)!.Message;
@@ -607,8 +606,27 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             // after a successful guard. Surface as -32000 (Geth wire parity) and warn so operators
             // can investigate whether it's a legitimate pruning gap or a deeper issue.
             if (_logger.IsWarn) _logger.Warn($"Missing trie node during {methodName}: {ex.Message}");
-            return GetErrorResponse(methodName, ErrorCodes.ResourceNotFound, ex.Message, ex.ToString(), in request.IdRef, returnAction);
+            return GetErrorResponse(methodName, ErrorCodes.ResourceNotFound, ex.Message, GetExceptionText(ex), in request.IdRef, returnAction);
         }
+    }
+
+    /// <summary>Renders an exception chain for <c>error.data</c> without exposing its stack trace.</summary>
+    /// <remarks>
+    /// <c>error.data</c> is returned to unauthenticated callers, and <see cref="Exception.ToString"/> embeds the
+    /// stack trace, which these builds render with the build machine's absolute source paths and with the internal
+    /// call graph. Only the chain's types and messages are reported here; the full trace is written to the node log.
+    /// </remarks>
+    private static string GetExceptionText(Exception ex)
+    {
+        StringBuilder text = new();
+        Exception? current = (ex as TargetInvocationException)?.InnerException ?? ex;
+        for (int depth = 0; current is not null && depth < MaxReportedExceptionChainDepth; current = current.InnerException, depth++)
+        {
+            if (text.Length != 0) text.Append(" ---> ");
+            text.Append(current.GetType()).Append(": ").Append(current.Message);
+        }
+
+        return text.ToString();
     }
 
     private void LogRequest(string methodName, JsonElement providedParameters, ExpectedParameter[] expectedParameters)

--- a/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
@@ -227,10 +227,32 @@ public class StartupTests
                 contentLength: null),
             Throws.InstanceOf<ConnectionResetException>());
 
+    // A transport failure Kestrel surfaces as a *derived* IOException must keep propagating rather than being
+    // reframed as a client error: doing so would blame the caller for a broken connection and, because the 400
+    // handler logs at Debug, would leave a real I/O failure with no trace at default log level. The catch tests the
+    // exact type for this reason - a bare IOException is how Kestrel reports malformed chunk framing.
+    private sealed class DerivedIOException(string message) : IOException(message);
+
+    [Test]
+    public void ProcessJsonRpcRequest_BodyReadThrowsDerivedIOException_is_not_reframed_as_a_client_error() =>
+        Assert.That(async () => await ProcessJsonRpcRequestWithStatus(
+                new ThrowingReadStream(new DerivedIOException("The request stream was aborted.")),
+                contentLength: null),
+            Throws.InstanceOf<DerivedIOException>());
+
+    // 0x7fffffff is a legitimate chunk size, so it reaches Kestrel's MinRequestBodyDataRate timeout rather than
+    // anything this PR touches - the point of the case is that the fix does not over-catch and turn it into a 400.
+    // Explicit because it can only reach the 408 after that grace period plus a heartbeat tick elapse, which makes
+    // it a multi-second wall-clock test that depends on the runner not being starved. The narrowing itself is
+    // pinned instantly by the two IOException propagation tests above.
+    [Explicit("~5s: waits out Kestrel's MinRequestBodyDataRate grace period")]
+    [TestCase("7fffffff", StatusCodes.Status408RequestTimeout, TestName = "Chunk size int.MaxValue never completes")]
+    public Task Kestrel_ValidButUnfulfilledChunkSize_StillTimesOut(string chunkSizeLine, int expectedStatusCode) =>
+        Kestrel_MalformedChunkedRequestBody_ReturnsFramedJsonRpcError(chunkSizeLine, expectedStatusCode);
+
     [TestCase("80000000", StatusCodes.Status400BadRequest, TestName = "Chunk size int.MaxValue + 1")]
     [TestCase("ffffffff", StatusCodes.Status400BadRequest, TestName = "Chunk size uint.MaxValue")]
     [TestCase("zzz", StatusCodes.Status400BadRequest, TestName = "Non-hex chunk size")]
-    [TestCase("7fffffff", StatusCodes.Status408RequestTimeout, TestName = "Chunk size int.MaxValue never completes")]
     public async Task Kestrel_MalformedChunkedRequestBody_ReturnsFramedJsonRpcError(string chunkSizeLine, int expectedStatusCode)
     {
         await using KestrelJsonRpcHost host = await KestrelJsonRpcHost.StartAsync(Startup, CreateUrl());

--- a/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
@@ -10,12 +10,20 @@ using System.IO;
 using System.IO.Abstractions;
 using System.IO.Pipelines;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Nethermind.Core;
 using Nethermind.Core.Authentication;
 using Nethermind.JsonRpc;
@@ -173,6 +181,37 @@ public class StartupTests
 
         Assert.That(statusCode, Is.EqualTo(StatusCodes.Status413PayloadTooLarge));
         AssertErrorCodeResponse(response, ErrorCodes.LimitExceeded);
+    }
+
+    [Test]
+    public async Task ProcessJsonRpcRequest_BodyReadThrowsIOException_ReturnsBadRequestFramedError()
+    {
+        // Kestrel reports a chunk-size line that overflows Int32 (e.g. "80000000") as a plain
+        // IOException rather than a BadHttpRequestException.
+        (string response, int statusCode) = await ProcessJsonRpcRequestWithStatus(
+            new ThrowingReadStream(new IOException("Bad chunk size data.")),
+            contentLength: null);
+
+        Assert.That(statusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+        AssertErrorCodeResponse(response, ErrorCodes.InvalidRequest);
+    }
+
+    [TestCase("80000000", StatusCodes.Status400BadRequest, TestName = "Chunk size int.MaxValue + 1")]
+    [TestCase("ffffffff", StatusCodes.Status400BadRequest, TestName = "Chunk size uint.MaxValue")]
+    [TestCase("zzz", StatusCodes.Status400BadRequest, TestName = "Non-hex chunk size")]
+    [TestCase("7fffffff", StatusCodes.Status408RequestTimeout, TestName = "Chunk size int.MaxValue never completes")]
+    public async Task Kestrel_MalformedChunkedRequestBody_ReturnsFramedJsonRpcError(string chunkSizeLine, int expectedStatusCode)
+    {
+        await using KestrelJsonRpcHost host = await KestrelJsonRpcHost.StartAsync(Startup, CreateUrl());
+        byte[] request = Encoding.ASCII.GetBytes(
+            "POST / HTTP/1.1\r\nHost: h\r\nContent-Type: application/json\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n"
+            + chunkSizeLine + "\r\n" + CreateJsonRpcRequest());
+
+        (int statusCode, string body) = await host.SendRawAsync(request);
+
+        Assert.That(statusCode, Is.EqualTo(expectedStatusCode));
+        Assert.That(body, Is.Not.Empty, "Expected a framed JSON-RPC error body");
+        AssertErrorCodeResponse(body, ErrorCodes.InvalidRequest);
     }
 
     [Test]
@@ -480,17 +519,31 @@ public class StartupTests
         bool isAuthenticated = false)
     {
         byte[] requestBytes = Encoding.UTF8.GetBytes(request);
+        return await ProcessJsonRpcRequestWithStatus(
+            new MemoryStream(requestBytes),
+            setContentLength ? requestBytes.Length : null,
+            maxRequestBodySize,
+            startup,
+            isAuthenticated);
+    }
 
+    private static async Task<(string Response, int StatusCode)> ProcessJsonRpcRequestWithStatus(
+        Stream body,
+        long? contentLength,
+        long? maxRequestBodySize = null,
+        Startup? startup = null,
+        bool isAuthenticated = false)
+    {
         DefaultHttpContext ctx = new()
         {
             Request =
             {
                 Method = "POST",
                 ContentType = "application/json",
-                Body = new MemoryStream(requestBytes)
+                Body = body
             }
         };
-        if (setContentLength) ctx.Request.ContentLength = requestBytes.Length;
+        if (contentLength is not null) ctx.Request.ContentLength = contentLength;
 
         ctx.Request.Headers.Authorization = "Bearer test";
         MemoryStream responseBody = new();
@@ -666,6 +719,132 @@ public class StartupTests
             await writer.FlushAsync(cancellationToken);
             onFlushed?.Invoke();
             writer.Write("]"u8);
+        }
+    }
+
+    private sealed class ThrowingReadStream(Exception exception) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw exception;
+        public override int Read(Span<byte> buffer) => throw exception;
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) => Task.FromException<int>(exception);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => ValueTask.FromException<int>(exception);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Real Kestrel listener on a loopback ephemeral port routing every request to
+    /// <see cref="Startup.ProcessJsonRpcRequestCoreAsync"/>, so tests can exercise Kestrel's own
+    /// HTTP/1.1 framing (chunk parsing, body data-rate timeouts) which <c>DefaultHttpContext</c> bypasses.
+    /// </summary>
+    private sealed class KestrelJsonRpcHost(IHost host, int port) : IAsyncDisposable
+    {
+        private static readonly TimeSpan ResponseTimeout = TimeSpan.FromSeconds(30);
+
+        public static async Task<KestrelJsonRpcHost> StartAsync(Startup startup, JsonRpcUrl url)
+        {
+            IHost host = new HostBuilder()
+                .ConfigureWebHost(webHost => webHost
+                    .UseKestrel(static options =>
+                    {
+                        options.Listen(IPAddress.Loopback, 0);
+                        // Kestrel requires a grace period above its 1 s heartbeat; keep it short so a body that never completes times out quickly.
+                        options.Limits.MinRequestBodyDataRate = new MinDataRate(bytesPerSecond: 240, gracePeriod: TimeSpan.FromSeconds(2));
+                    })
+                    .Configure(app => app.Run(ctx => startup.ProcessJsonRpcRequestCoreAsync(ctx, url))))
+                .Build();
+            await host.StartAsync();
+
+            int port = 0;
+            foreach (string address in host.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>()!.Addresses)
+            {
+                port = new Uri(address).Port;
+            }
+
+            return new KestrelJsonRpcHost(host, port);
+        }
+
+        public async Task<(int StatusCode, string Body)> SendRawAsync(byte[] request)
+        {
+            using TcpClient client = new();
+            await client.ConnectAsync(IPAddress.Loopback, port);
+            using NetworkStream stream = client.GetStream();
+            await stream.WriteAsync(request);
+
+            using CancellationTokenSource cts = new(ResponseTimeout);
+            StringBuilder raw = new();
+            byte[] buffer = new byte[16 * 1024];
+            string? headers = null;
+            string body = string.Empty;
+            while (true)
+            {
+                int read = await stream.ReadAsync(buffer, cts.Token);
+                if (read == 0) break;
+
+                // Latin-1 keeps byte count == char count, so Content-Length arithmetic works on the string.
+                raw.Append(Encoding.Latin1.GetString(buffer, 0, read));
+                string received = raw.ToString();
+                int headersEnd = received.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+                if (headersEnd < 0) continue;
+
+                headers = received[..headersEnd];
+                body = received[(headersEnd + 4)..];
+                if (IsBodyComplete(headers, body)) break;
+            }
+
+            Assert.That(headers, Is.Not.Null, $"Incomplete HTTP response: {raw}");
+            int statusCode = int.Parse(headers.Split(' ', 3)[1]);
+            if (IsChunked(headers)) body = Dechunk(body);
+            return (statusCode, body);
+        }
+
+        private static bool IsChunked(string headers) =>
+            headers.Contains("Transfer-Encoding: chunked", StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsBodyComplete(string headers, string body)
+        {
+            if (IsChunked(headers)) return body.EndsWith("0\r\n\r\n", StringComparison.Ordinal);
+
+            const string contentLengthHeader = "Content-Length: ";
+            int index = headers.IndexOf(contentLengthHeader, StringComparison.OrdinalIgnoreCase);
+            if (index < 0) return false;
+
+            int valueStart = index + contentLengthHeader.Length;
+            int valueEnd = headers.IndexOf("\r\n", valueStart, StringComparison.Ordinal);
+            long contentLength = long.Parse(valueEnd < 0 ? headers[valueStart..] : headers[valueStart..valueEnd]);
+            return body.Length >= contentLength;
+        }
+
+        private static string Dechunk(string chunked)
+        {
+            StringBuilder result = new();
+            int position = 0;
+            while (true)
+            {
+                int lineEnd = chunked.IndexOf("\r\n", position, StringComparison.Ordinal);
+                if (lineEnd < 0) break;
+
+                int size = Convert.ToInt32(chunked[position..lineEnd], 16);
+                if (size == 0) break;
+
+                result.Append(chunked, lineEnd + 2, size);
+                position = lineEnd + 2 + size + 2;
+            }
+
+            return result.ToString();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await host.StopAsync();
+            host.Dispose();
         }
     }
 

--- a/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
@@ -246,14 +246,14 @@ public class StartupTests
     // it a multi-second wall-clock test that depends on the runner not being starved. The narrowing itself is
     // pinned instantly by the two IOException propagation tests above.
     [Explicit("~5s: waits out Kestrel's MinRequestBodyDataRate grace period")]
-    [TestCase("7fffffff", StatusCodes.Status408RequestTimeout, TestName = "Chunk size int.MaxValue never completes")]
-    public Task Kestrel_ValidButUnfulfilledChunkSize_StillTimesOut(string chunkSizeLine, int expectedStatusCode) =>
-        Kestrel_MalformedChunkedRequestBody_ReturnsFramedJsonRpcError(chunkSizeLine, expectedStatusCode);
+    [TestCase("7fffffff", StatusCodes.Status408RequestTimeout, "Request body read timed out.", TestName = "Chunk size int.MaxValue never completes")]
+    public Task Kestrel_ValidButUnfulfilledChunkSize_StillTimesOut(string chunkSizeLine, int expectedStatusCode, string expectedMessage) =>
+        Kestrel_MalformedChunkedRequestBody_ReturnsFramedJsonRpcError(chunkSizeLine, expectedStatusCode, expectedMessage);
 
-    [TestCase("80000000", StatusCodes.Status400BadRequest, TestName = "Chunk size int.MaxValue + 1")]
-    [TestCase("ffffffff", StatusCodes.Status400BadRequest, TestName = "Chunk size uint.MaxValue")]
-    [TestCase("zzz", StatusCodes.Status400BadRequest, TestName = "Non-hex chunk size")]
-    public async Task Kestrel_MalformedChunkedRequestBody_ReturnsFramedJsonRpcError(string chunkSizeLine, int expectedStatusCode)
+    [TestCase("80000000", StatusCodes.Status400BadRequest, "Invalid request body.", TestName = "Chunk size int.MaxValue + 1")]
+    [TestCase("ffffffff", StatusCodes.Status400BadRequest, "Invalid request body.", TestName = "Chunk size uint.MaxValue")]
+    [TestCase("zzz", StatusCodes.Status400BadRequest, "Invalid request body.", TestName = "Non-hex chunk size")]
+    public async Task Kestrel_MalformedChunkedRequestBody_ReturnsFramedJsonRpcError(string chunkSizeLine, int expectedStatusCode, string expectedMessage)
     {
         await using KestrelJsonRpcHost host = await KestrelJsonRpcHost.StartAsync(Startup, CreateUrl());
         byte[] request = Encoding.ASCII.GetBytes(
@@ -265,10 +265,11 @@ public class StartupTests
         Assert.That(statusCode, Is.EqualTo(expectedStatusCode));
         Assert.That(body, Is.Not.Empty, "Expected a framed JSON-RPC error body");
         AssertErrorCodeResponse(body, ErrorCodes.InvalidRequest);
-        // "zzz" is rejected by Kestrel itself, with its own "Bad chunk size data." text. This endpoint serves
-        // unauthenticated callers, so what reaches them has to be a message this repo authored either way.
+        // Kestrel authors its own text for these - "Bad chunk size data." for "zzz", a MinRequestBodyDataRate
+        // message for the 408. This endpoint serves unauthenticated callers, so what reaches them has to be a
+        // message this repo authored, which is why the expectation is a literal per status rather than a passthrough.
         AssertJsonResponse(body, root =>
-            Assert.That(root.GetProperty("error").GetProperty("message").GetString(), Is.EqualTo("Invalid request body.")));
+            Assert.That(root.GetProperty("error").GetProperty("message").GetString(), Is.EqualTo(expectedMessage)));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
@@ -265,6 +265,10 @@ public class StartupTests
         Assert.That(statusCode, Is.EqualTo(expectedStatusCode));
         Assert.That(body, Is.Not.Empty, "Expected a framed JSON-RPC error body");
         AssertErrorCodeResponse(body, ErrorCodes.InvalidRequest);
+        // "zzz" is rejected by Kestrel itself, with its own "Bad chunk size data." text. This endpoint serves
+        // unauthenticated callers, so what reaches them has to be a message this repo authored either way.
+        AssertJsonResponse(body, root =>
+            Assert.That(root.GetProperty("error").GetProperty("message").GetString(), Is.EqualTo("Invalid request body.")));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/JsonRpc/StartupTests.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
@@ -195,6 +196,36 @@ public class StartupTests
         Assert.That(statusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
         AssertErrorCodeResponse(response, ErrorCodes.InvalidRequest);
     }
+
+    // The framed 400 renders the exception's Message into the client-visible JSON-RPC error, and this endpoint is
+    // reachable unauthenticated, so the transport-layer message must not survive into the response.
+    [Test]
+    public async Task ProcessJsonRpcRequest_BodyReadThrowsIOException_does_not_echo_the_transport_message()
+    {
+        const string transportDetail = "Reading the request body timed out due to data arriving too slowly. See MinRequestBodyDataRate. /home/build/src/Kestrel";
+
+        (string response, int statusCode) = await ProcessJsonRpcRequestWithStatus(
+            new ThrowingReadStream(new IOException(transportDetail)),
+            contentLength: null);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(statusCode, Is.EqualTo(StatusCodes.Status400BadRequest));
+            Assert.That(response, Does.Not.Contain("MinRequestBodyDataRate"));
+            Assert.That(response, Does.Not.Contain("/home/build"));
+            Assert.That(response, Does.Contain("Invalid request body."));
+        }
+        AssertErrorCodeResponse(response, ErrorCodes.InvalidRequest);
+    }
+
+    // A reset connection is a transport failure, not a malformed request: there is no client left to receive a 400,
+    // and framing it as one would blame the caller for a dropped connection.
+    [Test]
+    public void ProcessJsonRpcRequest_BodyReadThrowsConnectionReset_is_not_reframed_as_a_client_error() =>
+        Assert.That(async () => await ProcessJsonRpcRequestWithStatus(
+                new ThrowingReadStream(new ConnectionResetException("connection reset")),
+                contentLength: null),
+            Throws.InstanceOf<ConnectionResetException>());
 
     [TestCase("80000000", StatusCodes.Status400BadRequest, TestName = "Chunk size int.MaxValue + 1")]
     [TestCase("ffffffff", StatusCodes.Status400BadRequest, TestName = "Chunk size uint.MaxValue")]

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -54,6 +54,10 @@ public class Startup : IStartup
     // Rendered straight into the client-visible JSON-RPC error, so it must not carry transport-layer detail.
     private const string MalformedRequestBodyMessage = "Invalid request body.";
 
+    // Kestrel's own 408 names MinRequestBodyDataRate. AddServerHeader is false for the same reason, so the server
+    // stack must not be re-advertised through an error this endpoint serves unauthenticated.
+    private const string RequestBodyTimeoutMessage = "Request body read timed out.";
+
     private JsonRpcProcessor _jsonRpcProcessor = null!;
     private JsonRpcService _jsonRpcService = null!;
     private IJsonRpcLocalStats _jsonRpcLocalStats = null!;
@@ -506,9 +510,17 @@ public class Startup : IStartup
             if (_logger.IsDebug) LogBadRequest(_logger, e);
             ctx.Response.Headers.ContentType = JsonContentTypeHeader;
             ctx.Response.StatusCode = e.StatusCode;
-            JsonRpcErrorResponse errResp = _jsonRpcService.GetErrorResponse(
-                e.StatusCode == StatusCodes.Status413PayloadTooLarge ? ErrorCodes.LimitExceeded : ErrorCodes.InvalidRequest,
-                e.Message);
+            // Kestrel raises this for its own body-phase rejections too - a MinRequestBodyDataRate 408, a malformed
+            // trailer - and those messages name the server stack or echo the caller's bytes. Only the size limit is
+            // ours to disclose, so every other status answers with a message this repo authored.
+            (int errorCode, string message) = e.StatusCode switch
+            {
+                // ThrowRequestBodyTooLarge below: the configured limit is exactly what the caller needs back.
+                StatusCodes.Status413PayloadTooLarge => (ErrorCodes.LimitExceeded, e.Message),
+                StatusCodes.Status408RequestTimeout => (ErrorCodes.InvalidRequest, RequestBodyTimeoutMessage),
+                _ => (ErrorCodes.InvalidRequest, MalformedRequestBodyMessage),
+            };
+            JsonRpcErrorResponse errResp = _jsonRpcService.GetErrorResponse(errorCode, message);
             await _jsonSerializer.SerializeAsync(ctx.Response.BodyWriter, errResp);
             await ctx.Response.CompleteAsync();
         }
@@ -577,10 +589,9 @@ public class Startup : IStartup
                     // dropped connection and, because the handler below logs at Debug, would leave a real I/O
                     // failure with no trace at default log level. They keep propagating instead.
                     //
-                    // The message is a constant on purpose. The handler below renders it straight into the
-                    // client-visible JSON-RPC error, and this endpoint is reachable unauthenticated, so an arbitrary
-                    // transport-layer message must not be echoed back. The real one stays on the inner exception,
-                    // which LogBadRequest writes at Debug.
+                    // The message is a constant on purpose, even though the handler below no longer echoes an
+                    // arbitrary one: the real transport-layer message stays on the inner exception, which
+                    // LogBadRequest writes at Debug.
                     throw new Microsoft.AspNetCore.Http.BadHttpRequestException(MalformedRequestBodyMessage, StatusCodes.Status400BadRequest, e);
                 }
 

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -557,7 +557,18 @@ public class Startup : IStartup
         {
             while (true)
             {
-                ReadResult readResult = await bodyReader.ReadAsync(cancellationToken);
+                ReadResult readResult;
+                try
+                {
+                    readResult = await bodyReader.ReadAsync(cancellationToken);
+                }
+                catch (IOException e) when (e is not Microsoft.AspNetCore.Http.BadHttpRequestException)
+                {
+                    // Kestrel reports some malformed bodies (e.g. a chunk-size line overflowing Int32) as a plain
+                    // IOException; without this it escapes as an unhandled 500 instead of a framed 400.
+                    throw new Microsoft.AspNetCore.Http.BadHttpRequestException(e.Message, StatusCodes.Status400BadRequest, e);
+                }
+
                 ReadOnlySequence<byte> buffer = readResult.Buffer;
 
                 long newBytesRead = collectedBody.BytesRead + buffer.Length;

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -18,6 +18,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -527,6 +528,8 @@ public class Startup : IStartup
         }
     }
 
+    private const string MalformedRequestBodyMessage = "Invalid request body.";
+
     private static async ValueTask CollectHttpRequestBodyAsync(
         HttpContext context,
         long? contentLength,
@@ -562,11 +565,20 @@ public class Startup : IStartup
                 {
                     readResult = await bodyReader.ReadAsync(cancellationToken);
                 }
-                catch (IOException e) when (e is not Microsoft.AspNetCore.Http.BadHttpRequestException)
+                catch (IOException e) when (e is not Microsoft.AspNetCore.Http.BadHttpRequestException and not ConnectionResetException)
                 {
                     // Kestrel reports some malformed bodies (e.g. a chunk-size line overflowing Int32) as a plain
                     // IOException; without this it escapes as an unhandled 500 instead of a framed 400.
-                    throw new Microsoft.AspNetCore.Http.BadHttpRequestException(e.Message, StatusCodes.Status400BadRequest, e);
+                    //
+                    // The message is a constant on purpose. The handler below renders it straight into the
+                    // client-visible JSON-RPC error, and this endpoint is reachable unauthenticated, so an arbitrary
+                    // transport-layer message must not be echoed back. The real one stays on the inner exception,
+                    // which LogBadRequest writes at Debug.
+                    //
+                    // ConnectionResetException is excluded because it is a genuine transport failure, not a malformed
+                    // request: there is no longer a client to send a 400 to, and labelling it "invalid request" would
+                    // blame the caller for a dropped connection.
+                    throw new Microsoft.AspNetCore.Http.BadHttpRequestException(MalformedRequestBodyMessage, StatusCodes.Status400BadRequest, e);
                 }
 
                 ReadOnlySequence<byte> buffer = readResult.Buffer;

--- a/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
+++ b/src/Nethermind/Nethermind.Runner/JsonRpc/Startup.cs
@@ -18,7 +18,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -51,6 +50,9 @@ public class Startup : IStartup
 {
     private const string ApplicationJsonContentType = "application/json";
     private static readonly StringValues JsonContentTypeHeader = new(ApplicationJsonContentType);
+
+    // Rendered straight into the client-visible JSON-RPC error, so it must not carry transport-layer detail.
+    private const string MalformedRequestBodyMessage = "Invalid request body.";
 
     private JsonRpcProcessor _jsonRpcProcessor = null!;
     private JsonRpcService _jsonRpcService = null!;
@@ -528,8 +530,6 @@ public class Startup : IStartup
         }
     }
 
-    private const string MalformedRequestBodyMessage = "Invalid request body.";
-
     private static async ValueTask CollectHttpRequestBodyAsync(
         HttpContext context,
         long? contentLength,
@@ -565,19 +565,22 @@ public class Startup : IStartup
                 {
                     readResult = await bodyReader.ReadAsync(cancellationToken);
                 }
-                catch (IOException e) when (e is not Microsoft.AspNetCore.Http.BadHttpRequestException and not ConnectionResetException)
+                catch (IOException e) when (e.GetType() == typeof(IOException))
                 {
-                    // Kestrel reports some malformed bodies (e.g. a chunk-size line overflowing Int32) as a plain
+                    // Kestrel reports some malformed bodies (e.g. a chunk-size line overflowing Int32) as a *bare*
                     // IOException; without this it escapes as an unhandled 500 instead of a framed 400.
+                    //
+                    // The exact-type test is deliberate. Everything Kestrel surfaces from the body pipe derives from
+                    // IOException, including BadHttpRequestException (already handled below) and the genuine
+                    // transport failures - ConnectionResetException, a mid-body TLS or stream error, an IOException
+                    // wrapping a socket error. Reframing those as a client error would blame the caller for a
+                    // dropped connection and, because the handler below logs at Debug, would leave a real I/O
+                    // failure with no trace at default log level. They keep propagating instead.
                     //
                     // The message is a constant on purpose. The handler below renders it straight into the
                     // client-visible JSON-RPC error, and this endpoint is reachable unauthenticated, so an arbitrary
                     // transport-layer message must not be echoed back. The real one stays on the inner exception,
                     // which LogBadRequest writes at Debug.
-                    //
-                    // ConnectionResetException is excluded because it is a genuine transport failure, not a malformed
-                    // request: there is no longer a client to send a 400 to, and labelling it "invalid request" would
-                    // blame the caller for a dropped connection.
                     throw new Microsoft.AspNetCore.Http.BadHttpRequestException(MalformedRequestBodyMessage, StatusCodes.Status400BadRequest, e);
                 }
 


### PR DESCRIPTION
Fixes #13194, #13195, #13197, #13198, #13156

Five JSON-RPC findings from the 2.0.0-rc soak, grouped because they overlap in `JsonRpcProcessor`, `JsonRpcService`, `Startup` and `EstimateGasTracer`.

## Changes

**#13194 — undecodable request bytes escaped `JsonRpcProcessor` unhandled.** Bad UTF-8, overlong encodings, lone surrogates and non-object batch elements throw `InvalidOperationException`, not `JsonException`. `IsRequestDecodingException` guards six decode sites only, never an outer catch that also wraps execution: `-32700` per single request, `-32600` per bad batch element instead of a throw, and `sink.StopRequested` re-read at each `continue` so the batch body limit still binds. Dispatch on the direct-memory path also moved out of that catch, so a `JsonException` from executing a decoded request now propagates instead of being answered as a parse error.

**#13195 — a chunk-size line ≥ `0x80000000` was one unhandled exception per request.** Kestrel reports that `Int32` overflow as a *bare* `IOException`, so `Startup` catches exactly `typeof(IOException)` around `bodyReader.ReadAsync` and answers HTTP 400, leaving derived types (`ConnectionResetException`, socket errors) to propagate. `BadHttpRequestException` also stops echoing `e.Message`: 413 keeps the size-limit text, 408 answers `"Request body read timed out."`, everything else `"Invalid request body."`; Kestrel's own wording stays on the inner exception, at Debug.

**#13197 — `eth_estimateGas` answered `-32603 "Stack empty."` on deep recursion.** `MaxGasNeeded` compounds the EIP-150 64/63 rule with call depth, and its `OverflowException` inside the VM's `try` unbalanced the tracer's action stack. `EstimateGasTracer` now saturates throughout, with a new `MaxScalableGas = ulong.MaxValue / 64 * 63` short-circuiting the scaling loop before the overflowing step. `CalculateAdditionalGasRequired` can therefore return `ulong.MaxValue`, which `GasEstimator.CheckFunds` reports as a successful `"0xffffffffffffffff"` estimate where it previously threw; an explicit `Failure` was deferred.

**#13198 — `error.data` leaked stack traces and absolute build paths.** `GetExceptionText` is rewritten to emit only the chain's types and messages (cap `MaxReportedExceptionChainDepth = 8`) and to unwrap a `TargetInvocationException` first, so the first link is the real exception type; all seven producers route through it (five used `ex.ToString()`). The trace stays in the log: at Error where the arm already logged one, otherwise at Debug, from a new `KeepTrace` helper in `HandleInvocationException` that wraps exactly the five arms which answer with `GetExceptionText` but log nothing of their own (`HandleException` keeps its own Error line and is not routed through it).

**#13156 — client-fault errors logged at WARN with a params echo and a stack trace.**

- `IsDemotableRequestError` demotes the four `ErrorCodes.IsRequestError` codes (`-32700`, `-32600`, `-32601`, `-32602`) to Debug **only for unauthenticated callers**, and only when `Error.OperatorActionable` is false. JWT Engine and IPC keep WARN for every code.
- `GetParsingError` takes the same split instead of an unconditional `Error`, with master's separate `Debug` line folded in — so with Debug on, an authenticated ERROR line now carries the request text (1000-char slice). `Metrics.JsonRpcRequestDeserializationFailures` stays unconditional.
- Binding drops its params echo and exception to Debug, but `IsNodeFault` (`OutOfMemoryException`/`ObjectDisposedException` anywhere in the chain) goes Warn → Error under a new message, `Failed to bind JSON RPC parameters for {method}`, with no params echo, `OperatorActionable` set, and a constant `"Invalid params"` where master returned `GetSafePublicMessage(e) ?? "Invalid params"`. `Disabled`/`EndpointDisabled` are operator-actionable too, keeping that `-32600` at WARN.

**Public API:** additive only — `Error.OperatorActionable` (`[JsonIgnore]`) and `ErrorCodes.IsRequestError(int)`.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

22 new test methods / 80 executing cases, plus one `[Explicit]` case: `JsonRpcProcessorTests` 7 / 58 (shape cases over `HttpMemory`/`HttpPipe`/`WsPipe`), `JsonRpcServiceTests` 5 / 9 plus 2 existing cases, `StartupTests` 6 / 7, and 4 / 4 across `EstimateGasTracerTests` (new), `GasEstimationTests` and `EthRpcModuleTests` (two partial-class files).

The expected transport message is a per-`TestCase` parameter now, so the `[Explicit]` `7fffffff` case asserts `"Request body read timed out."`; the empty-string/null block-parameter cases pin master behaviour (#13235).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Client-fault errors from unauthenticated callers move from WARN to Debug, node-fault binding failures get a new `Failed to bind JSON RPC parameters for {method}` ERROR line, and malformed or timed-out bodies answer with our own message rather than Kestrel's.

## Remarks

- **Client-visible error text changed** for malformed bodies and body-read timeouts, and an `IExceptionWithSafePublicMessage` nested under a binding node fault no longer reaches the caller. Codes and statuses are unchanged otherwise, apart from 500 → 400.
- **`Metrics.JsonRpcInvalidRequests` now also increments once per undecodable batch element**, where such a batch previously incremented it zero times and threw. Its once-per-request increment for a non-object root is unchanged.
- **Residuals:** `error.data` still carries each link's raw `Exception.Message`, so a path inside a message can surface; `MaxReportedExceptionChainDepth = 8` is untested.