### PR TITLE
ci: disable Ethereum fixture coverage and remove legacy VM sharding

### DIFF
--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -169,7 +169,7 @@ jobs:
         env:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
-          flags="${{ matrix.runner == 'ubuntu-latest' && matrix.project != 'Nethermind.Hive.Test' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
+          flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
           if [ "$RUNNER_OS" = "Linux" ]; then
             dotnet restore ${{ matrix.project }}.csproj          # binaries from the shared Linux artifact
           else
@@ -207,7 +207,7 @@ jobs:
           retention-days: 3
 
       - name: Upload coverage report
-        if: matrix.runner == 'ubuntu-latest' && matrix.project != 'Nethermind.Hive.Test' && env.COLLECT_COVERAGE == 'true'
+        if: matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}-coverage
@@ -245,19 +245,6 @@ jobs:
           - Ethereum.Transaction.Test
           - Ethereum.Trie.Test
         chunk: ['']
-        exclude: # Legacy VM uses eight chunks on ubuntu-latest.
-          - runner: ubuntu-latest
-            project: Ethereum.Legacy.VM.Test
-            chunk: ''
-        include:
-          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 1of8 }
-          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 2of8 }
-          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 3of8 }
-          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 4of8 }
-          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 5of8 }
-          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 6of8 }
-          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 7of8 }
-          - { runner: ubuntu-latest, project: Ethereum.Legacy.VM.Test, chunk: 8of8 }
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/nethermind-tests.yml
+++ b/.github/workflows/nethermind-tests.yml
@@ -169,7 +169,7 @@ jobs:
         env:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
-          flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
+          flags="${{ matrix.runner == 'ubuntu-latest' && matrix.project != 'Nethermind.Hive.Test' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
           if [ "$RUNNER_OS" = "Linux" ]; then
             dotnet restore ${{ matrix.project }}.csproj          # binaries from the shared Linux artifact
           else
@@ -207,7 +207,7 @@ jobs:
           retention-days: 3
 
       - name: Upload coverage report
-        if: matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true'
+        if: matrix.runner == 'ubuntu-latest' && matrix.project != 'Nethermind.Hive.Test' && env.COLLECT_COVERAGE == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}-coverage
@@ -245,7 +245,7 @@ jobs:
           - Ethereum.Transaction.Test
           - Ethereum.Trie.Test
         chunk: ['']
-        exclude: # Legacy VM unchunked on ubuntu-latest is replaced by 8 chunks below (coverage makes it too slow)
+        exclude: # Legacy VM uses eight chunks on ubuntu-latest.
           - runner: ubuntu-latest
             project: Ethereum.Legacy.VM.Test
             chunk: ''
@@ -283,7 +283,6 @@ jobs:
         env:
           TEST_CHUNK: ${{ matrix.chunk }}
         run: |
-          flags="${{ matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true' && '--coverage --coverage-output-format cobertura --coverage-settings ../codecoverage.json' || '' }}"
           if [ "$RUNNER_OS" = "Linux" ]; then
             dotnet restore ${{ matrix.project }}.csproj          # binaries from the shared Linux artifact
           else
@@ -296,7 +295,7 @@ jobs:
           test_args=(--no-build --no-restore --hangdump --hangdump-timeout 8m --hangdump-type Mini)
 
           set +e
-          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" $flags
+          dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}"
           rc=$?
           set -e
           if [[ $rc -eq 0 ]]; then
@@ -308,7 +307,7 @@ jobs:
             exit 1
           else
             echo "::warning::Test process crashed (exit code $rc), retrying..."
-            dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}" $flags
+            dotnet test --project ${{ matrix.project }}.csproj -c release "${test_args[@]}"
           fi
 
       - name: Upload hang dump
@@ -319,14 +318,6 @@ jobs:
           path: src/Nethermind/${{ matrix.project }}/TestResults/*_hang.*
           if-no-files-found: ignore
           retention-days: 3
-
-      - name: Upload coverage report
-        if: matrix.runner == 'ubuntu-latest' && env.COLLECT_COVERAGE == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.project }}${{ matrix.chunk && format('-{0}', matrix.chunk) || '' }}-coverage
-          path: src/Nethermind/artifacts/bin/${{ matrix.project }}/release/TestResults/*.cobertura.xml
-          retention-days: 1
 
   tests-chunked:
     name: Run ${{ matrix.test.project }}${{ matrix.test.label && format(' [{0}]', matrix.test.label) || '' }} (${{ matrix.test.chunk }}) (${{ matrix.runner }})


### PR DESCRIPTION
## Changes

Coverage instrumentation makes long Ethereum VM fixtures exceed the eight-minute inactivity watchdog. In [the failing job](https://github.com/NethermindEth/nethermind/actions/runs/34166162834/job/101897832776), 363 tests passed with no assertion failures before the host was killed while two ten-million-iteration loop tests were still executing. Running those two tests with the exact CI binaries in Docker took 6.7 seconds without coverage versus 122.7 seconds with coverage; both runs passed.

- Remove coverage instrumentation and report upload from the Ethereum specification test job, including the legacy VM fixtures.
- Run the legacy VM fixture suite unchunked on both runners, removing seven redundant Linux jobs.
- Retain all unit-test coverage, including `Nethermind.Hive.Test`, and retain retries and the hang watchdog.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

- Parsed the workflow YAML and checked that the specification job has no coverage flags or upload step, unit-test coverage remains enabled and the legacy VM matrix is unchunked, and the eight-minute watchdog remains enabled.
- `git diff --check` passed.
- The full unchunked legacy VM suite passed all 2,890 tests in 32.6 seconds in Linux x64 Docker using the exact failing CI binaries, without coverage and with the eight-minute watchdog enabled. This is local test duration, not hosted-runner job time. The complete modified workflow has not yet run; the CI timeout itself was not reproduced locally.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Paths exercised only by Ethereum fixtures will no longer contribute to the coverage report, even though those tests still execute. Reported coverage may decrease; this does not mean the corresponding tests were removed.
