### PR TITLE
test(jsonrpc): make Nethermind.JsonRpc.Test safe to run twice at once (#13204, #13249)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Find/BlockParameter.cs
@@ -98,6 +98,32 @@ namespace Nethermind.JsonRpc.Data
 
     public class BlockParameterConverter : JsonConverter<BlockParameter>
     {
+        private readonly bool? _strictQuantity;
+
+        /// <summary>
+        /// Used by the <see cref="System.Text.Json.Serialization.JsonConverterAttribute"/> on
+        /// <see cref="BlockParameter"/>, which System.Text.Json instantiates itself and cannot pass arguments to.
+        /// Strictness is then read from <see cref="EthereumJsonSerializer.StrictHexFormat"/> at parse time.
+        /// </summary>
+        public BlockParameterConverter()
+        {
+        }
+
+        /// <summary>
+        /// Pins strictness for this converter instead of consulting the process-global
+        /// <see cref="EthereumJsonSerializer.StrictHexFormat"/>.
+        /// </summary>
+        /// <remarks>
+        /// The global is written once at startup from <c>IJsonRpcConfig.StrictHexFormat</c>, which is correct for a
+        /// running node but makes parsing depend on process-wide state: anything else that writes it changes how an
+        /// unrelated, concurrent parse behaves. Registering an instance in
+        /// <see cref="JsonSerializerOptions.Converters"/> - which takes precedence over the type attribute - gives a
+        /// caller a strictness no other thread can change.
+        /// </remarks>
+        public BlockParameterConverter(bool strictQuantity) => _strictQuantity = strictQuantity;
+
+        private bool StrictQuantity => _strictQuantity ?? EthereumJsonSerializer.StrictHexFormat;
+
         public override bool HandleNull => true;
 
         public override void Write(Utf8JsonWriter writer, BlockParameter value, JsonSerializerOptions options)
@@ -151,7 +177,7 @@ namespace Nethermind.JsonRpc.Data
                                             ReadStringFormatValueSequence(ref reader, options),
                 JsonTokenType.StartObject => ReadObjectFormat(ref reader, typeToConvert, options),
                 JsonTokenType.Null => BlockParameter.Latest,
-                JsonTokenType.Number when !EthereumJsonSerializer.StrictHexFormat =>
+                JsonTokenType.Number when !StrictQuantity =>
                     reader.TryGetUInt64(out ulong parsed)
                         ? new BlockParameter(parsed)
                         : throw new JsonException("block number must be a non-negative integer"),
@@ -199,7 +225,7 @@ namespace Nethermind.JsonRpc.Data
             };
         }
 
-        private static BlockParameter ReadStringFormat(ReadOnlySpan<byte> span)
+        private BlockParameter ReadStringFormat(ReadOnlySpan<byte> span)
         {
             int length = span.Length;
             // Creates a jmp table based on length
@@ -235,7 +261,7 @@ namespace Nethermind.JsonRpc.Data
         }
 
         [SkipLocalsInit]
-        private static BlockParameter ReadStringFormatValueSequence(ref Utf8JsonReader reader, JsonSerializerOptions options)
+        private BlockParameter ReadStringFormatValueSequence(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             if (reader.ValueSequence.Length > 66)
             {
@@ -253,7 +279,7 @@ namespace Nethermind.JsonRpc.Data
         private static BlockParameter ReadStringComplex(ref Utf8JsonReader reader, JsonSerializerOptions options)
             => JsonSerializer.Deserialize<BlockParameter>(reader.GetString()!, options)!;
 
-        private static BlockParameter ReadStringFormatOther(ReadOnlySpan<byte> span)
+        private BlockParameter ReadStringFormatOther(ReadOnlySpan<byte> span)
         {
             // Try hex format
             if (span.Length >= 2 && span.StartsWith("0x"u8))
@@ -267,7 +293,7 @@ namespace Nethermind.JsonRpc.Data
                     return new BlockParameter(new Hash256(bytes));
                 }
 
-                if (EthereumJsonSerializer.StrictHexFormat)
+                if (StrictQuantity)
                 {
                     // EIP-1474 quantity: the empty "0x" is not a valid block number.
                     if (span.Length == 0)
@@ -287,7 +313,7 @@ namespace Nethermind.JsonRpc.Data
             }
 
             // Try decimal format (if not strict)
-            if (!EthereumJsonSerializer.StrictHexFormat && Utf8Parser.TryParse(span, out ulong decimalValue, out _))
+            if (!StrictQuantity && Utf8Parser.TryParse(span, out ulong decimalValue, out _))
             {
                 return new BlockParameter(decimalValue);
             }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/BlockParameterConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/BlockParameterConverterTests.cs
@@ -15,16 +15,14 @@ namespace Nethermind.JsonRpc.Test.Data
     [TestFixture]
     public class BlockParameterConverterTests : SerializationTestBase
     {
-        // This fixture used to set EthereumJsonSerializer.StrictHexFormat in SetUp and put it back in TearDown.
-        // That static is process-global: while this fixture held it at false, every other fixture parsing a block
-        // parameter concurrently saw false too, so tests such as "Block number boundary leading zero" and
-        // "leading zero in gasLimit" failed with -32603/-32602 in roughly a third of runs (#13204).
-        // [NonParallelizable] did not help - NUnit only keeps such a test off a worker thread, it does not stop the
-        // rest of the assembly from running alongside it.
-        //
-        // Strictness is a property of the converter now, so these tests name the strictness they want in the
-        // options they parse with and touch no shared state. An options-level converter takes precedence over the
+        // Strictness is a property of the converter, so each test names the strictness it wants in the options it
+        // parses with and touches no shared state. An options-level converter takes precedence over the
         // [JsonConverter] attribute on BlockParameter.
+        //
+        // EthereumJsonSerializer.StrictHexFormat must not be used for this instead: it is process-global, so a
+        // fixture holding it at one value makes every concurrent block-parameter parse in the assembly read that
+        // value, which is #13204. [NonParallelizable] is not a fix - NUnit only keeps such a test off a worker
+        // thread, it does not stop the rest of the assembly from running alongside it.
         /// <summary>
         /// Options whose strictness is pinned on the converter instances rather than read from
         /// <see cref="EthereumJsonSerializer.StrictHexFormat"/>, so these cases do not depend on process state.

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Data/BlockParameterConverterTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Data/BlockParameterConverterTests.cs
@@ -2,30 +2,50 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Text.Json;
 using Nethermind.Blockchain.Find;
 using Nethermind.Core.Crypto;
+using Nethermind.JsonRpc.Data;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Serialization.Json;
 using NUnit.Framework;
 
 namespace Nethermind.JsonRpc.Test.Data
 {
-    [NonParallelizable]
     [TestFixture]
     public class BlockParameterConverterTests : SerializationTestBase
     {
-        private bool _previousStrictHexFormat;
+        // This fixture used to set EthereumJsonSerializer.StrictHexFormat in SetUp and put it back in TearDown.
+        // That static is process-global: while this fixture held it at false, every other fixture parsing a block
+        // parameter concurrently saw false too, so tests such as "Block number boundary leading zero" and
+        // "leading zero in gasLimit" failed with -32603/-32602 in roughly a third of runs (#13204).
+        // [NonParallelizable] did not help - NUnit only keeps such a test off a worker thread, it does not stop the
+        // rest of the assembly from running alongside it.
+        //
+        // Strictness is a property of the converter now, so these tests name the strictness they want in the
+        // options they parse with and touch no shared state. An options-level converter takes precedence over the
+        // [JsonConverter] attribute on BlockParameter.
+        /// <summary>
+        /// Options whose strictness is pinned on the converter instances rather than read from
+        /// <see cref="EthereumJsonSerializer.StrictHexFormat"/>, so these cases do not depend on process state.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Hash256Converter"/> is included because <see cref="BlockParameter"/> can hold a hash, and an
+        /// instance-registered converter takes precedence over the type attribute - so leaving it out would let the
+        /// hash half of the type fall back to the global while the number half does not.
+        /// </remarks>
+        private static JsonSerializerOptions OptionsWithStrictness(bool strictQuantity) =>
+            new()
+            {
+                Converters =
+                {
+                    new BlockParameterConverter(strictQuantity),
+                    new Hash256Converter(strictQuantity)
+                }
+            };
 
-        [SetUp]
-        public void SetUp()
-        {
-            _previousStrictHexFormat = EthereumJsonSerializer.StrictHexFormat;
-            EthereumJsonSerializer.StrictHexFormat = false;
-        }
-
-        [TearDown]
-        public void TearDown() =>
-            EthereumJsonSerializer.StrictHexFormat = _previousStrictHexFormat;
+        private static BlockParameter? Deserialize(string input, bool strictQuantity) =>
+            JsonSerializer.Deserialize<BlockParameter>(input, OptionsWithStrictness(strictQuantity));
 
         [TestCase("0", 0UL)]
         [TestCase("100", 100UL)]
@@ -37,8 +57,7 @@ namespace Nethermind.JsonRpc.Test.Data
         [TestCase("{ \"blockNumber\": \"0xa\" }", 10UL)]
         public void Can_read_block_number(string input, ulong output)
         {
-            IJsonSerializer serializer = new EthereumJsonSerializer();
-            BlockParameter blockParameter = serializer.Deserialize<BlockParameter>(input)!;
+            BlockParameter blockParameter = Deserialize(input, strictQuantity: false)!;
 
             Assert.That(blockParameter.BlockNumber, Is.EqualTo(output));
         }
@@ -55,23 +74,30 @@ namespace Nethermind.JsonRpc.Test.Data
         [TestCase("{ \"blockNumber\": \"100\" }", true)]
         public void Cant_read_block_number_when_strict_hex_format_is_enabled(string input, bool throws)
         {
-            bool original = EthereumJsonSerializer.StrictHexFormat;
-            try
-            {
-                EthereumJsonSerializer.StrictHexFormat = true;
-                IJsonSerializer serializer = new EthereumJsonSerializer();
+            Func<BlockParameter?> action = () => Deserialize(input, strictQuantity: true);
 
-                Func<BlockParameter?> action = () => serializer.Deserialize<BlockParameter>(input);
+            if (throws)
+                Assert.That(action, Throws.InstanceOf<FormatException>());
+            else
+                Assert.That(action, Throws.Nothing);
+        }
 
-                if (throws)
-                    Assert.That(action, Throws.InstanceOf<FormatException>());
-                else
-                    Assert.That(action, Throws.Nothing);
-            }
-            finally
-            {
-                EthereumJsonSerializer.StrictHexFormat = original;
-            }
+        // Strictness is a property of the converter instance, not of process state, so two of them can hold
+        // different answers at once - which is what stops one caller's setting from changing another's parse
+        // (#13204). A leading-zero hex quantity is refused under EIP-1474 and accepted leniently, so it separates
+        // the two.
+        [Test]
+        public void Two_converters_can_hold_different_strictness()
+        {
+            JsonSerializerOptions strict = OptionsWithStrictness(strictQuantity: true);
+            JsonSerializerOptions lenient = OptionsWithStrictness(strictQuantity: false);
+
+            Assert.That(
+                () => JsonSerializer.Deserialize<BlockParameter>("\"0x0a\"", strict),
+                Throws.InstanceOf<FormatException>());
+            Assert.That(
+                JsonSerializer.Deserialize<BlockParameter>("\"0x0a\"", lenient)!.BlockNumber,
+                Is.EqualTo(10UL));
         }
 
         [TestCase("null", BlockParameterType.Latest)]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -49,18 +49,12 @@ public class JsonRpcServiceTests
         _configurationProvider = new ConfigProvider();
         _logManager = LimboLogs.Instance;
         _context = new JsonRpcContext(RpcEndpoint.Http);
-        _previousStrictHexFormat = EthereumJsonSerializer.StrictHexFormat;
-        EthereumJsonSerializer.StrictHexFormat = _configurationProvider.GetConfig<IJsonRpcConfig>().StrictHexFormat;
+        // StrictHexFormat is pinned for the assembly by StrictHexFormatAssemblySetup. Setting and restoring it here
+        // used to race this fixture's own test methods against each other - see that class and #13204.
     }
 
     [TearDown]
-    public void TearDown()
-    {
-        EthereumJsonSerializer.StrictHexFormat = _previousStrictHexFormat;
-        _context?.Dispose();
-    }
-
-    private bool _previousStrictHexFormat;
+    public void TearDown() => _context?.Dispose();
 
     private IJsonRpcService _jsonRpcService = null!;
     private IConfigProvider _configurationProvider = null!;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -49,8 +49,8 @@ public class JsonRpcServiceTests
         _configurationProvider = new ConfigProvider();
         _logManager = LimboLogs.Instance;
         _context = new JsonRpcContext(RpcEndpoint.Http);
-        // StrictHexFormat is pinned for the assembly by StrictHexFormatAssemblySetup. Setting and restoring it here
-        // used to race this fixture's own test methods against each other - see that class and #13204.
+        // StrictHexFormat is pinned for the whole assembly by StrictHexFormatAssemblySetup; no fixture may touch
+        // that static, because it is process-global and every concurrent block-parameter parse reads it (#13204).
     }
 
     [TearDown]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
@@ -510,19 +510,13 @@ public class JsonRpcSocketsClientTests
         }
 
         /// <summary>
-        /// Binds a loopback listener on an OS-assigned port and reports the endpoint it actually got.
+        /// Binds a loopback listener on an OS-assigned port and reports the endpoint it actually got, so two
+        /// concurrent runs of this assembly cannot collide on one port.
         /// </summary>
         /// <remarks>
-        /// These fixtures used to hard-code one fixed port for every one of them, so two concurrent runs of this
-        /// assembly fought over it: the loser fails with AddressAlreadyInUse, which surfaces as unrelated-looking
-        /// assertion failures in whichever tests lost the race. Worse, a run killed mid-suite leaves the listener
-        /// behind, and the next run then blocks in Accept indefinitely instead of failing.
-        ///
-        /// Binding happens here rather than inside <c>OneShotServer</c> so that the listener is already accepting
-        /// before the test's client task starts connecting. The old code relied on the same ordering incidentally,
-        /// by binding synchronously ahead of its first await.
+        /// Binding happens here rather than inside <c>OneShotServer</c> so that the listener is already
+        /// accepting before the test's client task starts connecting.
         /// </remarks>
-        /// <summary>Listens on an OS-assigned loopback port, so concurrent runs cannot collide.</summary>
         private static Socket ListenOnLoopback(out IPEndPoint boundEndPoint)
         {
             Socket listener = new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcSocketsClientTests.cs
@@ -96,9 +96,9 @@ public class JsonRpcSocketsClientTests
         [Explicit("Takes too long to run")]
         public async Task Can_handle_very_large_objects()
         {
-            IPEndPoint ipEndPoint = IPEndPoint.Parse("127.0.0.1:1337");
+            using Socket listener = ListenOnLoopback(out IPEndPoint ipEndPoint);
 
-            Task<int> receiveBytes = OneShotServer(ipEndPoint, CountNumberOfBytes);
+            Task<int> receiveBytes = OneShotServer(listener, CountNumberOfBytes);
 
             JsonRpcSuccessResponse bigObject = RandomSuccessResponse(200_000);
             Task<int> sendJsonRpcResult = Task.Run(async () =>
@@ -150,9 +150,9 @@ public class JsonRpcSocketsClientTests
                 return messages;
             }
 
-            IPEndPoint ipEndPoint = IPEndPoint.Parse("127.0.0.1:1337");
+            using Socket listener = ListenOnLoopback(out IPEndPoint ipEndPoint);
 
-            Task<int> receiveMessages = OneShotServer(ipEndPoint, CountNumberOfMessages);
+            Task<int> receiveMessages = OneShotServer(listener, CountNumberOfMessages);
 
             Task<int> sendMessages = Task.Run(async () =>
             {
@@ -386,12 +386,12 @@ public class JsonRpcSocketsClientTests
                 return messages;
             }
 
-            IPEndPoint ipEndPoint = IPEndPoint.Parse("127.0.0.1:1337");
+            using Socket listener = ListenOnLoopback(out IPEndPoint ipEndPoint);
 
             List<byte[]> sentMessages = [];
             List<byte[]> receivedMessages = [];
 
-            Task<int> receiveMessages = OneShotServer(ipEndPoint, socket => ReadMessages(socket, receivedMessages));
+            Task<int> receiveMessages = OneShotServer(listener, socket => ReadMessages(socket, receivedMessages));
 
             Task<int> sendMessages = Task.Run(async () =>
             {
@@ -509,13 +509,40 @@ public class JsonRpcSocketsClientTests
             return processor;
         }
 
-        private static async Task<T> OneShotServer<T>(IPEndPoint ipEndPoint, Func<Socket, Task<T>> func)
+        /// <summary>
+        /// Binds a loopback listener on an OS-assigned port and reports the endpoint it actually got.
+        /// </summary>
+        /// <remarks>
+        /// These fixtures used to hard-code one fixed port for every one of them, so two concurrent runs of this
+        /// assembly fought over it: the loser fails with AddressAlreadyInUse, which surfaces as unrelated-looking
+        /// assertion failures in whichever tests lost the race. Worse, a run killed mid-suite leaves the listener
+        /// behind, and the next run then blocks in Accept indefinitely instead of failing.
+        ///
+        /// Binding happens here rather than inside <c>OneShotServer</c> so that the listener is already accepting
+        /// before the test's client task starts connecting. The old code relied on the same ordering incidentally,
+        /// by binding synchronously ahead of its first await.
+        /// </remarks>
+        /// <summary>Listens on an OS-assigned loopback port, so concurrent runs cannot collide.</summary>
+        private static Socket ListenOnLoopback(out IPEndPoint boundEndPoint)
         {
-            using Socket socket = new(ipEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            socket.Bind(ipEndPoint);
-            socket.Listen();
+            Socket listener = new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            try
+            {
+                listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                listener.Listen();
+                boundEndPoint = (IPEndPoint)listener.LocalEndPoint!;
+                return listener;
+            }
+            catch
+            {
+                listener.Dispose();
+                throw;
+            }
+        }
 
-            Socket handler = await socket.AcceptAsync();
+        private static async Task<T> OneShotServer<T>(Socket listener, Func<Socket, Task<T>> func)
+        {
+            Socket handler = await listener.AcceptAsync();
 
             return await func(handler);
         }
@@ -542,11 +569,12 @@ public class JsonRpcSocketsClientTests
         {
             using CancellationTokenSource cts = new();
 
-            Task<int> receiveMessages = OneShotServer("http://localhost:1337/", webSocket => CountMessages(webSocket, cts.Token));
+            int port = FindFreeLoopbackPort();
+            Task<int> receiveMessages = OneShotServer($"http://localhost:{port}/", webSocket => CountMessages(webSocket, cts.Token));
 
             Task<int> sendMessages = Task.Run(async () =>
             {
-                using TestClient<WebSocketMessageStream> ws = await TestClient.ConnectWsAsync();
+                using TestClient<WebSocketMessageStream> ws = await TestClient.ConnectWsAsync(port);
                 using JsonRpcResult result = JsonRpcResult.Single(RandomSuccessResponse(1_000), default);
 
                 for (int i = 0; i < messageCount; i++)
@@ -570,11 +598,12 @@ public class JsonRpcSocketsClientTests
         {
             using CancellationTokenSource cts = new();
 
-            Task<int> server = OneShotServer("http://localhost:1337/", webSocket => CountMessages(webSocket, cts.Token));
+            int port = FindFreeLoopbackPort();
+            Task<int> server = OneShotServer($"http://localhost:{port}/", webSocket => CountMessages(webSocket, cts.Token));
 
             Task sendCollection = Task.Run(async () =>
             {
-                using TestClient<WebSocketMessageStream> ws = await TestClient.ConnectWsAsync();
+                using TestClient<WebSocketMessageStream> ws = await TestClient.ConnectWsAsync(port);
                 await SendRandomBatchAsync(ws.Stream, RpcEndpoint.Ws, maxBatchResponseBodySize: null, elements, 100);
                 await Task.Delay(100);
                 await cts.CancelAsync();
@@ -590,11 +619,12 @@ public class JsonRpcSocketsClientTests
         {
             using CancellationTokenSource cts = new();
 
-            Task<long> receiveBytes = OneShotServer("http://localhost:1337/", webSocket => CountBytes(webSocket, cts.Token));
+            int port = FindFreeLoopbackPort();
+            Task<long> receiveBytes = OneShotServer($"http://localhost:{port}/", webSocket => CountBytes(webSocket, cts.Token));
 
             Task<int> sendCollection = Task.Run(async () =>
             {
-                using TestClient<WebSocketMessageStream> ws = await TestClient.ConnectWsAsync(maxBatchResponseBodySize: maxByteCount);
+                using TestClient<WebSocketMessageStream> ws = await TestClient.ConnectWsAsync(port, maxBatchResponseBodySize: maxByteCount);
                 int sent = (int)await SendRandomBatchAsync(ws.Stream, RpcEndpoint.Ws, maxByteCount, 10, 100);
                 await Task.Delay(100);
                 await cts.CancelAsync();
@@ -644,6 +674,22 @@ public class JsonRpcSocketsClientTests
                 webSocket.Dispose();
             }
             return value;
+        }
+
+        /// <summary>
+        /// Returns a loopback port that was free a moment ago.
+        /// </summary>
+        /// <remarks>
+        /// Inherently racy: <see cref="HttpListener"/> prefixes cannot ask for port 0, so the port has to be named
+        /// before the listener exists, and nothing holds it in between. It is better than a hard-coded port and no
+        /// more than that. These cases are <c>[Explicit]</c> and do not run in CI, which is why this is tolerable
+        /// here and not in <see cref="ListenOnLoopback"/>.
+        /// </remarks>
+        private static int FindFreeLoopbackPort()
+        {
+            using Socket probe = new(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            probe.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            return ((IPEndPoint)probe.LocalEndPoint!).Port;
         }
 
         private static async Task<T> OneShotServer<T>(string uri, Func<WebSocket, Task<T>> func)
@@ -782,10 +828,10 @@ public class JsonRpcSocketsClientTests
             return new TestClient<IpcSocketMessageStream>(stream, owner: socket);
         }
 
-        public static async Task<TestClient<WebSocketMessageStream>> ConnectWsAsync(long? maxBatchResponseBodySize = null)
+        public static async Task<TestClient<WebSocketMessageStream>> ConnectWsAsync(int port, long? maxBatchResponseBodySize = null)
         {
             ClientWebSocket socket = new();
-            await socket.ConnectAsync(new Uri("ws://localhost:1337/"), CancellationToken.None);
+            await socket.ConnectAsync(new Uri($"ws://localhost:{port}/"), CancellationToken.None);
             WebSocketMessageStream stream = new(socket, NullLogManager.Instance);
             return new TestClient<WebSocketMessageStream>(stream, RpcEndpoint.Ws, maxBatchResponseBodySize: maxBatchResponseBodySize, owner: socket);
         }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/TestRpcBlockchain.cs
@@ -41,7 +41,6 @@ using Nethermind.JsonRpc.Modules.Trace;
 using Nethermind.Network;
 using Nethermind.Network.P2P.ProtocolHandlers;
 using Nethermind.Network.Rlpx;
-using Nethermind.Serialization.Json;
 using Nethermind.State;
 using Nethermind.Stats;
 using Nethermind.History;
@@ -52,7 +51,6 @@ namespace Nethermind.JsonRpc.Test.Modules
 {
     public class TestRpcBlockchain : TestBlockchain
     {
-        private bool? _previousStrictHexFormat;
 
         public IJsonRpcConfig RpcConfig { get; private set; } = new JsonRpcConfig() { Timeout = -1 };
         public IEthRpcModule EthRpcModule { get; private set; } = null!;
@@ -216,8 +214,8 @@ namespace Nethermind.JsonRpc.Test.Modules
 
         protected override async Task<TestBlockchain> Build(Action<ContainerBuilder>? configurer = null)
         {
-            _previousStrictHexFormat ??= EthereumJsonSerializer.StrictHexFormat;
-            EthereumJsonSerializer.StrictHexFormat = RpcConfig.StrictHexFormat;
+            // StrictHexFormat is not set here. It is a process-global that every fixture in this assembly shares,
+            // and writing it per build raced concurrent fixtures - see StrictHexFormatAssemblySetup and #13204.
             await base.Build(builder =>
             {
                 builder.AddSingleton<ISpecProvider>(new TestSpecProvider(Berlin.Instance));
@@ -251,22 +249,6 @@ namespace Nethermind.JsonRpc.Test.Modules
             EthRpcModule = _ethRpcModuleBuilder(this);
 
             return this;
-        }
-
-        public override void Dispose()
-        {
-            try
-            {
-                base.Dispose();
-            }
-            finally
-            {
-                if (_previousStrictHexFormat is bool previousStrictHexFormat)
-                {
-                    EthereumJsonSerializer.StrictHexFormat = previousStrictHexFormat;
-                    _previousStrictHexFormat = null;
-                }
-            }
         }
 
         public Task<string> TestEthRpc(string method, params object?[]? parameters) =>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/StrictHexFormatAssemblySetup.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/StrictHexFormatAssemblySetup.cs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Config;
+using Nethermind.Serialization.Json;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test;
+
+/// <summary>
+/// Pins <see cref="EthereumJsonSerializer.StrictHexFormat"/> for the whole assembly, once, before any test runs.
+/// </summary>
+/// <remarks>
+/// That property is process-global and its backing field defaults to <see langword="false"/>, while
+/// <see cref="JsonRpcConfig.StrictHexFormat"/> - what a running node actually uses - defaults to
+/// <see langword="true"/>. A node sets it once at startup (<c>ApiBuilder</c>); tests used to set it per fixture or
+/// per test and restore the previous value afterwards, which does not compose:
+///
+/// <list type="bullet">
+/// <item>The first restore in the run puts back the field default, <see langword="false"/>, not the config
+/// default.</item>
+/// <item>Fixtures run concurrently, so one fixture's teardown flips the flag out from under another fixture's
+/// in-flight parse. That is #13204: <c>eth_getBalance</c> with <c>"0x00"</c> should be refused as -32602, but a
+/// concurrent restore to <see langword="false"/> makes the leading zero acceptable, the module gets called, and the
+/// assertion that it was not called fails. Roughly a third of runs were affected.</item>
+/// <item><c>[NonParallelizable]</c> is not a fix - it keeps a test off a worker thread, it does not stop the rest of
+/// the assembly running alongside it.</item>
+/// </list>
+///
+/// Setting it once here and never restoring it means no test mutates it during the run, so there is nothing to race
+/// with. A test that needs a specific strictness should say so locally instead: construct
+/// <c>BlockParameterConverter(strictQuantity)</c> and register it in the options it parses with, which takes
+/// precedence over the type attribute. <c>BlockParameterConverterTests</c> does exactly that.
+/// </remarks>
+[SetUpFixture]
+public class StrictHexFormatAssemblySetup
+{
+    [OneTimeSetUp]
+    public void PinStrictHexFormatToTheConfigDefault() =>
+        EthereumJsonSerializer.StrictHexFormat = new ConfigProvider().GetConfig<IJsonRpcConfig>().StrictHexFormat;
+}


### PR DESCRIPTION
Fixes #13204, fixes #13249

Two unrelated defects in `Nethermind.JsonRpc.Test`, grouped only because both live in that assembly. Each fix stands alone.

- **#13204** breaks an ordinary single run. `BlockParameterConverter` reads the process-global `EthereumJsonSerializer.StrictHexFormat` at parse time, and three places in the assembly wrote it. Fixtures run concurrently, so one teardown restores the field's `false` default under another fixture's in-flight parse: `JsonRpcServiceTests` then accepts `"0x00"` for `eth_getBalance` and that case's `-32602` / `DidNotReceive` assertions fail. Roughly a third of runs.
- **#13249** is the two-processes-on-one-machine problem: `JsonRpcSocketsClientTests` bound a hard-coded `127.0.0.1:1337`.

## Changes

**`Nethermind.Blockchain` — production code, not test-only:**

- `BlockParameterConverter` gains a **public `BlockParameterConverter(bool strictQuantity)`** pinning EIP-1474 quantity strictness on the instance. A new private `StrictQuantity` (`BlockParameter.cs:125`) falls back to the global when unpinned, so the attribute-instantiated converter a node gets — global set once by `ApiBuilder.cs:40` — is unchanged. A parameterless constructor is added back: declaring the overload removes the implicit one `[JsonConverter]` needs.
- `ReadStringFormatOther` becomes an instance method to read `StrictQuantity` (`:296`, `:316`); `ReadStringFormat` follows because it calls it, and `ReadStringFormatValueSequence` because it calls `ReadStringFormat`. All three stay private.
- It pins the **quantity half only**: `ReadObjectFormat` still deserializes `blockHash` through the ambient options (`:205`), and production builds `Hash256Converter` from the global (`EthereumJsonSerializer.cs:135`), so registering only the new converter leaves the hash half on the global. The constructor's XML doc states the strictness guarantee but not this limit.

**#13204 — the mutable static:**

- New `StrictHexFormatAssemblySetup` (`[SetUpFixture]` / `[OneTimeSetUp]`) sets the static once from `IJsonRpcConfig.StrictHexFormat` and never restores it.
- All three writers go: `JsonRpcServiceTests` SetUp/TearDown, `BlockParameterConverterTests`, and `TestRpcBlockchain.Build`. `TestRpcBlockchain`'s `Dispose` override existed only to restore the flag and is deleted.
- `BlockParameterConverterTests` drops `[NonParallelizable]`, and its two strictness-sensitive methods parse through per-test `JsonSerializerOptions` holding `new BlockParameterConverter(strict)` plus `new Hash256Converter(strict)` — options-level converters beat the type attribute. Its other six methods still go through `EthereumJsonSerializer`, safe only because nothing mutates the static during a run.

**#13249 — the hard-coded port:**

- `UsingIpc` binds `IPAddress.Loopback:0` through a new `ListenOnLoopback` helper and reads the assigned endpoint back (3 call sites). Ownership moves with it: `OneShotServer<T>` now takes a `Socket`, not an `IPEndPoint`, and the `using Socket` that owned the listener sits in each test method, so it stays bound for the whole test instead of closing when the server task completes.
- `UsingWebSockets` (an `[Explicit]` fixture) uses `FindFreeLoopbackPort()` and threads the port through `TestClient.ConnectWsAsync(int port, …)`.
- 1337 is not gone from the assembly: `SubscribeModuleTests.cs:885` and `:918` still hard-code `ws://localhost:1337/`, both `[Explicit("Requires a WS server running")]`, so they do not run by default.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- **One** test method added: `Two_converters_can_hold_different_strictness` — a strict and a lenient converter instance disagree on `"0x0a"` (refused under EIP-1474, `10` leniently), with no concurrency involved.
- No cases added or removed in that file: 51 `[TestCase]` attributes before and after.
- Neither the assembly-wide pin nor the port-0 bind has a test. Both verified by running two `Nethermind.JsonRpc.Test` processes at once: both exit 0, against `Can_send_multiple_messages` / `Fuzz_messages_integrity` failing on master.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

- **Strictness silently flips in three other assemblies.** `TestRpcBlockchain.Build` no longer applies `RpcConfig.StrictHexFormat`, and the replacement pin covers this assembly only. `Nethermind.Blockchain.Test`, `Nethermind.Merge.Plugin.Test` and `Nethermind.Optimism.Test` also build a `TestRpcBlockchain` and inherited the setting as a side effect; they now parse at `EthereumJsonSerializer`'s backing-field default (`EthereumJsonSerializer.cs:51`, `false`) instead of `JsonRpcConfig`'s `true`. None mentions `StrictHexFormat` or asserts `-32602`, so nothing there catches it; opinions welcome on whether they need their own pin. Inside this assembly the pin goes the other way — `true` from before the first test, where previously `false` applied until some fixture wrote the static.
- **`FindFreeLoopbackPort` is still TOCTOU-racy.** `HttpListener` prefixes cannot ask for port 0, so the probe releases the port before the listener claims it — narrower than 1337, not closed. Confined to the `[Explicit]` fixture, which does not run in CI; flagged in review and documented on the method.
- The new public constructor is API surface AGENTS.md discourages: additive, but production code reached from a test-motivated fix.