### PR TITLE
fix(rpc): drop the chainspec-misconfiguration false positive, and say when JSON-RPC opens (#13202, #13203)

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/ChainSpecFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ChainSpecFilesTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Nethermind.Logging;
 using NUnit.Framework;
@@ -38,5 +39,40 @@ namespace Nethermind.Runner.Test
         [TestCase("chainspec/op-mainnet.json.zst", 10UL)]
         public void Zstandard_Compressed_ChainSpec(string chainSpecPath, ulong chainId) =>
             Assert.That(_loader.LoadEmbeddedOrFromFile(chainSpecPath).ChainId, Is.EqualTo(chainId));
+
+        // SpecProviderBase.LoadTransitions refuses a transition list in which a block-number transition could
+        // never activate (#13202), so every shipped chainspec has to be proven to construct a provider - not just
+        // the handful Nethermind.Specs.Test names one by one. This project is the only test project referencing
+        // Nethermind.Runner, and TypeDiscovery walks the output directory, so it is the only place the plugin
+        // chains' engine parameters resolve at all: Taiko, Linea, JOC and Surge otherwise fail to load with "No
+        // seal engine in chain spec".
+        [TestCaseSource(nameof(ShippedChainSpecs))]
+        public void Every_shipped_chainspec_builds_a_spec_provider(string chainSpecPath)
+        {
+            ChainSpec chainSpec = _loader.LoadEmbeddedOrFromFile(chainSpecPath);
+
+            Assert.That(() => new ChainSpecBasedSpecProvider(chainSpec, LimboLogs.Instance), Throws.Nothing);
+        }
+
+        private static string[] ShippedChainSpecs()
+        {
+            string folder = Path.Combine(TestContext.CurrentContext.TestDirectory, "chainspec");
+            List<string> paths = [];
+            foreach (string path in Directory.EnumerateFiles(folder))
+            {
+                if (path.EndsWith(".json", StringComparison.Ordinal) || path.EndsWith(".json.zst", StringComparison.Ordinal))
+                {
+                    paths.Add(path);
+                }
+            }
+
+            paths.Sort(StringComparer.Ordinal);
+
+            // An empty source is reported as a pass, which is the one outcome this must not have. Thrown rather
+            // than asserted: this runs at discovery time, where an assertion failure is a fixture load error.
+            if (paths.Count == 0) throw new InvalidOperationException($"no chainspecs found under {folder}");
+
+            return paths.ToArray();
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Runner.Test/ChainSpecFilesTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/ChainSpecFilesTests.cs
@@ -42,10 +42,11 @@ namespace Nethermind.Runner.Test
 
         // SpecProviderBase.LoadTransitions refuses a transition list in which a block-number transition could
         // never activate (#13202), so every shipped chainspec has to be proven to construct a provider - not just
-        // the handful Nethermind.Specs.Test names one by one. This project is the only test project referencing
-        // Nethermind.Runner, and TypeDiscovery walks the output directory, so it is the only place the plugin
-        // chains' engine parameters resolve at all: Taiko, Linea, JOC and Surge otherwise fail to load with "No
-        // seal engine in chain spec".
+        // the handful Nethermind.Specs.Test names one by one. It lives here because TypeDiscovery resolves plugin
+        // types through the reference closure - loaded assemblies plus what they reference - and referencing
+        // Nethermind.Runner is what pulls every plugin assembly into it. Without that reference the plugin chains'
+        // engine parameters do not resolve at all and Taiko, Linea, JOC and Surge fail with "No seal engine in
+        // chain spec".
         [TestCaseSource(nameof(ShippedChainSpecs))]
         public void Every_shipped_chainspec_builds_a_spec_provider(string chainSpecPath)
         {

--- a/src/Nethermind/Nethermind.Runner/Ethereum/JsonRpcRunner.cs
+++ b/src/Nethermind/Nethermind.Runner/Ethereum/JsonRpcRunner.cs
@@ -130,7 +130,10 @@ namespace Nethermind.Runner.Ethereum
                 await NetworkHelper.HandlePortTakenError(
                     () => _webApp.StartAsync(cancellationToken), urls
                 );
-                if (_logger.IsDebug) _logger.Debug($"JSON RPC     : {urlsString}");
+                // #13203: the first point at which the ports actually accept a request. The engine URL is in the
+                // same set, so this is also when the consensus client can connect. At Debug there was nothing to
+                // distinguish a node still gated behind startup work from one already serving.
+                if (_logger.IsInfo) _logger.Info($"JSON-RPC is listening on {urlsString}");
             }
         }
 

--- a/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
+++ b/src/Nethermind/Nethermind.Specs.Test/ChainSpecStyle/ChainSpecBasedSpecProviderTests.cs
@@ -136,58 +136,38 @@ public class ChainSpecBasedSpecProviderTests
     }
 
 
-    [TestCase(0ul, null, false, false, false)]
-    [TestCase(0ul, 0ul, false, false, false)]
-    [TestCase(0ul, 4660ul, false, false, false)]
-    [TestCase(1ul, 4660ul, false, false, false)]
-    [TestCase(1ul, 4661ul, false, false, false)]
-    [TestCase(1ul, 4672ul, false, false, false)]
-    [TestCase(2ul, 4673ul, false, false, true)]
-    [TestCase(3ul, 4680ul, false, false, true)]
-    [TestCase(4ul, 4672ul, false, true, false)]
-    [TestCase(5ul, 4672ul, true, true, false)]
-    [TestCase(5ul, 4673ul, true, true, false)]
-    [TestCase(6ul, 4680ul, true, true, false)]
-    [NonParallelizable]
-    public void Logs_warning_when_timestampActivation_happens_before_blockActivation(ulong blockNumber, ulong? timestamp, bool isEip3855Enabled, bool isEip3198Enabled, bool receivesWarning)
+    // A chainspec is either misconfigured or it is not, so a verdict that changes with the activation being
+    // queried was never a verdict about the file: (2, 4673) and (3, 4680) - which the predecessor of this test
+    // required the warning for - are a node whose head is below the block-4 fork asking what applies at the
+    // current time, i.e. an ordinary syncing node (#13202).
+    [TestCase(0ul, null)]
+    [TestCase(0ul, 0ul)]
+    [TestCase(0ul, 4660ul)]
+    [TestCase(1ul, 4660ul)]
+    [TestCase(1ul, 4661ul)]
+    [TestCase(1ul, 4672ul)]
+    [TestCase(2ul, 4673ul)]
+    [TestCase(3ul, 4680ul)]
+    [TestCase(4ul, 4672ul)]
+    [TestCase(5ul, 4672ul)]
+    [TestCase(5ul, 4673ul)]
+    [TestCase(6ul, 4680ul)]
+    public void Never_warns_that_the_chainspec_is_misconfigured(ulong blockNumber, ulong? timestamp)
     {
         ChainSpecFileLoader loader = new(new EthereumJsonSerializer(), LimboLogs.Instance);
         string path = Path.Combine(TestContext.CurrentContext.WorkDirectory,
             $"../../../../{Assembly.GetExecutingAssembly().GetName().Name}/Specs/Logs_warning_when_timestampActivation_happens_before_blockActivation_test.json");
         ChainSpec chainSpec = loader.LoadEmbeddedOrFromFile(path);
-        Assert.That(chainSpec.Parameters.Eip2537Transition, Is.Null);
         InterfaceLogger iLogger = Substitute.For<InterfaceLogger>();
         iLogger.IsWarn.Returns(true);
         ILogger logger = new(iLogger);
         ILogManager logManager = Substitute.For<ILogManager>();
         logManager.GetClassLogger<ChainSpecBasedSpecProvider>().Returns(logger);
         ChainSpecBasedSpecProvider provider = new(chainSpec, logManager);
-        ReleaseSpec expectedSpec = ((ReleaseSpec)MainnetSpecProvider
-            .Instance.GetSpec((MainnetSpecProvider.GrayGlacierBlockNumber, null))).Clone();
-        expectedSpec.Name = "Genesis_with_non_zero_timestamp";
-        expectedSpec.IsEip3651Enabled = true;
-        expectedSpec.IsEip3198Enabled = isEip3198Enabled;
-        expectedSpec.IsEip3855Enabled = isEip3855Enabled;
-        expectedSpec.Eip1559TransitionBlock = 0;
-        expectedSpec.DifficultyBombDelay = 0;
-        List<ForkActivation> forkActivationsToTest =
-        [
-            (blockNumber, timestamp),
-        ];
 
-        foreach (ForkActivation activation in forkActivationsToTest)
-        {
-            provider.GetSpec(activation);
-        }
+        provider.GetSpec(new ForkActivation(blockNumber, timestamp));
 
-        if (receivesWarning)
-        {
-            iLogger.Received(1).Warn(Arg.Is("Chainspec file is misconfigured! Timestamp transition is configured to happen before the last block transition."));
-        }
-        else
-        {
-            iLogger.DidNotReceive().Warn(Arg.Is("Chainspec file is misconfigured! Timestamp transition is configured to happen before the last block transition."));
-        }
+        iLogger.DidNotReceive().Warn(Arg.Is<string>(static text => text.Contains("misconfigured")));
     }
 
     public static IEnumerable<TestCaseData> SepoliaActivations
@@ -733,6 +713,79 @@ public class ChainSpecBasedSpecProviderTests
             Assert.That(activation.Timestamp, Is.Null.Or.LessThanOrEqualTo(Nethermind.Core.Specs.SpecProviderExtensions.LastScheduledForkTimestamp),
                 $"{chain} schedules a fork above the unscheduled-fork band, which GetFinalSpec would skip");
         }
+    }
+
+    // #13202: "Chainspec file is misconfigured!" was emitted once per eth_estimateGas call on a syncing mainnet
+    // node running the chainspec we ship. eth_estimateGas asks for the spec at (head + 1, wall-clock now) - see
+    // BlockchainBridge's treatBlockHeaderAsParentBlock path - so while the head is below the chain's largest block
+    // transition and the clock is past the first timestamp fork, the old per-call check was always true.
+    [TestCase("foundation")]
+    [TestCase("gnosis")]
+    public void No_misconfiguration_warning_for_a_shipped_chainspec_below_its_last_block_transition(string chain)
+    {
+        ChainSpec chainSpec = LoadChainSpecFromChainFolder(chain);
+        CapturingLogger logger = new();
+        ChainSpecBasedSpecProvider provider = new(chainSpec, new OneLoggerLogManager(new(logger)));
+
+        ulong lastBlockTransition = provider.TransitionActivations
+            .Where(static a => a.Timestamp is null)
+            .Select(static a => a.BlockNumber)
+            .DefaultIfEmpty(0UL)
+            .Max();
+        ulong firstTimestampTransition = provider.TransitionActivations
+            .Where(static a => a.Timestamp is not null)
+            .Select(static a => a.Timestamp!.Value)
+            .Min();
+
+        // A node halfway to the last block-number fork, asked "what spec applies right now?".
+        ulong staleHead = lastBlockTransition / 2;
+        ulong now = firstTimestampTransition + 1;
+        provider.GetSpec(new ForkActivation(staleHead + 1, now));
+
+        Assert.That(
+            logger.Lines.Where(static l => l.Contains("misconfigured")),
+            Is.Empty,
+            $"{chain} is correctly configured; a node below block {lastBlockTransition} is behind, not misconfigured");
+    }
+
+    // The replacement check, which the old one could not express: a block-number transition placed after a timestamp
+    // transition ends up compared by timestamp and can never activate, so it must not load silently.
+    [Test]
+    public void Block_transition_after_a_timestamp_transition_is_rejected_at_load()
+    {
+        (ForkActivation, IReleaseSpec)[] transitions =
+        [
+            (new ForkActivation(0UL), Frontier.Instance),
+            (new ForkActivation(100UL, 1_000UL), Shanghai.Instance),
+            (new ForkActivation(200UL), London.Instance),
+        ];
+
+        Assert.That(
+            () => new TransitionsOnlySpecProvider(transitions),
+            Throws.InstanceOf<ArgumentException>().With.Message.Contains("can never activate"));
+    }
+
+    private sealed class CapturingLogger : InterfaceLogger
+    {
+        public List<string> Lines { get; } = [];
+
+        public bool IsInfo => true;
+        public bool IsWarn => true;
+        public bool IsDebug => true;
+        public bool IsTrace => true;
+        public bool IsError => true;
+
+        public void Info(string text) => Lines.Add(text);
+        public void Warn(string text) => Lines.Add(text);
+        public void Debug(string text) => Lines.Add(text);
+        public void Trace(string text) => Lines.Add(text);
+        public void Error(string text, Exception? ex = null) => Lines.Add(text);
+    }
+
+    private sealed class TransitionsOnlySpecProvider : SpecProviderBase
+    {
+        public TransitionsOnlySpecProvider((ForkActivation Activation, IReleaseSpec Spec)[] transitions) =>
+            LoadTransitions(transitions);
     }
 
     private ChainSpec LoadChainSpecFromChainFolder(string chain)

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderBase.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderBase.cs
@@ -17,6 +17,9 @@ public abstract class SpecProviderBase(ILogger? logger = null)
     protected readonly ILogger _logger = logger ?? LimboTraceLogger.Instance;
     private IReleaseSpec? _genesisSpec;
 
+    /// <exception cref="ArgumentException">
+    /// A block-number transition is ordered after a timestamp transition, so it could never activate.
+    /// </exception>
     protected void LoadTransitions((ForkActivation Activation, IReleaseSpec Spec)[] transitions)
     {
         if (transitions.Length == 0)
@@ -31,6 +34,20 @@ public abstract class SpecProviderBase(ILogger? logger = null)
 
         _blockTransitions = transitions.TakeWhile(static t => t.Activation.Timestamp is null).ToArray();
         _timestampTransitions = transitions.SkipWhile(static t => t.Activation.Timestamp is null).ToArray();
+
+        // The split above assumes every block-number transition precedes every timestamp transition. One that does
+        // not lands in _timestampTransitions, where GetSpec compares it by timestamp against a null Timestamp, so
+        // it silently never activates.
+        int strayBlockTransition = Array.FindIndex(_timestampTransitions, static t => t.Activation.Timestamp is null);
+        if (strayBlockTransition >= 0)
+        {
+            throw new ArgumentException(
+                $"Release transitions passed to {GetType()} put a block-number transition " +
+                $"({_timestampTransitions[strayBlockTransition].Activation.BlockNumber}) after a timestamp " +
+                $"transition ({_timestampTransitions[0].Activation.Timestamp}). Every block-number transition must " +
+                "come first, otherwise it can never activate.",
+                nameof(transitions));
+        }
         _firstTimestampActivation = _timestampTransitions.Length != 0 ? _timestampTransitions.First().Activation : null;
         _genesisSpec = transitions.First().Spec;
     }
@@ -47,16 +64,15 @@ public abstract class SpecProviderBase(ILogger? logger = null)
 
         (ForkActivation Activation, IReleaseSpec Spec)[] consideredTransitions = _blockTransitions;
 
-        if (_firstTimestampActivation is not null && activation.Timestamp is not null)
+        // Ordering is validated in LoadTransitions, not here. A per-call check cannot see a file error:
+        // ChainSpecBasedSpecProvider derives the block number of every timestamp activation from the chainspec's
+        // own largest block transition, so comparing it against the caller's block number only ever says that the
+        // node is below that fork - an ordinary syncing node (#13202).
+        if (_firstTimestampActivation is not null
+            && activation.Timestamp is not null
+            && _firstTimestampActivation.Value.Timestamp <= activation.Timestamp)
         {
-            if (_firstTimestampActivation.Value.Timestamp < activation.Timestamp
-                && _firstTimestampActivation.Value.BlockNumber > activation.BlockNumber)
-            {
-                if (_logger.IsWarn) _logger.Warn($"Chainspec file is misconfigured! Timestamp transition is configured to happen before the last block transition.");
-            }
-
-            if (_firstTimestampActivation.Value.Timestamp <= activation.Timestamp)
-                consideredTransitions = _timestampTransitions;
+            consideredTransitions = _timestampTransitions;
         }
 
         return consideredTransitions.TryGetSearchedItem(activation,

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderBase.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/SpecProviderBase.cs
@@ -18,7 +18,8 @@ public abstract class SpecProviderBase(ILogger? logger = null)
     private IReleaseSpec? _genesisSpec;
 
     /// <exception cref="ArgumentException">
-    /// A block-number transition is ordered after a timestamp transition, so it could never activate.
+    /// <paramref name="transitions"/> is empty, does not start at genesis block 0, or orders a block-number
+    /// transition after a timestamp transition, where it could never activate.
     /// </exception>
     protected void LoadTransitions((ForkActivation Activation, IReleaseSpec Spec)[] transitions)
     {

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -157,9 +157,15 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
     }
 
     /// <summary>
-    /// Activate all block-number-based forks from genesis so that biggestBlockTransition stays at 0,
-    /// preventing the "Chainspec file is misconfigured" warning in short test chains.
+    /// Activates all block-number-based forks from genesis, so a short test chain resolves the specs it should.
     /// </summary>
+    /// <remarks>
+    /// A chainspec leaves block-number forks at their mainnet heights (London at 12,965,000). These tests build
+    /// ~1000 blocks with post-merge timestamps, so <c>GetSpec</c> resolves against the timestamp transitions and
+    /// nothing block-based would ever activate. Pulling them to genesis also keeps
+    /// <c>biggestBlockTransition</c> at 0, which is what every timestamp activation's block number is derived
+    /// from.
+    /// </remarks>
     private static void ActivateAllBlockTransitionsFromGenesis(ChainSpec spec)
     {
         // ChainSpec block-number properties (collected by BuildTransitions via EndsWith("BlockNumber"))
@@ -268,11 +274,8 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             Nonce = Eip7251TestConstants.Nonce
         };
 
-        // Activate all block-number-based forks from genesis. The test builds a short chain
-        // (1000 blocks) with post-merge timestamps. Without this, the chainspec has block
-        // transitions at high mainnet block numbers (e.g. London at 12,965,000), causing a
-        // legitimate "Chainspec file is misconfigured" warning when GetSpec is called with
-        // low block numbers but high timestamps.
+        // Without this the chainspec's block transitions sit at mainnet heights while this chain is ~1000 blocks
+        // long with post-merge timestamps, so none of them would activate. See the helper's remarks.
         ActivateAllBlockTransitionsFromGenesis(spec);
 
         if (isPostMerge)


### PR DESCRIPTION
Fixes #13202
Partially addresses #13203 — see Remarks.

## Changes

**`SpecProviderBase.GetSpec` — drop the "Chainspec file is misconfigured!" warning (#13202)**

- It compared two node-derived values: `CreateTransitions` gives every timestamp activation the chainspec's largest block transition as its block number (`ChainSpecBasedSpecProvider.cs:193`), so it fired only when the caller was below that fork — a syncing node, not a bad file.
- **Transition selection is unchanged**: the surviving `Timestamp <= activation.Timestamp` condition is the one that already switched to `_timestampTransitions`. Only the `Warn` branch and its nesting go.

**`SpecProviderBase.LoadTransitions` — validate the ordering the warning gestured at**

- A block-number transition placed after a timestamp one lands in `_timestampTransitions`, leaving that array unsorted under `ForkActivation.CompareTo`, which falls back to block number when either side has no timestamp (`ForkActivation.cs:47-50`). `GetSpec`'s binary search then picks the wrong element: on `[(0) Frontier, (100, 1000) Shanghai, (200) London]`, `GetSpec((250, 2000))` returns London — a silently wrong lookup, not a dead transition.
- That is now a fatal `ArgumentException` — every caller invokes `LoadTransitions` from a constructor, so bad ordering builds no spec provider — and an `<exception cref>` doc covers all three throws (empty array, no genesis-0 transition, this rule). Its message still says "can never activate": stale wording, worth a follow-up.

**`JsonRpcRunner.Start` — say when JSON-RPC opens (#13203)**

- `Debug($"JSON RPC     : {urlsString}")` becomes `Info($"JSON-RPC is listening on {urlsString}")` (`JsonRpcRunner.cs:136`). Not a new site: it stays after `_webApp.StartAsync`, inside the cancellation check, so a cancelled start logs nothing.

**`E2ESyncTests`** — comments only; `ActivateAllBlockTransitionsFromGenesis` now cites mainnet-height block forks on a ~1000-block chain, not the deleted warning.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `No_misconfiguration_warning_for_a_shipped_chainspec_below_its_last_block_transition` — `foundation` and `gnosis`, stale head at a current timestamp; asserts nothing logged contains "misconfigured".
- `Block_transition_after_a_timestamp_transition_is_rejected_at_load` — pins the new `ArgumentException`.
- `ChainSpecFilesTests.Every_shipped_chainspec_builds_a_spec_provider` — `[TestCaseSource]` over the runner's `chainspec` output folder, one case per `.json`/`.json.zst` (70 today). It sits in `Nethermind.Runner.Test` because `TypeDiscovery` resolves plugin types through the reference closure - loaded assemblies plus what they reference (`TypeDiscovery.cs:42`, `:85-106`) - and that project's references pull in every engine plugin: Taiko and Surge via its `Nethermind.Runner` reference, Linea and JOC (`clique`), the OP chains and XDC via direct references (`Nethermind.Runner.Test.csproj:14-17`). In `Nethermind.Specs.Test` (Core, Specs, Ethash, AuRa only) those chainspecs fail with "No seal engine in chain spec".

Rewritten, not added: `Logs_warning_when_timestampActivation_happens_before_blockActivation` → `Never_warns_that_the_chainspec_is_misconfigured`; the same 12 activations now all assert the warning never appears. The assertion also loosens — exact-message `Received(1).Warn(...)` gives way to a `Contains("misconfigured")` check (`ChainSpecBasedSpecProviderTests.cs:170`), so nothing pins the text. It also drops dead `expectedSpec` scaffolding, an `Eip2537Transition` assertion, and a method-level `[NonParallelizable]` the fixture already carries (`:29`).

Both touched suites pass, Debug build clean. On nodes: warning 5→0 across 5 `eth_estimateGas` calls; Info line at 418 s into a gnosis restart.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

`Chainspec file is misconfigured!` no longer exists — drop any alert or filter matching it. The Debug line `JSON RPC     : <urls>` is gone as a log site too, surviving only in the `ThisNodeInfo` banner (`JsonRpcRunner.cs:124`). Nodes now log `JSON-RPC is listening on <urls>` at Info once the ports (engine included) accept requests.

## Remarks

- **#13203 is only half done.** The Info line ships; RPC and the Engine API stay gated behind `StartRpc → RegisterRpcModules → InitializeBlockProducer → ReviewBlockTree`, untouched here. The issue's proposed fix — gating that edge on `ShouldStartBlockProduction()` — cannot work: `MergeBlockProductionPolicy` returns `true` unconditionally (`:12`).
- **The guard is reachable from code, not from a chainspec.** `CreateTransitions` is private and emits all block transitions before all timestamp ones, so no chainspec can trip it; the 70-case fixture pins that invariant, not an at-risk file. Exposure is programmatic: `CustomSpecProvider` (27 sites) pre-sorts with `OrderBy(t => t.Activation)`, which cannot establish the invariant — `CompareTo` is no total order across mixed activations. Its sites survive because the ones that mix both kinds put the timestamp activations last anyway - `BlockchainTestBase.cs:107` uses `ForkActivation.TimestampOnly` (`BlockNumber` = `ulong.MaxValue`), which always sorts last.
- **Nothing pins the new Info line** — `JsonRpcRunner` has no startup-logging test; it was verified on a node.