### PR TITLE
feat(sync): make a stalled snap sync visible at default log level (#13248)

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/SnapSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/SnapSyncFeedTests.cs
@@ -62,10 +62,6 @@ public class SnapSyncFeedTests
         snapProvider.Received(1).ReleaseRequest(batch, responseHandled: false);
     }
 
-    // A snap request that yields nothing usable is recorded only at Trace (a timeout) or in a detailed-only
-    // metric (a bad range), while the progress report keeps printing the same percentage - so a node whose every
-    // request fails is indistinguishable from one working slowly. Observed on an OP mainnet node: 23 h in
-    // StateNodes, 24 peers at head, 0 accounts, and nothing above Trace to say so.
     /// <summary>Short enough to keep these tests quick; production uses five minutes.</summary>
     private static readonly TimeSpan ShortThreshold = TimeSpan.FromMilliseconds(100);
 
@@ -151,6 +147,68 @@ public class SnapSyncFeedTests
         await Drive(feed, 1500);
 
         Assert.That(StallWarnings(logger), Has.Count.EqualTo(1));
+    }
+
+    // SimpleDispatcher hands the batch back with no peer when the pool could not allocate one. That is the shape
+    // of a stall with no usable peers, and nothing else in the feed records it.
+    [Test]
+    [NonParallelizable]
+    public async Task A_request_that_never_got_a_peer_counts_towards_the_stall()
+    {
+        (Synchronization.SnapSync.SnapSyncFeed feed, TestLogger logger) = CreateFeed(ShortThreshold);
+
+        using (SnapSyncBatch batch = new() { AccountRangeRequest = new AccountRange(Keccak.Zero, Keccak.Zero) })
+        {
+            Assert.That(feed.HandleResponse(batch, null), Is.EqualTo(SyncResponseHandlingResult.NotAssigned));
+        }
+
+        Assert.That(Metrics.SnapConsecutiveUnproductiveResponses, Is.GreaterThan(0));
+
+        await Drive(feed, 500);
+
+        Assert.That(StallWarnings(logger), Is.Not.Empty);
+        Assert.That(StallWarnings(logger)[0], Does.Contain("no peer available"));
+    }
+
+    /// <summary>
+    /// Long enough that only a missing reset, rather than a slow runner, can produce a warning: each run is
+    /// driven for a tenth of it, so a false warning would need most of a second of scheduling delay.
+    /// </summary>
+    private const int RestartThresholdMs = 1000;
+
+    // The feed is a singleton and outlives one run: a reorg during BAL healing restarts snap on the same instance.
+    // Healing can run for longer than the threshold, and that gap belongs to no run.
+    [Test]
+    public async Task A_restarted_run_is_not_blamed_for_the_gap_before_it()
+    {
+        (Synchronization.SnapSync.SnapSyncFeed feed, TestLogger logger) =
+            CreateFeed(TimeSpan.FromMilliseconds(RestartThresholdMs));
+
+        // Each Drive ends where the dispatcher ends a run, so this is two runs with a gap between them.
+        await Drive(feed, RestartThresholdMs / 10);
+        await Task.Delay(RestartThresholdMs + RestartThresholdMs / 5);
+        await Drive(feed, RestartThresholdMs / 10);
+
+        Assert.That(StallWarnings(logger), Is.Empty,
+            "neither run was driven for as long as the threshold; the gap between them belongs to neither");
+    }
+
+    // ReleaseRequest, which lets IsFinished report the run over, runs before the response is analyzed, so the
+    // dispatcher can end the run while the response that ended it is still on its way to the stall clock.
+    [Test]
+    public async Task A_response_landing_after_the_run_ended_does_not_restart_the_clock()
+    {
+        (Synchronization.SnapSync.SnapSyncFeed feed, TestLogger logger) =
+            CreateFeed(TimeSpan.FromMilliseconds(RestartThresholdMs));
+
+        await Drive(feed, RestartThresholdMs / 10);
+        feed.AnalyzeResponsePerPeer(AddRangeResult.OK, new PeerInfo(Substitute.For<ISyncPeer>()));
+
+        await Task.Delay(RestartThresholdMs + RestartThresholdMs / 5);
+        await Drive(feed, RestartThresholdMs / 10);
+
+        Assert.That(StallWarnings(logger), Is.Empty,
+            "the range was stored by the run that just ended, so it cannot start the next run's clock");
     }
 
     private static (Synchronization.SnapSync.SnapSyncFeed, TestLogger) CreateFeed(TimeSpan? stallWarningThreshold = null)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/SnapSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/SnapSyncFeedTests.cs
@@ -1,8 +1,13 @@
 // SPDX-FileCopyrightText: 2023 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using System.IO;
 using Nethermind.Core.Collections;
+using Nethermind.Core.Test;
 using Nethermind.Core.Crypto;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Logging;
@@ -56,4 +61,131 @@ public class SnapSyncFeedTests
 
         snapProvider.Received(1).ReleaseRequest(batch, responseHandled: false);
     }
+
+    // A snap request that yields nothing usable is recorded only at Trace (a timeout) or in a detailed-only
+    // metric (a bad range), while the progress report keeps printing the same percentage - so a node whose every
+    // request fails is indistinguishable from one working slowly. Observed on an OP mainnet node: 23 h in
+    // StateNodes, 24 peers at head, 0 accounts, and nothing above Trace to say so.
+    /// <summary>Short enough to keep these tests quick; production uses five minutes.</summary>
+    private static readonly TimeSpan ShortThreshold = TimeSpan.FromMilliseconds(100);
+
+    // A request in flight that is never answered and never timed out moves no response-driven counter, so only
+    // elapsed time can see it. This is the case the check exists for.
+    [Test]
+    public async Task A_wedged_request_that_never_answers_is_still_reported()
+    {
+        (Synchronization.SnapSync.SnapSyncFeed feed, TestLogger logger) = CreateFeed(ShortThreshold);
+
+        await Drive(feed, 500);
+
+        Assert.That(StallWarnings(logger), Is.Not.Empty);
+        Assert.That(StallWarnings(logger)[0], Does.Contain("none recorded"));
+    }
+
+    [Test]
+    public async Task No_stall_warning_while_the_threshold_has_not_elapsed()
+    {
+        (Synchronization.SnapSync.SnapSyncFeed feed, TestLogger logger) = CreateFeed(TimeSpan.FromHours(1));
+        PeerInfo peer = new(Substitute.For<ISyncPeer>());
+
+        TimeOutOneRequest(feed, peer);
+        await Drive(feed, 300);
+
+        Assert.That(StallWarnings(logger), Is.Empty, "a brief gap is normal - a punished peer or a pivot update");
+    }
+
+    [Test]
+    public async Task A_stall_warning_names_the_last_unproductive_reason()
+    {
+        (Synchronization.SnapSync.SnapSyncFeed feed, TestLogger logger) = CreateFeed(ShortThreshold);
+
+        TimeOutOneRequest(feed, new PeerInfo(Substitute.For<ISyncPeer>()));
+        await Drive(feed, 500);
+
+        Assert.That(StallWarnings(logger), Is.Not.Empty);
+        Assert.That(StallWarnings(logger)[0], Does.Contain("no response"));
+    }
+
+    [Test]
+    public async Task An_unusable_range_counts_towards_the_stall_and_names_itself()
+    {
+        (Synchronization.SnapSync.SnapSyncFeed feed, TestLogger logger) = CreateFeed(ShortThreshold);
+
+        // A fresh peer each time so the per-peer budget never trips and only the stall check can fire.
+        feed.AnalyzeResponsePerPeer(AddRangeResult.InvalidProof, new PeerInfo(Substitute.For<ISyncPeer>()));
+        await Drive(feed, 500);
+
+        Assert.That(StallWarnings(logger), Is.Not.Empty);
+        Assert.That(StallWarnings(logger)[0], Does.Contain(nameof(AddRangeResult.InvalidProof)));
+    }
+
+    // The gauge, not the log line, is what an alert watches.
+    [Test]
+    [NonParallelizable]
+    public async Task A_useful_range_clears_the_unproductive_streak()
+    {
+        (Synchronization.SnapSync.SnapSyncFeed feed, TestLogger logger) = CreateFeed(ShortThreshold);
+        PeerInfo peer = new(Substitute.For<ISyncPeer>());
+
+        TimeOutOneRequest(feed, peer);
+        Assert.That(Metrics.SnapConsecutiveUnproductiveResponses, Is.GreaterThan(0));
+
+        feed.AnalyzeResponsePerPeer(AddRangeResult.OK, peer);
+        Assert.That(Metrics.SnapConsecutiveUnproductiveResponses, Is.Zero);
+
+        await Drive(feed, 500);
+
+        Assert.That(StallWarnings(logger), Is.Not.Empty, "the clock restarts, it does not stop");
+        Assert.That(StallWarnings(logger)[0], Does.Contain("0 unproductive responses"));
+        Assert.That(StallWarnings(logger)[0], Does.Contain("none recorded"));
+    }
+
+    // The dispatcher can retire hundreds of failed requests a minute; one line per failure would bury the log
+    // it is meant to explain.
+    [Test]
+    public async Task A_continuing_stall_does_not_repeat_within_the_threshold()
+    {
+        // Generous margins: the first warning is due at 1000 ms and a repeat could not come before 2000 ms.
+        (Synchronization.SnapSync.SnapSyncFeed feed, TestLogger logger) = CreateFeed(TimeSpan.FromSeconds(1));
+
+        await Drive(feed, 1500);
+
+        Assert.That(StallWarnings(logger), Has.Count.EqualTo(1));
+    }
+
+    private static (Synchronization.SnapSync.SnapSyncFeed, TestLogger) CreateFeed(TimeSpan? stallWarningThreshold = null)
+    {
+        TestLogger logger = new();
+        ILogManager logManager = Substitute.For<ILogManager>();
+        logManager.GetClassLogger<Synchronization.SnapSync.SnapSyncFeed>().Returns(new ILogger(logger));
+        return (new Synchronization.SnapSync.SnapSyncFeed(Substitute.For<ISnapProvider>(), logManager, stallWarningThreshold), logger);
+    }
+
+    /// <summary>
+    /// Runs the request loop for <paramref name="milliseconds"/>. A substituted provider offers no batch and
+    /// never reports finished, so the loop idles - which is exactly when a stalled node is sitting there.
+    /// </summary>
+    private static async Task Drive(Synchronization.SnapSync.SnapSyncFeed feed, int milliseconds)
+    {
+        using CancellationTokenSource cts = new(milliseconds);
+        try
+        {
+            // PrepareRequest awaits its idle delay outside its own try, so cancelling the loop surfaces here.
+            // That is how SimpleDispatcher.Run ends too.
+            await feed.PrepareRequest(cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    /// <summary>A batch with a request but no response of any kind is what the dispatcher hands back on timeout.</summary>
+    private static void TimeOutOneRequest(Synchronization.SnapSync.SnapSyncFeed feed, PeerInfo peer)
+    {
+        using SnapSyncBatch batch = new() { AccountRangeRequest = new AccountRange(Keccak.Zero, Keccak.Zero) };
+        feed.HandleResponse(batch, peer);
+    }
+
+    private static List<string> StallWarnings(TestLogger logger) =>
+        logger.LogList.FindAll(static line => line.Contains("Snap sync has not stored a usable range"));
 }

--- a/src/Nethermind/Nethermind.Synchronization/Metrics.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Metrics.cs
@@ -65,6 +65,14 @@ namespace Nethermind.Synchronization
         [Description("Synced bytecodes via SNAP Sync")]
         public static long SnapSyncedCodes;
 
+        [CounterMetric]
+        [Description("SNAP Sync requests that produced no response at all. Distinguishes an unresponsive or non-serving peer set from one answering with unusable data, which SnapRangeResult covers.")]
+        public static long SnapRequestTimeouts;
+
+        [GaugeMetric]
+        [Description("Consecutive SNAP Sync requests that yielded no usable range, reset by the first one that does. A value that keeps climbing means snap sync is stalled; sustained non-zero is the alertable condition.")]
+        public static long SnapConsecutiveUnproductiveResponses;
+
         [GaugeMetric]
         [Description("Number of sync peers.")]
         [KeyIsLabel("client_type")]

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -30,11 +30,15 @@ namespace Nethermind.Synchronization.SnapSync
         // A snap request that produced nothing usable is otherwise recorded only at Trace (a timeout) or in a
         // detailed-only metric (a bad range), while ProgressTracker keeps reporting the same percentage - so a
         // node whose every request fails looks exactly like one that is working slowly. These three make the
-        // stall itself sayable: how many requests it covers, and how long it has run. All under _syncLock.
+        // stall itself sayable: how many requests it covers, and how long it has run. Written under _syncLock;
+        // the only unlocked access is WarnIfStalled's fast-path read of the timestamp.
         private int _consecutiveUnproductiveResponses;
-        private string _lastUnproductiveReason = "none recorded";
+        private string _lastUnproductiveReason = NoUnproductiveReason;
         private long _lastProductiveTimestamp;
         private long _lastStallWarningTimestamp;
+
+        private const string NoUnproductiveReason = "none recorded";
+        private const string NoPeerReason = "no peer available";
 
         /// <summary>How long snap sync may go without storing a usable range before it is called a stall.</summary>
         /// <remarks>
@@ -70,11 +74,13 @@ namespace Nethermind.Synchronization.SnapSync
                     if (finished)
                     {
                         _snapProvider.Dispose();
+                        OnRunEnded();
                         return null;
                     }
                 }
                 catch (OperationCanceledException)
                 {
+                    OnRunEnded();
                     return EmptyBatch;
                 }
                 catch (Exception e)
@@ -82,10 +88,41 @@ namespace Nethermind.Synchronization.SnapSync
                     _logger.Error("Error when preparing a batch", e);
                 }
 
-                await Task.Delay(50, token);
+                try
+                {
+                    await Task.Delay(50, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Awaited outside the try above, so this is the one run-ending exit that leaves by throwing.
+                    OnRunEnded();
+                    throw;
+                }
             }
 
+            OnRunEnded();
             return EmptyBatch;
+        }
+
+        /// <summary>Ends the stall measurement at the end of a snap-sync run.</summary>
+        /// <remarks>
+        /// This feed outlives a single run: a reorg under the pivot during BAL healing discards the synced state
+        /// and starts snap over on the same instance (<c>StateSyncRunner.RunSnapSyncWithBalHealing</c>). Between the
+        /// two runs nothing stores a range, and healing can take far longer than the stall threshold, so a clock
+        /// left running would make the next run's first request report a stall that never happened, and a streak
+        /// left standing would make it name the previous run's failures. A null return from
+        /// <see cref="PrepareRequest"/> is exactly where the dispatcher ends a run.
+        /// </remarks>
+        private void OnRunEnded()
+        {
+            lock (_syncLock)
+            {
+                _lastProductiveTimestamp = 0;
+                _lastStallWarningTimestamp = 0;
+                _consecutiveUnproductiveResponses = 0;
+                _lastUnproductiveReason = NoUnproductiveReason;
+                Metrics.SnapConsecutiveUnproductiveResponses = 0;
+            }
         }
 
         public SyncResponseHandlingResult HandleResponse(SnapSyncBatch batch, PeerInfo? peer = null)
@@ -124,6 +161,11 @@ namespace Nethermind.Synchronization.SnapSync
                 {
                     if (peer is null)
                     {
+                        // SimpleDispatcher hands the batch straight back when the pool could not allocate one.
+                        // No peer means no range either, so it counts: otherwise a sync that cannot get a peer at
+                        // all leaves the streak and the reason frozen at whatever the last answered request left,
+                        // and the gauge reading zero for the whole stall.
+                        OnUnproductiveResponse(NoPeerReason);
                         return SyncResponseHandlingResult.NotAssigned;
                     }
 
@@ -184,9 +226,15 @@ namespace Nethermind.Synchronization.SnapSync
                     {
                         _stalePivotUpdateTrigger = null;
                         _consecutiveUnproductiveResponses = 0;
-                        _lastUnproductiveReason = "none recorded";
-                        _lastProductiveTimestamp = Stopwatch.GetTimestamp();
+                        _lastUnproductiveReason = NoUnproductiveReason;
                         Metrics.SnapConsecutiveUnproductiveResponses = 0;
+
+                        // Zero means no run is under way. ReleaseRequest, in the finally above, is what lets
+                        // IsFinished report the run over, so the dispatcher can end the run between there and
+                        // here - and a timestamp written after that would be charged to the next run.
+                        // Within a run this is always non-zero: WarnIfStalled starts the clock at the top of
+                        // PrepareRequest, before any batch can be handed out.
+                        if (_lastProductiveTimestamp != 0) _lastProductiveTimestamp = Stopwatch.GetTimestamp();
                     }
                 }
 
@@ -316,8 +364,8 @@ namespace Nethermind.Synchronization.SnapSync
         /// every response-driven counter frozen, so no streak of unproductive responses can reach any threshold.
         /// Elapsed time since the last stored range covers that as well as the every-request-fails shape.
         /// <para>
-        /// The clock starts at the first call rather than at construction, so the wait before snap sync is first
-        /// driven is not counted against it.
+        /// Only time within one snap-sync run counts. The clock starts at the first request of a run rather than at
+        /// construction, and <see cref="OnRunEnded"/> stops it when the run finishes.
         /// </para>
         /// </remarks>
         private void WarnIfStalled()
@@ -333,6 +381,8 @@ namespace Nethermind.Synchronization.SnapSync
             lock (_syncLock)
             {
                 long now = Stopwatch.GetTimestamp();
+                // Zero means no run is under way yet, or the last one ended: start the clock here rather than
+                // charging this run for the gap since the previous one stored a range.
                 if (_lastProductiveTimestamp == 0)
                 {
                     _lastProductiveTimestamp = now;

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Core.Crypto;
@@ -12,7 +13,7 @@ using Nethermind.Synchronization.Peers;
 
 namespace Nethermind.Synchronization.SnapSync
 {
-    public class SnapSyncFeed(ISnapProvider snapProvider, ILogManager logManager) : ISimpleSyncFeed<SnapSyncBatch>
+    public class SnapSyncFeed(ISnapProvider snapProvider, ILogManager logManager, TimeSpan? stallWarningThreshold = null) : ISimpleSyncFeed<SnapSyncBatch>
     {
         private readonly Lock _syncLock = new();
 
@@ -26,6 +27,25 @@ namespace Nethermind.Synchronization.SnapSync
         // a peer that drops and comes back between two streaks would otherwise start over as a first offender.
         private PublicKey? _stalePivotUpdateTrigger;
 
+        // A snap request that produced nothing usable is otherwise recorded only at Trace (a timeout) or in a
+        // detailed-only metric (a bad range), while ProgressTracker keeps reporting the same percentage - so a
+        // node whose every request fails looks exactly like one that is working slowly. These three make the
+        // stall itself sayable: how many requests it covers, and how long it has run. All under _syncLock.
+        private int _consecutiveUnproductiveResponses;
+        private string _lastUnproductiveReason = "none recorded";
+        private long _lastProductiveTimestamp;
+        private long _lastStallWarningTimestamp;
+
+        /// <summary>How long snap sync may go without storing a usable range before it is called a stall.</summary>
+        /// <remarks>
+        /// Also the interval between repeats. A healthy snap sync stores ranges continuously, so this only has to
+        /// clear the pauses the recovery mechanisms themselves cause - punishing a peer, or a pivot update
+        /// invalidating the in-flight requests. Overridable so tests do not have to wait it out.
+        /// </remarks>
+        private static readonly TimeSpan DefaultStallWarningThreshold = TimeSpan.FromMinutes(5);
+
+        private readonly TimeSpan _stallWarningThreshold = stallWarningThreshold ?? DefaultStallWarningThreshold;
+
         private const SnapSyncBatch EmptyBatch = null;
 
         private readonly ISnapProvider _snapProvider = snapProvider;
@@ -38,6 +58,8 @@ namespace Nethermind.Synchronization.SnapSync
             {
                 try
                 {
+                    WarnIfStalled();
+
                     bool finished = _snapProvider.IsFinished(out SnapSyncBatch request);
 
                     if (request is not null)
@@ -106,6 +128,8 @@ namespace Nethermind.Synchronization.SnapSync
                     }
 
                     _logger.Trace($"SNAP - timeout {peer}");
+                    Interlocked.Increment(ref Metrics.SnapRequestTimeouts);
+                    OnUnproductiveResponse("no response");
                     return SyncResponseHandlingResult.LesserQuality;
                 }
 
@@ -159,6 +183,10 @@ namespace Nethermind.Synchronization.SnapSync
                     lock (_syncLock)
                     {
                         _stalePivotUpdateTrigger = null;
+                        _consecutiveUnproductiveResponses = 0;
+                        _lastUnproductiveReason = "none recorded";
+                        _lastProductiveTimestamp = Stopwatch.GetTimestamp();
+                        Metrics.SnapConsecutiveUnproductiveResponses = 0;
                     }
                 }
 
@@ -166,6 +194,8 @@ namespace Nethermind.Synchronization.SnapSync
             }
             else
             {
+                OnUnproductiveResponse(result.ToString());
+
                 int allLastSuccess = 0;
                 int allLastFailures = 0;
                 int peerLastFailures = 0;
@@ -257,6 +287,76 @@ namespace Nethermind.Synchronization.SnapSync
                 }
 
                 return SyncResponseHandlingResult.OK;
+            }
+        }
+
+        /// <summary>Records a snap request that yielded no usable range.</summary>
+        /// <remarks>
+        /// A code response is not counted either way: it carries no <see cref="AddRangeResult"/>, so it neither
+        /// restarts the clock nor advances the streak. The codes-only tail of a sync is bounded, so this cannot
+        /// hold a warning open indefinitely.
+        /// </remarks>
+        /// <param name="reason">Why the response was unusable - an <see cref="AddRangeResult"/> name, or that none arrived.</param>
+        private void OnUnproductiveResponse(string reason)
+        {
+            lock (_syncLock)
+            {
+                Metrics.SnapConsecutiveUnproductiveResponses = ++_consecutiveUnproductiveResponses;
+                _lastUnproductiveReason = reason;
+            }
+        }
+
+        /// <summary>
+        /// Warns, rate-limited, once snap sync has gone <see cref="DefaultStallWarningThreshold"/> without storing a
+        /// usable range.
+        /// </summary>
+        /// <remarks>
+        /// Driven from the request side rather than the response side on purpose. A stall does not necessarily
+        /// produce responses to count: a request that stays in flight and is neither answered nor timed out leaves
+        /// every response-driven counter frozen, so no streak of unproductive responses can reach any threshold.
+        /// Elapsed time since the last stored range covers that as well as the every-request-fails shape.
+        /// <para>
+        /// The clock starts at the first call rather than at construction, so the wait before snap sync is first
+        /// driven is not counted against it.
+        /// </para>
+        /// </remarks>
+        private void WarnIfStalled()
+        {
+            // Runs once per snap request, and is a no-op on a healthy node, so the common case stays off the lock
+            // that AnalyzeResponsePerPeer holds while walking its result log.
+            long lastProductive = Volatile.Read(ref _lastProductiveTimestamp);
+            if (lastProductive != 0 && Stopwatch.GetElapsedTime(lastProductive) < _stallWarningThreshold) return;
+
+            int streak;
+            string reason;
+            TimeSpan stalledFor;
+            lock (_syncLock)
+            {
+                long now = Stopwatch.GetTimestamp();
+                if (_lastProductiveTimestamp == 0)
+                {
+                    _lastProductiveTimestamp = now;
+                    return;
+                }
+
+                stalledFor = Stopwatch.GetElapsedTime(_lastProductiveTimestamp, now);
+                if (stalledFor < _stallWarningThreshold) return;
+                if (_lastStallWarningTimestamp != 0
+                    && Stopwatch.GetElapsedTime(_lastStallWarningTimestamp, now) < _stallWarningThreshold)
+                {
+                    return;
+                }
+
+                _lastStallWarningTimestamp = now;
+                streak = _consecutiveUnproductiveResponses;
+                reason = _lastUnproductiveReason;
+            }
+
+            if (_logger.IsWarn)
+            {
+                _logger.Warn($"Snap sync has not stored a usable range for {stalledFor.TotalMinutes:N1} min " +
+                             $"({streak} unproductive responses, most recent: {reason}). The state percentage " +
+                             "will not move until a peer answers with a range at the current pivot.");
             }
         }
     }


### PR DESCRIPTION
Fixes #13248

## Changes

A stalled snap sync is invisible at default settings: a timeout is only a `Trace` line, an unusable range only the `[DetailedMetric]` `Metrics.SnapRangeResult`, and `ProgressTracker` reprints the same percentage. This adds a default-on signal. Production changes are confined to `SnapSyncFeed.cs` and `Metrics.cs`; the diff's third file is the test file.

- **`Metrics.SnapRequestTimeouts`** (`[CounterMetric]`) — `Interlocked.Increment` beside the Trace line, on the unfilled-batch branch (`SnapSyncFeed.cs:172-175`).
- **`Metrics.SnapConsecutiveUnproductiveResponses`** (`[GaugeMetric]`) — consecutive requests yielding no usable range. Advanced by a timeout, a non-`OK` `AddRangeResult`, and a batch handed back with no peer (`SimpleDispatcher.cs:58-62`). Zeroed by the first `OK` range result — account range, storage range, *or account refresh*, since `HandleResponse` leaves `isRangeResult = true` on the refresh branch (`:156-159`) — and again at run end.
- **One `Warn`, rate-limited to one per threshold interval**, from `PrepareRequest` after 5 minutes with no usable range stored: how long the stall has run, how many unproductive responses it covers, and the latest reason — an `AddRangeResult` name, `no response`, `no peer available`, or `none recorded`.

**Driven from the request side, not a response streak**, since a request stuck in flight freezes every response-driven counter. It has a limit: `WarnIfStalled` runs inside `PrepareRequest` (`:61-65`), which `SimpleDispatcher.Run` re-enters only after `semaphore.WaitAsync` frees a slot (`SimpleDispatcher.cs:64`) — a dispatcher with *all* slots wedged silences it too. A `Volatile.Read` fast path keeps the healthy case off `_syncLock`: it runs at least once per snap request, and every 50 ms while the feed idles.

**Scoped to one run.** The feed is a singleton outliving a run: `RunSnapSyncWithBalHealing` restarts snap on the same instance after a `PivotReorgedException`, and healing can outlast the threshold. So the clock starts at a run's first request, and `OnRunEnded` clears clock, streak, reason and gauge wherever `PrepareRequest` returns null. The `OK`-range write is conditional on a run being under way (`:237`), as `ReleaseRequest` runs in the `finally` first.

Diagnostics only. This does not make a stalled snap sync recover.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [x] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- 9 new `[Test]` methods in `SnapSyncFeedTests` (2 → 11 in the file): the timer firing while the feed idles and no response-driven counter can move; silence below the threshold; the reason named for a timeout and for `InvalidProof`; the gauge cleared by an `OK` range; no repeat within the interval; the no-peer path; two run-boundary regressions.
- They drive the real `PrepareRequest` loop against a substituted `ISnapProvider`, threshold via the constructor, so they are wall-clock based — about 0.3–1.5 s each, ~7 s for the nine. Thresholds are 100 ms, 1 s and 1000 ms, plus a deliberate 1-hour one to assert silence. The two asserting the gauge are `[NonParallelizable]`, as `Metrics` fields are static.
- **Gaps.** `SnapRequestTimeouts` is asserted by no test. Nothing covers the run-end reset on the *completion* path (`:74-79`): the substituted `IsFinished` always returns false and every run ends by cancellation, so `finished == true` never happens. And nothing dispatches a real request that never returns — the idle-loop test reproduces the frozen-counter shape, not that mechanism.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

The two new `[Description]` strings (`Metrics.cs:68-74`) are *not* picked up by DocGen - `MetricsGenerator` enumerates `GetProperties()` only (`tools/DocGen/MetricsGenerator.cs:80`), and these are fields - so they stay in-source. The timeout one also points at `SnapRangeResult`, a C# field name; operators query `nethermind_snap_range_result`, which is `[DetailedMetric]` and absent unless `EnableDetailedMetric` is on.

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Two default-on metrics (`nethermind_snap_request_timeouts`, `nethermind_snap_consecutive_unproductive_responses`) and a default-level stall warning.

## Remarks

- **Public API change**: the constructor gains an optional `TimeSpan? stallWarningThreshold = null` — source-compatible, binary-breaking. A test seam; `ISyncConfig` and `ITimestamper` were raised and not taken, so there is deliberately **no operator knob**.
- **`SnapRequestTimeouts` counts more than timeouts.** `SnapSyncDownloader.Dispatch` swallows every exception itself (`:56-63`) and returns normally for a peer with no `Protocol.Snap` satellite (`:26`, no `else`). Both come back as an unfilled batch and increment the counter, as does a local `ConcurrencyLimitReachedException` — so the name is narrower than the counter.
- **Bytecode responses count neither way**: no `AddRangeResult`, so they neither restart the clock nor advance the streak. Bounded — `CodesToRetrieve` is finite and a request drains up to `CODES_BATCH_SIZE` (1000) hashes — but the asymmetry is a chosen tradeoff.
- **Two disarm conditions on the gauge.** `OnRunEnded` zeroes it on successful completion *and* on every cancellation path out of `PrepareRequest` (`:77, 83, 98, 103`), so a shutdown or a sync-mode switch away from snap resets it to 0 mid-stall.
- #13252 also adds declarations to `Nethermind.Synchronization/Metrics.cs` — whichever merges second needs a small resolution there.