### PR TITLE
perf(evm): name opcode handlers for profiler attribution

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="DynamicExpresso.Core" Version="2.19.3" />
     <PackageVersion Include="FastEnum" Version="2.0.7" />
     <PackageVersion Include="Fody" Version="6.9.3" />
+    <PackageVersion Include="FodyHelpers" Version="6.9.3" />
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Google.Protobuf.Tools" Version="3.35.1" />
     <PackageVersion Include="Grpc" Version="2.46.6" />

--- a/nix/nuget-deps.json
+++ b/nix/nuget-deps.json
@@ -105,6 +105,11 @@
     "hash": "sha256-JLom3mbO4NCUXDHoU86l720QXlRx52+ROb5wBwcC5nM="
   },
   {
+    "pname": "FodyHelpers",
+    "version": "6.9.3",
+    "hash": "sha256-2F6jkmn7Ja0cM86avL+FFDHaWTBsV8e+M06vNb26LGU="
+  },
+  {
     "pname": "Fractions",
     "version": "7.3.0",
     "hash": "sha256-wr4I1mj1qrXjD2Z3dca70OBe14zZNGagDLW9/8xQtCU="

--- a/src/Nethermind/Benchmarks.slnx
+++ b/src/Nethermind/Benchmarks.slnx
@@ -18,10 +18,10 @@
     <Project Path="Nethermind.Era1/Nethermind.Era1.csproj" />
     <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
     <Project Path="Nethermind.EthStats/Nethermind.EthStats.csproj" />
-    <Project Path="Nethermind.Evm.Test/Nethermind.Evm.Test.csproj" />
-    <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
     <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
     <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
+    <Project Path="Nethermind.Evm.Test/Nethermind.Evm.Test.csproj" />
+    <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
     <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />
     <Project Path="Nethermind.Grpc/Nethermind.Grpc.csproj" />
     <Project Path="Nethermind.History/Nethermind.History.csproj" />

--- a/src/Nethermind/Benchmarks.slnx
+++ b/src/Nethermind/Benchmarks.slnx
@@ -19,8 +19,8 @@
     <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
     <Project Path="Nethermind.EthStats/Nethermind.EthStats.csproj" />
     <Project Path="Nethermind.Evm.Test/Nethermind.Evm.Test.csproj" />
-    <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
     <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
+    <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
     <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
     <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />
     <Project Path="Nethermind.Grpc/Nethermind.Grpc.csproj" />

--- a/src/Nethermind/Benchmarks.slnx
+++ b/src/Nethermind/Benchmarks.slnx
@@ -19,6 +19,7 @@
     <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
     <Project Path="Nethermind.EthStats/Nethermind.EthStats.csproj" />
     <Project Path="Nethermind.Evm.Test/Nethermind.Evm.Test.csproj" />
+    <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
     <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
     <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
     <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />

--- a/src/Nethermind/Directory.Build.props
+++ b/src/Nethermind/Directory.Build.props
@@ -21,12 +21,10 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- Exclude the analyzer itself and the source generator (netstandard2.0, can't reference analyzers).
+  <!-- Exclude the analyzer itself, source generator and EVM weaver (netstandard2.0, can't reference analyzers).
        Also skipped on the ZisK guest build (EnableZkEvm), where the analyzers/generators are not wired and
        the generated members are stubbed (e.g. ChainSpecStyle/HardforkLabels.cs). Mainline MUST keep this:
        removing it left HardforkLabels.All empty and broke ChainSpec/BlobSchedule transitions. -->
-  <!-- Nethermind.Evm.Fody is referenced with publish properties removed; giving it an analyzer reference would
-       build Nethermind.Analyzers a second time into the same output while other projects compile against it. -->
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'Nethermind.Analyzers' AND '$(MSBuildProjectName)' != 'Nethermind.Serialization.SszGenerator' AND '$(MSBuildProjectName)' != 'Nethermind.Evm.Fody' AND '$(EnableZkEvm)' != 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.Analyzers/Nethermind.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>

--- a/src/Nethermind/Directory.Build.props
+++ b/src/Nethermind/Directory.Build.props
@@ -25,7 +25,9 @@
        Also skipped on the ZisK guest build (EnableZkEvm), where the analyzers/generators are not wired and
        the generated members are stubbed (e.g. ChainSpecStyle/HardforkLabels.cs). Mainline MUST keep this:
        removing it left HardforkLabels.All empty and broke ChainSpec/BlobSchedule transitions. -->
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Nethermind.Analyzers' AND '$(MSBuildProjectName)' != 'Nethermind.Serialization.SszGenerator' AND '$(EnableZkEvm)' != 'true'">
+  <!-- Nethermind.Evm.Fody is referenced with publish properties removed; giving it an analyzer reference would
+       build Nethermind.Analyzers a second time into the same output while other projects compile against it. -->
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Nethermind.Analyzers' AND '$(MSBuildProjectName)' != 'Nethermind.Serialization.SszGenerator' AND '$(MSBuildProjectName)' != 'Nethermind.Evm.Fody' AND '$(EnableZkEvm)' != 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.Analyzers/Nethermind.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/src/Nethermind/EthereumTests.slnx
+++ b/src/Nethermind/EthereumTests.slnx
@@ -16,9 +16,9 @@
     <Project Path="Nethermind.Db/Nethermind.Db.csproj" />
     <Project Path="Nethermind.Era1/Nethermind.Era1.csproj" />
     <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
+    <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
     <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
     <Project Path="Nethermind.Evm.Test/Nethermind.Evm.Test.csproj" />
-    <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
     <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
     <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />
     <Project Path="Nethermind.Grpc/Nethermind.Grpc.csproj" />

--- a/src/Nethermind/EthereumTests.slnx
+++ b/src/Nethermind/EthereumTests.slnx
@@ -18,6 +18,7 @@
     <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
     <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
     <Project Path="Nethermind.Evm.Test/Nethermind.Evm.Test.csproj" />
+    <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
     <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
     <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />
     <Project Path="Nethermind.Grpc/Nethermind.Grpc.csproj" />

--- a/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
@@ -15,6 +15,8 @@ internal sealed class MethodCloner(MethodDefinition source, Action<string> warn)
 
     public MethodDefinition Clone(string name)
     {
+        if (!source.IsStatic)
+            throw new WeavingException($"Only static methods can be cloned: {source.FullName}.");
         _target = new MethodDefinition(name, source.Attributes, source.ReturnType)
         {
             DeclaringType = source.DeclaringType,
@@ -104,24 +106,33 @@ internal sealed class MethodCloner(MethodDefinition source, Action<string> warn)
         return _target;
     }
 
-    private ScopeDebugInformation CloneScope(ScopeDebugInformation scope, Dictionary<int, Instruction> byOffset, MethodBody body)
+    private ScopeDebugInformation? CloneScope(ScopeDebugInformation scope, Dictionary<int, Instruction> byOffset, MethodBody body)
     {
-        ScopeDebugInformation copy = new(MapOffset(scope.Start), MapOffset(scope.End)) { Import = scope.Import };
+        if (!TryMapOffset(scope.Start, out Instruction? start) || !TryMapOffset(scope.End, out Instruction? end))
+            return null;
+        ScopeDebugInformation copy = new(start, end) { Import = scope.Import };
         foreach (VariableDebugInformation variable in scope.Variables)
+        {
+            if ((uint)variable.Index >= (uint)body.Variables.Count)
+            {
+                warn($"Debug variable {variable.Name} at index {variable.Index} in {source.FullName} has no local.");
+                continue;
+            }
             copy.Variables.Add(new VariableDebugInformation(body.Variables[variable.Index], variable.Name) { Attributes = variable.Attributes });
+        }
         foreach (ConstantDebugInformation constant in scope.Constants)
             copy.Constants.Add(new ConstantDebugInformation(constant.Name, MapType(constant.ConstantType), constant.Value));
         foreach (ScopeDebugInformation nested in scope.Scopes)
-            copy.Scopes.Add(CloneScope(nested, byOffset, body));
+            if (CloneScope(nested, byOffset, body) is { } cloned) copy.Scopes.Add(cloned);
         return copy;
 
         // A scope end at the method's end has no instruction; Cecil represents it as an unresolved offset.
-        Instruction? MapOffset(InstructionOffset offset)
+        bool TryMapOffset(InstructionOffset offset, out Instruction? instruction)
         {
-            if (offset.IsEndOfMethod) return null;
-            if (!byOffset.TryGetValue(offset.Offset, out Instruction? instruction))
-                throw new WeavingException($"Scope boundary at IL_{offset.Offset:x4} in {source.FullName} is not an instruction.");
-            return instruction;
+            instruction = null;
+            if (offset.IsEndOfMethod || byOffset.TryGetValue(offset.Offset, out instruction)) return true;
+            warn($"Scope boundary at IL_{offset.Offset:x4} in {source.FullName} is not an instruction; dropping scope.");
+            return false;
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Nethermind.Evm.Fody;
+
+internal sealed class MethodCloner(MethodDefinition source)
+{
+    private MethodDefinition _target = null!;
+
+    public MethodDefinition Clone(string name)
+    {
+        _target = new MethodDefinition(name, source.Attributes, source.ReturnType)
+        {
+            DeclaringType = source.DeclaringType,
+            ImplAttributes = source.ImplAttributes,
+            CallingConvention = source.CallingConvention
+        };
+        foreach (GenericParameter parameter in source.GenericParameters)
+            _target.GenericParameters.Add(new GenericParameter(parameter.Name, _target) { Attributes = parameter.Attributes });
+        for (int i = 0; i < source.GenericParameters.Count; i++)
+            foreach (GenericParameterConstraint constraint in source.GenericParameters[i].Constraints)
+                _target.GenericParameters[i].Constraints.Add(new GenericParameterConstraint(MapType(constraint.ConstraintType)));
+        _target.ReturnType = MapType(source.ReturnType);
+        foreach (ParameterDefinition parameter in source.Parameters)
+            _target.Parameters.Add(new ParameterDefinition(parameter.Name, parameter.Attributes, MapType(parameter.ParameterType)));
+        foreach (CustomAttribute attribute in source.CustomAttributes) _target.CustomAttributes.Add(attribute);
+
+        MethodBody body = _target.Body;
+        body.InitLocals = source.Body.InitLocals;
+        body.MaxStackSize = source.Body.MaxStackSize;
+        foreach (VariableDefinition variable in source.Body.Variables)
+            body.Variables.Add(new VariableDefinition(MapType(variable.VariableType)));
+
+        Dictionary<Instruction, Instruction> instructions = [];
+        foreach (Instruction instruction in source.Body.Instructions)
+        {
+            Instruction copy = Instruction.Create(OpCodes.Nop);
+            copy.OpCode = instruction.OpCode;
+            instructions.Add(instruction, copy);
+            body.Instructions.Add(copy);
+        }
+        foreach (Instruction instruction in source.Body.Instructions)
+        {
+            instructions[instruction].Operand = instruction.Operand switch
+            {
+                Instruction branch => instructions[branch],
+                Instruction[] branches => MapBranches(branches, instructions),
+                VariableDefinition variable => body.Variables[variable.Index],
+                ParameterDefinition parameter => _target.Parameters[parameter.Index],
+                TypeReference type => MapType(type),
+                MethodReference method => MapMethod(method),
+                FieldReference field => new FieldReference(field.Name, MapType(field.FieldType), MapType(field.DeclaringType)),
+                CallSite site => MapCallSite(site),
+                object operand => operand,
+                null => null
+            };
+        }
+        foreach (ExceptionHandler handler in source.Body.ExceptionHandlers)
+            body.ExceptionHandlers.Add(new ExceptionHandler(handler.HandlerType)
+            {
+                CatchType = handler.CatchType is null ? null : MapType(handler.CatchType),
+                TryStart = instructions[handler.TryStart],
+                TryEnd = handler.TryEnd is null ? null : instructions[handler.TryEnd],
+                HandlerStart = instructions[handler.HandlerStart],
+                HandlerEnd = handler.HandlerEnd is null ? null : instructions[handler.HandlerEnd],
+                FilterStart = handler.FilterStart is null ? null : instructions[handler.FilterStart]
+            });
+        foreach (SequencePoint point in source.DebugInformation.SequencePoints)
+        {
+            foreach (Instruction instruction in source.Body.Instructions)
+            {
+                if (instruction.Offset != point.Offset) continue;
+                _target.DebugInformation.SequencePoints.Add(new SequencePoint(instructions[instruction], point.Document)
+                {
+                    StartLine = point.StartLine, StartColumn = point.StartColumn,
+                    EndLine = point.EndLine, EndColumn = point.EndColumn
+                });
+                break;
+            }
+        }
+        return _target;
+    }
+
+    private static Instruction[] MapBranches(Instruction[] branches, Dictionary<Instruction, Instruction> instructions)
+    {
+        Instruction[] result = new Instruction[branches.Length];
+        for (int i = 0; i < result.Length; i++) result[i] = instructions[branches[i]];
+        return result;
+    }
+
+    private TypeReference MapType(TypeReference type)
+    {
+        if (type is GenericParameter parameter && parameter.Owner == source)
+            return _target.GenericParameters[parameter.Position];
+        if (type is GenericInstanceType instance)
+        {
+            GenericInstanceType result = new(MapType(instance.ElementType));
+            foreach (TypeReference argument in instance.GenericArguments) result.GenericArguments.Add(MapType(argument));
+            return result;
+        }
+        return type switch
+        {
+            ByReferenceType reference => new ByReferenceType(MapType(reference.ElementType)),
+            PointerType pointer => new PointerType(MapType(pointer.ElementType)),
+            PinnedType pinned => new PinnedType(MapType(pinned.ElementType)),
+            ArrayType array => new ArrayType(MapType(array.ElementType), array.Rank),
+            RequiredModifierType modifier => new RequiredModifierType(MapType(modifier.ModifierType), MapType(modifier.ElementType)),
+            OptionalModifierType modifier => new OptionalModifierType(MapType(modifier.ModifierType), MapType(modifier.ElementType)),
+            FunctionPointerType pointer => MapFunctionPointer(pointer),
+            _ => type
+        };
+    }
+
+    private FunctionPointerType MapFunctionPointer(FunctionPointerType pointer)
+    {
+        FunctionPointerType result = new()
+        {
+            ReturnType = MapType(pointer.ReturnType), CallingConvention = pointer.CallingConvention,
+            HasThis = pointer.HasThis, ExplicitThis = pointer.ExplicitThis
+        };
+        foreach (ParameterDefinition parameter in pointer.Parameters)
+            result.Parameters.Add(new ParameterDefinition(MapType(parameter.ParameterType)));
+        return result;
+    }
+
+    private MethodReference MapMethod(MethodReference method)
+    {
+        if (method is GenericInstanceMethod instance)
+        {
+            GenericInstanceMethod result = new(MapMethod(instance.ElementMethod));
+            foreach (TypeReference argument in instance.GenericArguments) result.GenericArguments.Add(MapType(argument));
+            return result;
+        }
+        MethodReference reference = new(method.Name, MapType(method.ReturnType), MapType(method.DeclaringType))
+        {
+            HasThis = method.HasThis, ExplicitThis = method.ExplicitThis, CallingConvention = method.CallingConvention
+        };
+        foreach (GenericParameter parameter in method.GenericParameters)
+            reference.GenericParameters.Add(new GenericParameter(parameter.Name, reference));
+        foreach (ParameterDefinition parameter in method.Parameters)
+            reference.Parameters.Add(new ParameterDefinition(MapType(parameter.ParameterType)));
+        return reference;
+    }
+
+    private CallSite MapCallSite(CallSite site)
+    {
+        CallSite result = new(MapType(site.ReturnType))
+        {
+            HasThis = site.HasThis, ExplicitThis = site.ExplicitThis, CallingConvention = site.CallingConvention
+        };
+        foreach (ParameterDefinition parameter in site.Parameters)
+            result.Parameters.Add(new ParameterDefinition(MapType(parameter.ParameterType)));
+        return result;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
@@ -70,22 +70,38 @@ internal sealed class MethodCloner(MethodDefinition source)
                 HandlerEnd = handler.HandlerEnd is null ? null : instructions[handler.HandlerEnd],
                 FilterStart = handler.FilterStart is null ? null : instructions[handler.FilterStart]
             });
+        Dictionary<int, Instruction> byOffset = [];
+        foreach (Instruction instruction in source.Body.Instructions) byOffset[instruction.Offset] = instructions[instruction];
         foreach (SequencePoint point in source.DebugInformation.SequencePoints)
         {
-            foreach (Instruction instruction in source.Body.Instructions)
+            if (!byOffset.TryGetValue(point.Offset, out Instruction? instruction)) continue;
+            _target.DebugInformation.SequencePoints.Add(new SequencePoint(instruction, point.Document)
             {
-                if (instruction.Offset != point.Offset) continue;
-                _target.DebugInformation.SequencePoints.Add(new SequencePoint(instructions[instruction], point.Document)
-                {
-                    StartLine = point.StartLine,
-                    StartColumn = point.StartColumn,
-                    EndLine = point.EndLine,
-                    EndColumn = point.EndColumn
-                });
-                break;
-            }
+                StartLine = point.StartLine,
+                StartColumn = point.StartColumn,
+                EndLine = point.EndLine,
+                EndColumn = point.EndColumn
+            });
         }
+        if (source.DebugInformation.Scope is not null)
+            _target.DebugInformation.Scope = CloneScope(source.DebugInformation.Scope, byOffset, body);
         return _target;
+    }
+
+    private ScopeDebugInformation CloneScope(ScopeDebugInformation scope, Dictionary<int, Instruction> byOffset, MethodBody body)
+    {
+        ScopeDebugInformation copy = new(MapOffset(scope.Start), MapOffset(scope.End)) { Import = scope.Import };
+        foreach (VariableDebugInformation variable in scope.Variables)
+            copy.Variables.Add(new VariableDebugInformation(body.Variables[variable.Index], variable.Name) { Attributes = variable.Attributes });
+        foreach (ConstantDebugInformation constant in scope.Constants)
+            copy.Constants.Add(new ConstantDebugInformation(constant.Name, MapType(constant.ConstantType), constant.Value));
+        foreach (ScopeDebugInformation nested in scope.Scopes)
+            copy.Scopes.Add(CloneScope(nested, byOffset, body));
+        return copy;
+
+        // A scope end at the method's end has no instruction; Cecil represents it as an unresolved offset.
+        Instruction? MapOffset(InstructionOffset offset) =>
+            offset.IsEndOfMethod ? null : byOffset[offset.Offset];
     }
 
     private static Instruction[] MapBranches(Instruction[] branches, Dictionary<Instruction, Instruction> instructions)

--- a/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using Fody;
 using Mono.Cecil;
@@ -8,7 +9,7 @@ using Mono.Cecil.Cil;
 
 namespace Nethermind.Evm.Fody;
 
-internal sealed class MethodCloner(MethodDefinition source)
+internal sealed class MethodCloner(MethodDefinition source, Action<string> warn)
 {
     private MethodDefinition _target = null!;
 
@@ -71,7 +72,9 @@ internal sealed class MethodCloner(MethodDefinition source)
                 HandlerEnd = handler.HandlerEnd is null ? null : instructions[handler.HandlerEnd],
                 FilterStart = handler.FilterStart is null ? null : instructions[handler.FilterStart]
             });
-        // Instructions an earlier weaver inserted still carry offset zero, so recompute before keying on offsets.
+        // Cecil exposes sequence points and scope bounds by offset only, and instructions an earlier weaver
+        // inserted still carry offset zero. Writing the recomputed offsets back to the source makes them a
+        // truthful join key; the writer recomputes them again anyway.
         int offset = 0;
         Dictionary<int, Instruction> byOffset = [];
         foreach (Instruction instruction in source.Body.Instructions)
@@ -83,7 +86,11 @@ internal sealed class MethodCloner(MethodDefinition source)
         foreach (SequencePoint point in source.DebugInformation.SequencePoints)
         {
             if (!byOffset.TryGetValue(point.Offset, out Instruction? instruction))
-                throw new WeavingException($"Sequence point at IL_{point.Offset:x4} in {source.FullName} is not an instruction.");
+            {
+                // Debug info only: a stale point drifts a line number, so it is not worth failing the build.
+                warn($"Sequence point at IL_{point.Offset:x4} in {source.FullName} is not an instruction.");
+                continue;
+            }
             _target.DebugInformation.SequencePoints.Add(new SequencePoint(instruction, point.Document)
             {
                 StartLine = point.StartLine,
@@ -118,7 +125,7 @@ internal sealed class MethodCloner(MethodDefinition source)
         }
     }
 
-    /// <summary>Copies an attribute read from the image by blob; one another weaver built in memory has no blob, so copy its arguments.</summary>
+    /// <summary>Copies an attribute read from the image by blob; an attribute another weaver built in memory has no blob, so copy its arguments instead.</summary>
     private static CustomAttribute CloneAttribute(CustomAttribute attribute)
     {
         if (!attribute.IsResolved) return new CustomAttribute(attribute.Constructor, attribute.GetBlob());

--- a/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
@@ -27,7 +27,8 @@ internal sealed class MethodCloner(MethodDefinition source)
         _target.ReturnType = MapType(source.ReturnType);
         foreach (ParameterDefinition parameter in source.Parameters)
             _target.Parameters.Add(new ParameterDefinition(parameter.Name, parameter.Attributes, MapType(parameter.ParameterType)));
-        foreach (CustomAttribute attribute in source.CustomAttributes) _target.CustomAttributes.Add(attribute);
+        foreach (CustomAttribute attribute in source.CustomAttributes)
+            _target.CustomAttributes.Add(new CustomAttribute(attribute.Constructor, attribute.GetBlob()));
 
         MethodBody body = _target.Body;
         body.InitLocals = source.Body.InitLocals;

--- a/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
@@ -131,7 +131,7 @@ internal sealed class MethodCloner(MethodDefinition source, Action<string> warn)
         {
             instruction = null;
             if (offset.IsEndOfMethod || byOffset.TryGetValue(offset.Offset, out instruction)) return true;
-            warn($"Scope boundary at IL_{offset.Offset:x4} in {source.FullName} is not an instruction; dropping scope.");
+            warn($"Scope boundary at IL_{offset.Offset:x4} in {source.FullName} is not an instruction; dropping scope and its nested scopes.");
             return false;
         }
     }

--- a/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using Fody;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -28,7 +29,7 @@ internal sealed class MethodCloner(MethodDefinition source)
         foreach (ParameterDefinition parameter in source.Parameters)
             _target.Parameters.Add(new ParameterDefinition(parameter.Name, parameter.Attributes, MapType(parameter.ParameterType)));
         foreach (CustomAttribute attribute in source.CustomAttributes)
-            _target.CustomAttributes.Add(new CustomAttribute(attribute.Constructor, attribute.GetBlob()));
+            _target.CustomAttributes.Add(CloneAttribute(attribute));
 
         MethodBody body = _target.Body;
         body.InitLocals = source.Body.InitLocals;
@@ -70,11 +71,19 @@ internal sealed class MethodCloner(MethodDefinition source)
                 HandlerEnd = handler.HandlerEnd is null ? null : instructions[handler.HandlerEnd],
                 FilterStart = handler.FilterStart is null ? null : instructions[handler.FilterStart]
             });
+        // Instructions an earlier weaver inserted still carry offset zero, so recompute before keying on offsets.
+        int offset = 0;
         Dictionary<int, Instruction> byOffset = [];
-        foreach (Instruction instruction in source.Body.Instructions) byOffset[instruction.Offset] = instructions[instruction];
+        foreach (Instruction instruction in source.Body.Instructions)
+        {
+            instruction.Offset = offset;
+            byOffset.Add(offset, instructions[instruction]);
+            offset += instruction.GetSize();
+        }
         foreach (SequencePoint point in source.DebugInformation.SequencePoints)
         {
-            if (!byOffset.TryGetValue(point.Offset, out Instruction? instruction)) continue;
+            if (!byOffset.TryGetValue(point.Offset, out Instruction? instruction))
+                throw new WeavingException($"Sequence point at IL_{point.Offset:x4} in {source.FullName} is not an instruction.");
             _target.DebugInformation.SequencePoints.Add(new SequencePoint(instruction, point.Document)
             {
                 StartLine = point.StartLine,
@@ -100,8 +109,24 @@ internal sealed class MethodCloner(MethodDefinition source)
         return copy;
 
         // A scope end at the method's end has no instruction; Cecil represents it as an unresolved offset.
-        Instruction? MapOffset(InstructionOffset offset) =>
-            offset.IsEndOfMethod ? null : byOffset[offset.Offset];
+        Instruction? MapOffset(InstructionOffset offset)
+        {
+            if (offset.IsEndOfMethod) return null;
+            if (!byOffset.TryGetValue(offset.Offset, out Instruction? instruction))
+                throw new WeavingException($"Scope boundary at IL_{offset.Offset:x4} in {source.FullName} is not an instruction.");
+            return instruction;
+        }
+    }
+
+    /// <summary>Copies an attribute read from the image by blob; one another weaver built in memory has no blob, so copy its arguments.</summary>
+    private static CustomAttribute CloneAttribute(CustomAttribute attribute)
+    {
+        if (!attribute.IsResolved) return new CustomAttribute(attribute.Constructor, attribute.GetBlob());
+        CustomAttribute copy = new(attribute.Constructor);
+        foreach (CustomAttributeArgument argument in attribute.ConstructorArguments) copy.ConstructorArguments.Add(argument);
+        foreach (CustomAttributeNamedArgument field in attribute.Fields) copy.Fields.Add(field);
+        foreach (CustomAttributeNamedArgument property in attribute.Properties) copy.Properties.Add(property);
+        return copy;
     }
 
     private static Instruction[] MapBranches(Instruction[] branches, Dictionary<Instruction, Instruction> instructions)

--- a/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
@@ -76,8 +76,10 @@ internal sealed class MethodCloner(MethodDefinition source)
                 if (instruction.Offset != point.Offset) continue;
                 _target.DebugInformation.SequencePoints.Add(new SequencePoint(instructions[instruction], point.Document)
                 {
-                    StartLine = point.StartLine, StartColumn = point.StartColumn,
-                    EndLine = point.EndLine, EndColumn = point.EndColumn
+                    StartLine = point.StartLine,
+                    StartColumn = point.StartColumn,
+                    EndLine = point.EndLine,
+                    EndColumn = point.EndColumn
                 });
                 break;
             }
@@ -119,8 +121,10 @@ internal sealed class MethodCloner(MethodDefinition source)
     {
         FunctionPointerType result = new()
         {
-            ReturnType = MapType(pointer.ReturnType), CallingConvention = pointer.CallingConvention,
-            HasThis = pointer.HasThis, ExplicitThis = pointer.ExplicitThis
+            ReturnType = MapType(pointer.ReturnType),
+            CallingConvention = pointer.CallingConvention,
+            HasThis = pointer.HasThis,
+            ExplicitThis = pointer.ExplicitThis
         };
         foreach (ParameterDefinition parameter in pointer.Parameters)
             result.Parameters.Add(new ParameterDefinition(MapType(parameter.ParameterType)));
@@ -137,7 +141,9 @@ internal sealed class MethodCloner(MethodDefinition source)
         }
         MethodReference reference = new(method.Name, MapType(method.ReturnType), MapType(method.DeclaringType))
         {
-            HasThis = method.HasThis, ExplicitThis = method.ExplicitThis, CallingConvention = method.CallingConvention
+            HasThis = method.HasThis,
+            ExplicitThis = method.ExplicitThis,
+            CallingConvention = method.CallingConvention
         };
         foreach (GenericParameter parameter in method.GenericParameters)
             reference.GenericParameters.Add(new GenericParameter(parameter.Name, reference));
@@ -150,7 +156,9 @@ internal sealed class MethodCloner(MethodDefinition source)
     {
         CallSite result = new(MapType(site.ReturnType))
         {
-            HasThis = site.HasThis, ExplicitThis = site.ExplicitThis, CallingConvention = site.CallingConvention
+            HasThis = site.HasThis,
+            ExplicitThis = site.ExplicitThis,
+            CallingConvention = site.CallingConvention
         };
         foreach (ParameterDefinition parameter in site.Parameters)
             result.Parameters.Add(new ParameterDefinition(MapType(parameter.ParameterType)));

--- a/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Fody;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Nethermind.Evm.Fody;
+
+/// <summary>Gives opcode specializations distinct profiler-visible entry points.</summary>
+public sealed class ModuleWeaver : BaseModuleWeaver
+{
+    private readonly Dictionary<(MethodDefinition Template, string Opcode), MethodDefinition> _factories = [];
+    private readonly Dictionary<string, MethodDefinition> _handlers = [];
+
+    /// <inheritdoc />
+    public override IEnumerable<string> GetAssembliesForScanning() => Array.Empty<string>();
+
+    /// <inheritdoc />
+    public override void Execute()
+    {
+        TypeDefinition vm = ModuleDefinition.Types.Single(t => t.FullName == "Nethermind.Evm.VirtualMachine`1");
+        MethodDefinition handler = vm.Methods.Single(m => m.Name == "ExecuteOpcode");
+        if (!handler.Body.Instructions.Any(i => i.OpCode == OpCodes.Tail))
+            throw new WeavingException("Opcode naming must run after InlineIL and preserve the dispatch tail call.");
+
+        foreach (MethodDefinition method in vm.Methods.ToArray())
+        {
+            // CALL/CREATE carry an opcode type through several fork-selection factories.
+            // Clone that chain from its concrete entry point before redirecting its leaf.
+            if (!method.HasBody || IsFactory(method.Name)) continue;
+            foreach (Instruction instruction in method.Body.Instructions)
+            {
+                if (instruction.Operand is not GenericInstanceMethod call || !IsFactory(call.Name)
+                    || call.DeclaringType.Resolve() != vm) continue;
+                string name = call.Name switch
+                {
+                    "JumpIfOpcodeHandler" => "JumpI",
+                    "GetCallHandler" or "GetCreateHandler" => GetOperationName(call.GenericArguments[0]),
+                    _ => GetOpcodeName(call.GenericArguments[0])
+                };
+                instruction.Operand = Retarget(call, CloneFactory(call.Resolve(), name));
+            }
+        }
+
+        HashSet<string> names = new(_handlers.Keys, StringComparer.OrdinalIgnoreCase);
+        TypeDefinition instructionType = ModuleDefinition.Types.Single(t => t.FullName == "Nethermind.Evm.Instruction");
+        foreach (FieldDefinition opcode in instructionType.Fields)
+            if (opcode.HasConstant && !names.Remove(opcode.Name))
+                throw new WeavingException($"No named handler for opcode {opcode.Name}.");
+        if (!names.SetEquals(new[] { "BadInstruction" }))
+            throw new WeavingException("Named handlers do not match the instruction enum.");
+        VerifyTableHandlers(vm);
+        WriteInfo($"Named {_handlers.Count} opcode handlers without adding runtime calls.");
+    }
+
+    private void VerifyTableHandlers(TypeDefinition vm)
+    {
+        Stack<MethodDefinition> pending = [];
+        HashSet<MethodDefinition> visited = [];
+        HashSet<MethodDefinition> expected = [.. _handlers.Values];
+        HashSet<MethodDefinition> actual = [];
+        pending.Push(vm.Methods.Single(m => m.Name == "GenerateOpcodeHandlers"));
+        while (pending.Count != 0)
+        {
+            MethodDefinition method = pending.Pop();
+            if (!visited.Add(method) || !method.HasBody) continue;
+            foreach (Instruction instruction in method.Body.Instructions)
+            {
+                if (instruction.Operand is not MethodReference reference || reference.DeclaringType.Resolve() != vm) continue;
+                MethodDefinition target = reference.Resolve();
+                if (instruction.OpCode == OpCodes.Ldftn)
+                {
+                    if (!expected.Contains(target))
+                        throw new WeavingException($"Opcode table still references unnamed handler {target.Name}.");
+                    actual.Add(target);
+                }
+                else
+                {
+                    pending.Push(target);
+                }
+            }
+        }
+        if (!actual.SetEquals(expected))
+            throw new WeavingException("Named opcode handlers are not all reachable from the opcode table factories.");
+    }
+
+    private static bool IsFactory(string name) => name is
+        "OpcodeHandler" or "TerminatingOpcodeHandler" or "JumpIfOpcodeHandler" or "GetCallHandler" or "GetCreateHandler";
+
+    private MethodDefinition CloneFactory(MethodDefinition source, string opcode)
+    {
+        if (_factories.TryGetValue((source, opcode), out MethodDefinition? existing)) return existing;
+        MethodDefinition factory = new MethodCloner(source).Clone(source.Name + "_" + opcode);
+        _factories.Add((source, opcode), factory);
+        source.DeclaringType.Methods.Add(factory);
+        bool redirected = false;
+        foreach (Instruction instruction in factory.Body.Instructions)
+        {
+            if (instruction.Operand is not GenericInstanceMethod target || target.DeclaringType.Resolve() != source.DeclaringType)
+                continue;
+            if (IsFactory(target.Name))
+            {
+                instruction.Operand = Retarget(target, CloneFactory(target.Resolve(), opcode));
+                redirected = true;
+            }
+            else if (instruction.OpCode == OpCodes.Ldftn && target.Name is "ExecuteOpcode" or "ExecuteJumpIfOpcode")
+            {
+                if (!_handlers.TryGetValue(opcode, out MethodDefinition? handler))
+                {
+                    // Retain the generic parameters: only the metadata name and table target change.
+                    handler = new MethodCloner(target.Resolve()).Clone("Op" + opcode);
+                    source.DeclaringType.Methods.Add(handler);
+                    _handlers.Add(opcode, handler);
+                }
+                instruction.Operand = Retarget(target, handler);
+                redirected = true;
+            }
+        }
+        if (!redirected) throw new WeavingException($"Opcode factory {source.FullName} no longer selects a dispatch handler.");
+        return factory;
+    }
+
+    private static string GetOperationName(TypeReference type)
+    {
+        string name = type.Name.Split('`')[0];
+        if (type is GenericParameter || !name.StartsWith("Op", StringComparison.Ordinal))
+            throw new WeavingException($"Expected a concrete opcode operation, found {type.FullName}.");
+        return name.Substring(2);
+    }
+
+    private static string GetOpcodeName(TypeReference type)
+    {
+        string name = type.Name.Split('`')[0];
+        if (!name.EndsWith("Opcode", StringComparison.Ordinal))
+            throw new WeavingException($"Unknown opcode body {type.FullName}.");
+        name = name.Substring(0, name.Length - "Opcode".Length);
+        if (name is "Math1" or "Math2" or "Math3" or "Bitwise" or "Shift"
+            or "EnvAddress" or "Env32Bytes" or "EnvUInt256" or "EnvUInt32" or "EnvUInt64"
+            or "BlkAddress" or "BlkUInt256" or "BlkUInt64" or "Push" or "Dup" or "Swap" or "Log")
+        {
+            // These bodies are nested in VirtualMachine<TGasPolicy>; argument zero is the enclosing gas policy.
+            string operation = GetOperationName(((GenericInstanceType)type).GenericArguments[1]);
+            if (name is "Push" or "Dup" or "Swap" or "Log") return name + operation;
+            return operation.StartsWith("Bitwise", StringComparison.Ordinal) ? operation.Substring("Bitwise".Length) : operation;
+        }
+        return name switch
+        {
+            "CountLeadingZeros" => "Clz",
+            "ProgramCounter" => "Pc",
+            "Keccak" => "Keccak256",
+            "SStoreMetered" or "SStoreUnmetered" => "SStore",
+            _ => name
+        };
+    }
+
+    private static GenericInstanceMethod Retarget(GenericInstanceMethod original, MethodDefinition target)
+    {
+        MethodReference reference = new(target.Name, original.ElementMethod.ReturnType, original.DeclaringType)
+        {
+            HasThis = original.HasThis,
+            ExplicitThis = original.ExplicitThis,
+            CallingConvention = original.ElementMethod.CallingConvention
+        };
+        foreach (GenericParameter parameter in target.GenericParameters)
+            reference.GenericParameters.Add(new GenericParameter(parameter.Name, reference));
+        foreach (ParameterDefinition parameter in original.ElementMethod.Parameters)
+            reference.Parameters.Add(new ParameterDefinition(parameter.ParameterType));
+        GenericInstanceMethod result = new(reference);
+        foreach (TypeReference argument in original.GenericArguments) result.GenericArguments.Add(argument);
+        return result;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
@@ -97,7 +97,9 @@ public sealed class ModuleWeaver : BaseModuleWeaver
             if (!visited.Add(method) || !method.HasBody) continue;
             foreach (Instruction instruction in method.Body.Instructions)
             {
-                if (instruction.Operand is not MethodReference reference || reference.DeclaringType.Resolve() != vm) continue;
+                if (instruction.Operand is not MethodReference reference
+                    || reference.DeclaringType.GetElementType().FullName != vm.FullName
+                    || reference.DeclaringType.Resolve() != vm) continue;
                 MethodDefinition target = Resolve(reference);
                 if (instruction.OpCode == OpCodes.Ldftn)
                 {

--- a/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
@@ -80,9 +80,9 @@ public sealed class ModuleWeaver : BaseModuleWeaver
                 MethodDefinition target = Resolve(reference);
                 if (instruction.OpCode == OpCodes.Ldftn)
                 {
-                    if (!expected.Contains(target))
+                    if (expected.Contains(target)) actual.Add(target);
+                    else if (target.Name is "ExecuteOpcode" or "ExecuteJumpIfOpcode")
                         throw new WeavingException($"Opcode table still references unnamed handler {target.Name}.");
-                    actual.Add(target);
                 }
                 else
                 {

--- a/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
@@ -47,7 +47,7 @@ public sealed class ModuleWeaver : BaseModuleWeaver
                     "GetCallHandler" or "GetCreateHandler" => GetOperationName(call.GenericArguments[0]),
                     _ => GetOpcodeName(call.GenericArguments[0])
                 };
-                instruction.Operand = Retarget(call, CloneFactory(call.Resolve(), name));
+                instruction.Operand = Retarget(call, CloneFactory(Resolve(call), name));
             }
         }
 
@@ -77,7 +77,7 @@ public sealed class ModuleWeaver : BaseModuleWeaver
             foreach (Instruction instruction in method.Body.Instructions)
             {
                 if (instruction.Operand is not MethodReference reference || reference.DeclaringType.Resolve() != vm) continue;
-                MethodDefinition target = reference.Resolve();
+                MethodDefinition target = Resolve(reference);
                 if (instruction.OpCode == OpCodes.Ldftn)
                 {
                     if (!expected.Contains(target))
@@ -106,6 +106,9 @@ public sealed class ModuleWeaver : BaseModuleWeaver
         return result ?? throw new WeavingException($"Method {name} was not found in {type.FullName}.");
     }
 
+    private static MethodDefinition Resolve(MethodReference reference) =>
+        reference.Resolve() ?? throw new WeavingException($"Could not resolve {reference.FullName}.");
+
     private static bool IsFactory(string name) => name is
         "OpcodeHandler" or "TerminatingOpcodeHandler" or "JumpIfOpcodeHandler" or "GetCallHandler" or "GetCreateHandler";
 
@@ -122,7 +125,7 @@ public sealed class ModuleWeaver : BaseModuleWeaver
                 continue;
             if (IsFactory(target.Name))
             {
-                instruction.Operand = Retarget(target, CloneFactory(target.Resolve(), opcode));
+                instruction.Operand = Retarget(target, CloneFactory(Resolve(target), opcode));
                 redirected = true;
             }
             else if (instruction.OpCode == OpCodes.Ldftn && target.Name is "ExecuteOpcode" or "ExecuteJumpIfOpcode")
@@ -130,7 +133,7 @@ public sealed class ModuleWeaver : BaseModuleWeaver
                 if (!_handlers.TryGetValue(opcode, out MethodDefinition? handler))
                 {
                     // Retain the generic parameters: only the metadata name and table target change.
-                    handler = new MethodCloner(target.Resolve()).Clone("Op" + opcode);
+                    handler = new MethodCloner(Resolve(target)).Clone("Op" + opcode);
                     source.DeclaringType.Methods.Add(handler);
                     _handlers.Add(opcode, handler);
                 }
@@ -153,7 +156,7 @@ public sealed class ModuleWeaver : BaseModuleWeaver
     private static string GetOpcodeName(TypeReference type)
     {
         string name = type.Name.Split('`')[0];
-        if (!name.EndsWith("Opcode", StringComparison.Ordinal))
+        if (type is GenericParameter || !name.EndsWith("Opcode", StringComparison.Ordinal))
             throw new WeavingException($"Unknown opcode body {type.FullName}.");
         name = name.Substring(0, name.Length - "Opcode".Length);
         if (name is "Math1" or "Math2" or "Math3" or "Bitwise" or "Shift"
@@ -177,6 +180,8 @@ public sealed class ModuleWeaver : BaseModuleWeaver
 
     private static GenericInstanceMethod Retarget(GenericInstanceMethod original, MethodDefinition target)
     {
+        if (target.GenericParameters.Count != original.GenericArguments.Count)
+            throw new WeavingException($"Handler {target.Name} does not match the dispatch arity of {original.ElementMethod.FullName}.");
         MethodReference reference = new(target.Name, original.ElementMethod.ReturnType, original.DeclaringType)
         {
             HasThis = original.HasThis,

--- a/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
@@ -115,7 +115,7 @@ public sealed class ModuleWeaver : BaseModuleWeaver
     private MethodDefinition CloneFactory(MethodDefinition source, string opcode)
     {
         if (_factories.TryGetValue((source, opcode), out MethodDefinition? existing)) return existing;
-        MethodDefinition factory = new MethodCloner(source).Clone(source.Name + "_" + opcode);
+        MethodDefinition factory = new MethodCloner(source, WriteWarning).Clone(source.Name + "_" + opcode);
         _factories.Add((source, opcode), factory);
         source.DeclaringType.Methods.Add(factory);
         bool redirected = false;
@@ -133,7 +133,7 @@ public sealed class ModuleWeaver : BaseModuleWeaver
                 if (!_handlers.TryGetValue(opcode, out MethodDefinition? handler))
                 {
                     // Retain the generic parameters: only the metadata name and table target change.
-                    handler = new MethodCloner(Resolve(target)).Clone("Op" + opcode);
+                    handler = new MethodCloner(Resolve(target), WriteWarning).Clone("Op" + opcode);
                     source.DeclaringType.Methods.Add(handler);
                     _handlers.Add(opcode, handler);
                 }

--- a/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Fody;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -22,12 +21,18 @@ public sealed class ModuleWeaver : BaseModuleWeaver
     /// <inheritdoc />
     public override void Execute()
     {
-        TypeDefinition vm = ModuleDefinition.Types.Single(t => t.FullName == "Nethermind.Evm.VirtualMachine`1");
-        MethodDefinition handler = vm.Methods.Single(m => m.Name == "ExecuteOpcode");
-        if (!handler.Body.Instructions.Any(i => i.OpCode == OpCodes.Tail))
+        TypeDefinition vm = ModuleDefinition.GetType("Nethermind.Evm.VirtualMachine`1")
+            ?? throw new WeavingException("VirtualMachine type was not found.");
+        MethodDefinition handler = GetMethod(vm, "ExecuteOpcode");
+        bool hasTailCall = false;
+        foreach (Instruction instruction in handler.Body.Instructions)
+            if (instruction.OpCode == OpCodes.Tail) { hasTailCall = true; break; }
+        if (!hasTailCall)
             throw new WeavingException("Opcode naming must run after InlineIL and preserve the dispatch tail call.");
 
-        foreach (MethodDefinition method in vm.Methods.ToArray())
+        MethodDefinition[] methods = new MethodDefinition[vm.Methods.Count];
+        vm.Methods.CopyTo(methods, 0);
+        foreach (MethodDefinition method in methods)
         {
             // CALL/CREATE carry an opcode type through several fork-selection factories.
             // Clone that chain from its concrete entry point before redirecting its leaf.
@@ -47,7 +52,8 @@ public sealed class ModuleWeaver : BaseModuleWeaver
         }
 
         HashSet<string> names = new(_handlers.Keys, StringComparer.OrdinalIgnoreCase);
-        TypeDefinition instructionType = ModuleDefinition.Types.Single(t => t.FullName == "Nethermind.Evm.Instruction");
+        TypeDefinition instructionType = ModuleDefinition.GetType("Nethermind.Evm.Instruction")
+            ?? throw new WeavingException("Instruction enum was not found.");
         foreach (FieldDefinition opcode in instructionType.Fields)
             if (opcode.HasConstant && !names.Remove(opcode.Name))
                 throw new WeavingException($"No named handler for opcode {opcode.Name}.");
@@ -63,7 +69,7 @@ public sealed class ModuleWeaver : BaseModuleWeaver
         HashSet<MethodDefinition> visited = [];
         HashSet<MethodDefinition> expected = [.. _handlers.Values];
         HashSet<MethodDefinition> actual = [];
-        pending.Push(vm.Methods.Single(m => m.Name == "GenerateOpcodeHandlers"));
+        pending.Push(GetMethod(vm, "GenerateOpcodeHandlers"));
         while (pending.Count != 0)
         {
             MethodDefinition method = pending.Pop();
@@ -86,6 +92,18 @@ public sealed class ModuleWeaver : BaseModuleWeaver
         }
         if (!actual.SetEquals(expected))
             throw new WeavingException("Named opcode handlers are not all reachable from the opcode table factories.");
+    }
+
+    private static MethodDefinition GetMethod(TypeDefinition type, string name)
+    {
+        MethodDefinition? result = null;
+        foreach (MethodDefinition method in type.Methods)
+        {
+            if (method.Name != name) continue;
+            if (result is not null) throw new WeavingException($"Multiple methods named {name} in {type.FullName}.");
+            result = method;
+        }
+        return result ?? throw new WeavingException($"Method {name} was not found in {type.FullName}.");
     }
 
     private static bool IsFactory(string name) => name is

--- a/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
@@ -52,6 +52,8 @@ public sealed class ModuleWeaver : BaseModuleWeaver
         }
 
         HashSet<string> names = new(_handlers.Keys, StringComparer.OrdinalIgnoreCase);
+        if (names.Count != _handlers.Count)
+            throw new WeavingException("Named handlers differ only by case.");
         TypeDefinition instructionType = ModuleDefinition.GetType("Nethermind.Evm.Instruction")
             ?? throw new WeavingException("Instruction enum was not found.");
         foreach (FieldDefinition opcode in instructionType.Fields)
@@ -60,7 +62,25 @@ public sealed class ModuleWeaver : BaseModuleWeaver
         if (!names.SetEquals(new[] { "BadInstruction" }))
             throw new WeavingException("Named handlers do not match the instruction enum.");
         VerifyTableHandlers(vm);
+        RemoveUnusedFactories(vm, methods);
         WriteInfo($"Named {_handlers.Count} opcode handlers without adding runtime calls.");
+    }
+
+    private static void RemoveUnusedFactories(TypeDefinition vm, MethodDefinition[] originals)
+    {
+        HashSet<MethodDefinition> factories = [];
+        foreach (MethodDefinition method in originals)
+            if (IsFactory(method.Name)) factories.Add(method);
+        foreach (TypeDefinition type in vm.Module.GetTypes())
+            foreach (MethodDefinition method in type.Methods)
+            {
+                if (!method.HasBody || factories.Contains(method)) continue;
+                foreach (Instruction instruction in method.Body.Instructions)
+                    if (instruction.Operand is MethodReference reference && reference.DeclaringType.Resolve() == vm
+                        && factories.Contains(Resolve(reference)))
+                        throw new WeavingException($"Method {method.FullName} still references an original opcode factory.");
+            }
+        foreach (MethodDefinition factory in factories) vm.Methods.Remove(factory);
     }
 
     private void VerifyTableHandlers(TypeDefinition vm)
@@ -182,6 +202,15 @@ public sealed class ModuleWeaver : BaseModuleWeaver
     {
         if (target.GenericParameters.Count != original.GenericArguments.Count)
             throw new WeavingException($"Handler {target.Name} does not match the dispatch arity of {original.ElementMethod.FullName}.");
+        MethodDefinition template = Resolve(original);
+        if (target.HasThis != template.HasThis || target.ExplicitThis != template.ExplicitThis
+            || target.CallingConvention != template.CallingConvention
+            || target.ReturnType.FullName != template.ReturnType.FullName
+            || target.Parameters.Count != template.Parameters.Count)
+            throw new WeavingException($"Handler {target.Name} does not match the dispatch signature of {template.FullName}.");
+        for (int i = 0; i < target.Parameters.Count; i++)
+            if (target.Parameters[i].ParameterType.FullName != template.Parameters[i].ParameterType.FullName)
+                throw new WeavingException($"Handler {target.Name} does not match parameter {i} of {template.FullName}.");
         MethodReference reference = new(target.Name, original.ElementMethod.ReturnType, original.DeclaringType)
         {
             HasThis = original.HasThis,

--- a/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
@@ -76,7 +76,8 @@ public sealed class ModuleWeaver : BaseModuleWeaver
             {
                 if (!method.HasBody || factories.Contains(method)) continue;
                 foreach (Instruction instruction in method.Body.Instructions)
-                    if (instruction.Operand is MethodReference reference && reference.DeclaringType.Resolve() == vm
+                    if (instruction.Operand is MethodReference reference && IsFactory(reference.Name)
+                        && reference.DeclaringType.Resolve() == vm
                         && factories.Contains(Resolve(reference)))
                         throw new WeavingException($"Method {method.FullName} still references an original opcode factory.");
             }
@@ -198,7 +199,7 @@ public sealed class ModuleWeaver : BaseModuleWeaver
         };
     }
 
-    private static GenericInstanceMethod Retarget(GenericInstanceMethod original, MethodDefinition target)
+    internal static GenericInstanceMethod Retarget(GenericInstanceMethod original, MethodDefinition target)
     {
         if (target.GenericParameters.Count != original.GenericArguments.Count)
             throw new WeavingException($"Handler {target.Name} does not match the dispatch arity of {original.ElementMethod.FullName}.");

--- a/src/Nethermind/Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj
+++ b/src/Nethermind/Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FodyHelpers" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/src/Nethermind/Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj
+++ b/src/Nethermind/Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Nethermind.Evm.Test" />
     <PackageReference Include="FodyHelpers" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Nethermind/Nethermind.Evm.Fody/README.md
+++ b/src/Nethermind/Nethermind.Evm.Fody/README.md
@@ -1,0 +1,36 @@
+# Opcode naming
+
+This build-only Fody weaver gives every opcode a distinct `Op…` method
+name in CPU profiles, even when the profiler omits generic arguments.
+The EVM project runs it after InlineIL on ordinary builds.
+
+It clones `ExecuteOpcode` (or the dedicated JUMPI dispatcher) and its pointer factory for each opcode,
+then redirects the table construction calls to the named factories. The cloned
+methods retain all generic arguments, constraints, implementation flags and the
+explicit `tail.calli`. The instruction implementation stays in one source
+template; there is no runtime forwarding wrapper. Table refreshes use the same
+rewritten construction paths.
+
+CALL, CALLCODE, DELEGATECALL and STATICCALL have separate names, as do CREATE
+and CREATE2. Their fork-selection factory chains are cloned with the opcode name
+carried through to the final function pointer. Gas-policy and fork variants keep
+their generic specialization. The build fails if the generated names do not cover
+the instruction enum; unassigned table entries use `OpBadInstruction`.
+
+Validation:
+
+```sh
+dotnet build src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c Release -nr:false
+dotnet test --project src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c Release --no-build -- --filter FullyQualifiedName~VirtualMachineTests
+```
+
+When editing the weaver itself, disable MSBuild node reuse as above so a node
+cannot retain a previously loaded version of the add-in.
+
+For native-code inspection, set `DOTNET_JitDisasm` to
+`*:OpPush1 *:OpPush2 *:OpAdd *:OpSLoad` and
+`DOTNET_JitStdOutFile` to a local output file before running the tests.
+Confirm that the named methods contain the instruction work and tail transfers,
+not calls to `ExecuteOpcode`. Compare unprofiled timings separately before
+assuming unchanged throughput; identical IL semantics do not guarantee identical
+JIT layout or tiering behavior.

--- a/src/Nethermind/Nethermind.Evm.Fody/README.md
+++ b/src/Nethermind/Nethermind.Evm.Fody/README.md
@@ -4,6 +4,28 @@ This build-only Fody weaver gives every opcode a distinct `Op…` method
 name in CPU profiles, even when the profiler omits generic arguments.
 The EVM project runs it after InlineIL on ordinary builds.
 
+The generic shape is part of the execution design. Struct type arguments select
+the opcode body, gas policy, tracing, cancellation and fork behavior when the
+dispatch table is constructed. They give the JIT/AOT compiler concrete targets
+for static interface calls and constants for flag checks, allowing it to inline
+instruction work and eliminate disabled paths. One source template can therefore
+serve many specialized handlers without repeating dispatch logic for each opcode.
+Retaining those arguments and constraints preserves these optimization opportunities.
+
+The profiling side effect is that different native specializations still have
+the same metadata method name, `ExecuteOpcode`. Profilers that omit generic
+arguments show many indistinguishable entries under that name. When instruction
+bodies inline, their separate frames disappear too, making it difficult to tell
+which opcode accounts for the samples or to compare an opcode across runs.
+
+The renaming step gives those dispatch entry points stable names such as
+`OpSLoad`, `OpPush2` and `OpStaticCall` while keeping their generic shape. This
+makes opcode attribution visible even without generic arguments in the profile;
+tracing, cancellation and fork variants of the same opcode still share its name.
+Generating the named bodies after compilation keeps the source template shared
+and avoids relying on a forwarding wrapper being inlined to retain the dispatch
+shape.
+
 It clones `ExecuteOpcode` (or the dedicated JUMPI dispatcher) and its pointer factory for each opcode,
 then redirects the table construction calls to the named factories. The cloned
 methods retain all generic arguments, constraints, implementation flags and the
@@ -34,3 +56,30 @@ Confirm that the named methods contain the instruction work and tail transfers,
 not calls to `ExecuteOpcode`. Compare unprofiled timings separately before
 assuming unchanged throughput; identical IL semantics do not guarantee identical
 JIT layout or tiering behavior.
+
+## Measured scope
+
+Windows x64 .NET 10 FullOpts disassembly confirmed that the SLOAD, metered
+SSTORE and STATICCALL instruction bodies inline into their named handlers while
+retaining tail dispatch. This does not establish a block-processing speedup or
+total JIT code size across all generic specializations. `SkipLocalsInit` on
+local-free opcode bodies records the call-chain policy but changes no emitted
+local-initialization flag for those methods.
+
+For the naming and annotation changes relative to `014462bff6`, the pinned
+bflat/ZisK Docker toolchain in the guest Makefile produced these results on
+the existing block 25,532,382 witness:
+
+| Metric | Parent | Naming and annotations |
+|---|---:|---:|
+| Stripped ELF bytes | 4,651,736 | 4,651,528 |
+| `.text` bytes | 3,271,696 | 3,270,464 |
+| Executed steps | 396,212,620 | 396,802,794 |
+| Modeled memory cost | 4,076,629,105 | 4,084,009,643 |
+| Modeled total cost | 45,580,415,805 | 45,635,335,086 |
+
+Both guests validated the block with identical output. Naming alone had identical
+step counts and costs to the parent; the full annotation change increases steps
+by 0.149% and modeled total cost by 0.120% on this witness despite reducing code
+size. These are single-witness guest measurements, not proving time or desktop
+JIT performance measurements.

--- a/src/Nethermind/Nethermind.Evm.Fody/README.md
+++ b/src/Nethermind/Nethermind.Evm.Fody/README.md
@@ -39,6 +39,12 @@ carried through to the final function pointer. Gas-policy and fork variants keep
 their generic specialization. The build fails if the generated names do not cover
 the instruction enum; unassigned table entries use `OpBadInstruction`.
 
+After checking for remaining references, the weaver removes the original pointer
+factories. The two dispatch templates remain for the reflection tests that compare
+their IL and attributes against every named handler. Invalid debug sequence points,
+scope boundaries and local indices produce warnings and omit the affected debug
+information; invalid executable signatures still fail the build.
+
 Validation:
 
 ```sh
@@ -58,6 +64,11 @@ assuming unchanged throughput; identical IL semantics do not guarantee identical
 JIT layout or tiering behavior.
 
 ## Measured scope
+
+A Windows x64 Release build on SDK 10.0.400 produces a 487,424-byte managed
+`Nethermind.Evm.dll`. Named handler bodies and their specialized factories add IL
+and metadata even after unused factories are removed. Managed assembly size is
+separate from native JIT code size and the guest ELF measurements below.
 
 Windows x64 .NET 10 FullOpts disassembly confirmed that the SLOAD, metered
 SSTORE and STATICCALL instruction bodies inline into their named handlers while

--- a/src/Nethermind/Nethermind.Evm.Fody/README.md
+++ b/src/Nethermind/Nethermind.Evm.Fody/README.md
@@ -49,7 +49,7 @@ Validation:
 
 ```sh
 dotnet build src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c Release -nr:false
-dotnet test --project src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c Release --no-build -- --filter FullyQualifiedName~VirtualMachineTests
+dotnet test --project src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c Release --no-build -- --filter "FullyQualifiedName~VirtualMachineTests|FullyQualifiedName~OpcodeWeaverTests"
 ```
 
 When editing the weaver itself, disable MSBuild node reuse as above so a node

--- a/src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj
+++ b/src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FodyHelpers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ClearScript.V8" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" />
@@ -22,6 +23,9 @@
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Evm\Nethermind.Evm.csproj" />
+    <ProjectReference Include="../Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" PrivateAssets="all"
+                      GlobalPropertiesToRemove="RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;PublishAot"
+                      UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;PublishAot" />
     <ProjectReference Include="..\Nethermind.JsonRpc\Nethermind.JsonRpc.csproj" />
     <ProjectReference Include="..\Nethermind.Synchronization\Nethermind.Synchronization.csproj" />
   </ItemGroup>

--- a/src/Nethermind/Nethermind.Evm.Test/OpcodeWeaverTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/OpcodeWeaverTests.cs
@@ -12,7 +12,7 @@ using CilInstruction = Mono.Cecil.Cil.Instruction;
 
 namespace Nethermind.Evm.Test;
 
-[TestFixture]
+[TestFixture, Parallelizable(ParallelScope.All)]
 public class OpcodeWeaverTests
 {
     [Test]
@@ -113,10 +113,10 @@ public class OpcodeWeaverTests
     }
 
     [Test]
-    public void Opcode_factory_removal_ignores_unrelated_unresolved_calls_but_rejects_factory_calls([Values] bool factoryCall)
+    public void Opcode_validation_ignores_unrelated_unresolved_calls_but_rejects_factory_calls([Values] bool factoryCall, [Values] bool inTable)
     {
         using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
-        MethodDefinition factory = SetUpOpcodeTable(module, ["BadInstructionOpcode"]);
+        (MethodDefinition factory, MethodDefinition table) = SetUpOpcodeTable(module, ["BadInstructionOpcode"]);
         module.Types.Add(new TypeDefinition("Nethermind.Evm", "Instruction", TypeAttributes.Class, module.TypeSystem.Object));
         TypeDefinition unrelated = new("Test", "Unrelated", TypeAttributes.Class, module.TypeSystem.Object);
         module.Types.Add(unrelated);
@@ -124,7 +124,8 @@ public class OpcodeWeaverTests
         unrelated.Methods.Add(caller);
         AssemblyNameReference missing = new("MissingAssembly", new Version(1, 0));
         TypeReference external = new("Missing", "External", module, missing);
-        caller.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, new MethodReference("UnrelatedCall", module.TypeSystem.Void, external)));
+        MethodDefinition externalCaller = inTable ? table : caller;
+        externalCaller.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, new MethodReference("UnrelatedCall", module.TypeSystem.Void, external)));
         TypeDefinition vm = module.GetType("Nethermind.Evm.VirtualMachine`1");
         if (factoryCall)
             caller.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, factory));
@@ -141,7 +142,7 @@ public class OpcodeWeaverTests
         }
     }
 
-    private static MethodDefinition SetUpOpcodeTable(ModuleDefinition module, string[] opcodeNames)
+    private static (MethodDefinition Factory, MethodDefinition Table) SetUpOpcodeTable(ModuleDefinition module, string[] opcodeNames)
     {
         MethodDefinition handler = CreateWeaverMethod(module, "ExecuteOpcode");
         TypeDefinition vm = handler.DeclaringType;
@@ -161,7 +162,7 @@ public class OpcodeWeaverTests
             call.GenericArguments.Add(opcode);
             table.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, call));
         }
-        return factory;
+        return (factory, table);
     }
 
     private static MethodDefinition CreateWeaverMethod(ModuleDefinition module, string name)

--- a/src/Nethermind/Nethermind.Evm.Test/OpcodeWeaverTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/OpcodeWeaverTests.cs
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Fody;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Nethermind.Evm.Fody;
+using NUnit.Framework;
+using CilInstruction = Mono.Cecil.Cil.Instruction;
+
+namespace Nethermind.Evm.Test;
+
+[TestFixture]
+public class OpcodeWeaverTests
+{
+    [Test]
+    public void Opcode_cloner_rejects_instance_methods()
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Instance");
+        method.IsStatic = false;
+        method.HasThis = true;
+        method.Body.Instructions.Insert(0, CilInstruction.Create(OpCodes.Ldarg, method.Body.ThisParameter));
+
+        Assert.That(() => new MethodCloner(method, _ => { }).Clone("Clone"),
+            Throws.TypeOf<WeavingException>().With.Message.Contains("Only static methods"));
+    }
+
+    [Test]
+    public void Opcode_cloner_drops_stale_scopes([Values] bool nested, [Values] bool staleStart)
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Template");
+        CilInstruction first = method.Body.Instructions[0];
+        ScopeDebugInformation scope = new(first, null);
+        if (staleStart) scope.Start = new InstructionOffset(99);
+        else scope.End = new InstructionOffset(99);
+        scope.Scopes.Add(new ScopeDebugInformation(first, null));
+        method.DebugInformation.SequencePoints.Add(new SequencePoint(first, new Document("Test.cs")) { StartLine = 1, EndLine = 1 });
+        method.DebugInformation.Scope = nested ? new ScopeDebugInformation(first, null) : scope;
+        if (nested) method.DebugInformation.Scope.Scopes.Add(scope);
+        List<string> warnings = [];
+
+        MethodDefinition clone = new MethodCloner(method, warnings.Add).Clone("Clone");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warnings, Has.Count.EqualTo(1));
+            Assert.That(warnings[0], Does.Contain("dropping scope and its nested scopes"));
+            if (nested) Assert.That(clone.DebugInformation.Scope.Scopes, Is.Empty);
+            else Assert.That(clone.DebugInformation.Scope, Is.Null);
+            Assert.That(clone.Body.Instructions, Has.Count.EqualTo(1));
+            Assert.That(clone.DebugInformation.SequencePoints, Has.Count.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void Opcode_cloner_skips_stale_debug_locals()
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Template");
+        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+        VariableDefinition removed = new(module.TypeSystem.Int32);
+        method.Body.Variables.Add(removed);
+        method.DebugInformation.Scope = new ScopeDebugInformation(method.Body.Instructions[0], null);
+        method.DebugInformation.Scope.Variables.Add(new VariableDebugInformation(method.Body.Variables[0], "kept"));
+        method.DebugInformation.Scope.Variables.Add(new VariableDebugInformation(removed, "removed"));
+        MethodBody updatedBody = new(method);
+        updatedBody.Instructions.Add(method.Body.Instructions[0]);
+        updatedBody.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+        method.Body = updatedBody;
+        List<string> warnings = [];
+
+        MethodDefinition clone = new MethodCloner(method, warnings.Add).Clone("Clone");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warnings, Is.EqualTo(new[] { $"Debug variable removed at index 1 in {method.FullName} has no local." }));
+            Assert.That(clone.DebugInformation.Scope.Variables, Has.Count.EqualTo(1));
+            Assert.That(clone.DebugInformation.Scope.Variables[0].Name, Is.EqualTo("kept"));
+        }
+    }
+
+    [Test]
+    public void Opcode_retarget_rejects_incompatible_signatures([Values("count", "type", "return", "instance")] string mismatch)
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Template");
+        method.Parameters.Add(new ParameterDefinition(module.TypeSystem.Int32));
+        MethodDefinition clone = new MethodCloner(method, _ => { }).Clone("Clone");
+        switch (mismatch)
+        {
+            case "count": clone.Parameters.Clear(); break;
+            case "type": clone.Parameters[0].ParameterType = module.TypeSystem.Int64; break;
+            case "return": clone.ReturnType = module.TypeSystem.Int32; break;
+            case "instance": clone.HasThis = true; break;
+        }
+
+        Assert.That(() => ModuleWeaver.Retarget(new GenericInstanceMethod(method), clone),
+            Throws.TypeOf<WeavingException>());
+    }
+
+    [Test]
+    public void Opcode_weaver_rejects_names_differing_only_by_case()
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        SetUpOpcodeTable(module, ["SLoadOpcode", "SloadOpcode"]);
+        ModuleWeaver weaver = new() { ModuleDefinition = module };
+
+        Assert.That(weaver.Execute, Throws.TypeOf<WeavingException>().With.Message.Contains("differ only by case"));
+    }
+
+    [Test]
+    public void Opcode_factory_removal_ignores_unrelated_unresolved_calls_but_rejects_factory_calls([Values] bool factoryCall)
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition factory = SetUpOpcodeTable(module, ["BadInstructionOpcode"]);
+        module.Types.Add(new TypeDefinition("Nethermind.Evm", "Instruction", TypeAttributes.Class, module.TypeSystem.Object));
+        TypeDefinition unrelated = new("Test", "Unrelated", TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(unrelated);
+        MethodDefinition caller = new("Caller", MethodAttributes.Static, module.TypeSystem.Void);
+        unrelated.Methods.Add(caller);
+        AssemblyNameReference missing = new("MissingAssembly", new Version(1, 0));
+        TypeReference external = new("Missing", "External", module, missing);
+        caller.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, new MethodReference("UnrelatedCall", module.TypeSystem.Void, external)));
+        TypeDefinition vm = module.GetType("Nethermind.Evm.VirtualMachine`1");
+        if (factoryCall)
+            caller.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, factory));
+        caller.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
+        ModuleWeaver weaver = new() { ModuleDefinition = module };
+
+        if (factoryCall)
+            Assert.That(weaver.Execute, Throws.TypeOf<WeavingException>().With.Message.Contains("still references an original opcode factory"));
+        else
+        {
+            weaver.Execute();
+            foreach (MethodDefinition method in vm.Methods)
+                Assert.That(method.Name, Is.Not.EqualTo("OpcodeHandler"));
+        }
+    }
+
+    private static MethodDefinition SetUpOpcodeTable(ModuleDefinition module, string[] opcodeNames)
+    {
+        MethodDefinition handler = CreateWeaverMethod(module, "ExecuteOpcode");
+        TypeDefinition vm = handler.DeclaringType;
+        handler.Body.Instructions.Insert(0, CilInstruction.Create(OpCodes.Tail));
+        MethodDefinition factory = new("OpcodeHandler", MethodAttributes.Static, module.TypeSystem.Void);
+        vm.Methods.Add(factory);
+        factory.GenericParameters.Add(new GenericParameter("TOpcode", factory));
+        factory.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ldftn, new GenericInstanceMethod(handler)));
+        factory.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
+        MethodDefinition table = new("GenerateOpcodeHandlers", MethodAttributes.Static, module.TypeSystem.Void);
+        vm.Methods.Add(table);
+        foreach (string name in opcodeNames)
+        {
+            TypeDefinition opcode = new("Test", name, TypeAttributes.Class, module.TypeSystem.Object);
+            module.Types.Add(opcode);
+            GenericInstanceMethod call = new(factory);
+            call.GenericArguments.Add(opcode);
+            table.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, call));
+        }
+        return factory;
+    }
+
+    private static MethodDefinition CreateWeaverMethod(ModuleDefinition module, string name)
+    {
+        TypeDefinition vm = new("Nethermind.Evm", "VirtualMachine`1", TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(vm);
+        MethodDefinition method = new(name, MethodAttributes.Static, module.TypeSystem.Void);
+        vm.Methods.Add(method);
+        method.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
+        return method;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -9,11 +9,6 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Autofac;
-using Fody;
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using Nethermind.Evm.Fody;
-using CilInstruction = Mono.Cecil.Cil.Instruction;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
@@ -108,133 +103,11 @@ public class VirtualMachineTests : VirtualMachineTestsBase
     }
 
     [Test]
-    public void Opcode_cloner_rejects_instance_methods()
-    {
-        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
-        MethodDefinition method = CreateWeaverMethod(module, "Instance");
-        method.IsStatic = false;
-        method.HasThis = true;
-        method.Body.Instructions.Insert(0, CilInstruction.Create(OpCodes.Ldarg, method.Body.ThisParameter));
-
-        Assert.That(() => new MethodCloner(method, _ => { }).Clone("Clone"),
-            Throws.TypeOf<WeavingException>().With.Message.Contains("Only static methods"));
-    }
-
-    [Test]
-    public void Opcode_cloner_drops_stale_scopes([Values] bool nested, [Values] bool staleStart)
-    {
-        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
-        MethodDefinition method = CreateWeaverMethod(module, "Template");
-        CilInstruction first = method.Body.Instructions[0];
-        ScopeDebugInformation scope = new(first, null);
-        if (staleStart) scope.Start = new InstructionOffset(99);
-        else scope.End = new InstructionOffset(99);
-        method.DebugInformation.Scope = nested ? new ScopeDebugInformation(first, null) : scope;
-        if (nested) method.DebugInformation.Scope.Scopes.Add(scope);
-        List<string> warnings = [];
-
-        MethodDefinition clone = new MethodCloner(method, warnings.Add).Clone("Clone");
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(warnings, Has.Count.EqualTo(1));
-            Assert.That(warnings[0], Does.Contain("Scope boundary"));
-            if (nested) Assert.That(clone.DebugInformation.Scope.Scopes, Is.Empty);
-            else Assert.That(clone.DebugInformation.Scope, Is.Null);
-            Assert.That(clone.Body.Instructions, Has.Count.EqualTo(1));
-        }
-    }
-
-    [Test]
-    public void Opcode_cloner_skips_stale_debug_locals()
-    {
-        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
-        MethodDefinition method = CreateWeaverMethod(module, "Template");
-        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
-        VariableDefinition removed = new(module.TypeSystem.Int32);
-        method.Body.Variables.Add(removed);
-        method.DebugInformation.Scope = new ScopeDebugInformation(method.Body.Instructions[0], null);
-        method.DebugInformation.Scope.Variables.Add(new VariableDebugInformation(method.Body.Variables[0], "kept"));
-        method.DebugInformation.Scope.Variables.Add(new VariableDebugInformation(removed, "removed"));
-        Mono.Cecil.Cil.MethodBody updatedBody = new(method);
-        updatedBody.Instructions.Add(method.Body.Instructions[0]);
-        updatedBody.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
-        method.Body = updatedBody;
-        List<string> warnings = [];
-
-        MethodDefinition clone = new MethodCloner(method, warnings.Add).Clone("Clone");
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(warnings, Is.EqualTo(new[] { $"Debug variable removed at index 1 in {method.FullName} has no local." }));
-            Assert.That(clone.DebugInformation.Scope.Variables, Has.Count.EqualTo(1));
-            Assert.That(clone.DebugInformation.Scope.Variables[0].Name, Is.EqualTo("kept"));
-        }
-    }
-
-    [Test]
-    public void Opcode_retarget_rejects_incompatible_signatures([Values("count", "type", "return", "instance")] string mismatch)
-    {
-        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
-        MethodDefinition method = CreateWeaverMethod(module, "Template");
-        method.Parameters.Add(new ParameterDefinition(module.TypeSystem.Int32));
-        MethodDefinition clone = new MethodCloner(method, _ => { }).Clone("Clone");
-        switch (mismatch)
-        {
-            case "count": clone.Parameters.Clear(); break;
-            case "type": clone.Parameters[0].ParameterType = module.TypeSystem.Int64; break;
-            case "return": clone.ReturnType = module.TypeSystem.Int32; break;
-            case "instance": clone.HasThis = true; break;
-        }
-        MethodInfo retarget = typeof(ModuleWeaver).GetMethod("Retarget", BindingFlags.Static | BindingFlags.NonPublic)!;
-
-        Assert.That(() => retarget.Invoke(null, [new GenericInstanceMethod(method), clone]),
-            Throws.TypeOf<TargetInvocationException>().With.InnerException.TypeOf<WeavingException>());
-    }
-
-    [Test]
-    public void Opcode_weaver_rejects_names_differing_only_by_case()
-    {
-        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
-        MethodDefinition handler = CreateWeaverMethod(module, "ExecuteOpcode");
-        TypeDefinition vm = handler.DeclaringType;
-        handler.Body.Instructions.Insert(0, CilInstruction.Create(OpCodes.Tail));
-        MethodDefinition factory = new("OpcodeHandler", Mono.Cecil.MethodAttributes.Static, module.TypeSystem.Void);
-        vm.Methods.Add(factory);
-        factory.GenericParameters.Add(new GenericParameter("TOpcode", factory));
-        factory.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ldftn, new GenericInstanceMethod(handler)));
-        factory.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
-        MethodDefinition table = new("GenerateOpcodeHandlers", Mono.Cecil.MethodAttributes.Static, module.TypeSystem.Void);
-        vm.Methods.Add(table);
-        foreach (string name in new[] { "SLoadOpcode", "SloadOpcode" })
-        {
-            TypeDefinition opcode = new("Test", name, Mono.Cecil.TypeAttributes.Class, module.TypeSystem.Object);
-            module.Types.Add(opcode);
-            GenericInstanceMethod call = new(factory);
-            call.GenericArguments.Add(opcode);
-            table.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, call));
-        }
-        ModuleWeaver weaver = new() { ModuleDefinition = module };
-
-        Assert.That(weaver.Execute, Throws.TypeOf<WeavingException>().With.Message.Contains("differ only by case"));
-    }
-
-    [Test]
     public void Original_opcode_factories_are_removed()
     {
         Type vmType = typeof(VirtualMachine<EthereumGasPolicy>);
-        foreach (MethodInfo method in vmType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic))
+        foreach (MethodInfo method in vmType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
             Assert.That(method.Name, Is.Not.AnyOf("OpcodeHandler", "TerminatingOpcodeHandler", "JumpIfOpcodeHandler", "GetCallHandler", "GetCreateHandler"));
-    }
-
-    private static MethodDefinition CreateWeaverMethod(ModuleDefinition module, string name)
-    {
-        TypeDefinition vm = new("Nethermind.Evm", "VirtualMachine`1", Mono.Cecil.TypeAttributes.Class, module.TypeSystem.Object);
-        module.Types.Add(vm);
-        MethodDefinition method = new(name, Mono.Cecil.MethodAttributes.Static, module.TypeSystem.Void);
-        vm.Methods.Add(method);
-        method.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
-        return method;
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -119,6 +119,7 @@ public class VirtualMachineTests : VirtualMachineTestsBase
             Assert.That(handler.GetMethodBody()!.GetILAsByteArray()!.Length, Is.EqualTo(template.GetMethodBody()!.GetILAsByteArray()!.Length),
                 "the named entry point must contain the dispatch body rather than a forwarding wrapper");
             Assert.That(handler.GetMethodImplementationFlags(), Is.EqualTo(template.GetMethodImplementationFlags()));
+            Assert.That(handler.GetCustomAttributesData().Select(a => a.AttributeType), Is.EquivalentTo(template.GetCustomAttributesData().Select(a => a.AttributeType)));
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -103,6 +103,26 @@ public class VirtualMachineTests : VirtualMachineTestsBase
     }
 
     [Test]
+    public void Named_opcode_handlers_are_emitted([Values] Instruction opcode)
+    {
+        Type vmType = typeof(VirtualMachine<EthereumGasPolicy>);
+        MethodInfo template = vmType.GetMethod(opcode == Instruction.JUMPI ? "ExecuteJumpIfOpcode" : "ExecuteOpcode",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        MethodInfo handler = Array.Find(vmType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic), method =>
+            method.Name.Equals("Op" + opcode, StringComparison.OrdinalIgnoreCase)
+            && method.GetGenericArguments().Length == template.GetGenericArguments().Length
+            && method.GetParameters().Length == template.GetParameters().Length);
+        Assert.That(handler, Is.Not.Null, "the opcode naming weaver must run after InlineIL");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(handler.GetMethodBody()!.GetILAsByteArray()!.Length, Is.EqualTo(template.GetMethodBody()!.GetILAsByteArray()!.Length),
+                "the named entry point must contain the dispatch body rather than a forwarding wrapper");
+            Assert.That(handler.GetMethodImplementationFlags(), Is.EqualTo(template.GetMethodImplementationFlags()));
+        }
+    }
+
+    [Test]
     public void Frame_handlers_are_reused_across_blocks_and_reselected_across_forks()
     {
         Execute((0UL, 0UL), (byte)Instruction.STOP);

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -9,6 +9,11 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using Autofac;
+using Fody;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Nethermind.Evm.Fody;
+using CilInstruction = Mono.Cecil.Cil.Instruction;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
@@ -100,6 +105,136 @@ public class VirtualMachineTests : VirtualMachineTestsBase
             Assert.That(after, Is.Not.SameAs(before), "refresh must recapture the frame function pointers");
             Assert.That(getHandlers.Invoke(table, arguments), Is.SameAs(after), "subsequent transactions reuse the refreshed handlers");
         }
+    }
+
+    [Test]
+    public void Opcode_cloner_rejects_instance_methods()
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Instance");
+        method.IsStatic = false;
+        method.HasThis = true;
+        method.Body.Instructions.Insert(0, CilInstruction.Create(OpCodes.Ldarg, method.Body.ThisParameter));
+
+        Assert.That(() => new MethodCloner(method, _ => { }).Clone("Clone"),
+            Throws.TypeOf<WeavingException>().With.Message.Contains("Only static methods"));
+    }
+
+    [Test]
+    public void Opcode_cloner_drops_stale_scopes([Values] bool nested, [Values] bool staleStart)
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Template");
+        CilInstruction first = method.Body.Instructions[0];
+        ScopeDebugInformation scope = new(first, null);
+        if (staleStart) scope.Start = new InstructionOffset(99);
+        else scope.End = new InstructionOffset(99);
+        method.DebugInformation.Scope = nested ? new ScopeDebugInformation(first, null) : scope;
+        if (nested) method.DebugInformation.Scope.Scopes.Add(scope);
+        List<string> warnings = [];
+
+        MethodDefinition clone = new MethodCloner(method, warnings.Add).Clone("Clone");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warnings, Has.Count.EqualTo(1));
+            Assert.That(warnings[0], Does.Contain("Scope boundary"));
+            if (nested) Assert.That(clone.DebugInformation.Scope.Scopes, Is.Empty);
+            else Assert.That(clone.DebugInformation.Scope, Is.Null);
+            Assert.That(clone.Body.Instructions, Has.Count.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void Opcode_cloner_skips_stale_debug_locals()
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Template");
+        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+        VariableDefinition removed = new(module.TypeSystem.Int32);
+        method.Body.Variables.Add(removed);
+        method.DebugInformation.Scope = new ScopeDebugInformation(method.Body.Instructions[0], null);
+        method.DebugInformation.Scope.Variables.Add(new VariableDebugInformation(method.Body.Variables[0], "kept"));
+        method.DebugInformation.Scope.Variables.Add(new VariableDebugInformation(removed, "removed"));
+        Mono.Cecil.Cil.MethodBody updatedBody = new(method);
+        updatedBody.Instructions.Add(method.Body.Instructions[0]);
+        updatedBody.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+        method.Body = updatedBody;
+        List<string> warnings = [];
+
+        MethodDefinition clone = new MethodCloner(method, warnings.Add).Clone("Clone");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warnings, Is.EqualTo(new[] { $"Debug variable removed at index 1 in {method.FullName} has no local." }));
+            Assert.That(clone.DebugInformation.Scope.Variables, Has.Count.EqualTo(1));
+            Assert.That(clone.DebugInformation.Scope.Variables[0].Name, Is.EqualTo("kept"));
+        }
+    }
+
+    [Test]
+    public void Opcode_retarget_rejects_incompatible_signatures([Values("count", "type", "return", "instance")] string mismatch)
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Template");
+        method.Parameters.Add(new ParameterDefinition(module.TypeSystem.Int32));
+        MethodDefinition clone = new MethodCloner(method, _ => { }).Clone("Clone");
+        switch (mismatch)
+        {
+            case "count": clone.Parameters.Clear(); break;
+            case "type": clone.Parameters[0].ParameterType = module.TypeSystem.Int64; break;
+            case "return": clone.ReturnType = module.TypeSystem.Int32; break;
+            case "instance": clone.HasThis = true; break;
+        }
+        MethodInfo retarget = typeof(ModuleWeaver).GetMethod("Retarget", BindingFlags.Static | BindingFlags.NonPublic)!;
+
+        Assert.That(() => retarget.Invoke(null, [new GenericInstanceMethod(method), clone]),
+            Throws.TypeOf<TargetInvocationException>().With.InnerException.TypeOf<WeavingException>());
+    }
+
+    [Test]
+    public void Opcode_weaver_rejects_names_differing_only_by_case()
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition handler = CreateWeaverMethod(module, "ExecuteOpcode");
+        TypeDefinition vm = handler.DeclaringType;
+        handler.Body.Instructions.Insert(0, CilInstruction.Create(OpCodes.Tail));
+        MethodDefinition factory = new("OpcodeHandler", Mono.Cecil.MethodAttributes.Static, module.TypeSystem.Void);
+        vm.Methods.Add(factory);
+        factory.GenericParameters.Add(new GenericParameter("TOpcode", factory));
+        factory.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ldftn, new GenericInstanceMethod(handler)));
+        factory.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
+        MethodDefinition table = new("GenerateOpcodeHandlers", Mono.Cecil.MethodAttributes.Static, module.TypeSystem.Void);
+        vm.Methods.Add(table);
+        foreach (string name in new[] { "SLoadOpcode", "SloadOpcode" })
+        {
+            TypeDefinition opcode = new("Test", name, Mono.Cecil.TypeAttributes.Class, module.TypeSystem.Object);
+            module.Types.Add(opcode);
+            GenericInstanceMethod call = new(factory);
+            call.GenericArguments.Add(opcode);
+            table.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, call));
+        }
+        ModuleWeaver weaver = new() { ModuleDefinition = module };
+
+        Assert.That(weaver.Execute, Throws.TypeOf<WeavingException>().With.Message.Contains("differ only by case"));
+    }
+
+    [Test]
+    public void Original_opcode_factories_are_removed()
+    {
+        Type vmType = typeof(VirtualMachine<EthereumGasPolicy>);
+        foreach (MethodInfo method in vmType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic))
+            Assert.That(method.Name, Is.Not.AnyOf("OpcodeHandler", "TerminatingOpcodeHandler", "JumpIfOpcodeHandler", "GetCallHandler", "GetCreateHandler"));
+    }
+
+    private static MethodDefinition CreateWeaverMethod(ModuleDefinition module, string name)
+    {
+        TypeDefinition vm = new("Nethermind.Evm", "VirtualMachine`1", Mono.Cecil.TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(vm);
+        MethodDefinition method = new(name, Mono.Cecil.MethodAttributes.Static, module.TypeSystem.Void);
+        vm.Methods.Add(method);
+        method.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
+        return method;
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -252,6 +252,7 @@ public struct EvmPooledMemory
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ReadOnlyMemory<byte> Inspect(in UInt256 location, in UInt256 length)
     {
         if (length.IsZero)
@@ -283,6 +284,7 @@ public struct EvmPooledMemory
         return GetBackingMemory((int)location, (int)length);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private void ClearForTracing(ulong size)
     {
         ulong capacity = GetBackingCapacity();
@@ -584,6 +586,7 @@ public struct EvmPooledMemory
 
     private static readonly TraceMemory EmptyTraceMemory = new(0, default);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public TraceMemory GetTrace()
     {
         ulong size = Size;

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -1556,6 +1556,7 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public EvmExceptionType PushZero<TTracingInst, TCheckDepth>()
         where TTracingInst : struct, IFlag
         where TCheckDepth : struct, IFlag
@@ -1969,6 +1970,7 @@ public ref partial struct EvmStack
     /// <summary>
     /// Pops an address, reusing the cached instance when the popped bytes match the previously popped address.
     /// </summary>
+    [SkipLocalsInit]
     public Address? PopAddress(PoppedAddressCache cache)
     {
         nint head = Head - 1;
@@ -2200,6 +2202,7 @@ public ref partial struct EvmStack
         return true;
     }
 
+    [SkipLocalsInit]
     public bool PopWord256(out Span<byte> word)
     {
         nint head = Head - 1;

--- a/src/Nethermind/Nethermind.Evm/FodyWeavers.xml
+++ b/src/Nethermind/Nethermind.Evm/FodyWeavers.xml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
   <InlineIL />
+  <Nethermind.Evm />
 </Weavers>

--- a/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
@@ -46,6 +47,7 @@ public static class CodeInfoRepositoryExtensions
     /// <summary>
     /// Returns the <see cref="CodeInfo"/> at <paramref name="codeSource"/> without resolving any EIP-7702 delegation.
     /// </summary>
+    [SkipLocalsInit]
     public static CodeInfo GetCachedCodeInfoNoDelegation(this ICodeInfoRepository codeInfoRepository, Address codeSource, IReleaseSpec vmSpec)
         => codeInfoRepository.GetCachedCodeInfo(codeSource, false, vmSpec, out _);
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -83,6 +83,7 @@ public static partial class EvmInstructions
     /// An <see cref="EvmExceptionType"/> value indicating success or the type of error encountered.
     /// </returns>
     [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static EvmExceptionType InstructionCall<TGasPolicy, TOpCall, TTracingInst, TEip8037, TEip7708, TSpec>(
         ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
@@ -290,6 +291,7 @@ public static partial class EvmInstructions
 #else
     [MethodImpl(MethodImplOptions.NoInlining)]
 #endif
+    [SkipLocalsInit]
     private static EvmExceptionType CreateFullCallFrame<TGasPolicy, TOpCall, TTracingInst>(
         VirtualMachine<TGasPolicy> vm,
         ref EvmStack stack,
@@ -380,6 +382,7 @@ public static partial class EvmInstructions
     /// declines (returns <c>false</c>) so the call flows through its dedicated <c>InlinePrecompileCall</c> path.
     /// </remarks>
     /// <returns><c>true</c> when the call was handled inline (with the outcome in <paramref name="result"/>); otherwise <c>false</c>.</returns>
+    [SkipLocalsInit]
     private static partial bool TryInlineStaticPrecompileCall<TGasPolicy, TTracingInst>(
         VirtualMachine<TGasPolicy> vm,
         ref EvmStack stack,

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
@@ -75,6 +75,7 @@ public static partial class EvmInstructions
     /// CALLDATACOPY - copies a portion of the transaction's calldata into memory.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public static EvmExceptionType InstructionCallDataCopy<TGasPolicy, TTracingInst>(
         ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -440,6 +440,7 @@ public static partial class EvmInstructions
     /// <see cref="EvmExceptionType.None"/>, or <see cref="EvmExceptionType.BadInstruction"/> if blob base fee not set.
     /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public static EvmExceptionType InstructionBlobBaseFee<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -786,6 +787,7 @@ public static partial class EvmInstructions
     /// <returns>
     /// <see cref="EvmExceptionType.None"/>, or <see cref="EvmExceptionType.BadInstruction"/> if slot number not set.
     /// </returns>
+    [SkipLocalsInit]
     public static EvmExceptionType InstructionSlotNum<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -104,6 +104,7 @@ public static partial class EvmInstructions
     /// Push operation for two bytes.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public static EvmExceptionType InstructionPush2<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -441,6 +441,7 @@ public static partial class EvmInstructions
     /// <param name="gas">The gas state, updated by the operation's cost.</param>
     /// <returns>An <see cref="EvmExceptionType"/> indicating the outcome.</returns>
     [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static EvmExceptionType InstructionSStoreMetered<TGasPolicy, TTracingInst, TUseNetGasStipendFix, TEip8037, Eip8038, Eip2929>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -626,6 +627,7 @@ public static partial class EvmInstructions
     /// <param name="gas">The gas state, updated by the operation's cost.</param>
     /// <returns>An <see cref="EvmExceptionType"/> indicating the result of the operation.</returns>
     [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static EvmExceptionType InstructionSLoad<TGasPolicy, TTracingInst, Eip8038, Eip2929>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag

--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -11,9 +11,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" ReferenceOutputAssembly="false" OutputItemType="WeaverFiles" PrivateAssets="all"
+                      GlobalPropertiesToRemove="RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;PublishAot"
+                      UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;PublishAot" />
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />
     <ProjectReference Include="..\Nethermind.Serialization.Rlp\Nethermind.Serialization.Rlp.csproj" />
     <ProjectReference Include="..\Nethermind.Specs\Nethermind.Specs.csproj" />
   </ItemGroup>
+
+  <Target Name="TrackOpcodeWeaverChanges" BeforeTargets="CoreCompile" DependsOnTargets="ResolveProjectReferences">
+    <ItemGroup>
+      <CustomAdditionalCompileInputs Include="@(WeaverFiles)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Nethermind/Nethermind.Evm/State/WorldStateExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/State/WorldStateExtensions.cs
@@ -26,13 +26,16 @@ public static class WorldStateExtensions
     public static void AddToBalance(this IWorldState worldState, Address address, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.AddToBalance(address, balanceChange, spec, out _);
 
+    [SkipLocalsInit]
     public static bool AddToBalanceAndCreateIfNotExists(this IWorldState worldState, Address address, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.AddToBalanceAndCreateIfNotExists(address, balanceChange, spec, out _);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public static void AddToBalanceAndCreateIfNotExists(this IWorldState worldState, Address address, ExecutionType executionType, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.AddToBalanceAndCreateIfNotExists(address, executionType.GetBalanceCredit(in balanceChange), spec, out _);
 
+    [SkipLocalsInit]
     public static void SubtractFromBalance(this IWorldState worldState, Address address, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.SubtractFromBalance(address, balanceChange, spec, out _);
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
@@ -507,6 +507,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionStop(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Math2Opcode<TOpMath, TTracingInst> : IOpcodeBody
         where TOpMath : struct, EvmInstructions.IOpMath2Param
         where TTracingInst : struct, IFlag
@@ -530,6 +531,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct Math3Opcode<TOpMath, TTracingInst> : IOpcodeBody
         where TOpMath : struct, EvmInstructions.IOpMath3Param
         where TTracingInst : struct, IFlag
@@ -550,6 +552,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionMath3Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Math1Opcode<TOpMath, TTracingInst> : IOpcodeBody
         where TOpMath : struct, EvmInstructions.IOpMath1Param
         where TTracingInst : struct, IFlag
@@ -573,6 +576,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct BitwiseOpcode<TOpBitwise, TTracingInst> : IOpcodeBody
         where TOpBitwise : struct, EvmInstructions.IOpBitwise
         where TTracingInst : struct, IFlag
@@ -596,6 +600,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct ExpOpcode<TTracingInst, Eip160> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip160 : struct, IFlag
@@ -604,12 +609,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionExp<TGasPolicy, TTracingInst, Eip160>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SignExtendOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionSignExtend(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CountLeadingZerosOpcode : IOpcodeBody
     {
         public static bool HasCheckedBody => true;
@@ -621,6 +628,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.CountLeadingZerosCore<OffFlag>(ref stack);
     }
 
+    [SkipLocalsInit]
     private readonly struct ByteOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -637,6 +645,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionByte<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct ShiftOpcode<TOpShift, TTracingInst> : IOpcodeBody
         where TOpShift : struct, EvmInstructions.IOpShift
         where TTracingInst : struct, IFlag
@@ -657,6 +666,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionShift<TGasPolicy, TOpShift, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct SarOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -673,12 +683,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionSar<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct KeccakOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionKeccak256<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct EnvAddressOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvAddress<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -697,6 +709,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnvAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Env32BytesOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnv32Bytes<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -715,6 +728,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnv32Bytes<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct EnvUInt256Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -733,6 +747,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnvUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct EnvUInt32Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt32<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -751,6 +766,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnvUInt32<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct EnvUInt64Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -769,6 +785,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnvUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlkAddressOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkAddress<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -787,6 +804,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionBlkAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlkUInt256Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -805,6 +823,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionBlkUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlkUInt64Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -823,6 +842,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionBlkUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BalanceOpcode<TTracingInst, TSpec> : IOpcodeBody where TTracingInst : struct, IFlag
         where TSpec : struct, EvmInstructions.IAccessSpec
     {
@@ -830,6 +850,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionBalance<TGasPolicy, TTracingInst, TSpec>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CallDataLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody => true;
@@ -841,12 +862,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.CallDataLoadCore<TGasPolicy, TTracingInst>(ref stack, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CallDataCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionCallDataCopy<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CodeSizeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -863,12 +886,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionCodeSize<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct CodeCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionCodeCopy<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ExtCodeSizeOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
@@ -882,6 +907,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct ExtCodeCopyOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
@@ -891,6 +917,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionExtCodeCopy<TGasPolicy, TTracingInst, Eip8038, Eip2929>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ReturnDataSizeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -908,12 +935,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionReturnDataSize<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ReturnDataCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionReturnDataCopy<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ExtCodeHashOpcode<TTracingInst, TSpec> : IOpcodeBody where TTracingInst : struct, IFlag
         where TSpec : struct, EvmInstructions.IAccessSpec
     {
@@ -921,12 +950,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionExtCodeHash<TGasPolicy, TTracingInst, TSpec>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlockHashOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionBlockHash<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct PrevRandaoOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -944,6 +975,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionPrevRandao<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SelfBalanceOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -961,24 +993,28 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionSelfBalance<TGasPolicy, TTracingInst, OnFlag>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlobHashOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionBlobHash<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlobBaseFeeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionBlobBaseFee<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SlotNumOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionSlotNum<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct PopOpcode : IOpcodeBody
     {
         public static bool HasCheckedBody => true;
@@ -994,24 +1030,28 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct MLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionMLoad<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct MStoreOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionMStore<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct MStore8Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionMStore8<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private static delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>
         SStoreOpcodeHandler<TTracingInst, TCancelable, Eip8038, Eip2929>(IReleaseSpec spec)
         where TTracingInst : struct, IFlag
@@ -1028,6 +1068,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                     : OpcodeHandler<SStoreMeteredOpcode<TTracingInst, OffFlag, OffFlag, Eip8038, Eip2929>, TTracingInst, TCancelable>()
             : OpcodeHandler<SStoreUnmeteredOpcode<TTracingInst, Eip8038, Eip2929>, TTracingInst, TCancelable>();
 
+    [SkipLocalsInit]
     private readonly struct SLoadOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
@@ -1037,6 +1078,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionSLoad<TGasPolicy, TTracingInst, Eip8038, Eip2929>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SStoreMeteredOpcode<TTracingInst, TStipendFix, TEip8037, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where TStipendFix : struct, IFlag
@@ -1048,6 +1090,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionSStoreMetered<TGasPolicy, TTracingInst, TStipendFix, TEip8037, Eip8038, Eip2929>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SStoreUnmeteredOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
@@ -1057,6 +1100,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionSStoreUnmetered<TGasPolicy, TTracingInst, Eip8038, Eip2929>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct JumpOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
@@ -1069,6 +1113,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct ProgramCounterOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -1085,6 +1130,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionProgramCounter<TGasPolicy, TTracingInst>(ref stack, ref gas, vm, programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct GasOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -1101,30 +1147,35 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionGas<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct JumpDestOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionJumpDest(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct TLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionTLoad<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct TStoreOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionTStore(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct MCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionMCopy<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Push0Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static int PushSize => 0;
@@ -1144,12 +1195,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionPush0<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Push2Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionPush2<TGasPolicy, TTracingInst>(ref stack, ref gas, vm, ref programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct PushOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
@@ -1176,6 +1229,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct DupOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
@@ -1197,6 +1251,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionDup<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SwapOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
@@ -1217,30 +1272,35 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionSwap<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct LogOpcode<TOpCount> : IOpcodeBody where TOpCount : struct, EvmInstructions.IOpCount
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionLog<TGasPolicy, TOpCount>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct DupNOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionDupN<TGasPolicy, TTracingInst>(ref stack, ref gas, ref programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct SwapNOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionSwapN<TGasPolicy, TTracingInst>(ref stack, ref gas, ref programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct ExchangeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionExchange<TGasPolicy, TTracingInst>(ref stack, ref gas, ref programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct CreateOpcode<TOpCreate, TTracingInst, TEip8037, TSpec> : IOpcodeBody
         where TOpCreate : struct, EvmInstructions.IOpCreate
         where TTracingInst : struct, IFlag
@@ -1251,6 +1311,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionCreate<TGasPolicy, TOpCreate, TTracingInst, TEip8037, TSpec>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CallOpcode<TOpCall, TTracingInst, TEip8037, TEip7708, TSpec> : IOpcodeBody
         where TOpCall : struct, EvmInstructions.IOpCall
         where TTracingInst : struct, IFlag
@@ -1262,24 +1323,28 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionCall<TGasPolicy, TOpCall, TTracingInst, TEip8037, TEip7708, TSpec>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ReturnOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionReturn(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct RevertOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionRevert(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct InvalidOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionInvalid(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SelfDestructOpcode<TEip8037, TEip7708, TSpec> : IOpcodeBody
         where TEip8037 : struct, IFlag
         where TEip7708 : struct, IFlag

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -734,6 +734,7 @@ public partial class VirtualMachine<TGasPolicy>(
         GetExecutionHandlers().CreditStateGasRefund(this, ref gas, amount, trackSpillRefund);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     internal void CreditStateGasRefund<Eip8037>(ref TGasPolicy gas, long amount, bool trackSpillRefund = true)
         where Eip8037 : struct, IFlag
     {
@@ -994,6 +995,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     protected void TraceTransactionActionStart(VmState<TGasPolicy> currentState)
     {
         _txTracer.ReportAction(TGasPolicy.GetRemainingGas(currentState.Gas),
@@ -1022,6 +1024,7 @@ public partial class VirtualMachine<TGasPolicy>(
     /// <param name="callResult">
     /// The result of the executed call, including output bytes, exception and revert flags, and additional metadata.
     /// </param>
+    [MethodImpl(MethodImplOptions.NoInlining)]
     protected void TraceTransactionActionEnd(VmState<TGasPolicy> currentState, in CallResult callResult)
     {
         IReleaseSpec spec = BlockExecutionContext.Spec;

--- a/src/Nethermind/Nethermind.slnx
+++ b/src/Nethermind/Nethermind.slnx
@@ -126,6 +126,7 @@
   <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
   <Project Path="Nethermind.EthStats/Nethermind.EthStats.csproj" />
   <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
+  <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
   <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
   <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />
   <Project Path="Nethermind.Grpc/Nethermind.Grpc.csproj" />

--- a/src/Nethermind/Nethermind.slnx
+++ b/src/Nethermind/Nethermind.slnx
@@ -125,8 +125,8 @@
   <Project Path="Nethermind.Era1/Nethermind.Era1.csproj" />
   <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
   <Project Path="Nethermind.EthStats/Nethermind.EthStats.csproj" />
-  <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
   <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
+  <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
   <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
   <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />
   <Project Path="Nethermind.Grpc/Nethermind.Grpc.csproj" />


### PR DESCRIPTION
## Changes

- Adds `Nethermind.Evm.Fody`, a build-only Fody weaver that runs after InlineIL on the EVM assembly. For every opcode it clones the generic `ExecuteOpcode` (or the dedicated JUMPI dispatcher) and its function-pointer factory under a stable name such as `OpSLoad`, `OpPush2` or `OpStaticCall`, then redirects the opcode-table construction calls to the named clones. The clones keep every generic parameter, constraint, implementation flag and the explicit `tail. calli`, so there is no forwarding wrapper and the instruction source stays in one template. CALL/CALLCODE/DELEGATECALL/STATICCALL and CREATE/CREATE2 get separate names by cloning their fork-selection factory chains.
- The build fails if the generated names do not cover the `Instruction` enum, if any opcode-table `ldftn` still points at an unnamed handler, or if the weaver runs before InlineIL (no `tail.` prefix present).
- Marks `InstructionCall`, `InstructionSLoad` and `InstructionSStoreMetered` `AggressiveInlining` so their work lands in the named handler frame, and marks tracing-only paths (`EvmPooledMemory.Inspect`/`GetTrace`/`ClearForTracing`, `TraceTransactionActionStart`/`End`) `NoInlining` to keep them out of the hot handlers. Adds `SkipLocalsInit` along the opcode call chain; on local-free bodies this is a policy marker only and changes no emitted flag (documented in the README).

### Why

Generic specialization is what lets the JIT inline opcode work and fold disabled tracing, cancellation and fork paths. Its cost is that profilers which omit generic arguments show every specialization as `ExecuteOpcode`, and inlining removes the instruction frames that would otherwise identify them. Named entry points restore per-opcode attribution in dotTrace/perf without adding runtime calls, which is what makes the EVM profiles from the benchmark workflows actionable for follow-up work.

Before

<img alt="image" src="https://github.com/user-attachments/assets/e1075a9b-25bd-4bfb-9f6a-2c033e48a496" />

After

<img alt="image" src="https://github.com/user-attachments/assets/a8b9677d-d161-4677-b367-9c369fd54153" />



### Managed assembly size

The Release managed `Nethermind.Evm.dll` measures 487,424 bytes on Windows x64 / SDK 10.0.400 versus 360,960 bytes before opcode naming (+35.0%). The weaver removes unused original pointer factories after checking for remaining references; the two dispatch templates remain for reflection tests. Most of the managed size increase comes from the duplicated handler bodies and specialized factories. Managed IL and metadata size is separate from the native guest `.text` and ELF measurements below.

### zkEVM guest impact (bflat/ZisK, pinned images from the guest Makefile, block 25,532,382)

| Metric | Parent `014462bff6` | This PR | Delta |
|---|---:|---:|---:|
| `.text` bytes | 3,271,696 | 3,270,464 | -1,232 |
| Stripped ELF bytes | 4,651,736 | 4,651,528 | -208 |
| Executed steps | 396,212,620 | 396,802,794 | +0.149% |
| Modeled total cost | 45,580,415,805 | 45,635,335,086 | +0.120% |
| ROM usage | 20.75% | 20.74% | -0.01 pt |

Both guests produce identical output for the block. Naming alone is step- and cost-neutral against the parent; the small execution-cost increase comes from the inlining annotations and is about five times the layout-jitter band seen on this guest, so it is real but small. Measured twice independently (author and reviewer builds from clean worktrees) with matching figures.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `VirtualMachineTests.Named_opcode_handlers_are_emitted` runs once per `Instruction` value and asserts a named handler exists with the same generic arity, parameter count, IL length and implementation flags as the dispatch template, so a regression to a forwarding wrapper or a weaver-order change fails the build's own test run.
- Weaver invariants are enforced at build time (enum coverage, table reachability, InlineIL ordering).
- `Nethermind.Evm.Test` release run: 3,790 passed. Windows x64 FullOpts disassembly confirmed the SLOAD, metered SSTORE and STATICCALL bodies inline into `OpSLoad`/`OpSStore`/`OpStaticCall` while retaining the tail dispatch (see `Nethermind.Evm.Fody/README.md`, "Measured scope").
- zkEVM guest: built and emulated on both sides as tabled above; ISA gates and the manifest-resource check pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

`Nethermind.Evm.Fody/README.md` documents the weaver, the validation recipe and the measured scope.

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

- The weaver is referenced with `ReferenceOutputAssembly="false"`, so nothing from it ships in the runtime output. Publish-only properties (RID, AOT, single-file) are stripped from the reference so the netstandard2.0 weaver builds under every publish configuration.
- When editing the weaver, build with `-nr:false` so a reused MSBuild node cannot hold a stale copy of the add-in.
