### PR TITLE
Merge master into eip8141-frame-txs-devnet7 (port EVM opcode gas API to #13189)

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
@@ -45,7 +45,7 @@ namespace Nethermind.Consensus.Processing
                 balManager.SetBlockExecutionContext(blockExecutionContext);
             }
 
-            public virtual TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions,
+            public TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions,
                 BlockReceiptsTracer receiptsTracer, CancellationToken token = default)
             {
                 balManager.NextTransaction();

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockProductionTransactionsExecutor.cs
@@ -46,7 +46,7 @@ namespace Nethermind.Consensus.Processing
                 balManager.SetBlockExecutionContext(blockExecutionContext);
             }
 
-            public virtual TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions,
+            public TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions,
                 BlockReceiptsTracer receiptsTracer, CancellationToken token = default)
             {
                 balManager.NextTransaction();

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
@@ -33,9 +33,9 @@ public partial class BlockProcessor
         // PerTxTimingCollector's <remarks> for the full threading contract.
         private bool _enableTxTimingMetrics;
 
-        public virtual void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext) => transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);
+        public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext) => transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);
 
-        public virtual TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer, CancellationToken token)
+        public TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer, CancellationToken token)
         {
             Metrics.ResetBlockStats();
             SetupTxTimingMetrics(block);

--- a/src/Nethermind/Nethermind.Consensus/Producers/BlockProductionSnapshot.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/BlockProductionSnapshot.cs
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Int256;
 
-namespace Nethermind.Merge.Plugin.BlockProduction;
+namespace Nethermind.Consensus.Producers;
 
-public class NoBlockProductionContext(Block? currentBestBlock, UInt256 blockFees) : IBlockProductionContext
+/// <summary>An immutable block candidate paired with the fees it collected.</summary>
+public sealed class BlockProductionSnapshot(Block? currentBestBlock, UInt256 blockFees) : IBlockProductionContext
 {
     public Block? CurrentBestBlock { get; } = currentBestBlock;
     public UInt256 BlockFees { get; } = blockFees;

--- a/src/Nethermind/Nethermind.Consensus/Producers/IBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Consensus/Producers/IBlockImprovementContext.cs
@@ -7,8 +7,10 @@ using Nethermind.Core;
 
 namespace Nethermind.Consensus.Producers;
 
-public interface IBlockImprovementContext : IBlockProductionContext, IDisposable
+public interface IBlockImprovementContext : IDisposable
 {
+    /// <summary>The best candidate produced so far, replaced as a whole when a better block is built.</summary>
+    BlockProductionSnapshot Best { get; }
     Task<Block?> ImprovementTask { get; }
     bool Disposed { get; }
     DateTimeOffset StartDateTime { get; }

--- a/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/BlockValidator.cs
@@ -420,7 +420,7 @@ public class BlockValidator(
         return true;
     }
 
-    public virtual bool ValidateBlockLevelAccessList(Block block, IReleaseSpec spec, ref string? error)
+    public bool ValidateBlockLevelAccessList(Block block, IReleaseSpec spec, ref string? error)
     {
         // n.b. block BAL body is a side-channel property only set by engine API or local production.
         // It is NOT part of block RLP, so blocks from p2p/fixtures will have null BlockAccessList

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeaderValidator.cs
@@ -142,7 +142,7 @@ namespace Nethermind.Consensus.Validators
             return true;
         }
 
-        protected virtual bool ValidateBlockNumber(BlockHeader header, BlockHeader parent, ref string? error)
+        protected bool ValidateBlockNumber(BlockHeader header, BlockHeader parent, ref string? error)
         {
             // No parent-relative block-number check at genesis (parent is null only when ValidateParent already accepted genesis).
             if (parent is null) return true;
@@ -157,7 +157,7 @@ namespace Nethermind.Consensus.Validators
             return true;
         }
 
-        protected virtual bool ValidateGasUsed(BlockHeader header, ref string? error)
+        protected bool ValidateGasUsed(BlockHeader header, ref string? error)
         {
             if (header.GasUsed > header.GasLimit)
             {
@@ -171,7 +171,7 @@ namespace Nethermind.Consensus.Validators
 
         // Ethereum protocol hard-caps block gas limit at 2^63-1 to prevent overflow and ensure
         // compatibility with signed 64-bit systems.
-        protected virtual bool ValidateFieldLimit(BlockHeader header, ref string? error)
+        protected bool ValidateFieldLimit(BlockHeader header, ref string? error)
         {
             if (header.GasLimit > 0x7FFFFFFFFFFFFFFF)
             {
@@ -183,7 +183,7 @@ namespace Nethermind.Consensus.Validators
             return true;
         }
 
-        protected virtual bool ValidateParent(BlockHeader header, BlockHeader? parent, ref string? error)
+        protected bool ValidateParent(BlockHeader header, BlockHeader? parent, ref string? error)
         {
             if (parent is null)
             {
@@ -382,7 +382,7 @@ namespace Nethermind.Consensus.Validators
         protected virtual ulong? CalculateExcessBlobGas(BlockHeader parent, IReleaseSpec spec) =>
             BlobGasCalculator.CalculateExcessBlobGas(parent, spec);
 
-        protected virtual bool ValidateBlockAccessListHash(BlockHeader header, IReleaseSpec spec, ref string? error)
+        protected bool ValidateBlockAccessListHash(BlockHeader header, IReleaseSpec spec, ref string? error)
         {
             if (spec.BlockLevelAccessListsEnabled)
             {
@@ -405,7 +405,7 @@ namespace Nethermind.Consensus.Validators
             return true;
         }
 
-        protected virtual bool ValidateSlotNumber(BlockHeader header, BlockHeader parent, IReleaseSpec spec, ref string? error)
+        protected bool ValidateSlotNumber(BlockHeader header, BlockHeader parent, IReleaseSpec spec, ref string? error)
         {
             if (spec.IsEip7843Enabled)
             {

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmOpcodesBenchmark.cs
@@ -38,6 +38,10 @@ namespace Nethermind.Evm.Benchmark;
 /// Stack values are prepared per benchmark case based on <see cref="Opcode"/>.
 /// Run: dotnet run -c Release --filter "*EvmOpcodesBenchmark*"
 /// </summary>
+/// <remarks>
+/// Includes a harness call, gas reset and cleanup check per opcode. Use <see cref="OpcodeChainBenchmarks"/>
+/// to measure sustained interpreter dispatch without those per-opcode harness costs.
+/// </remarks>
 [Config(typeof(EvmOpcodesBenchmarkConfig))]
 public unsafe class EvmOpcodesBenchmark
 {
@@ -55,6 +59,7 @@ public unsafe class EvmOpcodesBenchmark
     private GCHandle _continuationHandlersHandle;
     private BenchmarkVm _vm = null!;
     private byte[] _opcodeCode = null!;
+    private CodeInfo _opcodeCodeInfo = null!;
     private byte[] _stackBuffer = null!;
     private int _stackOffset;
     private int _stackLength;
@@ -84,7 +89,7 @@ public unsafe class EvmOpcodesBenchmark
     private static readonly UInt256 ShiftAmount = new(64);
     private static readonly UInt256 BytePosition = new(15);
     private static readonly UInt256 SignExtendPosition = new(15);
-    private static readonly UInt256 JumpDestination = UInt256.Zero;
+    private static readonly UInt256 JumpDestination = UInt256.One;
     private static readonly UInt256 One = UInt256.One;
     private static readonly UInt256 CallTarget = new(0x1000UL);
     private static readonly UInt256 CallGasLimit = new(100_000UL);
@@ -225,22 +230,28 @@ public unsafe class EvmOpcodesBenchmark
             }
         }
 
-        ReadOnlyMemory<byte> inputData = Opcode == Instruction.CALLDATACOPY ? CopySource : default;
-        _env = ExecutionEnvironment.Rent(
-            codeInfo: new CodeInfo(bytecode),
-            executingAccount: address,
-            caller: address,
-            codeSource: address,
-            callDepth: 0,
-            value: 0,
-            inputData: inputData);
-
         _opcodeCode = (byte[])bytecode.Clone();
         _opcodeCode[0] = (byte)Opcode;
         if (Opcode is Instruction.DUPN or Instruction.SWAPN or Instruction.EXCHANGE)
         {
             _opcodeCode[1] = ExtendedStackImmediate;
         }
+        else if (Opcode is Instruction.JUMP or Instruction.JUMPI)
+        {
+            // Keep the taken destination separate from the opcode under test.
+            _opcodeCode[(int)JumpDestination] = (byte)Instruction.JUMPDEST;
+        }
+        _opcodeCodeInfo = new CodeInfo(_opcodeCode);
+
+        ReadOnlyMemory<byte> inputData = Opcode == Instruction.CALLDATACOPY ? CopySource : default;
+        _env = ExecutionEnvironment.Rent(
+            codeInfo: _opcodeCodeInfo,
+            executingAccount: address,
+            caller: address,
+            codeSource: address,
+            callDepth: 0,
+            value: 0,
+            inputData: inputData);
 
         _vmState = VmState<EthereumGasPolicy>.RentTopLevel(
             EthereumGasPolicy.FromULong(ulong.MaxValue),
@@ -303,7 +314,7 @@ public unsafe class EvmOpcodesBenchmark
 
     private EvmExceptionType ExecuteOpcodeWithStackWalk()
     {
-        EvmStack stack = new(_stackDepth, NullTxTracer.Instance, ref MemoryMarshal.GetReference(GetAlignedStackSpan()), _opcodeCode);
+        EvmStack stack = new(_stackDepth, NullTxTracer.Instance, ref MemoryMarshal.GetReference(GetAlignedStackSpan()), _opcodeCode, _opcodeCodeInfo);
         DispatchState state = CreateDispatchState();
         EvmExceptionType result = EvmExceptionType.None;
         int remaining = InnerCount;
@@ -327,7 +338,7 @@ public unsafe class EvmOpcodesBenchmark
 
     private EvmExceptionType ExecuteOpcodeWithPerRunRefresh()
     {
-        EvmStack stack = new(_stackDepth, NullTxTracer.Instance, ref MemoryMarshal.GetReference(GetAlignedStackSpan()), _opcodeCode);
+        EvmStack stack = new(_stackDepth, NullTxTracer.Instance, ref MemoryMarshal.GetReference(GetAlignedStackSpan()), _opcodeCode, _opcodeCodeInfo);
         DispatchState state = CreateDispatchState();
         EvmExceptionType result = EvmExceptionType.None;
         for (int runIndex = 0; runIndex < InnerCount; runIndex++)
@@ -345,7 +356,7 @@ public unsafe class EvmOpcodesBenchmark
 
     private EvmExceptionType ExecuteOpcodeWithIndependentBinaryInputs()
     {
-        EvmStack stack = new(_stackDepth, NullTxTracer.Instance, ref MemoryMarshal.GetReference(GetAlignedStackSpan()), _opcodeCode);
+        EvmStack stack = new(_stackDepth, NullTxTracer.Instance, ref MemoryMarshal.GetReference(GetAlignedStackSpan()), _opcodeCode, _opcodeCodeInfo);
         DispatchState state = CreateDispatchState();
         EvmExceptionType result = EvmExceptionType.None;
         int remaining = InnerCount;
@@ -701,7 +712,7 @@ public unsafe class EvmOpcodesBenchmark
 
     private long ExecuteOpcodeOnceForGas()
     {
-        EvmStack stack = new(_stackDepth, NullTxTracer.Instance, ref MemoryMarshal.GetReference(GetAlignedStackSpan()), _opcodeCode);
+        EvmStack stack = new(_stackDepth, NullTxTracer.Instance, ref MemoryMarshal.GetReference(GetAlignedStackSpan()), _opcodeCode, _opcodeCodeInfo);
         if (RequiresPerRunLocationSetup(Opcode))
         {
             stack.Head = _stackDepth;

--- a/src/Nethermind/Nethermind.Evm.Benchmark/EvmStackBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/EvmStackBenchmarks.cs
@@ -49,7 +49,7 @@ namespace Nethermind.Evm.Benchmark
         [ArgumentsSource(nameof(ValueSource))]
         public UInt256 Uint256(UInt256 v)
         {
-            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default);
+            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default, null);
 
             stack.PushUInt256<OffFlag>(in v);
             stack.PopUInt256(out UInt256 value);
@@ -69,20 +69,20 @@ namespace Nethermind.Evm.Benchmark
         [Benchmark(OperationsPerInvoke = 4)]
         public byte Byte()
         {
-            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default);
+            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default, null);
 
             int b = 1;
 
-            stack.PushByte<OffFlag>((byte)b);
+            stack.PushByte<OffFlag, OnFlag>((byte)b);
             b = stack.PopByte();
 
-            stack.PushByte<OffFlag>((byte)b);
+            stack.PushByte<OffFlag, OnFlag>((byte)b);
             b = stack.PopByte();
 
-            stack.PushByte<OffFlag>((byte)b);
+            stack.PushByte<OffFlag, OnFlag>((byte)b);
             b = stack.PopByte();
 
-            stack.PushByte<OffFlag>((byte)b);
+            stack.PushByte<OffFlag, OnFlag>((byte)b);
             b = stack.PopByte();
 
             return (byte)b;
@@ -91,18 +91,18 @@ namespace Nethermind.Evm.Benchmark
         [Benchmark(OperationsPerInvoke = 4)]
         public void PushZero()
         {
-            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default);
+            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default, null);
 
-            stack.PushZero<OffFlag>();
-            stack.PushZero<OffFlag>();
-            stack.PushZero<OffFlag>();
-            stack.PushZero<OffFlag>();
+            stack.PushZero<OffFlag, OnFlag>();
+            stack.PushZero<OffFlag, OnFlag>();
+            stack.PushZero<OffFlag, OnFlag>();
+            stack.PushZero<OffFlag, OnFlag>();
         }
 
         [Benchmark(OperationsPerInvoke = 4)]
         public void PushOne()
         {
-            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default);
+            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default, null);
 
             stack.PushOne<OffFlag>();
             stack.PushOne<OffFlag>();
@@ -113,45 +113,45 @@ namespace Nethermind.Evm.Benchmark
         [Benchmark(OperationsPerInvoke = 4)]
         public void PushUInt32()
         {
-            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default);
+            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default, null);
 
-            stack.PushUInt32<OffFlag>(0x10203040);
-            stack.PushUInt32<OffFlag>(0x50607080);
-            stack.PushUInt32<OffFlag>(0x90A0B0C0);
-            stack.PushUInt32<OffFlag>(0xD0E0F000);
+            stack.PushUInt32<OffFlag, OnFlag>(0x10203040);
+            stack.PushUInt32<OffFlag, OnFlag>(0x50607080);
+            stack.PushUInt32<OffFlag, OnFlag>(0x90A0B0C0);
+            stack.PushUInt32<OffFlag, OnFlag>(0xD0E0F000);
         }
 
         [Benchmark(OperationsPerInvoke = 4)]
         public void PushUInt64()
         {
-            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default);
+            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default, null);
 
-            stack.PushUInt64<OffFlag>(0x1020304050607080);
-            stack.PushUInt64<OffFlag>(0x90A0B0C0D0E0F000);
-            stack.PushUInt64<OffFlag>(0x0123456789ABCDEF);
-            stack.PushUInt64<OffFlag>(0xFEDCBA9876543210);
+            stack.PushUInt64<OffFlag, OnFlag>(0x1020304050607080);
+            stack.PushUInt64<OffFlag, OnFlag>(0x90A0B0C0D0E0F000);
+            stack.PushUInt64<OffFlag, OnFlag>(0x0123456789ABCDEF);
+            stack.PushUInt64<OffFlag, OnFlag>(0xFEDCBA9876543210);
         }
 
         [Benchmark(OperationsPerInvoke = 4)]
         public void Swap()
         {
-            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default);
+            EvmStack stack = new(0, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default, null);
 
-            stack.Swap<OffFlag>(2);
-            stack.Swap<OffFlag>(2);
-            stack.Swap<OffFlag>(2);
-            stack.Swap<OffFlag>(2);
+            stack.Swap<OffFlag, OnFlag>(2);
+            stack.Swap<OffFlag, OnFlag>(2);
+            stack.Swap<OffFlag, OnFlag>(2);
+            stack.Swap<OffFlag, OnFlag>(2);
         }
 
         [Benchmark(OperationsPerInvoke = 4)]
         public void Dup()
         {
-            EvmStack stack = new(1, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default);
+            EvmStack stack = new(1, NullTxTracer.Instance, ref MemoryMarshal.GetArrayDataReference(_stack), default, null);
 
-            stack.Dup<OffFlag>(1);
-            stack.Dup<OffFlag>(1);
-            stack.Dup<OffFlag>(1);
-            stack.Dup<OffFlag>(1);
+            stack.Dup<OffFlag, OnFlag>(1);
+            stack.Dup<OffFlag, OnFlag>(1);
+            stack.Dup<OffFlag, OnFlag>(1);
+            stack.Dup<OffFlag, OnFlag>(1);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/OpcodeChainBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/OpcodeChainBenchmarks.cs
@@ -1,0 +1,274 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Autofac;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Core.Container;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+
+namespace Nethermind.Evm.Benchmark;
+
+/// <summary>Measures dependent opcode chains through the production interpreter.</summary>
+/// <remarks>
+/// Results are normalized per executed opcode. Multiply by 3846 for time per contract execution.
+/// Frame entry, return and cleanup are amortized across the chain; no harness call separates opcodes.
+/// </remarks>
+[MemoryDiagnoser]
+public class OpcodeChainBenchmarks
+{
+    private const int BodyOpcodeCount = 3840;
+    private const int ExecutedOpcodeCount = BodyOpcodeCount + 6;
+    private IContainer _container = null!;
+    private ILifetimeScope _processingScope = null!;
+    private IDisposable _stateScope = null!;
+    private IWorldState _state = null!;
+    private IVirtualMachine _vm = null!;
+    private ITxTracer _tracer = null!;
+    private CodeInfo _code = null!;
+    private CodeInfo[] _codePool;
+    private int _codeIndex;
+    private byte[] _input = new byte[96];
+
+    [Params("BalanceColdExistingPair", "BalanceColdSingle", "DivIsZero", "MulDup", "SarAnd", "MemoryCopy", "MemoryHash", "BalanceColdPair", "ExpOne", "ExpCompute", "CallEmpty", "CallIdentity", "StaticIdentity", "StorageWrite", "StorageRead", "TransientRead", "BalanceRead", "SelfBalanceRead", "ExtCodeSizeRead", "DivOne", "ModOne", "DivZero", "ModZero", "DivSmall", "ModSmall", "DivWide", "ModWide", "JumpScattered", "JumpScatteredRotating", "JumpScatteredPush3", "Arithmetic", "AddMod", "MulMod", "AddModZero", "MulModZero", "Bitwise", "Predicate", "Stack", "Byte", "Shift", "Sar", "Clz", "Environment", "SmallValue", "CallData", "CallDataPartial", "CallDataMissing", "Context", "ReturnDataSize", "PrevRandao", "Memory", "MemoryByte", "MemoryBoundary", "CallReturn", "CallRevert", "CallInput", "JumpTaken", "JumpUntaken", "JumpAlternating")]
+    public string Chain { get; set; } = "Arithmetic";
+
+    [Params(false, true)]
+    public bool Cancelable { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _container = new ContainerBuilder()
+            .AddModule(new TestNethermindModule(Osaka.Instance))
+            .Build();
+        IWorldStateScopeProvider scopeProvider = _container.Resolve<IWorldStateManager>().GlobalWorldState;
+        _processingScope = _container.BeginLifetimeScope(builder => builder.AddSingleton(scopeProvider));
+        _state = _processingScope.Resolve<IWorldState>();
+        _vm = _processingScope.Resolve<IVirtualMachine>();
+        _stateScope = _state.BeginScope(IWorldState.PreGenesis);
+        _state.CreateAccount(Address.Zero, UInt256.One);
+        if (Chain == "BalanceColdExistingPair")
+            for (int i = 2; i <= BodyOpcodeCount / 8 + 1; i++)
+                _state.CreateAccount(Address.FromNumber((uint)i), UInt256.One);
+        if (Chain is "CallReturn" or "CallRevert" or "CallInput")
+        {
+            _state.CreateAccount(TestItem.AddressC, UInt256.One);
+            byte[] childCode = [(byte)Instruction.PUSH1, 32, (byte)Instruction.PUSH0,
+                (byte)(Chain == "CallRevert" ? Instruction.REVERT : Instruction.RETURN)];
+            _state.InsertCode(TestItem.AddressC, childCode, Osaka.Instance);
+        }
+        _state.Commit(Osaka.Instance);
+        if (Chain == "BalanceColdExistingPair") _state.CommitTree(0);
+        _vm.SetBlockExecutionContext(new BlockExecutionContext(Build.A.BlockHeader.TestObject, Osaka.Instance));
+        _vm.SetTxExecutionContext(new TxExecutionContext(Address.Zero, _processingScope.Resolve<ICodeInfoRepository>(), null, 0));
+        _tracer = Cancelable ? new CancellationTxTracer(NullTxTracer.Instance) : NullTxTracer.Instance;
+        _code = BuildCode();
+        if (Chain == "JumpScatteredRotating")
+        {
+            _codePool = new CodeInfo[256];
+            for (int i = 0; i < _codePool.Length; i++) _codePool[i] = new CodeInfo(_code.CodeSpan.ToArray());
+        }
+
+        ReadOnlyMemory<byte> output = ExecuteContract();
+        UInt256 expected = Chain switch
+        {
+            "MulDup" => (UInt256)System.Numerics.BigInteger.ModPow(3, BodyOpcodeCount / 4, System.Numerics.BigInteger.One << 256),
+            "BalanceColdPair" or "BalanceColdExistingPair" => (UInt256)(BodyOpcodeCount / 8 + 1),
+            "BalanceColdSingle" => (UInt256)(BodyOpcodeCount / 5 + 1),
+            "Arithmetic" => (UInt256)(BodyOpcodeCount / 2 + 1),
+            "AddMod" => (UInt256)((BodyOpcodeCount / 4 + 1) % 251),
+            "MulMod" => (UInt256)(ulong)System.Numerics.BigInteger.ModPow(3, BodyOpcodeCount / 4, 251),
+            "AddModZero" or "MulModZero" or "DivZero" or "ModZero" => UInt256.Zero,
+            "DivSmall" or "DivWide" => (UInt256)2,
+            "ModSmall" or "ModWide" => UInt256.One,
+            "DivOne" => (UInt256)3,
+            "ModOne" => UInt256.Zero,
+            "Predicate" => UInt256.MaxValue,
+            "JumpTaken" => UInt256.Zero,
+            "Byte" or "Shift" or "Sar" => UInt256.Zero,
+            "Clz" => (UInt256)248,
+            _ => UInt256.One
+        };
+        if (_vm.OpCodeCount != ExecutedOpcodeCount || !output.Span.SequenceEqual(expected.ToBigEndian()))
+            throw new InvalidOperationException($"Invalid {Chain} chain output or opcode count.");
+
+        for (int i = 0; i < 100_000; i++) ExecuteContract();
+        CodeInfo chain = _code;
+        CodeInfo[] codePool = _codePool;
+        _codePool = null;
+        _code = new CodeInfo(new byte[] { (byte)Instruction.STOP });
+        // Advance the periodic table refresh after warming the selected workload's instruction bodies.
+        for (int i = 0; i < 400_000; i++) ExecuteContract();
+        _code = chain;
+        _codePool = codePool;
+    }
+
+    [Benchmark(OperationsPerInvoke = ExecutedOpcodeCount)]
+    public ReadOnlyMemory<byte> ExecuteContract()
+    {
+        CodeInfo code = _codePool is { } pool ? pool[_codeIndex++ & (pool.Length - 1)] : _code;
+        using ExecutionEnvironment environment = ExecutionEnvironment.Rent(
+            executingAccount: Address.Zero, codeSource: Address.Zero, caller: Address.Zero,
+            codeInfo: code, callDepth: 0, value: 0, inputData: _input);
+        using StackAccessTracker accessTracker = new();
+        using VmState<EthereumGasPolicy> state = VmState<EthereumGasPolicy>.RentTopLevel(
+            EthereumGasPolicy.FromULong(10_000_000), ExecutionType.TRANSACTION, environment,
+            accessTracker, _state.TakeSnapshot());
+        TransactionSubstate result = _vm.ExecuteTransaction<OffFlag>(state, _state, _tracer);
+        if (result.IsError || result.ShouldRevert)
+            throw new InvalidOperationException($"Chain execution failed: {result.EvmExceptionType}");
+        _state.Reset();
+        return result.Output;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _stateScope?.Dispose();
+        _processingScope?.Dispose();
+        _container?.Dispose();
+    }
+
+    private CodeInfo BuildCode()
+    {
+        List<byte> code = [(byte)Instruction.PUSH1, Chain == "JumpTaken" ? (byte)0 : (byte)1];
+        if (Chain is "JumpScattered" or "JumpScatteredRotating" or "JumpScatteredPush3")
+        {
+            const int blocks = BodyOpcodeCount / 5;
+            const int stride = 24;
+            byte[] body = new byte[blocks * stride];
+            for (int i = 0; i < blocks; i++)
+            {
+                int offset = i * 73 % blocks * stride;
+                int destination = i + 1 == blocks ? 2 + body.Length : 2 + (i + 1) * 73 % blocks * stride;
+                int cursor = offset;
+                if (i != 0) body[cursor++] = (byte)Instruction.JUMPDEST;
+                body[cursor++] = (byte)Instruction.DUP1;
+                body[cursor++] = (byte)Instruction.POP;
+                body[cursor++] = (byte)(Chain == "JumpScatteredPush3" ? Instruction.PUSH3 : Instruction.PUSH2);
+                if (Chain == "JumpScatteredPush3") body[cursor++] = 0;
+                body[cursor++] = (byte)(destination >> 8);
+                body[cursor++] = (byte)destination;
+                body[cursor] = (byte)Instruction.JUMP;
+            }
+            code.AddRange(body);
+            code.Add((byte)Instruction.JUMPDEST);
+        }
+        else if (Chain != "DivIsZero" && (Chain.StartsWith("Div", StringComparison.Ordinal) || Chain.StartsWith("Mod", StringComparison.Ordinal)))
+        {
+            bool wide = Chain.EndsWith("Wide", StringComparison.Ordinal);
+            UInt256 divisor = Chain.EndsWith("Zero", StringComparison.Ordinal) ? UInt256.Zero
+                : Chain.EndsWith("One", StringComparison.Ordinal) ? UInt256.One
+                : wide ? UInt256.MaxValue / 4 : (UInt256)3;
+            UInt256 dividend = divisor.IsZero ? UInt256.MaxValue : divisor * 2 + 1;
+            code.Clear();
+            code.AddRange([(byte)Instruction.PUSH32, .. divisor.ToBigEndian(),
+                (byte)Instruction.PUSH32, .. dividend.ToBigEndian()]);
+            Instruction opcode = Chain.StartsWith("Div", StringComparison.Ordinal) ? Instruction.DIV : Instruction.MOD;
+            for (int i = 0; i < BodyOpcodeCount / 4; i++)
+            {
+                code.AddRange([(byte)Instruction.DUP2, (byte)Instruction.DUP2, (byte)opcode]);
+                if (i + 1 != BodyOpcodeCount / 4) code.Add((byte)Instruction.POP);
+            }
+        }
+        else if (Chain is "JumpTaken" or "JumpUntaken" or "JumpAlternating")
+        {
+            for (int i = 0; i < BodyOpcodeCount / 5; i++)
+            {
+                code.Add((byte)(Chain == "JumpAlternating" ? Instruction.ISZERO : Instruction.DUP1));
+                code.Add((byte)(Chain == "JumpAlternating" ? Instruction.DUP1 : Instruction.ISZERO));
+                int destination = code.Count + 4;
+                code.AddRange([(byte)Instruction.PUSH2, (byte)(destination >> 8), (byte)destination,
+                    (byte)Instruction.JUMPI, (byte)Instruction.JUMPDEST]);
+            }
+        }
+        else
+        {
+            (byte[] Sequence, int Opcodes) body = Chain switch
+            {
+                "DivIsZero" => ([(byte)Instruction.PUSH1, 3, (byte)Instruction.PUSH1, 7,
+                    (byte)Instruction.DIV, (byte)Instruction.ISZERO, (byte)Instruction.POP], 5),
+                "MulDup" => ([(byte)Instruction.PUSH1, 3, (byte)Instruction.MUL, (byte)Instruction.DUP1, (byte)Instruction.POP], 4),
+                "SarAnd" => ([(byte)Instruction.DUP1, (byte)Instruction.PUSH1, 0, (byte)Instruction.SAR, (byte)Instruction.AND], 4),
+                "MemoryCopy" => ([(byte)Instruction.PUSH1, 32, (byte)Instruction.PUSH0,
+                    (byte)Instruction.PUSH0, (byte)Instruction.CALLDATACOPY], 4),
+                "MemoryHash" => ([(byte)Instruction.PUSH1, 32, (byte)Instruction.PUSH0,
+                    (byte)Instruction.KECCAK256, (byte)Instruction.POP], 4),
+                "BalanceColdSingle" => ([(byte)Instruction.PUSH1, 1, (byte)Instruction.ADD,
+                    (byte)Instruction.DUP1, (byte)Instruction.BALANCE, (byte)Instruction.POP], 5),
+                "BalanceColdPair" or "BalanceColdExistingPair" => ([(byte)Instruction.PUSH1, 1, (byte)Instruction.ADD,
+                    (byte)Instruction.DUP1, (byte)Instruction.BALANCE, (byte)Instruction.POP,
+                    (byte)Instruction.DUP1, (byte)Instruction.BALANCE, (byte)Instruction.POP], 8),
+                "Arithmetic" => ([(byte)Instruction.PUSH1, 1, (byte)Instruction.ADD], 2),
+                "AddMod" or "MulMod" or "AddModZero" or "MulModZero" => ([(byte)Instruction.PUSH1, Chain is "AddModZero" or "MulModZero" ? (byte)0 : (byte)251,
+                    (byte)Instruction.SWAP1, (byte)Instruction.PUSH1, Chain is "MulMod" or "MulModZero" ? (byte)3 : (byte)1,
+                    (byte)(Chain is "MulMod" or "MulModZero" ? Instruction.MULMOD : Instruction.ADDMOD)], 4),
+                "StorageRead" or "TransientRead" or "BalanceRead" => ([(byte)Instruction.DUP1,
+                    (byte)(Chain == "StorageRead" ? Instruction.SLOAD : Chain == "TransientRead" ? Instruction.TLOAD : Instruction.BALANCE),
+                    (byte)Instruction.POP], 3),
+                "StorageWrite" => ([(byte)Instruction.PUSH0, (byte)Instruction.PUSH0, (byte)Instruction.SSTORE], 3),
+                "SelfBalanceRead" => ([(byte)Instruction.SELFBALANCE, (byte)Instruction.POP], 2),
+                "ExtCodeSizeRead" => ([(byte)Instruction.DUP1, (byte)Instruction.EXTCODESIZE, (byte)Instruction.POP], 3),
+                "ExpOne" or "ExpCompute" => ([(byte)Instruction.PUSH1, 7,
+                    (byte)Instruction.PUSH1, Chain == "ExpOne" ? (byte)1 : (byte)3, (byte)Instruction.EXP, (byte)Instruction.POP], 4),
+                "Bitwise" => ([(byte)Instruction.DUP1, (byte)Instruction.AND], 2),
+                "Predicate" => ([(byte)Instruction.ISZERO, (byte)Instruction.NOT], 2),
+                "Stack" => ([(byte)Instruction.DUP1, (byte)Instruction.SWAP1, (byte)Instruction.POP], 3),
+                "Byte" => ([(byte)Instruction.PUSH1, 0, (byte)Instruction.BYTE], 2),
+                "Shift" => ([(byte)Instruction.PUSH1, 1, (byte)Instruction.SHL], 2),
+                "Sar" => ([(byte)Instruction.PUSH1, 1, (byte)Instruction.SAR], 2),
+                "Clz" => ([(byte)Instruction.CLZ], 1),
+                "Environment" => ([(byte)Instruction.PC, (byte)Instruction.POP,
+                    (byte)Instruction.GAS, (byte)Instruction.POP, (byte)Instruction.CODESIZE, (byte)Instruction.POP], 6),
+                "SmallValue" => ([(byte)Instruction.CALLDATASIZE, (byte)Instruction.DUP1, (byte)Instruction.AND, (byte)Instruction.POP,
+                    (byte)Instruction.GAS, (byte)Instruction.DUP1, (byte)Instruction.AND, (byte)Instruction.POP], 8),
+                "CallData" or "CallDataPartial" or "CallDataMissing" => ([(byte)Instruction.PUSH1,
+                    Chain == "CallData" ? (byte)4 : Chain == "CallDataPartial" ? (byte)80 : (byte)96,
+                    (byte)Instruction.CALLDATALOAD, (byte)Instruction.POP], 3),
+                "Context" => ([(byte)Instruction.CALLER, (byte)Instruction.POP,
+                    (byte)Instruction.CALLDATASIZE, (byte)Instruction.POP, (byte)Instruction.TIMESTAMP, (byte)Instruction.POP], 6),
+                "ReturnDataSize" => ([(byte)Instruction.RETURNDATASIZE, (byte)Instruction.POP], 2),
+                "PrevRandao" => ([(byte)Instruction.PREVRANDAO, (byte)Instruction.POP], 2),
+                "Memory" => ([(byte)Instruction.DUP1, (byte)Instruction.PUSH0, (byte)Instruction.MSTORE,
+                    (byte)Instruction.PUSH0, (byte)Instruction.MLOAD, (byte)Instruction.POP], 6),
+                "MemoryByte" => ([(byte)Instruction.DUP1, (byte)Instruction.PUSH0, (byte)Instruction.MSTORE8,
+                    (byte)Instruction.PUSH0, (byte)Instruction.MLOAD, (byte)Instruction.POP], 6),
+                "MemoryBoundary" => ([(byte)Instruction.DUP1, (byte)Instruction.PUSH1, 63, (byte)Instruction.MSTORE8,
+                    (byte)Instruction.PUSH1, 48, (byte)Instruction.MLOAD, (byte)Instruction.POP,
+                    (byte)Instruction.DUP1, (byte)Instruction.PUSH1, 64, (byte)Instruction.MSTORE8,
+                    (byte)Instruction.PUSH1, 48, (byte)Instruction.MLOAD, (byte)Instruction.POP], 12),
+                "StaticIdentity" => ([(byte)Instruction.PUSH1, 32, (byte)Instruction.PUSH1, 32,
+                    (byte)Instruction.PUSH0, (byte)Instruction.PUSH0,
+                    (byte)Instruction.PUSH1, 4, (byte)Instruction.PUSH2, 0xff, 0xff,
+                    (byte)Instruction.STATICCALL, (byte)Instruction.POP], 8),
+                "CallEmpty" or "CallIdentity" => ([(byte)Instruction.PUSH1, 32, (byte)Instruction.PUSH1, 32,
+                    (byte)Instruction.PUSH0, (byte)Instruction.PUSH0, (byte)Instruction.PUSH0,
+                    (byte)Instruction.PUSH20, .. (Chain == "CallIdentity" ? Address.FromNumber(4).Bytes.ToArray() : TestItem.AddressC.Bytes.ToArray()),
+                    (byte)Instruction.PUSH2, 0xff, 0xff, (byte)Instruction.CALL, (byte)Instruction.POP,
+                    (byte)Instruction.PUSH0, (byte)Instruction.POP, (byte)Instruction.JUMPDEST], 12),
+                // Includes the three opcodes executed by the child frame.
+                "CallReturn" or "CallRevert" or "CallInput" => ([(byte)Instruction.PUSH1, 32, (byte)Instruction.PUSH1, 32,
+                    .. (Chain == "CallInput" ? new byte[] { (byte)Instruction.PUSH1, 32 } : new byte[] { (byte)Instruction.PUSH0 }),
+                    (byte)Instruction.PUSH0, (byte)Instruction.PUSH0,
+                    (byte)Instruction.PUSH20, .. TestItem.AddressC.Bytes, (byte)Instruction.PUSH2, 0xff, 0xff,
+                    (byte)Instruction.CALL, (byte)Instruction.POP], 12),
+                _ => throw new ArgumentOutOfRangeException(nameof(Chain))
+            };
+            for (int i = 0; i < BodyOpcodeCount / body.Opcodes; i++) code.AddRange(body.Sequence);
+        }
+        code.AddRange([(byte)Instruction.PUSH0, (byte)Instruction.MSTORE,
+            (byte)Instruction.PUSH1, 32, (byte)Instruction.PUSH0, (byte)Instruction.RETURN]);
+        return new CodeInfo(code.ToArray());
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/CallDataLoadTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallDataLoadTests.cs
@@ -12,18 +12,20 @@ using NUnit.Framework;
 namespace Nethermind.Evm.Test;
 
 [Parallelizable(ParallelScope.Self)]
-public class CallDataLoadTests : VirtualMachineTestsBase
+[TestFixture(false)]
+[TestFixture(true)]
+public class CallDataLoadTests(bool tracing) : VirtualMachineTestsBase
 {
     protected override ulong BlockNumber => MainnetSpecProvider.ParisBlockNumber;
     protected override ulong Timestamp => MainnetSpecProvider.CancunBlockTimestamp;
 
-    // Forces the OffFlag specialization of InstructionCallDataLoad; the default tracer
-    // has IsTracingInstructions = true which picks the OnFlag path.
-    protected override TestAllTracerWithOutput CreateTracer() => new NoInstructionTracer();
+    protected override TestAllTracerWithOutput CreateTracer() => new StackPushTracer(tracing);
 
-    private sealed class NoInstructionTracer : TestAllTracerWithOutput
+    private sealed class StackPushTracer(bool tracing) : TestAllTracerWithOutput
     {
-        public override bool IsTracingInstructions => false;
+        public override bool IsTracingInstructions => tracing;
+        public List<byte[]> Pushes { get; } = [];
+        public override void ReportStackPush(in ReadOnlySpan<byte> stackItem) => Pushes.Add(stackItem.ToArray());
     }
 
     private static readonly byte[] ThirtyTwoSequential = BuildSequential(32);
@@ -66,12 +68,25 @@ public class CallDataLoadTests : VirtualMachineTestsBase
         _processor.Execute(tx, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(Activation)), tracer);
 
         AssertStorage((UInt256)0, (ReadOnlySpan<byte>)expected);
+        if (tracing)
+        {
+            byte[] expectedPush = offset >= (UInt256)calldata.Length ? [0] : expected;
+            Assert.That(((StackPushTracer)tracer).Pushes[1], Is.EqualTo(expectedPush));
+        }
     }
 
     public static IEnumerable<TestCaseData> CallDataLoadCases()
     {
+        for (int available = 1; available < 32; available++)
+            yield return new TestCaseData(ThirtyTwoSequential, (UInt256)(32 - available),
+                RightPadded(ThirtyTwoSequential.AsSpan(32 - available))).SetName($"partial_{available}_bytes");
+        yield return new TestCaseData(ThirtyTwoSequential, UInt256.MaxValue, new byte[32]);
+        yield return new TestCaseData(ThirtyTwoSequential, new UInt256(0UL, 0UL, 1UL, 0UL), new byte[32]);
+        yield return new TestCaseData(ThirtyTwoSequential, new UInt256(0UL, 0UL, 0UL, 1UL), new byte[32]);
         yield return new TestCaseData(ThirtyTwoSequential, (UInt256)0, ThirtyTwoSequential)
             .SetName("offset_zero_full_32_bytes");
+        yield return new TestCaseData(new byte[32], UInt256.Zero, new byte[32])
+            .SetName("in_range_zero_word_preserves_full_trace_width");
 
         yield return new TestCaseData(TwoBytes, (UInt256)5, new byte[32])
             .SetName("offset_past_end_returns_zero");

--- a/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CallTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -193,7 +194,9 @@ namespace Nethermind.Evm.Test
             .Done;
 
         [Test]
-        public void Child_output_copy_preserves_memory_beyond_returned_bytes([Values] bool revert)
+        public void Child_output_copy_preserves_memory_beyond_returned_bytes(
+            [Values] bool revert, [Values(0, 31, 1023, 1024)] int outputOffset,
+            [Values(0, 1, 8, 64)] int requestedLength, [Values] bool traced, [Values] bool repeatCall)
         {
             Address target = TestItem.AddressC;
             Prepare childBuilder = Prepare.EvmCode
@@ -205,19 +208,118 @@ namespace Nethermind.Evm.Test
             TestState.InsertCode(target, childCode, SpecProvider.GenesisSpec);
 
             byte[] dirtyWord = Enumerable.Repeat((byte)0xff, EvmPooledMemory.WordSize).ToArray();
-            byte[] parentCode = Prepare.EvmCode
-                .MSTORE(0, dirtyWord)
-                .CALL(50_000, target, 0, 0, 0, 0, 8)
-                .Op(Instruction.POP)
-                .RETURN(0, 8)
+            Prepare parentBuilder = Prepare.EvmCode
+                .MSTORE((UInt256)outputOffset, dirtyWord)
+                .CALL(50_000, target, 0, 0, 0, (UInt256)outputOffset, (UInt256)requestedLength)
+                .Op(Instruction.POP);
+            if (repeatCall)
+            {
+                parentBuilder.CALL(50_000, target, 0, 0, 0, (UInt256)outputOffset, (UInt256)requestedLength)
+                    .Op(Instruction.POP);
+            }
+
+            byte[] parentCode = parentBuilder
+                .Op(Instruction.RETURNDATASIZE)
+                .MSTORE((UInt256)(outputOffset + 11))
+                .RETURNDATACOPY((UInt256)(outputOffset + 8), 0, 3)
+                .RETURN((UInt256)outputOffset, 43)
                 .Done;
 
-            TestAllTracerWithOutput tracer = Execute(parentCode);
+            TestAllTracerWithOutput tracer = new OutputCopyTracer(traced);
+            Execute(tracer, parentCode);
+            byte[] expected = new byte[43];
+            expected.AsSpan(0, 8).Fill(0xff);
+            expected[8] = 1;
+            expected[9] = 2;
+            expected[10] = 3;
+            expected[42] = 3;
+            for (int i = 0; i < Math.Min(3, requestedLength); i++) expected[i] = (byte)(i + 1);
 
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(tracer.Error, Is.Null);
-                Assert.That(tracer.ReturnValue, Is.EqualTo(new byte[] { 1, 2, 3, 0xff, 0xff, 0xff, 0xff, 0xff }));
+                Assert.That(tracer.ReturnValue, Is.EqualTo(expected));
+            }
+        }
+
+        private sealed class OutputCopyTracer(bool traced) : TestAllTracerWithOutput
+        {
+            public override bool IsTracingInstructions => traced;
+            public List<byte[]> StackPushes { get; } = [];
+            public override void ReportStackPush(in ReadOnlySpan<byte> stackItem) => StackPushes.Add(stackItem.ToArray());
+        }
+
+        [Test]
+        public void Child_receives_input_across_memory_boundaries(
+            [Values(0, 31, 1023, 1024)] int inputOffset,
+            [Values(0, 1, 32, 64)] int inputLength, [Values] bool traced)
+        {
+            byte[] data = new byte[64];
+            for (int i = 0; i < data.Length; i++) data[i] = (byte)(i + 1);
+            byte[] childCode = Prepare.EvmCode
+                .Op(Instruction.CALLDATASIZE).PushData(0).PushData(0).Op(Instruction.CALLDATACOPY)
+                .Op(Instruction.CALLDATASIZE).PushData(0).Op(Instruction.RETURN).Done;
+            TestState.CreateAccount(TestItem.AddressC, UInt256.Zero);
+            TestState.InsertCode(TestItem.AddressC, childCode, SpecProvider.GenesisSpec);
+            byte[] parentCode = Prepare.EvmCode.StoreDataInMemory(inputOffset, data)
+                .CALL(50_000, TestItem.AddressC, 0, (UInt256)inputOffset, (UInt256)inputLength, 2048, (UInt256)inputLength)
+                .Op(Instruction.POP).RETURN(2048, (UInt256)inputLength).Done;
+            AssertSuccessfulOutput(parentCode, data.AsSpan(0, inputLength).ToArray(), traced);
+        }
+
+        [Test]
+        public void Resumed_call_pushes_status_after_a_full_stack(
+            [Values(Instruction.CALL, Instruction.CALLCODE, Instruction.DELEGATECALL, Instruction.STATICCALL)] Instruction instruction,
+            [Values] bool revert, [Values] bool traced)
+        {
+            byte[] childCode = Prepare.EvmCode.PushData(0).PushData(0)
+                .Op(revert ? Instruction.REVERT : Instruction.RETURN).Done;
+            TestState.CreateAccount(TestItem.AddressC, UInt256.Zero);
+            TestState.InsertCode(TestItem.AddressC, childCode, SpecProvider.GenesisSpec);
+            bool hasValue = instruction is Instruction.CALL or Instruction.CALLCODE;
+            Prepare parent = Prepare.EvmCode;
+            for (int i = 0; i < 1024 - (hasValue ? 7 : 6); i++) parent.Op(Instruction.PUSH0);
+            parent.PushData(0).PushData(0).PushData(0).PushData(0);
+            if (hasValue) parent.PushData(0);
+            byte[] code = parent.PushData(TestItem.AddressC).PushData(50_000).Op(instruction)
+                .PushData(0).Op(Instruction.MSTORE).RETURN(0, 32).Done;
+            AssertSuccessfulOutput(code, ((UInt256)(revert ? 0 : 1)).ToBigEndian(), traced, [(byte)(revert ? 0 : 1)]);
+        }
+
+        [Test]
+        public void Resumed_create_pushes_result_after_a_full_stack(
+            [Values(Instruction.CREATE, Instruction.CREATE2)] Instruction instruction,
+            [Values] bool revert, [Values] bool traced)
+        {
+            byte[] initCode = Prepare.EvmCode.PushData(0).PushData(0)
+                .Op(revert ? Instruction.REVERT : Instruction.RETURN).Done;
+            Prepare parent = Prepare.EvmCode.StoreDataInMemory(0, initCode);
+            for (int i = 0; i < (instruction == Instruction.CREATE2 ? 1020 : 1021); i++) parent.Op(Instruction.PUSH0);
+            if (instruction == Instruction.CREATE2) parent.Op(Instruction.PUSH0);
+            byte[] code = parent.PushData(initCode.Length).PushData(0).PushData(0).Op(instruction)
+                .PushData(0).Op(Instruction.MSTORE).RETURN(0, 32).Done;
+            byte[] expected = new byte[32];
+            if (!revert)
+            {
+                Address address = instruction == Instruction.CREATE2
+                    ? ContractAddress.From(Recipient, new byte[32], initCode)
+                    : ContractAddress.From(Recipient, 0);
+                address.Bytes.CopyTo(expected.AsSpan(12));
+            }
+            AssertSuccessfulOutput(code, expected, traced, revert ? [0] : expected[12..]);
+        }
+
+        private void AssertSuccessfulOutput(byte[] code, byte[] expected, bool traced, byte[]? expectedResumePush = null)
+        {
+            OutputCopyTracer tracer = new(traced);
+            Execute(tracer, code);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(tracer.Error, Is.Null);
+                Assert.That(tracer.ReturnValue, Is.EqualTo(expected));
+                // The resumed result precedes the three arguments pushed for MSTORE and RETURN.
+                if (traced && expectedResumePush is not null)
+                    Assert.That(tracer.StackPushes[^4], Is.EqualTo(expectedResumePush));
             }
         }
 
@@ -371,5 +473,36 @@ namespace Nethermind.Evm.Test
                 Instruction.STATICCALL => Prepare.EvmCode.StaticCall(target, 50_000).Done,
                 _ => throw new ArgumentOutOfRangeException(nameof(instruction), instruction, null)
             };
+
+        [Test]
+        public void Jump_after_a_nested_call_validates_against_the_resumed_frame()
+        {
+            TestState.CreateAccount(TestItem.AddressC, 1.Ether);
+            TestState.InsertCode(TestItem.AddressC, Prepare.EvmCode.Op(Instruction.STOP).Done, SpecProvider.GenesisSpec);
+
+            // The destination fits a PUSH1 in both builds, so the probe has the layout of the real code.
+            int jumpDest = CallThenJump(1).Done.Length;
+            byte[] code = CallThenJump(jumpDest)
+                .Op(Instruction.JUMPDEST)
+                .PushData(1)
+                .PushData(0)
+                .Op(Instruction.SSTORE)
+                .Done;
+
+            TestAllTracerWithOutput result = Execute(code);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.Error, Is.Null);
+                AssertStorage(UInt256.Zero, new byte[] { 1 });
+            }
+
+            static Prepare CallThenJump(int destination) => Prepare.EvmCode
+                .Call(TestItem.AddressC, 50000)
+                .Op(Instruction.POP)
+                .PushData(destination)
+                .Op(Instruction.JUMP)
+                .Op(Instruction.INVALID);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Eip2780Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip2780Tests.cs
@@ -28,7 +28,7 @@ public class Eip2780Tests
     public void Call_value_cost_is_flat_under_eip2780()
     {
         EthereumGasPolicy gas = EthereumGasPolicy.FromULong(1_000_000);
-        Assert.That(EthereumGasPolicy.ConsumeCallValueTransferEip2780(ref gas), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeCallValueTransferEip2780(ref gas), Is.True);
         Assert.That(1_000_000 - EthereumGasPolicy.GetRemainingGas(in gas), Is.EqualTo(Eip8038Constants.CallValue));
     }
 
@@ -37,7 +37,7 @@ public class Eip2780Tests
         EthereumGasPolicy gas = EthereumGasPolicy.FromULong(1_000_000);
         using StackAccessTracker tracker = new();
         if (prewarm) tracker.WarmUp(TestItem.AddressB);
-        Assert.That(EthereumGasPolicy.ConsumeAccountAccessGas(ref gas, spec, in tracker, isTracingAccess: false, TestItem.AddressB), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeAccountAccessGas(ref gas, spec, in tracker, isTracingAccess: false, TestItem.AddressB), Is.True);
         return 1_000_000 - EthereumGasPolicy.GetRemainingGas(in gas);
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Eip2929Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip2929Tests.cs
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Int256;
 using Nethermind.Specs;
 using Nethermind.Core.Test.Builders;
 using NUnit.Framework;
@@ -33,6 +35,68 @@ namespace Nethermind.Evm.Test
             TestAllTracerWithOutput result = Execute(code);
             Assert.That(result.StatusCode, Is.EqualTo(1));
             AssertGas(result, GasCostOf.Transaction + expectedGasExcludingTx);
+        }
+
+        private sealed class StorageObservationTracer(bool storage) : TestAllTracerWithOutput
+        {
+            public override bool IsTracingInstructions => false;
+            public override bool IsTracingOpLevelStorage => storage;
+            public int StorageReads { get; private set; }
+
+            public override void LoadOperationStorage(Address address, UInt256 storageIndex, ReadOnlySpan<byte> value) => StorageReads++;
+        }
+
+        [TestCase(false, false)]
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        public void Storage_observation_flags_are_independent_and_refreshed(bool storage, bool access)
+        {
+            byte[] code = Bytes.FromHexString("6001545060015450");
+            Verify(storage, access);
+            Verify(!storage, !access);
+
+            void Verify(bool traceStorage, bool traceAccess)
+            {
+                StorageObservationTracer tracer = new(traceStorage) { IsTracingAccess = traceAccess };
+                Execute(tracer, code);
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
+                    Assert.That(tracer.StorageReads, Is.EqualTo(traceStorage ? 2 : 0));
+                    Assert.That(tracer.GasSpent, Is.EqualTo(traceAccess ? 21210UL : 23210UL));
+                }
+            }
+        }
+
+        private sealed class RefundObservationTracer(bool refunds, bool actions) : TestAllTracerWithOutput
+        {
+            public override bool IsTracingInstructions => false;
+            public override bool IsTracingRefunds => refunds;
+            public override bool IsTracingActions => actions;
+        }
+
+        [TestCase(false, false)]
+        [TestCase(false, true)]
+        [TestCase(true, false)]
+        [TestCase(true, true)]
+        public void Refund_and_action_flags_are_independent_and_refreshed(bool refunds, bool actions)
+        {
+            byte[] code = Bytes.FromHexString("60016000556000600055");
+            Verify(refunds, actions);
+            Verify(!refunds, !actions);
+
+            void Verify(bool traceRefunds, bool traceActions)
+            {
+                RefundObservationTracer tracer = new(traceRefunds, traceActions) { IsTracingAccess = false };
+                Execute(tracer, code);
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
+                    Assert.That(tracer.Refund, Is.EqualTo(traceRefunds ? RefundOf.SSetReversedHotCold : 0));
+                    Assert.That(tracer.Actions, Has.Count.EqualTo(traceActions ? 1 : 0));
+                }
+            }
         }
 
         protected override TestAllTracerWithOutput CreateTracer()

--- a/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip7928Tests.cs
@@ -1276,7 +1276,7 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
         ulong intrinsicGas = IntrinsicGasCalculator.Calculate(templateTx, Amsterdam.Instance, block.Header.GasLimit).MinimalGas;
         // Enough gas to push CALL operands and reach the cold-access charge for the EOA, but
         // 1 gas short of the cold-access charge for its delegation target. CALL pushes 7 stack
-        // operands (3 each of GasCostOf.VeryLow), pays GasCostOf.Call, then ConsumeAccountAccessGas
+        // operands (3 each of GasCostOf.VeryLow), pays GasCostOf.Call, then TryConsumeAccountAccessGas
         // for codeSource (cold), then for delegated (cold) — we cap at codeSource cold + 1 short.
         ulong pushOperandsCost = 7 * GasCostOf.VeryLow;
         ulong executionGas = pushOperandsCost + GasCostOf.Call + Eip8038Constants.ColdAccountAccess + GasCostOf.WarmStateRead - 1;
@@ -1681,6 +1681,17 @@ public class Eip7928Tests(bool parallel) : VirtualMachineTestsBase
             changes = [testAccount];
             yield return new TestCaseData(changes, code, null, GasCostOf.SelfBalance, EvmExceptionType.OutOfGas)
             { TestName = "selfbalance_oog_post_state_access" };
+
+            code = new byte[1025];
+            code.AsSpan(0, 1024).Fill((byte)Instruction.PUSH0);
+            code[^1] = (byte)Instruction.SELFBALANCE;
+            foreach (bool sufficientGas in new[] { false, true })
+            {
+                yield return new TestCaseData(changes, code, null,
+                    1024UL * GasCostOf.Base + GasCostOf.SelfBalance - (sufficientGas ? 0UL : 1UL),
+                    sufficientGas ? EvmExceptionType.StackOverflow : EvmExceptionType.OutOfGas)
+                { TestName = sufficientGas ? "selfbalance_stack_overflow" : "selfbalance_oog_before_stack_overflow" };
+            }
 
             code = Prepare.EvmCode
                 .PushData(TestItem.AddressB)

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8037Tests.cs
@@ -60,7 +60,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
     public void System_transaction_gas_keeps_execution_budget_and_state_reservoir()
     {
         EthereumGasPolicy intrinsicGas = EthereumGasPolicy.CreateSystemTransactionIntrinsicGas(Eip8037Constants.SystemCallGasLimit);
-        EthereumGasPolicy availableGas = EthereumGasPolicy.CreateSystemTransactionAvailableGas(Eip8037Constants.SystemCallGasLimit, in intrinsicGas, Amsterdam.Instance);
+        Assert.That(EthereumGasPolicy.TryCreateSystemTransactionAvailableGas(Eip8037Constants.SystemCallGasLimit, in intrinsicGas, Amsterdam.Instance, out EthereumGasPolicy availableGas), Is.True);
 
         Assert.That(
             (
@@ -83,7 +83,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
 
         for (ulong i = 0ul; i < Eip8037Constants.SystemMaxSstoresPerCall; i++)
         {
-            Assert.That(EthereumGasPolicy.ConsumeStateGas(ref availableGas, GasCostOf.SSetState), Is.True);
+            Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref availableGas, GasCostOf.SSetState), Is.True);
         }
 
         Assert.That(
@@ -108,7 +108,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
             StateReservoir = Eip8037Constants.SystemCallStateReservoir,
         };
 
-        EthereumGasPolicy availableGas = EthereumGasPolicy.CreateAvailableFromIntrinsic(Eip8037Constants.SystemCallGasLimit, in intrinsicGas, Amsterdam.Instance);
+        Assert.That(EthereumGasPolicy.TryCreateAvailableFromIntrinsic(Eip8037Constants.SystemCallGasLimit, in intrinsicGas, Amsterdam.Instance, out EthereumGasPolicy availableGas), Is.True);
         long expectedReservoir = (long)(Eip8037Constants.SystemCallGasLimit - Eip8037Constants.SystemCallStateReservoir - Eip7825Constants.DefaultTxGasLimitCap);
 
         Assert.That(
@@ -202,7 +202,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy gas = new() { Value = 100, StateReservoir = 50, StateGasUsed = 0 };
 
-        bool consumed = EthereumGasPolicy.ConsumeStateGas(ref gas, 70);
+        bool consumed = EthereumGasPolicy.TryConsumeStateGas(ref gas, 70);
 
         Assert.That((consumed, gas.Value, gas.StateReservoir, gas.StateGasUsed), Is.EqualTo((true, 80L, 0L, 70L)));
     }
@@ -212,10 +212,10 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy gas = new() { Value = 10, StateReservoir = 50, StateGasUsed = 0, StateGasSpill = 0 };
 
-        bool consumed = EthereumGasPolicy.ConsumeStateGas(ref gas, 70);
+        bool consumed = EthereumGasPolicy.TryConsumeStateGas(ref gas, 70);
 
-        Assert.That((consumed, gas.Value, gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpill, EthereumGasPolicy.IsOutOfGas(in gas)),
-            Is.EqualTo((false, 10UL, 50L, 0L, 0L, true)));
+        Assert.That((consumed, gas.Value, gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpill),
+            Is.EqualTo((false, 10UL, 50L, 0L, 0L)));
     }
 
     [Test]
@@ -241,7 +241,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         EthereumGasPolicy gas = new() { Value = 400, StateReservoir = 0, StateGasUsed = 100 };
 
         EthereumGasPolicy.AddStateGasRefundToReservoir(ref gas, 200, trackSpillRefund: true);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, 200), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref gas, 200), Is.True);
 
         EthereumGasPolicy.RemoveStateGasRefundFromReservoir(ref gas, 200);
 
@@ -253,8 +253,8 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy intrinsic = new() { Value = Eip7825Constants.DefaultTxGasLimitCap + 1, StateReservoir = 0 };
 
-        EthereumGasPolicy gas = EthereumGasPolicy.CreateAvailableFromIntrinsic(
-            Eip7825Constants.DefaultTxGasLimitCap + 2, in intrinsic, Amsterdam.Instance);
+        Assert.That(EthereumGasPolicy.TryCreateAvailableFromIntrinsic(
+            Eip7825Constants.DefaultTxGasLimitCap + 2, in intrinsic, Amsterdam.Instance, out EthereumGasPolicy gas), Is.True);
 
         Assert.That((gas.Value, gas.StateReservoir), Is.EqualTo((0UL, 1L)));
     }
@@ -275,7 +275,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy parent = new() { Value = 1_000, StateReservoir = 333, StateGasUsed = 50 };
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 444);
-        EthereumGasPolicy.ConsumeStateGas(ref child, 100);
+        EthereumGasPolicy.TryConsumeStateGas(ref child, 100);
         EthereumGasPolicy.UpdateGas(ref child, 150);
 
         EthereumGasPolicy.Refund(ref parent, in child);
@@ -328,7 +328,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         // inflating the reservoir would let later operations draw state gas the spec says is unavailable.
         EthereumGasPolicy gas = new() { Value = 10_000, StateReservoir = 0 };
 
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, 4000), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref gas, 4000), Is.True);
         Assert.That((gas.Value, gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpill),
             Is.EqualTo((6000L, 0L, 4000L, 4000L)), "charge with empty reservoir spills into execution gas");
 
@@ -343,7 +343,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         // Complementary case: a reservoir-funded charge refunds back to the reservoir (no spill).
         EthereumGasPolicy gas = new() { Value = 10_000, StateReservoir = 5000 };
 
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, 4000), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref gas, 4000), Is.True);
         Assert.That((gas.Value, gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpill),
             Is.EqualTo((10_000L, 1000L, 4000L, 0L)), "reservoir-funded charge does not touch execution gas");
 
@@ -392,9 +392,9 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy parent = new() { Value = 1_000, StateReservoir = 500, StateGasUsed = 10 };
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 600);
-        EthereumGasPolicy.ConsumeStateGas(ref child, 200);
+        EthereumGasPolicy.TryConsumeStateGas(ref child, 200);
 
-        EthereumGasPolicy.SetOutOfGas(ref child);
+        EthereumGasPolicy.ClearExecutionGas(ref child);
         Assert.That((child.Value, child.StateReservoir), Is.EqualTo((0L, 300L)));
 
         EthereumGasPolicy.RestoreChildStateGasOnHalt(ref parent, in child);
@@ -406,7 +406,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy parent = new() { Value = 1_000, StateReservoir = 0, StateGasUsed = 0 };
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 1_000);
-        EthereumGasPolicy.ConsumeStateGas(ref child, 200);
+        EthereumGasPolicy.TryConsumeStateGas(ref child, 200);
         EthereumGasPolicy.RefundStateGas(ref child, 200, stateGasFloor: 0);
 
         EthereumGasPolicy.RestoreChildStateGasOnHalt(ref parent, in child);
@@ -443,7 +443,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         // Net spill 0 after a full self-refund: revert adds nothing to the parent gas_left.
         EthereumGasPolicy parent = new() { Value = 1_000, StateReservoir = 0, StateGasUsed = 0 };
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, GasCostOf.CreateState);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref child, GasCostOf.CreateState), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref child, GasCostOf.CreateState), Is.True);
         EthereumGasPolicy.RefundStateGas(ref child, GasCostOf.CreateState, stateGasFloor: 0);
 
         EthereumGasPolicy.RestoreChildStateGas(ref parent, in child);
@@ -456,7 +456,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
     public void Refund_state_gas_marks_spilled_refund()
     {
         EthereumGasPolicy gas = new() { Value = 1_000, StateReservoir = 0, StateGasUsed = 0 };
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, 200), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref gas, 200), Is.True);
 
         EthereumGasPolicy.RefundStateGas(ref gas, 80, stateGasFloor: 0);
 
@@ -470,7 +470,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
     public void Refund_state_gas_from_child_halt_preserves_spill_accounting()
     {
         EthereumGasPolicy gas = new() { Value = GasCostOf.CreateState, StateReservoir = 0, StateGasUsed = 0 };
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, GasCostOf.CreateState), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref gas, GasCostOf.CreateState), Is.True);
 
         EthereumGasPolicy.RefundStateGas(ref gas, GasCostOf.CreateState, stateGasFloor: 0, trackSpillRefund: false);
 
@@ -483,7 +483,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy parent = new() { Value = 1_000, StateReservoir = 0, StateGasUsed = 0 };
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 500);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref child, 200), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref child, 200), Is.True);
         EthereumGasPolicy.RefundStateGas(ref child, 80, stateGasFloor: 0);
 
         EthereumGasPolicy.Refund(ref parent, in child);
@@ -545,7 +545,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy parent = new() { Value = 1_000, StateReservoir = 0, StateGasUsed = 0 };
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 500);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref child, 200), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref child, 200), Is.True);
         EthereumGasPolicy.RefundStateGas(ref child, 80, stateGasFloor: 0);
 
         EthereumGasPolicy.RestoreChildStateGas(ref parent, in child);
@@ -562,14 +562,14 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy parent = new();
         EthereumGasPolicy child = EthereumGasPolicy.FromULong(1_000);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref child, 200), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref child, 200), Is.True);
         if (stateGasRefund > 0)
         {
             EthereumGasPolicy.RefundStateGas(ref child, stateGasRefund, stateGasFloor: 0);
         }
 
         EthereumGasPolicy.Refund(ref parent, in child);
-        EthereumGasPolicy.Consume(ref parent, child.Value);
+        Assert.That(EthereumGasPolicy.UpdateGas(ref parent, child.Value), Is.True);
         EthereumGasPolicy.RevertRefundToHalt(ref parent, in child);
 
         Assert.That(
@@ -593,9 +593,9 @@ public class Eip8037Tests : VirtualMachineTestsBase
             StateGasSpillRefunded = 33,
         };
 
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref parent, parentStateGasUsed), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref parent, parentStateGasUsed), Is.True);
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, childExecutionGas);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref child, childStateGasUsed), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref child, childStateGasUsed), Is.True);
         EthereumGasPolicy.Refund(ref parent, in child);
 
         EthereumGasPolicy.RevertRefundToHalt(ref parent, in child);
@@ -627,7 +627,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         // the user does not keep paying for state-gas they didn't get to commit.
         EthereumGasPolicy gas = new() { Value = 100_000, StateReservoir = 1_000, StateGasUsed = 0 };
 
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, 5_000), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref gas, 5_000), Is.True);
         Assert.That((gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpill), Is.EqualTo((0L, 5_000L, 4_000L)),
             "consume 5_000 state-gas with 1_000 reservoir => reservoir=0, used=5_000, spill=4_000");
 
@@ -644,7 +644,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         // Top-level halt: block_state = post-reset StateGasUsed (intrinsic floor); the spilled
         // portion was paid from gas_left and burns as execution gas.
         EthereumGasPolicy gas = new() { Value = 100_000, StateReservoir = 1_000, StateGasUsed = 0 };
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, 5_000), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref gas, 5_000), Is.True);
         Assert.That((gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpill), Is.EqualTo((0L, 5_000L, 4_000L)),
             "after consuming 5_000 with 1_000 reservoir: reservoir=0, used=5_000 (= 1_000 reservoir-portion + 4_000 spill), spill=4_000");
 
@@ -666,7 +666,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         const long stateGasCharged = GasCostOf.SSetState;
 
         EthereumGasPolicy gas = new() { Value = 1_000_000, StateReservoir = reservoirAtTxStart, StateGasUsed = 0 };
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, stateGasCharged), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref gas, stateGasCharged), Is.True);
         Assert.That(gas.StateGasSpill, Is.EqualTo(0L), "reservoir covers full charge; no spill");
         Assert.That(gas.StateGasUsed, Is.EqualTo(stateGasCharged), "full charge recorded in StateGasUsed");
 
@@ -689,7 +689,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         const long stateGasCharged = 104_174;   // reservoir(100k) consumed + 4_174 spill
 
         EthereumGasPolicy gas = new() { Value = perTxGasLimit, StateReservoir = reservoirAtTxStart, StateGasUsed = intrinsicStateGas };
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref gas, stateGasCharged), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref gas, stateGasCharged), Is.True);
         Assert.That(gas.StateGasSpill, Is.EqualTo(4_174L), "4_174 spill from reservoir overflow");
 
         EthereumGasPolicy.ResetForHalt(ref gas, initialStateReservoir: reservoirAtTxStart, initialStateGasUsed: intrinsicStateGas);
@@ -707,7 +707,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         // propagated — a reverted child never inflates the parent's unrefunded spill.
         EthereumGasPolicy parent = new() { Value = 100_000, StateReservoir = 0, StateGasUsed = 0 };
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 50_000);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref child, 4_174L), Is.True,
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref child, 4_174L), Is.True,
             "child consumes 4_174 state-gas with reservoir=0; entirely spills from gas_left");
         Assert.That(child.StateGasSpill, Is.EqualTo(4_174L));
 
@@ -728,7 +728,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 400_000);
 
         EthereumGasPolicy grandchild = EthereumGasPolicy.CreateChildFrameGas(ref child, 200_000);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref grandchild, 4_174L), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref grandchild, 4_174L), Is.True);
         EthereumGasPolicy.RestoreChildStateGas(ref child, in grandchild);
         Assert.That(child.StateGasSpill, Is.EqualTo(0L), "reverted grandchild spill is not inherited by the child");
 
@@ -779,10 +779,10 @@ public class Eip8037Tests : VirtualMachineTestsBase
     public void Revert_restores_state_gas_to_parent_reservoir()
     {
         EthereumGasPolicy parent = new() { Value = 1_000, StateReservoir = 400, StateGasUsed = 20 };
-        EthereumGasPolicy.Consume(ref parent, 600);
+        EthereumGasPolicy.UpdateGas(ref parent, 600);
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 600);
         EthereumGasPolicy.UpdateGas(ref child, 100);
-        EthereumGasPolicy.ConsumeStateGas(ref child, 150);
+        EthereumGasPolicy.TryConsumeStateGas(ref child, 150);
 
         EthereumGasPolicy.UpdateGasUp(ref parent, EthereumGasPolicy.GetRemainingGas(in child));
         EthereumGasPolicy.RestoreChildStateGas(ref parent, in child);
@@ -795,7 +795,7 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy parent = new() { Value = 1_000, StateReservoir = 400, StateGasUsed = 20 };
         EthereumGasPolicy child = EthereumGasPolicy.CreateChildFrameGas(ref parent, 600);
-        EthereumGasPolicy.ConsumeStateGas(ref child, 150);
+        EthereumGasPolicy.TryConsumeStateGas(ref child, 150);
         EthereumGasPolicy.RefundStateGas(ref child, 40, stateGasFloor: 0);
 
         EthereumGasPolicy.RestoreChildStateGas(ref parent, in child);
@@ -808,10 +808,10 @@ public class Eip8037Tests : VirtualMachineTestsBase
     {
         EthereumGasPolicy parent = new() { Value = 500_000, StateReservoir = 0, StateGasUsed = 0 };
         EthereumGasPolicy outer = EthereumGasPolicy.CreateChildFrameGas(ref parent, 400_000);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref outer, GasCostOf.CreateState), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref outer, GasCostOf.CreateState), Is.True);
 
         EthereumGasPolicy inner = EthereumGasPolicy.CreateChildFrameGas(ref outer, 200_000);
-        Assert.That(EthereumGasPolicy.ConsumeStateGas(ref inner, GasCostOf.SSetState), Is.True);
+        Assert.That(EthereumGasPolicy.TryConsumeStateGas(ref inner, GasCostOf.SSetState), Is.True);
         EthereumGasPolicy.RefundStateGas(ref inner, GasCostOf.SSetState, stateGasFloor: 0);
         EthereumGasPolicy.RestoreChildStateGas(ref outer, in inner);
 

--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -16,6 +16,49 @@ namespace Nethermind.Evm.Test;
 
 public class EthereumGasPolicyTests
 {
+    [Test]
+    public void Memory_cost_preserves_preexpanded_range_and_full_width_validation(
+        [Values(0UL, 1UL, 31UL, 32UL, 33UL, ulong.MaxValue)] ulong offset,
+        [Values(0UL, 1UL, 32UL, 64UL)] ulong length, [Values] bool highLimb,
+        [Values] bool wideLength)
+    {
+        EvmPooledMemory memory = new();
+        memory.CalculateMemoryCost(UInt256.Zero, 64, out _);
+        UInt256 position = new(offset, highLimb ? 1UL : 0UL, 0, 0);
+        UInt256 uint256Length = length;
+        EthereumGasPolicy gas = EthereumGasPolicy.FromULong(0);
+
+        bool success = wideLength
+            ? EthereumGasPolicy.UpdateMemoryCost(ref gas, in position, in uint256Length, ref memory)
+            : EthereumGasPolicy.UpdateMemoryCost(ref gas, in position, length, ref memory);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(success, Is.EqualTo(length == 0 || (!highLimb && offset <= 64 && length <= 64 - offset)));
+            Assert.That(EthereumGasPolicy.GetRemainingGas(in gas), Is.Zero);
+        }
+    }
+
+    [Test]
+    public void Memory_cost_rejects_full_width_length(
+        [Values] bool maxOffset, [Values(0UL, ulong.MaxValue)] ulong availableGas)
+    {
+        EvmPooledMemory memory = new();
+        memory.CalculateMemoryCost(UInt256.Zero, 64, out _);
+        UInt256 position = maxOffset ? UInt256.MaxValue : UInt256.Zero;
+        UInt256 length = new(0, 1, 0, 0);
+        EthereumGasPolicy gas = EthereumGasPolicy.FromULong(availableGas);
+
+        bool success = EthereumGasPolicy.UpdateMemoryCost(ref gas, in position, in length, ref memory);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(success, Is.False);
+            Assert.That(memory.Size, Is.EqualTo(64));
+            Assert.That(EthereumGasPolicy.GetRemainingGas(in gas), Is.EqualTo(availableGas));
+        }
+    }
+
     [Test, Combinatorial]
     public void Specialized_account_access_matches_dynamic_policy_without_reading_fork_flags(
         [Values] bool eip8038,
@@ -35,15 +78,15 @@ public class EthereumGasPolicyTests
         }
         EthereumGasPolicy dynamicGas = EthereumGasPolicy.FromULong(availableGas);
         EthereumGasPolicy specializedGas = EthereumGasPolicy.FromULong(availableGas);
-        bool expected = EthereumGasPolicy.ConsumeAccountAccessGas(ref dynamicGas, spec, in dynamicTracker, tracingAccess, TestItem.AddressC, kind);
+        bool expected = EthereumGasPolicy.TryConsumeAccountAccessGas(ref dynamicGas, spec, in dynamicTracker, tracingAccess, TestItem.AddressC, kind);
         spec.ClearReceivedCalls();
 
         bool actual = (hotAndCold, eip8038) switch
         {
-            (true, true) => EthereumGasPolicy.ConsumeAccountAccessGas<OnFlag, OnFlag>(ref specializedGas, spec, in specializedTracker, tracingAccess, TestItem.AddressC, kind),
-            (true, false) => EthereumGasPolicy.ConsumeAccountAccessGas<OnFlag, OffFlag>(ref specializedGas, spec, in specializedTracker, tracingAccess, TestItem.AddressC, kind),
-            (false, true) => EthereumGasPolicy.ConsumeAccountAccessGas<OffFlag, OnFlag>(ref specializedGas, spec, in specializedTracker, tracingAccess, TestItem.AddressC, kind),
-            (false, false) => EthereumGasPolicy.ConsumeAccountAccessGas<OffFlag, OffFlag>(ref specializedGas, spec, in specializedTracker, tracingAccess, TestItem.AddressC, kind),
+            (true, true) => EthereumGasPolicy.TryConsumeAccountAccessGas<OnFlag, OnFlag>(ref specializedGas, spec, in specializedTracker, tracingAccess, TestItem.AddressC, kind),
+            (true, false) => EthereumGasPolicy.TryConsumeAccountAccessGas<OnFlag, OffFlag>(ref specializedGas, spec, in specializedTracker, tracingAccess, TestItem.AddressC, kind),
+            (false, true) => EthereumGasPolicy.TryConsumeAccountAccessGas<OffFlag, OnFlag>(ref specializedGas, spec, in specializedTracker, tracingAccess, TestItem.AddressC, kind),
+            (false, false) => EthereumGasPolicy.TryConsumeAccountAccessGas<OffFlag, OffFlag>(ref specializedGas, spec, in specializedTracker, tracingAccess, TestItem.AddressC, kind),
         };
 
         using (Assert.EnterMultipleScope())
@@ -76,15 +119,15 @@ public class EthereumGasPolicyTests
         }
         EthereumGasPolicy dynamicGas = EthereumGasPolicy.FromULong(availableGas);
         EthereumGasPolicy specializedGas = EthereumGasPolicy.FromULong(availableGas);
-        bool expected = EthereumGasPolicy.ConsumeStorageAccessGas(ref dynamicGas, in dynamicTracker, tracingAccess, in cell, kind, spec);
+        bool expected = EthereumGasPolicy.TryConsumeStorageAccessGas(ref dynamicGas, in dynamicTracker, tracingAccess, in cell, kind, spec);
         spec.ClearReceivedCalls();
 
         bool actual = (hotAndCold, eip8038) switch
         {
-            (true, true) => EthereumGasPolicy.ConsumeStorageAccessGas<OnFlag, OnFlag>(ref specializedGas, in specializedTracker, tracingAccess, in cell, kind, spec),
-            (true, false) => EthereumGasPolicy.ConsumeStorageAccessGas<OnFlag, OffFlag>(ref specializedGas, in specializedTracker, tracingAccess, in cell, kind, spec),
-            (false, true) => EthereumGasPolicy.ConsumeStorageAccessGas<OffFlag, OnFlag>(ref specializedGas, in specializedTracker, tracingAccess, in cell, kind, spec),
-            (false, false) => EthereumGasPolicy.ConsumeStorageAccessGas<OffFlag, OffFlag>(ref specializedGas, in specializedTracker, tracingAccess, in cell, kind, spec),
+            (true, true) => EthereumGasPolicy.TryConsumeStorageAccessGas<OnFlag, OnFlag>(ref specializedGas, in specializedTracker, tracingAccess, in cell, kind, spec),
+            (true, false) => EthereumGasPolicy.TryConsumeStorageAccessGas<OnFlag, OffFlag>(ref specializedGas, in specializedTracker, tracingAccess, in cell, kind, spec),
+            (false, true) => EthereumGasPolicy.TryConsumeStorageAccessGas<OffFlag, OnFlag>(ref specializedGas, in specializedTracker, tracingAccess, in cell, kind, spec),
+            (false, false) => EthereumGasPolicy.TryConsumeStorageAccessGas<OffFlag, OffFlag>(ref specializedGas, in specializedTracker, tracingAccess, in cell, kind, spec),
         };
 
         using (Assert.EnterMultipleScope())
@@ -108,8 +151,8 @@ public class EthereumGasPolicyTests
         bool expected = NetMeteredDynamic(ref dynamicGas, spec);
         spec.ClearReceivedCalls();
         bool actual = eip8038
-            ? EthereumGasPolicy.ConsumeNetMeteredSStoreGas<OnFlag>(ref specializedGas, spec)
-            : EthereumGasPolicy.ConsumeNetMeteredSStoreGas<OffFlag>(ref specializedGas, spec);
+            ? EthereumGasPolicy.TryConsumeNetMeteredSStoreGas<OnFlag>(ref specializedGas, spec)
+            : EthereumGasPolicy.TryConsumeNetMeteredSStoreGas<OffFlag>(ref specializedGas, spec);
 
         using (Assert.EnterMultipleScope())
         {
@@ -141,28 +184,28 @@ public class EthereumGasPolicyTests
 
     // The net-metered charge has no non-generic form on the policy, so reach the interface default.
     private static bool NetMeteredDynamic<TPolicy>(ref TPolicy gas, IReleaseSpec spec)
-        where TPolicy : struct, IGasPolicy<TPolicy> => TPolicy.ConsumeNetMeteredSStoreGas(ref gas, spec);
+        where TPolicy : struct, IGasPolicy<TPolicy> => TPolicy.TryConsumeNetMeteredSStoreGas(ref gas, spec);
 
     private static bool StorageWriteDynamic(ref EthereumGasPolicy gas, IReleaseSpec spec, bool eip8037, bool slotCreation) =>
         (eip8037, slotCreation) switch
         {
-            (true, true) => EthereumGasPolicy.ConsumeStorageWrite<OnFlag, OnFlag>(ref gas, spec),
-            (true, false) => EthereumGasPolicy.ConsumeStorageWrite<OnFlag, OffFlag>(ref gas, spec),
-            (false, true) => EthereumGasPolicy.ConsumeStorageWrite<OffFlag, OnFlag>(ref gas, spec),
-            (false, false) => EthereumGasPolicy.ConsumeStorageWrite<OffFlag, OffFlag>(ref gas, spec),
+            (true, true) => EthereumGasPolicy.TryConsumeStorageWrite<OnFlag, OnFlag>(ref gas, spec),
+            (true, false) => EthereumGasPolicy.TryConsumeStorageWrite<OnFlag, OffFlag>(ref gas, spec),
+            (false, true) => EthereumGasPolicy.TryConsumeStorageWrite<OffFlag, OnFlag>(ref gas, spec),
+            (false, false) => EthereumGasPolicy.TryConsumeStorageWrite<OffFlag, OffFlag>(ref gas, spec),
         };
 
     private static bool StorageWriteSpecialized(ref EthereumGasPolicy gas, IReleaseSpec spec, bool eip8037, bool slotCreation, bool eip8038) =>
         (eip8037, slotCreation, eip8038) switch
         {
-            (true, true, true) => EthereumGasPolicy.ConsumeStorageWrite<OnFlag, OnFlag, OnFlag>(ref gas, spec),
-            (true, true, false) => EthereumGasPolicy.ConsumeStorageWrite<OnFlag, OnFlag, OffFlag>(ref gas, spec),
-            (true, false, true) => EthereumGasPolicy.ConsumeStorageWrite<OnFlag, OffFlag, OnFlag>(ref gas, spec),
-            (true, false, false) => EthereumGasPolicy.ConsumeStorageWrite<OnFlag, OffFlag, OffFlag>(ref gas, spec),
-            (false, true, true) => EthereumGasPolicy.ConsumeStorageWrite<OffFlag, OnFlag, OnFlag>(ref gas, spec),
-            (false, true, false) => EthereumGasPolicy.ConsumeStorageWrite<OffFlag, OnFlag, OffFlag>(ref gas, spec),
-            (false, false, true) => EthereumGasPolicy.ConsumeStorageWrite<OffFlag, OffFlag, OnFlag>(ref gas, spec),
-            (false, false, false) => EthereumGasPolicy.ConsumeStorageWrite<OffFlag, OffFlag, OffFlag>(ref gas, spec),
+            (true, true, true) => EthereumGasPolicy.TryConsumeStorageWrite<OnFlag, OnFlag, OnFlag>(ref gas, spec),
+            (true, true, false) => EthereumGasPolicy.TryConsumeStorageWrite<OnFlag, OnFlag, OffFlag>(ref gas, spec),
+            (true, false, true) => EthereumGasPolicy.TryConsumeStorageWrite<OnFlag, OffFlag, OnFlag>(ref gas, spec),
+            (true, false, false) => EthereumGasPolicy.TryConsumeStorageWrite<OnFlag, OffFlag, OffFlag>(ref gas, spec),
+            (false, true, true) => EthereumGasPolicy.TryConsumeStorageWrite<OffFlag, OnFlag, OnFlag>(ref gas, spec),
+            (false, true, false) => EthereumGasPolicy.TryConsumeStorageWrite<OffFlag, OnFlag, OffFlag>(ref gas, spec),
+            (false, false, true) => EthereumGasPolicy.TryConsumeStorageWrite<OffFlag, OffFlag, OnFlag>(ref gas, spec),
+            (false, false, false) => EthereumGasPolicy.TryConsumeStorageWrite<OffFlag, OffFlag, OffFlag>(ref gas, spec),
         };
 
     // The costs have to agree with the flag: SpecGasCosts folds NetMeteredSStoreCost to Free under
@@ -190,7 +233,6 @@ public class EthereumGasPolicyTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(EthereumGasPolicy.GetRemainingGas(in actual), Is.EqualTo(EthereumGasPolicy.GetRemainingGas(in expected)));
-            Assert.That(EthereumGasPolicy.IsOutOfGas(in actual), Is.EqualTo(EthereumGasPolicy.IsOutOfGas(in expected)));
         }
     }
 
@@ -260,10 +302,10 @@ public class EthereumGasPolicyTests
         where TSpec : struct, EvmInstructions.ICreateSpec =>
         (eip8037, create2) switch
         {
-            (true, true) => TSpec.ConsumeCreateGas<EthereumGasPolicy, OnFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
-            (true, false) => TSpec.ConsumeCreateGas<EthereumGasPolicy, OnFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
-            (false, true) => TSpec.ConsumeCreateGas<EthereumGasPolicy, OffFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
-            (false, false) => TSpec.ConsumeCreateGas<EthereumGasPolicy, OffFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
+            (true, true) => TSpec.TryConsumeCreateGas<EthereumGasPolicy, OnFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
+            (true, false) => TSpec.TryConsumeCreateGas<EthereumGasPolicy, OnFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
+            (false, true) => TSpec.TryConsumeCreateGas<EthereumGasPolicy, OffFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
+            (false, false) => TSpec.TryConsumeCreateGas<EthereumGasPolicy, OffFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
         };
 
     /// <summary>The policy's own spec-reading create charge, the oracle the specialized specs must match.</summary>
@@ -271,13 +313,13 @@ public class EthereumGasPolicyTests
         where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
         (eip8037, create2) switch
         {
-            (true, true) => TGasPolicy.ConsumeCreateGas<OnFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
-            (true, false) => TGasPolicy.ConsumeCreateGas<OnFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
-            (false, true) => TGasPolicy.ConsumeCreateGas<OffFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
-            (false, false) => TGasPolicy.ConsumeCreateGas<OffFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
+            (true, true) => TGasPolicy.TryConsumeCreateGas<OnFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
+            (true, false) => TGasPolicy.TryConsumeCreateGas<OnFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
+            (false, true) => TGasPolicy.TryConsumeCreateGas<OffFlag, EvmInstructions.OpCreate2>(ref gas, spec, words),
+            (false, false) => TGasPolicy.TryConsumeCreateGas<OffFlag, EvmInstructions.OpCreate>(ref gas, spec, words),
         };
 
-    // Locks the ConsumeDataCopyGas contract: the policy computes base access cost + per-word copy
+    // Locks the TryConsumeDataCopyGas contract: the policy computes base access cost + per-word copy
     // cost internally, so any multidimensional policy can rely on (and re-categorize) the same total.
     [TestCase(false, 0UL, TestName = "CODECOPY/CALLDATACOPY/RETURNDATACOPY, empty")]
     [TestCase(false, 5UL, TestName = "CODECOPY/CALLDATACOPY/RETURNDATACOPY, 5 words")]
@@ -287,7 +329,7 @@ public class EthereumGasPolicyTests
     {
         const ulong initial = 1_000_000;
         EthereumGasPolicy gas = EthereumGasPolicy.FromULong(initial);
-        EthereumGasPolicy.ConsumeDataCopyGas(ref gas, Cancun.Instance, isExternalCode, words);
+        EthereumGasPolicy.TryConsumeDataCopyGas(ref gas, Cancun.Instance, isExternalCode, words);
 
         ulong baseCost = isExternalCode ? Cancun.Instance.GasCosts.ExtCodeCost : GasCostOf.VeryLow;
         ulong expected = baseCost + GasCostOf.Memory * words;
@@ -313,16 +355,43 @@ public class EthereumGasPolicyTests
         Assert.That(defaultImplementations, Is.GreaterThan(0));
     }
 
-    [Test]
-    public void CreateAvailableFromIntrinsic_returns_out_of_gas_when_gas_limit_below_intrinsic()
+    [TestCase(0UL)]
+    [TestCase(100UL)]
+    public void ClearExecutionGas_preserves_state_gas_accounting(ulong executionGas)
+    {
+        EthereumGasPolicy gas = new()
+        {
+            Value = executionGas,
+            StateReservoir = 50,
+            StateGasUsed = 30,
+            StateGasSpill = 20,
+            StateGasSpillRefunded = 10,
+        };
+
+        EthereumGasPolicy.ClearExecutionGas(ref gas);
+
+        Assert.That((gas.Value, gas.StateReservoir, gas.StateGasUsed, gas.StateGasSpill, gas.StateGasSpillRefunded),
+            Is.EqualTo((0UL, 50L, 30L, 20L, 10L)));
+    }
+
+    [TestCase(29_999UL, false, 0UL)]
+    [TestCase(30_000UL, false, 0UL)]
+    [TestCase(213_599UL, false, 0UL)]
+    [TestCase(213_600UL, true, 0UL)]
+    [TestCase(213_601UL, true, 1UL)]
+    public void CreateAvailableFromIntrinsic_checks_execution_and_state_gas(ulong gasLimit, bool expectedSuccess, ulong expectedRemaining)
     {
         EthereumGasPolicy intrinsic = new() { Value = 30_000, StateReservoir = 183_600 };
 
-        EthereumGasPolicy available = EthereumGasPolicy.CreateAvailableFromIntrinsic(30_000, in intrinsic, Amsterdam.Instance);
+        bool success = EthereumGasPolicy.TryCreateAvailableFromIntrinsic(gasLimit, in intrinsic, Amsterdam.Instance, out EthereumGasPolicy available);
 
-        Assert.That(EthereumGasPolicy.IsOutOfGas(in available), Is.True);
-        Assert.That(EthereumGasPolicy.GetRemainingGas(in available), Is.EqualTo(0UL));
-        Assert.That(EthereumGasPolicy.GetStateReservoir(in available), Is.EqualTo(0L));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(success, Is.EqualTo(expectedSuccess));
+            Assert.That(EthereumGasPolicy.GetRemainingGas(in available), Is.EqualTo(expectedRemaining));
+            Assert.That(EthereumGasPolicy.GetStateReservoir(in available), Is.Zero);
+            Assert.That(EthereumGasPolicy.GetStateGasUsed(in available), Is.EqualTo(expectedSuccess ? intrinsic.StateReservoir : 0));
+        }
     }
 
     [Test]
@@ -366,6 +435,56 @@ public class EthereumGasPolicyTests
         ulong preRefundGas = GetPreRefundGas(in gas, gasLimit);
 
         Assert.That(preRefundGas, Is.EqualTo(expected));
+    }
+
+    [Test, Combinatorial]
+    public void Specialized_sload_base_matches_price_book(
+        [Values] bool hotAndCold,
+        [Values(0UL, 99UL, 800UL, 10000UL)] ulong availableGas)
+    {
+        IReleaseSpec spec = CreateAccessSpec(hotAndCold, false);
+        EthereumGasPolicy expectedGas = EthereumGasPolicy.FromULong(availableGas);
+        EthereumGasPolicy actualGas = expectedGas;
+        bool expected = EthereumGasPolicy.UpdateGas(ref expectedGas, spec.GasCosts.SLoadCost);
+        spec.ClearReceivedCalls();
+
+        bool actual = hotAndCold
+            ? EthereumGasPolicy.TryConsumeSLoadBaseGas<OnFlag>(ref actualGas, spec)
+            : EthereumGasPolicy.TryConsumeSLoadBaseGas<OffFlag>(ref actualGas, spec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actual, Is.EqualTo(expected));
+            AssertGasMatches(in actualGas, in expectedGas);
+            if (hotAndCold) Assert.That(spec.ReceivedCalls(), Is.Empty);
+        }
+    }
+
+    [Test, Combinatorial]
+    public void Specialized_exp_price_matches_price_book(
+        [Values] bool eip160,
+        [Values(0UL, 1UL, 32UL)] ulong exponentBytes,
+        [Values(0UL, 9UL, 10UL, 49UL, 50UL, 1599UL, 1600UL)] ulong availableGas)
+    {
+        IReleaseSpec spec = Substitute.For<IReleaseSpec>();
+        spec.UseExpDDosProtection.Returns(eip160);
+        SpecGasCosts gasCosts = new(spec);
+        spec.GasCosts.Returns(gasCosts);
+        EthereumGasPolicy expectedGas = EthereumGasPolicy.FromULong(availableGas);
+        EthereumGasPolicy actualGas = expectedGas;
+        bool expected = EthereumGasPolicy.UpdateGas(ref expectedGas, spec.GasCosts.ExpByteCost * exponentBytes);
+        spec.ClearReceivedCalls();
+
+        bool actual = eip160
+            ? EthereumGasPolicy.TryConsumeExpBytes<OnFlag>(ref actualGas, spec, exponentBytes)
+            : EthereumGasPolicy.TryConsumeExpBytes<OffFlag>(ref actualGas, spec, exponentBytes);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actual, Is.EqualTo(expected));
+            AssertGasMatches(in actualGas, in expectedGas);
+            Assert.That(spec.ReceivedCalls(), Is.Empty);
+        }
     }
 
     private static ulong GetPreRefundGas<TGasPolicy>(in TGasPolicy gas, ulong gasLimit)

--- a/src/Nethermind/Nethermind.Evm.Test/EvmStackTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmStackTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Evm.GasPolicy;
@@ -14,6 +15,28 @@ namespace Nethermind.Evm.Test;
 
 public class EvmStackTests
 {
+    [Test]
+    public void UInt256_writeback_preserves_aliases_and_unaligned_slots(
+        [Values(0, 1, 7, 8, 31)] int offset, [Values] bool alias)
+    {
+        byte[] buffer = new byte[offset + EvmPooledMemory.WordSize + 1];
+        Array.Fill(buffer, (byte)0xa5);
+        UInt256 value = new(0x0123456789abcdef, 0xfedcba9876543210, 0x1122334455667788, 0x8877665544332211);
+        byte[] expected = value.ToBigEndian();
+        ref byte slot = ref buffer[offset];
+        Unsafe.WriteUnaligned(ref slot, value);
+        ref UInt256 source = ref (alias ? ref Unsafe.As<byte, UInt256>(ref slot) : ref value);
+
+        EvmStack.WriteUInt256ToSlot(ref slot, in source);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(buffer.AsSpan(offset, EvmPooledMemory.WordSize).ToArray(), Is.EqualTo(expected));
+            Assert.That(buffer[^1], Is.EqualTo(0xa5));
+            if (offset > 0) Assert.That(buffer[offset - 1], Is.EqualTo(0xa5));
+        }
+    }
+
     // Regression coverage:
     // - Pop operations on empty stack must return the failure signal without mutating Head.
     //   Bug: previous Head-- post-decrement left Head = -1 on underflow (PopAddress, PopWord256).
@@ -87,8 +110,8 @@ public class EvmStackTests
 
         EvmExceptionType result = op switch
         {
-            Dup => stack.Dup<OffFlag>(2),            // need >= 2 elements
-            Swap => stack.Swap<OffFlag>(2),          // swap top with 2nd, need >= 2
+            Dup => stack.Dup<OffFlag, OnFlag>(2),            // need >= 2 elements
+            Swap => stack.Swap<OffFlag, OnFlag>(2),          // swap top with 2nd, need >= 2
             Exchange => stack.Exchange<OffFlag>(1, 2), // need depth >= 2
             _ => throw new System.ArgumentOutOfRangeException(nameof(op), op, null),
         };
@@ -124,7 +147,7 @@ public class EvmStackTests
     }
 
     [Test]
-    public void Truncated_PUSH32_preserves_leading_bytes_and_zero_pads_tail([Values(0, 1, 5, 16, 31)] int used)
+    public void Truncated_PUSH32_preserves_leading_bytes_and_zero_pads_tail([Values(0, 1, 5, 16, 31)] int used, [Values] bool checkDepth)
     {
         // EVM spec: truncated PUSH{n} (where code ends before n bytes of immediate) must push
         // <available-bytes, 00...00> in big-endian. Available bytes go to the high end;
@@ -135,10 +158,9 @@ public class EvmStackTests
         byte[] immediate = new byte[used];
         for (int i = 0; i < used; i++) immediate[i] = (byte)(0xA0 + i);
 
-        EvmExceptionType result = stack.PushBothPaddedBytes<OffFlag>(
-            ref MemoryMarshal.GetArrayDataReference(immediate),
-            used,
-            pushSize: 32);
+        EvmExceptionType result = checkDepth
+            ? stack.PushBothPaddedBytes<OffFlag, OnFlag>(ref MemoryMarshal.GetArrayDataReference(immediate), used, 32)
+            : stack.PushBothPaddedBytes<OffFlag, OffFlag>(ref MemoryMarshal.GetArrayDataReference(immediate), used, 32);
 
         Assert.That(result, Is.EqualTo(EvmExceptionType.None));
         Assert.That(stack.PopWord256(out Span<byte> word), Is.True);
@@ -147,18 +169,68 @@ public class EvmStackTests
     }
 
     [Test]
-    public void PushRightPaddedBytes_traces_the_completed_word([Values(0, 1, 17, 31, 32)] int length)
+    public void Truncated_PUSH_reports_the_completed_word([Range(2, 32)] int width, [Values] bool hasData)
+    {
+        using VmState<EthereumGasPolicy> vmState = CreateEvmState();
+        int used = hasData ? width - 1 : 0;
+        byte[] immediate = new byte[used];
+        byte[] expected = new byte[32];
+        for (int i = 0; i < used; i++) expected[32 - width + i] = immediate[i] = (byte)(0xa0 + i);
+        StackPushTracer tracer = new();
+        vmState.InitializeStacks(tracer, default, out EvmStack stack);
+
+        EvmExceptionType result = stack.PushBothPaddedBytes<OnFlag, OnFlag>(ref MemoryMarshal.GetArrayDataReference(immediate), used, width);
+
+        Assert.That(stack.PopUInt256(out UInt256 value), Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(EvmExceptionType.None));
+            Assert.That(value, Is.EqualTo(new UInt256(expected, isBigEndian: true)));
+            Assert.That(tracer.StackItem, Is.EqualTo(expected));
+        }
+    }
+
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    public void Traced_PUSH2_zero_pads_missing_immediate_bytes(int used)
+    {
+        using VmState<EthereumGasPolicy> vmState = CreateEvmState();
+        byte[] immediate = new byte[used];
+        for (int i = 0; i < used; i++) immediate[i] = (byte)(0xa0 + i);
+        StackPushTracer tracer = new();
+        vmState.InitializeStacks(tracer, immediate, out EvmStack stack);
+        EthereumGasPolicy gas = EthereumGasPolicy.FromULong(GasCostOf.VeryLow);
+        nint pc = 0;
+
+        EvmExceptionType result = EvmInstructions.InstructionPush2<EthereumGasPolicy, OnFlag>(ref stack, ref gas, null!, ref pc);
+
+        UInt256 expected = used switch { 0 => 0, 1 => 0xa000, _ => 0xa0a1 };
+        Assert.That(stack.PopUInt256(out UInt256 value), Is.True);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(EvmExceptionType.None));
+            Assert.That(value, Is.EqualTo(expected));
+            Assert.That(new UInt256(tracer.StackItem, isBigEndian: true), Is.EqualTo(expected));
+            Assert.That(pc, Is.EqualTo((nint)2));
+            Assert.That(EthereumGasPolicy.GetRemainingGas(in gas), Is.Zero);
+        }
+    }
+
+    [Test]
+    public void PushRightPaddedBytes_traces_the_completed_word(
+        [Values(0, 1, 17, 31, 32)] int length, [Values(0, 1, 7, 31)] int offset)
     {
         using VmState<EthereumGasPolicy> vmState = CreateEvmState();
         StackPushTracer tracer = new();
         vmState.InitializeStacks(tracer, default, out EvmStack stack);
-        byte[] source = new byte[EvmPooledMemory.WordSize];
+        byte[] source = new byte[EvmPooledMemory.WordSize + offset];
         for (int i = 0; i < source.Length; i++) source[i] = (byte)(i + 1);
         byte[] expected = new byte[EvmPooledMemory.WordSize];
-        source.AsSpan(0, length).CopyTo(expected);
+        source.AsSpan(offset, length).CopyTo(expected);
 
         EvmExceptionType result = stack.PushRightPaddedBytes<OnFlag>(
-            ref MemoryMarshal.GetArrayDataReference(source),
+            ref source[offset],
             (uint)length);
 
         using (Assert.EnterMultipleScope())
@@ -213,46 +285,17 @@ public class EvmStackTests
     // and breaks consensus. Verifies: low-end contains the N immediate bytes in the supplied
     // order; high-end (32-N bytes) is zero. Values 0xA0..0xA0+N-1 chosen so that byte-swap or
     // lane-swap regressions are immediately visible in the failure message.
-    [TestCase(1)]
-    [TestCase(2)]
-    [TestCase(3)]
-    [TestCase(4)]
-    [TestCase(5)]
-    [TestCase(6)]
-    [TestCase(7)]
-    [TestCase(8)]
-    [TestCase(9)]
-    [TestCase(10)]
-    [TestCase(11)]
-    [TestCase(12)]
-    [TestCase(13)]
-    [TestCase(14)]
-    [TestCase(15)]
-    [TestCase(16)]
-    [TestCase(17)]
-    [TestCase(18)]
-    [TestCase(19)]
-    [TestCase(20)]
-    [TestCase(21)]
-    [TestCase(22)]
-    [TestCase(23)]
-    [TestCase(24)]
-    [TestCase(25)]
-    [TestCase(26)]
-    [TestCase(27)]
-    [TestCase(28)]
-    [TestCase(29)]
-    [TestCase(30)]
-    [TestCase(31)]
-    [TestCase(32)]
-    public void PushNBytes_encodes_big_endian_low_padded_high_zero(int n)
+    [Test]
+    public void PushNBytes_encodes_big_endian_low_padded_high_zero([Range(1, 32)] int n, [Values] bool checkDepth)
     {
         using VmState<EthereumGasPolicy> vmState = CreateEvmState();
         vmState.InitializeStacks(default, out EvmStack stack);
         byte[] immediate = new byte[n];
         for (int i = 0; i < n; i++) immediate[i] = (byte)(0xA0 + i);
 
-        EvmExceptionType result = InvokePushNBytes(n, ref stack, ref MemoryMarshal.GetArrayDataReference(immediate));
+        EvmExceptionType result = checkDepth
+            ? InvokePushNBytes<OnFlag>(n, ref stack, ref MemoryMarshal.GetArrayDataReference(immediate))
+            : InvokePushNBytes<OffFlag>(n, ref stack, ref MemoryMarshal.GetArrayDataReference(immediate));
 
         Assert.That(result, Is.EqualTo(EvmExceptionType.None));
         Assert.That(stack.PopWord256(out Span<byte> word), Is.True);
@@ -263,53 +306,53 @@ public class EvmStackTests
             Assert.That(word[32 - n + i], Is.EqualTo((byte)(0xA0 + i)), $"immediate byte {i} of PUSH{n}");
     }
 
-    private static EvmExceptionType InvokePushNBytes(int n, ref EvmStack stack, ref byte imm) => n switch
+    private static EvmExceptionType InvokePushNBytes<TCheckDepth>(int n, ref EvmStack stack, ref byte imm) where TCheckDepth : struct, IFlag => n switch
     {
-        1 => stack.PushByte<OffFlag>(imm),
-        2 => stack.Push2Bytes<OffFlag>(ref imm),
-        3 => stack.Push3Bytes<OffFlag>(ref imm),
-        4 => stack.Push4Bytes<OffFlag>(ref imm),
-        5 => stack.Push5Bytes<OffFlag>(ref imm),
-        6 => stack.Push6Bytes<OffFlag>(ref imm),
-        7 => stack.Push7Bytes<OffFlag>(ref imm),
-        8 => stack.Push8Bytes<OffFlag>(ref imm),
-        9 => stack.Push9Bytes<OffFlag>(ref imm),
-        10 => stack.Push10Bytes<OffFlag>(ref imm),
-        11 => stack.Push11Bytes<OffFlag>(ref imm),
-        12 => stack.Push12Bytes<OffFlag>(ref imm),
-        13 => stack.Push13Bytes<OffFlag>(ref imm),
-        14 => stack.Push14Bytes<OffFlag>(ref imm),
-        15 => stack.Push15Bytes<OffFlag>(ref imm),
-        16 => stack.Push16Bytes<OffFlag>(ref imm),
-        17 => stack.Push17Bytes<OffFlag>(ref imm),
-        18 => stack.Push18Bytes<OffFlag>(ref imm),
-        19 => stack.Push19Bytes<OffFlag>(ref imm),
-        20 => stack.Push20Bytes<OffFlag>(ref imm),
-        21 => stack.Push21Bytes<OffFlag>(ref imm),
-        22 => stack.Push22Bytes<OffFlag>(ref imm),
-        23 => stack.Push23Bytes<OffFlag>(ref imm),
-        24 => stack.Push24Bytes<OffFlag>(ref imm),
-        25 => stack.Push25Bytes<OffFlag>(ref imm),
-        26 => stack.Push26Bytes<OffFlag>(ref imm),
-        27 => stack.Push27Bytes<OffFlag>(ref imm),
-        28 => stack.Push28Bytes<OffFlag>(ref imm),
-        29 => stack.Push29Bytes<OffFlag>(ref imm),
-        30 => stack.Push30Bytes<OffFlag>(ref imm),
-        31 => stack.Push31Bytes<OffFlag>(ref imm),
-        32 => stack.Push32Bytes<OffFlag>(ref imm),
+        1 => stack.PushByte<OffFlag, TCheckDepth>(imm),
+        2 => stack.Push2Bytes<OffFlag, TCheckDepth>(ref imm),
+        3 => stack.Push3Bytes<OffFlag, TCheckDepth>(ref imm),
+        4 => stack.Push4Bytes<OffFlag, TCheckDepth>(ref imm),
+        5 => stack.Push5Bytes<OffFlag, TCheckDepth>(ref imm),
+        6 => stack.Push6Bytes<OffFlag, TCheckDepth>(ref imm),
+        7 => stack.Push7Bytes<OffFlag, TCheckDepth>(ref imm),
+        8 => stack.Push8Bytes<OffFlag, TCheckDepth>(ref imm),
+        9 => stack.Push9Bytes<OffFlag, TCheckDepth>(ref imm),
+        10 => stack.Push10Bytes<OffFlag, TCheckDepth>(ref imm),
+        11 => stack.Push11Bytes<OffFlag, TCheckDepth>(ref imm),
+        12 => stack.Push12Bytes<OffFlag, TCheckDepth>(ref imm),
+        13 => stack.Push13Bytes<OffFlag, TCheckDepth>(ref imm),
+        14 => stack.Push14Bytes<OffFlag, TCheckDepth>(ref imm),
+        15 => stack.Push15Bytes<OffFlag, TCheckDepth>(ref imm),
+        16 => stack.Push16Bytes<OffFlag, TCheckDepth>(ref imm),
+        17 => stack.Push17Bytes<OffFlag, TCheckDepth>(ref imm),
+        18 => stack.Push18Bytes<OffFlag, TCheckDepth>(ref imm),
+        19 => stack.Push19Bytes<OffFlag, TCheckDepth>(ref imm),
+        20 => stack.Push20Bytes<OffFlag, TCheckDepth>(ref imm),
+        21 => stack.Push21Bytes<OffFlag, TCheckDepth>(ref imm),
+        22 => stack.Push22Bytes<OffFlag, TCheckDepth>(ref imm),
+        23 => stack.Push23Bytes<OffFlag, TCheckDepth>(ref imm),
+        24 => stack.Push24Bytes<OffFlag, TCheckDepth>(ref imm),
+        25 => stack.Push25Bytes<OffFlag, TCheckDepth>(ref imm),
+        26 => stack.Push26Bytes<OffFlag, TCheckDepth>(ref imm),
+        27 => stack.Push27Bytes<OffFlag, TCheckDepth>(ref imm),
+        28 => stack.Push28Bytes<OffFlag, TCheckDepth>(ref imm),
+        29 => stack.Push29Bytes<OffFlag, TCheckDepth>(ref imm),
+        30 => stack.Push30Bytes<OffFlag, TCheckDepth>(ref imm),
+        31 => stack.Push31Bytes<OffFlag, TCheckDepth>(ref imm),
+        32 => stack.Push32Bytes<OffFlag, TCheckDepth>(ref imm),
         _ => throw new System.ArgumentOutOfRangeException(nameof(n), n, null),
     };
 
     private static EvmExceptionType InvokePush(string op, ref EvmStack stack) => op switch
     {
-        PushByte => stack.PushByte<OffFlag>(42),
+        PushByte => stack.PushByte<OffFlag, OnFlag>(42),
         PushOne => stack.PushOne<OffFlag>(),
-        PushZero => stack.PushZero<OffFlag>(),
-        PushUInt32 => stack.PushUInt32<OffFlag>(0xdeadbeef),
-        PushUInt64 => stack.PushUInt64<OffFlag>(0xdeadbeefcafebabeUL),
+        PushZero => stack.PushZero<OffFlag, OnFlag>(),
+        PushUInt32 => stack.PushUInt32<OffFlag, OnFlag>(0xdeadbeef),
+        PushUInt64 => stack.PushUInt64<OffFlag, OnFlag>(0xdeadbeefcafebabeUL),
         PushUInt256 => PushUInt256Value(ref stack),
         PushBytes => stack.PushBytes<OffFlag>(new byte[32]),
-        Dup => stack.Dup<OffFlag>(1),
+        Dup => stack.Dup<OffFlag, OnFlag>(1),
         _ => throw new System.ArgumentOutOfRangeException(nameof(op), op, null),
     };
 

--- a/src/Nethermind/Nethermind.Evm.Test/GasPolicyContractTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/GasPolicyContractTests.cs
@@ -16,25 +16,37 @@ public class GasPolicyContractTests<TGasPolicy> where TGasPolicy : struct, IGasP
     {
         TGasPolicy gas = TGasPolicy.FromULong(value);
         Assert.That(TGasPolicy.GetRemainingGas(in gas), Is.EqualTo(value));
-        Assert.That(TGasPolicy.IsOutOfGas(in gas), Is.False);
+    }
+
+    [TestCase(0UL, 0UL, true, 0UL)]
+    [TestCase(0UL, 1UL, false, 0UL)]
+    [TestCase(100UL, 100UL, true, 0UL)]
+    [TestCase(100UL, 101UL, false, 0UL)]
+    [TestCase(1000UL, 100UL, true, 900UL)]
+    public void UpdateGas_reports_affordability(ulong available, ulong cost, bool expectedSuccess, ulong expectedRemaining)
+    {
+        TGasPolicy gas = TGasPolicy.FromULong(available);
+        bool success = TGasPolicy.UpdateGas(ref gas, cost);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(success, Is.EqualTo(expectedSuccess));
+            Assert.That(TGasPolicy.GetRemainingGas(in gas), Is.EqualTo(expectedRemaining));
+        }
     }
 
     [Test]
-    public void Consume_reduces_remaining_when_affordable()
+    public void ClearExecutionGas_zeros_remaining_and_preserves_state_gas([Values(0UL, 1000UL)] ulong available)
     {
-        TGasPolicy gas = TGasPolicy.FromULong(1000);
-        TGasPolicy.Consume(ref gas, 100);
-        Assert.That(TGasPolicy.GetRemainingGas(in gas), Is.EqualTo(900UL));
-        Assert.That(TGasPolicy.IsOutOfGas(in gas), Is.False);
-    }
-
-    [Test]
-    public void Consume_floors_at_zero_and_flags_out_of_gas_when_unaffordable()
-    {
-        TGasPolicy gas = TGasPolicy.FromULong(100);
-        TGasPolicy.Consume(ref gas, 101);
-        Assert.That(TGasPolicy.GetRemainingGas(in gas), Is.EqualTo(0UL));
-        Assert.That(TGasPolicy.IsOutOfGas(in gas), Is.True);
+        TGasPolicy gas = TGasPolicy.FromULong(available);
+        long reservoir = TGasPolicy.GetStateReservoir(in gas);
+        long stateUsed = TGasPolicy.GetStateGasUsed(in gas);
+        TGasPolicy.ClearExecutionGas(ref gas);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(TGasPolicy.GetRemainingGas(in gas), Is.Zero);
+            Assert.That(TGasPolicy.GetStateReservoir(in gas), Is.EqualTo(reservoir));
+            Assert.That(TGasPolicy.GetStateGasUsed(in gas), Is.EqualTo(stateUsed));
+        }
     }
 
     [Test]
@@ -43,7 +55,6 @@ public class GasPolicyContractTests<TGasPolicy> where TGasPolicy : struct, IGasP
         TGasPolicy gas = TGasPolicy.FromULong(100);
         Assert.That(TGasPolicy.TryConsume(ref gas, 101), Is.False);
         Assert.That(TGasPolicy.GetRemainingGas(in gas), Is.EqualTo(100UL));
-        Assert.That(TGasPolicy.IsOutOfGas(in gas), Is.False);
     }
 
     [Test]
@@ -52,24 +63,6 @@ public class GasPolicyContractTests<TGasPolicy> where TGasPolicy : struct, IGasP
         TGasPolicy gas = TGasPolicy.FromULong(100);
         Assert.That(TGasPolicy.TryConsume(ref gas, 40), Is.True);
         Assert.That(TGasPolicy.GetRemainingGas(in gas), Is.EqualTo(60UL));
-    }
-
-    [Test]
-    public void UpdateGas_flags_out_of_gas_when_unaffordable()
-    {
-        TGasPolicy gas = TGasPolicy.FromULong(100);
-        Assert.That(TGasPolicy.UpdateGas(ref gas, 101), Is.False);
-        Assert.That(TGasPolicy.GetRemainingGas(in gas), Is.EqualTo(0UL));
-        Assert.That(TGasPolicy.IsOutOfGas(in gas), Is.True);
-    }
-
-    [Test]
-    public void SetOutOfGas_zeros_remaining_and_flags()
-    {
-        TGasPolicy gas = TGasPolicy.FromULong(1000);
-        TGasPolicy.SetOutOfGas(ref gas);
-        Assert.That(TGasPolicy.GetRemainingGas(in gas), Is.EqualTo(0UL));
-        Assert.That(TGasPolicy.IsOutOfGas(in gas), Is.True);
     }
 
     [TestCase(10UL, 20UL)]

--- a/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/IntrinsicGasCalculatorTests.cs
@@ -226,18 +226,24 @@ namespace Nethermind.Evm.Test
             Assert.That(() => IntrinsicGasCalculator.Calculate(tx, Cancun.Instance), Throws.InstanceOf<InvalidDataException>());
         }
 
-        [Test]
-        public void Eip8037_policy_intrinsic_gas_splits_authorization_cost()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Eip8037_policy_intrinsic_gas_splits_authorization_cost(bool eip8038Enabled)
         {
             Transaction tx = Build.A.Transaction.SignedAndResolved()
                 .WithAuthorizationCode(new AuthorizationTuple(1, TestItem.AddressF, 0, 0, UInt256.One, UInt256.One))
                 .TestObject;
-            IntrinsicGas<EthereumGasPolicy> intrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(tx, Amsterdam.Instance);
+            OverridableReleaseSpec spec = new(Amsterdam.Instance) { IsEip8038Enabled = eip8038Enabled };
+            IntrinsicGas<EthereumGasPolicy> intrinsicGas = EthereumGasPolicy.CalculateIntrinsicGas(tx, spec);
 
             // Recipient touch: COLD + TX_VALUE (transfer log folded into TX_VALUE); authorization: state-independent base.
-            ulong recipientExecution = Eip8038Constants.ColdAccountAccess + GasCostOf.TxValueCostEip2780;
-            Assert.That(intrinsicGas.Standard.Value, Is.EqualTo(GasCostOf.TransactionEip2780 + recipientExecution + Eip8038Constants.PerAuthBaseExecution));
-            Assert.That(intrinsicGas.Standard.StateReservoir, Is.Zero);
+            ulong recipientExecution = (eip8038Enabled ? Eip8038Constants.ColdAccountAccess : GasCostOf.ColdAccountAccess) + GasCostOf.TxValueCostEip2780;
+            ulong authorizationExecution = eip8038Enabled ? Eip8038Constants.PerAuthBaseExecution : GasCostOf.PerAuthBaseExecution;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(intrinsicGas.Standard.Value, Is.EqualTo(GasCostOf.TransactionEip2780 + recipientExecution + authorizationExecution));
+                Assert.That(intrinsicGas.Standard.StateReservoir, Is.Zero);
+            }
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/MemoryPositionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/MemoryPositionTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Specs;
@@ -9,10 +10,19 @@ using NUnit.Framework;
 namespace Nethermind.Evm.Test;
 
 [Parallelizable(ParallelScope.Self)]
-public class MemoryPositionTests : VirtualMachineTestsBase
+[TestFixture(false)]
+[TestFixture(true)]
+public class MemoryPositionTests(bool tracing) : VirtualMachineTestsBase
 {
     protected override ulong BlockNumber => MainnetSpecProvider.ParisBlockNumber;
     protected override ulong Timestamp => MainnetSpecProvider.CancunBlockTimestamp;
+
+    protected override TestAllTracerWithOutput CreateTracer() => tracing ? new TestAllTracerWithOutput() : new NoInstructionTracer();
+
+    private sealed class NoInstructionTracer : TestAllTracerWithOutput
+    {
+        public override bool IsTracingInstructions => false;
+    }
 
     // A position is popped as its low 64 bits plus a marker for the other three limbs. Each case
     // sets one bit in one of those limbs and leaves the low limb zero, so dropping the marker
@@ -20,6 +30,86 @@ public class MemoryPositionTests : VirtualMachineTestsBase
     private const string HighLimb = "0x0000000000000001000000000000000000000000000000000000000000000000";
     private const string MiddleLimb = "0x0000000000000000000000000000000100000000000000000000000000000000";
     private const string LowerLimb = "0x0000000000000000000000000000000000000000000000010000000000000000";
+
+    [Test]
+    public void Empty_return_ignores_an_unaddressable_position(
+        [Values(Instruction.RETURN, Instruction.REVERT)] Instruction instruction)
+    {
+        byte[] code = Prepare.EvmCode.PushData(0).PushData(HighLimb).Op(instruction).Done;
+
+        TestAllTracerWithOutput tracer = Execute(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Error, Is.EqualTo(instruction == Instruction.REVERT ? TransactionSubstate.Revert : null));
+            Assert.That(tracer.ReturnValue, Is.Empty);
+        }
+    }
+
+    [Test]
+    public void Memory_opcode_preserves_gas_and_stack_failure_order(
+        [Values(Instruction.MLOAD, Instruction.MSTORE, Instruction.MSTORE8)] Instruction instruction,
+        [Values(0, 1, 2)] int depth, [Values(2UL, 3UL, 5UL, 6UL)] ulong availableGas)
+    {
+        Prepare code = Prepare.EvmCode;
+        for (int i = 0; i < depth; i++) code = code.PushData(0);
+        int requiredDepth = instruction == Instruction.MLOAD ? 1 : 2;
+        string? error = availableGas < 3 ? nameof(EvmExceptionType.OutOfGas)
+            : depth < requiredDepth ? nameof(EvmExceptionType.StackUnderflow)
+            : availableGas < 6 ? nameof(EvmExceptionType.OutOfGas) : null;
+        ulong gasLimit = GasCostOf.Transaction + (ulong)depth * GasCostOf.VeryLow + availableGas;
+
+        TestAllTracerWithOutput tracer = Execute(Activation, gasLimit, code.Op(instruction).Done);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Error, Is.EqualTo(error));
+            Assert.That(tracer.GasSpent, Is.EqualTo(gasLimit));
+        }
+    }
+
+    [Test]
+    public void Word_count_overflow_exhausts_execution_gas(
+        [Values(Instruction.CODECOPY, Instruction.CALLDATACOPY, Instruction.EXTCODECOPY,
+            Instruction.RETURNDATACOPY, Instruction.KECCAK256, Instruction.MCOPY)] Instruction instruction,
+        [Values(LowerLimb, "0x2000000000")] string length)
+    {
+        const ulong gasLimit = 100_000;
+        Prepare code = Prepare.EvmCode.PushData(length).PushData(0);
+        if (instruction != Instruction.KECCAK256) code = code.PushData(0);
+        if (instruction == Instruction.EXTCODECOPY) code = code.PushData(TestItem.AddressC);
+
+        TestAllTracerWithOutput tracer = Execute(Activation, gasLimit, code.Op(instruction).Done);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Error, Is.EqualTo(nameof(EvmExceptionType.OutOfGas)));
+            Assert.That(tracer.GasSpent, Is.EqualTo(gasLimit));
+        }
+    }
+
+    [Test]
+    public void Byte_store_followed_by_word_load_preserves_neighbours(
+        [Values(0, 7, 8, 31, 32, 63, 64, 127, 128, 255, 256, 511, 512)] int position)
+    {
+        int wordPosition = position / EvmStack.WordSize * EvmStack.WordSize;
+        byte[] expected = Bytes.FromHexString("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
+        byte[] code = Prepare.EvmCode
+            .PushData(expected).PushData(wordPosition).Op(Instruction.MSTORE)
+            .PushData(0x1234ab).PushData(position).Op(Instruction.MSTORE8)
+            .PushData(wordPosition).Op(Instruction.MLOAD)
+            .PushData(0).Op(Instruction.MSTORE)
+            .PushData(EvmStack.WordSize).PushData(0).Op(Instruction.RETURN).Done;
+        expected[position - wordPosition] = 0xab;
+
+        TestAllTracerWithOutput tracer = Execute(code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Error, Is.Null);
+            Assert.That(tracer.ReturnValue, Is.EqualTo(expected));
+        }
+    }
 
     [TestCase(Instruction.MSTORE, HighLimb)]
     [TestCase(Instruction.MSTORE, MiddleLimb)]

--- a/src/Nethermind/Nethermind.Evm.Test/SpecFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/SpecFlagsTests.cs
@@ -44,6 +44,7 @@ public class SpecFlagsTests
     [
         ("Eip150", "Use63Over64Rule", static s => s.Use63Over64Rule),
         ("Eip158", "ClearEmptyAccountWhenTouched", static s => s.ClearEmptyAccountWhenTouched),
+        ("Eip160", "UseExpDDosProtection", static s => s.UseExpDDosProtection),
         ("Eip2200", "UseNetGasMeteringWithAStipendFix", static s => s.UseNetGasMeteringWithAStipendFix),
         ("Eip2780", nameof(IReleaseSpec.IsEip2780Enabled), static s => s.IsEip2780Enabled),
         ("Eip2929", "UseHotAndColdStorage", static s => s.UseHotAndColdStorage),

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
@@ -17,6 +18,7 @@ using Nethermind.Core.Test.Modules;
 using Nethermind.Blockchain.Tracing.GethStyle;
 using Nethermind.Crypto;
 using Nethermind.Evm.Precompiles;
+using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.Test.Tracing;
 using Nethermind.Evm.Tracing;
@@ -118,10 +120,36 @@ public class VirtualMachineTests : VirtualMachineTestsBase
     }
 
     [Test]
-    public void Warm_up_opcode_handlers_does_not_throw() =>
+    public void Warm_up_opcode_handlers_returns_the_pooled_access_tracker()
+    {
+        object trackingState;
+        using (StackAccessTracker tracker = new())
+            trackingState = ReadWarmedOpcodeField(typeof(StackAccessTracker), "_trackingState", tracker);
+
         Assert.That(
             () => EthereumVirtualMachine.WarmUpEvmInstructions(TestState, CodeInfoRepository),
             Throws.Nothing);
+
+        using StackAccessTracker reused = new();
+        Assert.That(ReadWarmedOpcodeField(typeof(StackAccessTracker), "_trackingState", reused), Is.SameAs(trackingState));
+    }
+
+    [Test]
+    public void Warm_up_code_preserves_each_opcodes_jump_bitmap([Values(Instruction.JUMP, Instruction.JUMPI)] Instruction instruction)
+    {
+        MethodInfo factory = typeof(VirtualMachine<EthereumGasPolicy>).GetMethod("CreateWarmUpCodeInfo", BindingFlags.Static | BindingFlags.NonPublic)!;
+        CodeInfo jump = (CodeInfo)factory.Invoke(null, [instruction])!;
+        Assert.That(jump.ValidateJump(1), Is.True);
+
+        CodeInfo push = (CodeInfo)factory.Invoke(null, [Instruction.PUSH32])!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(push.ValidateJump(1), Is.False);
+            Assert.That(jump.ValidateJump(1), Is.True);
+            Assert.That(jump.CodeSpan[0], Is.EqualTo((byte)instruction));
+            Assert.That(push.CodeSpan[0], Is.EqualTo((byte)Instruction.PUSH32));
+        }
+    }
 
     [TestCase(0UL, 0UL)]
     [TestCase(MainnetSpecProvider.ByzantiumBlockNumber, 0UL)]
@@ -249,36 +277,339 @@ public class VirtualMachineTests : VirtualMachineTestsBase
         }
     }
 
-    [TestCase(1023, true, 1)]
-    [TestCase(1024, false, 1)]
-    [TestCase(1024, true, 2)]
-    [TestCase(2048, true, 3)]
+    [TestCase(1023, true, 1, Instruction.JUMPDEST)]
+    [TestCase(1024, false, 1, Instruction.JUMPDEST)]
+    [TestCase(1024, true, 2, Instruction.JUMPDEST)]
+    [TestCase(2048, true, 3, Instruction.JUMPDEST)]
+    [TestCase(1023, true, 1, Instruction.RETURNDATASIZE)]
+    [TestCase(1024, false, 1, Instruction.RETURNDATASIZE)]
+    [TestCase(1024, true, 2, Instruction.RETURNDATASIZE)]
+    [TestCase(2048, true, 3, Instruction.RETURNDATASIZE)]
     public void Cancellation_is_polled_before_the_first_opcode_and_each_complete_1024_opcode_batch(
         int continuingOpcodeCount,
         bool appendStop,
-        int expectedPollCount)
+        int expectedPollCount,
+        Instruction opcode)
     {
-        byte[] code = new byte[continuingOpcodeCount + (appendStop ? 1 : 0)];
-        Array.Fill(code, (byte)Instruction.JUMPDEST);
-        if (appendStop)
-            code[^1] = (byte)Instruction.STOP;
+        byte[] code = CreateCancellationCode(continuingOpcodeCount, appendStop, opcode);
         CountingCancellationTracer tracer = new();
 
         Execute(tracer, code);
 
-        Assert.That(tracer.PollCount, Is.EqualTo(expectedPollCount));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Error, Is.Null);
+            Assert.That(tracer.PollCount, Is.EqualTo(expectedPollCount));
+            Assert.That(Machine.OpCodeCount, Is.EqualTo(continuingOpcodeCount + (appendStop ? 1 : 0)));
+        }
     }
 
-    [Test]
-    public void Cancellation_at_a_1024_opcode_boundary_stops_before_the_next_opcode()
+    [TestCase(Instruction.JUMPDEST)]
+    [TestCase(Instruction.RETURNDATASIZE)]
+    public void Cancellation_at_a_1024_opcode_boundary_stops_before_the_next_opcode(Instruction opcode)
     {
-        byte[] code = new byte[1025];
-        Array.Fill(code, (byte)Instruction.JUMPDEST);
-        code[^1] = (byte)Instruction.STOP;
+        byte[] code = CreateCancellationCode(1024, true, opcode);
         CountingCancellationTracer tracer = new(cancelAtPoll: 2);
 
         Assert.Throws<OperationCanceledException>(() => Execute(tracer, code));
         Assert.That(tracer.PollCount, Is.EqualTo(2));
+    }
+
+    private static byte[] CreateCancellationCode(int continuingOpcodeCount, bool appendStop, Instruction opcode)
+    {
+        byte[] code = new byte[continuingOpcodeCount + (appendStop ? 1 : 0)];
+        for (int i = 0; i < continuingOpcodeCount; i++)
+            code[i] = (byte)(opcode == Instruction.RETURNDATASIZE && (i & 1) == 0 ? Instruction.POP : opcode);
+        if (opcode == Instruction.RETURNDATASIZE)
+            code[0] = (byte)opcode;
+        if (appendStop)
+            code[^1] = (byte)Instruction.STOP;
+        return code;
+    }
+
+    private static IEnumerable<TestCaseData> FixedCostOpcodeGasCases()
+    {
+        (Instruction Opcode, int Depth, ulong Cost)[] operations =
+        [
+            (Instruction.ADD, 2, 3), (Instruction.MUL, 2, 5), (Instruction.SUB, 2, 3),
+            (Instruction.ADDMOD, 3, 8), (Instruction.MULMOD, 3, 8),
+            (Instruction.DIV, 2, 5), (Instruction.SDIV, 2, 5), (Instruction.MOD, 2, 5),
+            (Instruction.SMOD, 2, 5), (Instruction.LT, 2, 3), (Instruction.GT, 2, 3),
+            (Instruction.SLT, 2, 3), (Instruction.SGT, 2, 3), (Instruction.EQ, 2, 3),
+            (Instruction.ISZERO, 1, 3), (Instruction.NOT, 1, 3),
+            (Instruction.POP, 1, 2),
+            (Instruction.CALLDATALOAD, 1, 3),
+            (Instruction.BYTE, 2, 3), (Instruction.CLZ, 1, 5),
+            (Instruction.SHL, 2, 3), (Instruction.SHR, 2, 3), (Instruction.SAR, 2, 3),
+            (Instruction.DUP1, 1, 3), (Instruction.DUP2, 2, 3), (Instruction.DUP3, 3, 3), (Instruction.DUP4, 4, 3),
+            (Instruction.DUP5, 5, 3), (Instruction.DUP6, 6, 3), (Instruction.DUP7, 7, 3), (Instruction.DUP8, 8, 3),
+            (Instruction.DUP9, 9, 3), (Instruction.DUP10, 10, 3), (Instruction.DUP11, 11, 3), (Instruction.DUP12, 12, 3),
+            (Instruction.DUP13, 13, 3), (Instruction.DUP14, 14, 3), (Instruction.DUP15, 15, 3), (Instruction.DUP16, 16, 3),
+            (Instruction.AND, 2, 3), (Instruction.OR, 2, 3), (Instruction.XOR, 2, 3),
+            (Instruction.SWAP1, 2, 3), (Instruction.SWAP2, 3, 3), (Instruction.SWAP3, 4, 3), (Instruction.SWAP4, 5, 3),
+            (Instruction.SWAP5, 6, 3), (Instruction.SWAP6, 7, 3), (Instruction.SWAP7, 8, 3), (Instruction.SWAP8, 9, 3),
+            (Instruction.SWAP9, 10, 3), (Instruction.SWAP10, 11, 3), (Instruction.SWAP11, 12, 3), (Instruction.SWAP12, 13, 3),
+            (Instruction.SWAP13, 14, 3), (Instruction.SWAP14, 15, 3), (Instruction.SWAP15, 16, 3), (Instruction.SWAP16, 17, 3)
+        ];
+        foreach ((Instruction opcode, int depth, ulong cost) in operations)
+        {
+            if (opcode is not (>= Instruction.DUP1 and <= Instruction.DUP16))
+                foreach (int fullDepth in new[] { 1023, 1024 })
+                    foreach (int tracerMode in new[] { 0, 1, 2 })
+                        foreach (bool sufficientGas in new[] { false, true })
+                            yield return new TestCaseData(opcode, fullDepth, cost, tracerMode, true, sufficientGas, false)
+                                .SetName($"Fixed_cost_full_stack_{opcode}_tracer_{tracerMode}_depth_{fullDepth}_gas_{sufficientGas}");
+            foreach (int tracerMode in new[] { 0, 1, 2 })
+            {
+                foreach (bool sufficientStack in new[] { false, true })
+                {
+                    foreach (bool sufficientGas in new[] { false, true })
+                    {
+                        foreach (bool appendStop in new[] { false, true })
+                        {
+                            yield return new TestCaseData(opcode, depth, cost, tracerMode, sufficientStack, sufficientGas, appendStop)
+                                .SetName($"Fixed_cost_gas_{opcode}_tracer_{tracerMode}_stack_{sufficientStack}_gas_{sufficientGas}_stop_{appendStop}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    [TestCaseSource(nameof(FixedCostOpcodeGasCases))]
+    public void Fixed_cost_opcode_gas_status_preserves_failure_precedence(
+        Instruction opcode, int depth, ulong cost, int tracerMode, bool sufficientStack, bool sufficientGas, bool appendStop)
+    {
+        int pushes = sufficientStack ? depth : depth - 1;
+        byte[] code = new byte[pushes * 2 + 1 + (appendStop ? 1 : 0)];
+        for (int i = 0; i < pushes; i++)
+        {
+            code[i * 2] = (byte)Instruction.PUSH1;
+            code[i * 2 + 1] = 1;
+        }
+        code[pushes * 2] = (byte)opcode;
+        ulong gasLimit = GasCostOf.Transaction + (ulong)pushes * GasCostOf.VeryLow + cost - (sufficientGas ? 0UL : 1UL);
+        (Block block, Transaction transaction) = PrepareTx(Activation, gasLimit, code);
+        block.Header.Number = MainnetSpecProvider.OsakaActivation.BlockNumber;
+        block.Header.Timestamp = MainnetSpecProvider.OsakaBlockTimestamp;
+        TestAllTracerWithOutput tracer = tracerMode switch
+        {
+            0 => new NoInstructionTracer(),
+            1 => new TestAllTracerWithOutput(),
+            _ => new CountingCancellationTracer()
+        };
+
+        _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+
+        string expectedError = !sufficientGas ? nameof(EvmExceptionType.OutOfGas)
+            : !sufficientStack ? nameof(EvmExceptionType.StackUnderflow) : null;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Error, Is.EqualTo(expectedError));
+            Assert.That(tracer.StatusCode, Is.EqualTo(expectedError is null ? StatusCode.Success : StatusCode.Failure));
+            Assert.That(tracer.GasSpent, Is.EqualTo(gasLimit));
+            Assert.That(Machine.OpCodeCount, Is.EqualTo(pushes + 1 + (appendStop && expectedError is null ? 1 : 0)));
+        }
+    }
+
+    /// <remarks>
+    /// Reflection discovers checked-body families; opcode mappings are maintained by hand.
+    /// Update the mapping and boundary cases when registering another opcode to an existing family.
+    /// </remarks>
+    [Test]
+    public void Checked_opcode_bodies_have_boundary_cases()
+    {
+        Dictionary<string, Instruction[]> coveredBodies = new()
+        {
+            ["Math2Opcode"] = [Instruction.ADD, Instruction.MUL, Instruction.SUB, Instruction.DIV, Instruction.SDIV, Instruction.MOD, Instruction.SMOD, Instruction.LT, Instruction.GT, Instruction.SLT, Instruction.SGT],
+            ["Math3Opcode"] = [Instruction.ADDMOD, Instruction.MULMOD],
+            ["Math1Opcode"] = [Instruction.ISZERO, Instruction.NOT],
+            ["BitwiseOpcode"] = [Instruction.EQ, Instruction.AND, Instruction.OR, Instruction.XOR],
+            ["CountLeadingZerosOpcode"] = [Instruction.CLZ],
+            ["ByteOpcode"] = [Instruction.BYTE],
+            ["ShiftOpcode"] = [Instruction.SHL, Instruction.SHR],
+            ["SarOpcode"] = [Instruction.SAR],
+            ["EnvAddressOpcode"] = [Instruction.ADDRESS, Instruction.CALLER],
+            ["Env32BytesOpcode"] = [Instruction.ORIGIN, Instruction.CHAINID],
+            ["EnvUInt256Opcode"] = [Instruction.CALLVALUE],
+            ["EnvUInt32Opcode"] = [Instruction.CALLDATASIZE],
+            ["EnvUInt64Opcode"] = [Instruction.MSIZE],
+            ["BlkAddressOpcode"] = [Instruction.COINBASE],
+            ["BlkUInt256Opcode"] = [Instruction.GASPRICE, Instruction.BASEFEE],
+            ["BlkUInt64Opcode"] = [Instruction.TIMESTAMP, Instruction.NUMBER, Instruction.GASLIMIT],
+            ["CallDataLoadOpcode"] = [Instruction.CALLDATALOAD],
+            ["CodeSizeOpcode"] = [Instruction.CODESIZE],
+            ["ReturnDataSizeOpcode"] = [Instruction.RETURNDATASIZE],
+            ["PrevRandaoOpcode"] = [Instruction.PREVRANDAO],
+            ["SelfBalanceOpcode"] = [Instruction.SELFBALANCE],
+            ["PopOpcode"] = [Instruction.POP],
+            ["ProgramCounterOpcode"] = [Instruction.PC],
+            ["GasOpcode"] = [Instruction.GAS],
+            ["Push0Opcode"] = [Instruction.PUSH0],
+            ["PushOpcode"] = OpcodeRange(Instruction.PUSH1, Instruction.PUSH32),
+            ["DupOpcode"] = OpcodeRange(Instruction.DUP1, Instruction.DUP16),
+            ["SwapOpcode"] = OpcodeRange(Instruction.SWAP1, Instruction.SWAP16),
+        };
+        HashSet<Instruction> coveredOpcodes = [.. StackGrowingOpcodes()];
+        foreach (TestCaseData testCase in FixedCostOpcodeGasCases())
+            coveredOpcodes.Add((Instruction)testCase.Arguments[0]);
+
+        using (Assert.EnterMultipleScope())
+        {
+            foreach (Type body in typeof(VirtualMachine<>).GetNestedTypes(BindingFlags.NonPublic))
+            {
+                if (!body.IsValueType || body.GetProperty("HasCheckedBody", BindingFlags.Public | BindingFlags.Static) is null)
+                    continue;
+
+                // Include conditional checked bodies even when this host disables their fast path.
+                string name = body.Name.Split('`')[0];
+                bool covered = coveredBodies.TryGetValue(name, out Instruction[] opcodes);
+                Assert.That(covered, Is.True, $"Add boundary cases for {name}.");
+                if (covered)
+                    foreach (Instruction opcode in opcodes)
+                        Assert.That(coveredOpcodes, Does.Contain(opcode), $"Missing {name}: {opcode}.");
+            }
+        }
+    }
+
+    private static Instruction[] OpcodeRange(Instruction first, Instruction last)
+    {
+        Instruction[] opcodes = new Instruction[last - first + 1];
+        for (int i = 0; i < opcodes.Length; i++) opcodes[i] = (Instruction)((int)first + i);
+        return opcodes;
+    }
+
+    private static IEnumerable<TestCaseData> StackGrowthCases()
+    {
+        foreach (Instruction opcode in StackGrowingOpcodes())
+        {
+            int width = opcode is >= Instruction.PUSH0 and <= Instruction.PUSH32 ? opcode - Instruction.PUSH0 : 0;
+            int[] lengths = width == 0 ? [0] : width == 1 ? [0, 1] : [0, width / 2, width];
+            foreach (int depth in new[] { 1023, 1024 })
+                foreach (bool sufficientGas in new[] { false, true })
+                    foreach (int tracerMode in new[] { 0, 1, 2 })
+                        foreach (int immediateLength in lengths)
+                            yield return new TestCaseData(opcode, depth, sufficientGas, tracerMode, immediateLength);
+        }
+    }
+
+    private static IEnumerable<Instruction> StackGrowingOpcodes()
+    {
+        for (Instruction opcode = Instruction.PUSH0; opcode <= Instruction.DUP16; opcode++) yield return opcode;
+        yield return Instruction.PC;
+        yield return Instruction.GAS;
+        yield return Instruction.CODESIZE;
+        yield return Instruction.ADDRESS;
+        yield return Instruction.ORIGIN;
+        yield return Instruction.CALLER;
+        yield return Instruction.CALLVALUE;
+        yield return Instruction.CALLDATASIZE;
+        yield return Instruction.PREVRANDAO;
+        yield return Instruction.RETURNDATASIZE;
+        yield return Instruction.SELFBALANCE;
+        yield return Instruction.GASPRICE;
+        yield return Instruction.COINBASE;
+        yield return Instruction.TIMESTAMP;
+        yield return Instruction.NUMBER;
+        yield return Instruction.GASLIMIT;
+        yield return Instruction.CHAINID;
+        yield return Instruction.BASEFEE;
+        yield return Instruction.MSIZE;
+    }
+
+    [Test]
+    public void Push_immediate_consumes_only_declared_width([Range(1, 32)] int width, [Values] bool traced)
+    {
+        byte[] code = new byte[width + 1];
+        code[0] = (byte)((byte)Instruction.PUSH1 + width - 1);
+        byte[] expected = new byte[32];
+        for (int i = 0; i < width; i++)
+            expected[32 - width + i] = code[1 + i] = (byte)(0xa0 + i);
+        AssertStackValue(code, expected, traced);
+    }
+
+    [Test]
+    public void Environment_value_is_pushed_after_charging_gas(
+        [Values(Instruction.PC, Instruction.GAS, Instruction.CODESIZE)] Instruction opcode, [Values] bool traced)
+    {
+        UInt256 expected = opcode switch
+        {
+            Instruction.PC => 0,
+            Instruction.GAS => 100000UL - GasCostOf.Transaction - GasCostOf.Base,
+            _ => 9
+        };
+        AssertStackValue([(byte)opcode], expected.ToBigEndian(), traced);
+    }
+
+    [Test]
+    public void Modular_arithmetic_preserves_full_width_operands(
+        [Values(Instruction.ADDMOD, Instruction.MULMOD)] Instruction opcode,
+        [Values(0, 1, 251, -1)] int modulusValue, [Values] bool traced)
+    {
+        BigInteger a = (BigInteger.One << 256) - 1;
+        BigInteger b = a - 1;
+        BigInteger modulus = modulusValue == -1 ? a - 2 : modulusValue;
+        BigInteger expected = modulus.IsZero ? BigInteger.Zero
+            : (opcode == Instruction.ADDMOD ? a + b : a * b) % modulus;
+        byte[] code = [(byte)Instruction.PUSH32, .. ((UInt256)modulus).ToBigEndian(),
+            (byte)Instruction.PUSH32, .. ((UInt256)b).ToBigEndian(),
+            (byte)Instruction.PUSH32, .. ((UInt256)a).ToBigEndian(), (byte)opcode];
+
+        AssertStackValue(code, ((UInt256)expected).ToBigEndian(), traced, 9);
+    }
+
+    private void AssertStackValue(byte[] prefix, byte[] expected, bool traced, int expectedOpcodeCount = 6)
+    {
+        byte[] code = [.. prefix, (byte)Instruction.PUSH1, 0, (byte)Instruction.MSTORE,
+            (byte)Instruction.PUSH1, 32, (byte)Instruction.PUSH1, 0, (byte)Instruction.RETURN];
+        TestAllTracerWithOutput tracer = traced ? new TestAllTracerWithOutput() : new NoInstructionTracer();
+
+        Execute(tracer, code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That(tracer.ReturnValue, Is.EqualTo(expected));
+            Assert.That(Machine.OpCodeCount, Is.EqualTo(expectedOpcodeCount));
+        }
+    }
+
+    [TestCaseSource(nameof(StackGrowthCases))]
+    public void Stack_growth_preserves_limit_and_gas_precedence(Instruction opcode, int depth, bool sufficientGas, int tracerMode, int immediateLength)
+    {
+        byte[] code = new byte[depth * 2 + 1 + immediateLength];
+        for (int i = 0; i < depth; i++)
+        {
+            code[i * 2] = (byte)Instruction.PUSH1;
+            code[i * 2 + 1] = 1;
+        }
+        code[depth * 2] = (byte)opcode;
+        code.AsSpan(depth * 2 + 1).Fill(0xa5);
+        ulong cost = opcode == Instruction.SELFBALANCE ? GasCostOf.SelfBalance
+            : opcode is >= Instruction.PUSH1 and <= Instruction.DUP16 ? GasCostOf.VeryLow : GasCostOf.Base;
+        ulong gasLimit = GasCostOf.Transaction + (ulong)depth * GasCostOf.VeryLow + cost - (sufficientGas ? 0UL : 1UL);
+        (Block block, Transaction transaction) = PrepareTx(Activation, gasLimit, code);
+        // PrepareTx retains the activation on this shared fixture; change only this execution's header.
+        block.Header.Number = MainnetSpecProvider.CancunActivation.BlockNumber;
+        block.Header.Timestamp = MainnetSpecProvider.CancunBlockTimestamp;
+        TestAllTracerWithOutput tracer = tracerMode switch
+        {
+            0 => new NoInstructionTracer(),
+            1 => new TestAllTracerWithOutput(),
+            _ => new CountingCancellationTracer()
+        };
+
+        _processor.Execute(transaction, new BlockExecutionContext(block.Header, SpecProvider.GetSpec(block.Header)), tracer);
+
+        string expectedError = !sufficientGas ? nameof(EvmExceptionType.OutOfGas)
+            : depth == 1024 ? nameof(EvmExceptionType.StackOverflow) : null;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Error, Is.EqualTo(expectedError));
+            Assert.That(tracer.StatusCode, Is.EqualTo(expectedError is null ? StatusCode.Success : StatusCode.Failure));
+            Assert.That(tracer.GasSpent, Is.EqualTo(gasLimit));
+            Assert.That(Machine.OpCodeCount, Is.EqualTo(depth + 1));
+        }
     }
 
     [TestCaseSource(nameof(JumpCompletionCases))]

--- a/src/Nethermind/Nethermind.Evm.ZkEvm.Test/GuestDispatchFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.ZkEvm.Test/GuestDispatchFlagsTests.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Evm.Tracing;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.ZkEvm.Test;
+
+public class GuestDispatchFlagsTests
+{
+    [Test]
+    public void Rejects_unsupported_tracer_capability([Values(
+        nameof(ITxTracer.IsTracingInstructions),
+        nameof(ITxTracer.IsCancelable),
+        nameof(ITxTracer.IsTracingActions),
+        nameof(ITxTracer.IsTracingRefunds),
+        nameof(ITxTracer.IsTracingAccess),
+        nameof(ITxTracer.IsTracingOpLevelStorage),
+        nameof(ITxTracer.IsTracingLogs),
+        nameof(ITxTracer.IsTracingBlockHash))] string capability)
+    {
+        using CapabilityTracer tracer = new(capability);
+
+        Assert.Throws<NotSupportedException>(() => DispatchFlags.Validate(tracer));
+    }
+
+    [Test]
+    public void Accepts_supported_tracer([Values("", nameof(ITxTracer.IsTracingReceipt))] string capability)
+    {
+        using CapabilityTracer tracer = new(capability);
+
+        Assert.DoesNotThrow(() => DispatchFlags.Validate(tracer));
+    }
+
+    /// <remarks>Re-lists ITxTracer so Validate observes this IsCancelable implementation instead of the default interface value.</remarks>
+    private sealed class CapabilityTracer : TxTracer, ITxTracer
+    {
+        public CapabilityTracer(string capability)
+        {
+            IsTracingInstructions = capability == nameof(IsTracingInstructions);
+            IsCancelable = capability == nameof(IsCancelable);
+            IsTracingActions = capability == nameof(IsTracingActions);
+            IsTracingRefunds = capability == nameof(IsTracingRefunds);
+            IsTracingAccess = capability == nameof(IsTracingAccess);
+            IsTracingOpLevelStorage = capability == nameof(IsTracingOpLevelStorage);
+            IsTracingLogs = capability == nameof(IsTracingLogs);
+            IsTracingBlockHash = capability == nameof(IsTracingBlockHash);
+            IsTracingReceipt = capability == nameof(IsTracingReceipt);
+        }
+
+        public bool IsCancelable { get; }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -69,6 +69,9 @@ public sealed class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     public bool ValidateJump(int destination)
         => _analyzer?.ValidateJump(destination) ?? false;
 
+    /// <summary>The jump-destination bitmap of this code, built on first use.</summary>
+    internal long[] JumpDestinationBitmap => _analyzer?.JumpDestinationBitmap ?? JumpDestinationAnalyzer.EmptyBitmap;
+
     void IThreadPoolWorkItem.Execute()
         => _analyzer?.Execute();
 

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/JumpDestinationAnalyzer.cs
@@ -34,11 +34,17 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
     private const ulong PackByteHighBits = 0x0002040810204081UL;
 
     private static readonly long[] _emptyJumpDestinationBitmap = new long[1];
+    /// <summary>A bitmap with no valid jump destination, for code that has no analyzer.</summary>
+    internal static long[] EmptyBitmap => _emptyJumpDestinationBitmap;
     private long[]? _jumpDestinationBitmap = (codeInfo.Code.Length == 0 || skipAnalysis) ? _emptyJumpDestinationBitmap : null;
 
     private object? _analysisComplete;
     public ReadOnlyMemory<byte> MachineCode => codeInfo.Code;
 
+    /// <summary>The jump-destination bitmap, built on first use; one bit per code byte.</summary>
+    internal long[] JumpDestinationBitmap => _jumpDestinationBitmap ??= CreateOrWaitForJumpDestinationBitmap();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool ValidateJump(int destination)
     {
         _jumpDestinationBitmap ??= CreateOrWaitForJumpDestinationBitmap();
@@ -538,7 +544,7 @@ public sealed class JumpDestinationAnalyzer(CodeInfo codeInfo, bool skipAnalysis
     /// Checks if the position is in a code segment.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsJumpDestination(long[] bitvec, int pos)
+    internal static bool IsJumpDestination(long[] bitvec, int pos)
     {
         int vecIndex = pos >> BitShiftPerInt64;
         // Check if in bounds, Jit will add slightly more expensive exception throwing check if we don't.

--- a/src/Nethermind/Nethermind.Evm/DispatchFlags.std.cs
+++ b/src/Nethermind/Nethermind.Evm/DispatchFlags.std.cs
@@ -6,25 +6,25 @@ using Nethermind.Evm.Tracing;
 namespace Nethermind.Evm;
 
 /// <summary>
-/// The tracer capabilities the dispatch specializes on, taken from the tracer running the
-/// transaction.
+/// Selects tracing and cancellation capabilities supported by the current build.
 /// </summary>
 /// <remarks>
-/// Each is read once per transaction, so routing them through this type costs nothing at run time.
-/// It exists so the zkEVM build can answer with a constant: an ahead-of-time compiler emits every
-/// reachable specialization, and a guest that never traces and never cancels would otherwise carry a
-/// second opcode table and a second dispatch loop it can never enter. See
-/// <c>DispatchFlags.zkevm.cs</c>.
+/// The standard build forwards tracer capabilities through identity methods that inline away.
+/// The zkEVM build returns constants so ahead-of-time compilation can remove unsupported dispatch
+/// specializations and per-site tracing branches. See <c>DispatchFlags.zkevm.cs</c>.
 /// </remarks>
 internal static partial class DispatchFlags
 {
-    /// <summary>Whether the coming transaction reports every opcode to the tracer.</summary>
-    public static bool Tracing(bool tracerIsTracingInstructions) => tracerIsTracingInstructions;
+    /// <summary>Whether this build supports EVM tracing.</summary>
+    public const bool ConstTracing = true;
+
+    /// <summary>Whether the requested EVM tracing capability is enabled.</summary>
+    public static bool Tracing(bool isTracing) => isTracing;
 
     /// <summary>Whether the coming transaction can be cancelled part-way through.</summary>
     public static bool Cancelable(bool tracerIsCancelable) => tracerIsCancelable;
 
     /// <summary>Rejects a tracer this build cannot serve.</summary>
-    /// <remarks>Both capabilities are taken from the tracer here, so every tracer is servable.</remarks>
+    /// <remarks>Capabilities are taken from the tracer here, so every tracer is servable.</remarks>
     public static void Validate(ITxTracer tracer) { }
 }

--- a/src/Nethermind/Nethermind.Evm/DispatchFlags.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/DispatchFlags.zkevm.cs
@@ -9,20 +9,20 @@ namespace Nethermind.Evm;
 /// <inheritdoc cref="DispatchFlags"/>
 internal static partial class DispatchFlags
 {
-    /// <summary>The guest proves a block; it reports nothing per opcode.</summary>
+    /// <summary>Disables EVM tracing in the guest; receipt collection remains supported.</summary>
     public const bool ConstTracing = false;
 
     /// <summary>The guest runs to completion or fails; there is nothing to cancel it.</summary>
     public const bool ConstCancelable = false;
 
-    public static bool Tracing(bool tracerIsTracingInstructions) => ConstTracing;
+    public static bool Tracing(bool isTracing) => ConstTracing;
 
     public static bool Cancelable(bool tracerIsCancelable) => ConstCancelable;
 
     /// <summary>Rejects a tracer whose capabilities this build compiled away.</summary>
     /// <remarks>
-    /// Without this a tracing tracer would silently see no opcodes, and a cancelable one would run
-    /// past its cancellation, because neither specialization was compiled.
+    /// Unsupported tracers would lose reports or access-list gas simulation, and cancelable tracers
+    /// would run past cancellation. Receipt collection remains supported.
     /// </remarks>
     public static void Validate(ITxTracer tracer)
     {
@@ -30,5 +30,8 @@ internal static partial class DispatchFlags
             throw new NotSupportedException("The zkEVM guest compiles no instruction-tracing dispatch.");
         if (tracer.IsCancelable != ConstCancelable)
             throw new NotSupportedException("The zkEVM guest compiles no cancelable dispatch.");
+        if (tracer.IsTracingActions || tracer.IsTracingRefunds || tracer.IsTracingAccess
+            || tracer.IsTracingOpLevelStorage || tracer.IsTracingLogs || tracer.IsTracingBlockHash)
+            throw new NotSupportedException("The zkEVM guest compiles no EVM tracing.");
     }
 }

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -13,6 +13,7 @@ using System.Runtime.Intrinsics.X86;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.Tracing;
 using Nethermind.Int256;
 
@@ -28,19 +29,21 @@ public ref partial struct EvmStack
     public const int WordSize = 32;
     public const int AddressSize = 20;
 
-    public EvmStack(int head, ITxTracer txTracer, ref byte stack, scoped in ReadOnlySpan<byte> codeSpan)
+    public EvmStack(int head, ITxTracer txTracer, ref byte stack, scoped in ReadOnlySpan<byte> codeSpan, CodeInfo? codeInfo)
     {
         Head = head;
         _tracer = txTracer;
+        _codeInfo = codeInfo;
         _stack = ref stack;
         Code = ref MemoryMarshal.GetReference(codeSpan);
         CodeLength = codeSpan.Length;
     }
 
-    public EvmStack(int head, ref byte stack, scoped in ReadOnlySpan<byte> codeSpan)
+    public EvmStack(int head, ref byte stack, scoped in ReadOnlySpan<byte> codeSpan, CodeInfo? codeInfo)
     {
         Head = head;
         _tracer = null!;
+        _codeInfo = codeInfo;
         _stack = ref stack;
         Code = ref MemoryMarshal.GetReference(codeSpan);
         CodeLength = codeSpan.Length;
@@ -67,6 +70,25 @@ public ref partial struct EvmStack
     /// with a program counter.
     /// </remarks>
     internal readonly nint CodeLength;
+    private readonly CodeInfo? _codeInfo;
+    private long[]? _jumpDestinations;
+
+    /// <summary>The jump-destination bitmap of <see cref="Code"/>, resolved on the first in-range jump and kept in the frame.</summary>
+    /// <remarks>
+    /// Kept on the stack so a jump validates against the frame it is executing without walking
+    /// <c>vm.VmState.Env.CodeInfo</c>. Resolving lazily keeps the analysis off the path of frames that
+    /// never jump. Only a stack built over no code may omit the code info; the empty bitmap then rejects
+    /// every destination.
+    /// </remarks>
+    internal long[] JumpDestinations
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get
+        {
+            Debug.Assert(_codeInfo is not null || CodeLength == 0, "A stack that executes code must carry that code's CodeInfo.");
+            return _jumpDestinations ??= _codeInfo?.JumpDestinationBitmap ?? JumpDestinationAnalyzer.EmptyBitmap;
+        }
+    }
 
     /// <summary>
     /// Reserves the next stack slot and returns a ref to it. On overflow returns <see cref="Unsafe.NullRef{T}"/>;
@@ -228,6 +250,14 @@ public ref partial struct EvmStack
 
         ref byte dst = ref Unsafe.Add(ref _stack, headOffset * WordSize);
 
+        return WriteRightPaddedBytes<TTracingInst>(ref dst, ref src, length);
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal EvmExceptionType WriteRightPaddedBytes<TTracingInst>(ref byte dst, ref byte src, uint length)
+        where TTracingInst : struct, IFlag
+    {
         if (length != WordSize)
         {
             return PushBytesPartialZeroPadded<TTracingInst>(ref dst, ref src, length);
@@ -235,7 +265,7 @@ public ref partial struct EvmStack
 
         if (Vector256.IsHardwareAccelerated)
         {
-            Unsafe.As<byte, EvmWord>(ref dst) = Unsafe.As<byte, EvmWord>(ref src);
+            Unsafe.As<byte, EvmWord>(ref dst) = Unsafe.ReadUnaligned<EvmWord>(ref src);
         }
         else
         {
@@ -391,7 +421,7 @@ public ref partial struct EvmStack
     /// <param name="position">The decoded position.</param>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void ReadMemoryPositionFromSlot(ref byte slot, out UInt256 position)
+    internal static void ReadMemoryPositionFromSlot(ref byte slot, out UInt256 position)
     {
         ref ulong limbs = ref Unsafe.As<byte, ulong>(ref slot);
         ulong unreachable = limbs | Unsafe.Add(ref limbs, 1) | Unsafe.Add(ref limbs, 2);
@@ -438,12 +468,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push10Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push10Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -467,12 +498,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push11Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push11Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -496,12 +528,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push12Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push12Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -524,12 +557,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push13Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push13Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -552,12 +586,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push14Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push14Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -580,12 +615,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push15Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push15Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -608,12 +644,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push16Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push16Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -642,12 +679,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push17Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push17Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -671,12 +709,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push18Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push18Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -700,12 +739,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push19Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push19Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -729,12 +769,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push20Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push20Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -758,12 +799,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push21Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push21Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -787,12 +829,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push22Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push22Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -816,12 +859,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push23Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push23Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -845,12 +889,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push24Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push24Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -874,12 +919,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push25Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push25Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -903,12 +949,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push26Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push26Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -932,12 +979,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push27Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push27Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -961,12 +1009,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push28Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push28Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -990,12 +1039,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push29Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push29Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1019,12 +1069,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push2Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push2Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1049,12 +1100,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push30Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push30Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1078,12 +1130,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push31Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push31Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1107,12 +1160,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push32Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push32Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1130,12 +1184,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push3Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push3Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1160,12 +1215,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push4Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push4Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1188,12 +1244,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push5Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push5Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1218,12 +1275,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push6Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push6Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1248,12 +1306,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push7Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push7Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1279,12 +1338,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push8Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push8Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1307,12 +1367,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push9Bytes<TTracingInst>(ref byte value)
+    public EvmExceptionType Push9Bytes<TTracingInst, TCheckDepth>(ref byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1335,12 +1396,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType PushByte<TTracingInst>(byte value)
+    public EvmExceptionType PushByte<TTracingInst, TCheckDepth>(byte value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1364,12 +1426,13 @@ public ref partial struct EvmStack
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public EvmExceptionType PushAddress<TTracingInst>(Address address)
         where TTracingInst : struct, IFlag
-        => Push20Bytes<TTracingInst>(ref MemoryMarshal.GetReference(address.Bytes));
+        => Push20Bytes<TTracingInst, OnFlag>(ref MemoryMarshal.GetReference(address.Bytes));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Push32Bytes<TTracingInst>(in ValueHash256 hash)
+    public EvmExceptionType Push32Bytes<TTracingInst, TCheckDepth>(in ValueHash256 hash)
         where TTracingInst : struct, IFlag
-        => Push32Bytes<TTracingInst>(ref Unsafe.As<ValueHash256, byte>(ref Unsafe.AsRef(in hash)));
+        where TCheckDepth : struct, IFlag
+        => Push32Bytes<TTracingInst, TCheckDepth>(ref Unsafe.As<ValueHash256, byte>(ref Unsafe.AsRef(in hash)));
 
     /// <summary>
     /// Fallback writer for truncated PUSH{n} where fewer than <paramref name="pushSize"/> immediate
@@ -1380,26 +1443,24 @@ public ref partial struct EvmStack
     /// <param name="used">Number of immediate bytes available in code (0 <= used <= pushSize).</param>
     /// <param name="pushSize">The PUSH opcode's declared immediate length (2..32).</param>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public EvmExceptionType PushBothPaddedBytes<TTracingInst>(ref byte start, int used, int pushSize)
+    public EvmExceptionType PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref byte start, int used, int pushSize)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
         Head = newOffset;
-
-        if (TTracingInst.IsActive)
-            ReportStackPush(ref start, used);
 
         ref byte dst = ref Unsafe.Add(ref _stack, headOffset * WordSize);
 
         // Truncated PUSH32 is just a right-padded partial write, so reuse the tighter helper.
         if (pushSize == WordSize)
         {
-            return PushBytesPartialZeroPadded<OffFlag>(ref dst, ref start, (uint)used);
+            return PushBytesPartialZeroPadded<TTracingInst>(ref dst, ref start, (uint)used);
         }
 
         // Zeros on both sides.
@@ -1415,21 +1476,15 @@ public ref partial struct EvmStack
 
         // When no immediate bytes are available (truncated PUSH at end of code), the
         // zero-filled word is already correct.
-        if (used == 0)
+        if (used != 0)
         {
-            return EvmExceptionType.None;
+            // Positions [WordSize - pushSize + used, WordSize) stay zero as the spec requires.
+            CopyUpTo32(ref Unsafe.Add(ref dst, WordSize - pushSize), ref start, (uint)used);
         }
 
-        // Copy `used` bytes to the high end of the `pushSize`-byte tail. Positions
-        // [WordSize - pushSize + used, WordSize) stay zero as the spec requires.
-        dst = ref Unsafe.Add(ref dst, WordSize - pushSize);
-        CopyUpTo32(ref dst, ref start, (uint)used);
+        if (TTracingInst.IsActive) ReportPushWord(ref dst);
         return EvmExceptionType.None;
     }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private readonly void ReportStackPush(ref byte start, int used)
-        => _tracer.ReportStackPush(MemoryMarshal.CreateReadOnlySpan(ref start, used));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void CopyUpTo32(ref byte dest, ref byte source, uint len)
@@ -1501,12 +1556,13 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType PushZero<TTracingInst>()
+    public EvmExceptionType PushZero<TTracingInst, TCheckDepth>()
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1532,13 +1588,14 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType PushUInt32<TTracingInst>(uint value)
+    public EvmExceptionType PushUInt32<TTracingInst, TCheckDepth>(uint value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
         ref EvmWord head = ref Unsafe.As<byte, EvmWord>(ref Unsafe.Add(ref _stack, headOffset * WordSize));
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1558,13 +1615,14 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType PushUInt64<TTracingInst>(ulong value)
+    public EvmExceptionType PushUInt64<TTracingInst, TCheckDepth>(ulong value)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
         ref EvmWord head = ref Unsafe.As<byte, EvmWord>(ref Unsafe.Add(ref _stack, headOffset * WordSize));
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -1592,11 +1650,18 @@ public ref partial struct EvmStack
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public EvmExceptionType PushUInt256<TTracingInst>(in UInt256 value)
         where TTracingInst : struct, IFlag
+        => PushUInt256<TTracingInst, OnFlag>(in value);
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal EvmExceptionType PushUInt256<TTracingInst, TCheckDepth>(in UInt256 value)
+        where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint headOffset = Head;
         nint newOffset = headOffset + 1;
         ref EvmWord head = ref Unsafe.As<byte, EvmWord>(ref Unsafe.Add(ref _stack, headOffset * WordSize));
-        if (newOffset >= MaxStackSize)
+        if (TCheckDepth.IsActive && newOffset >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -2030,21 +2095,16 @@ public ref partial struct EvmStack
     /// <see cref="EnsureDepth"/>.
     /// </summary>
     /// <remarks>Same reasoning as <see cref="Pop1Peek32BytesUnchecked()"/>.</remarks>
-    /// <param name="a">The first popped value, from the slot two words above the returned one.</param>
-    /// <param name="b">The second popped value, from the slot one word above the returned one.</param>
     /// <returns>Reference to the new top slot.</returns>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [UnscopedRef]
-    internal ref byte Pop2Peek32BytesUnchecked(out UInt256 a, out UInt256 b)
+    internal ref byte Pop2Peek32BytesUnchecked()
     {
         Debug.Assert(Head >= 3, "Caller must establish the depth before popping unchecked");
         nuint head = (nuint)Head;
         Head = (nint)(head - 2);
-        ref byte topRef = ref Unsafe.Add(ref _stack, (nint)((head - 3) * WordSize));
-        ReadUInt256FromSlot(ref Unsafe.Add(ref topRef, WordSize), out b);
-        ReadUInt256FromSlot(ref Unsafe.Add(ref topRef, 2 * WordSize), out a);
-        return ref topRef;
+        return ref Unsafe.Add(ref _stack, (nint)((head - 3) * WordSize));
     }
 
     /// <summary>
@@ -2218,13 +2278,15 @@ public ref partial struct EvmStack
         return true;
     }
 
+    /// <remarks>When <typeparamref name="TCheckDepth"/> is inactive, the caller must verify <paramref name="depth"/> items and room for one more.</remarks>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public EvmExceptionType Dup<TTracingInst>(int depth)
+    public EvmExceptionType Dup<TTracingInst, TCheckDepth>(int depth)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint head = Head;
-        if (head < depth)
+        if (TCheckDepth.IsActive && head < depth)
         {
             return EvmExceptionType.StackUnderflow;
         }
@@ -2237,7 +2299,8 @@ public ref partial struct EvmStack
         ref byte to = ref Unsafe.Add(ref bytes, headOffset);
         ref byte from = ref Unsafe.Add(ref bytes, headOffset - depthBytes);
 
-        if (++head >= MaxStackSize)
+        head++;
+        if (TCheckDepth.IsActive && head >= MaxStackSize)
         {
             return EvmExceptionType.StackOverflow;
         }
@@ -2252,13 +2315,15 @@ public ref partial struct EvmStack
     public readonly bool EnsureDepth(int depth)
         => Head >= depth;
 
+    /// <remarks>When <typeparamref name="TCheckDepth"/> is inactive, the caller must have verified at least <paramref name="depth"/> stack items.</remarks>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly EvmExceptionType Swap<TTracingInst>(int depth)
+    public readonly EvmExceptionType Swap<TTracingInst, TCheckDepth>(int depth)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         nint head = Head;
-        if (head < depth)
+        if (TCheckDepth.IsActive && head < depth)
         {
             return EvmExceptionType.StackUnderflow;
         }

--- a/src/Nethermind/Nethermind.Evm/EvmStack.std.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.std.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics;
 using Nethermind.Core.Extensions;
 using Nethermind.Int256;
 
@@ -19,7 +18,11 @@ public ref partial struct EvmStack
         ulong u1 = Bytes.Bswap64(value.u1);
         ulong u0 = Bytes.Bswap64(value.u0);
 
-        head = Vector256.Create(u3, u2, u1, u0).AsByte();
+        ref byte destination = ref Unsafe.As<EvmWord, byte>(ref head);
+        Unsafe.WriteUnaligned(ref destination, u3);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destination, sizeof(ulong)), u2);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destination, 2 * sizeof(ulong)), u1);
+        Unsafe.WriteUnaligned(ref Unsafe.Add(ref destination, 3 * sizeof(ulong)), u0);
     }
 
     /// <summary>Reads one big-endian 32-byte stack word into a <see cref="UInt256"/>.</summary>

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/AccountAccessKind.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/AccountAccessKind.cs
@@ -5,7 +5,7 @@ namespace Nethermind.Evm.GasPolicy;
 
 /// <summary>
 /// Discriminator for account access gas charging.
-/// Allows <see cref="IGasPolicy{TSelf}.ConsumeAccountAccessGas"/> to vary
+/// Allows <see cref="IGasPolicy{TSelf}.TryConsumeAccountAccessGas"/> to vary
 /// its resource-kind split based on the calling opcode's semantics.
 /// </summary>
 public enum AccountAccessKind : byte

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -33,8 +33,6 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     public long StateGasSpill;
     /// <summary>State gas spill repaid to execution gas and excluded from net spill accounting.</summary>
     public long StateGasSpillRefunded;
-    /// <summary>Indicates that execution encountered an out of gas condition.</summary>
-    public bool OutOfGas;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static EthereumGasPolicy FromULong(ulong value) => new() { Value = value };
@@ -48,22 +46,27 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EthereumGasPolicy CreateSystemTransactionAvailableGas(ulong gasLimit, in EthereumGasPolicy intrinsicGas, IReleaseSpec spec)
+    public static bool TryCreateSystemTransactionAvailableGas(ulong gasLimit, in EthereumGasPolicy intrinsicGas, IReleaseSpec spec, out EthereumGasPolicy available)
     {
         if (spec.IsEip8037Enabled)
         {
             long reservoir = Math.Min((long)gasLimit, intrinsicGas.StateReservoir);
-            return new EthereumGasPolicy
+            available = new EthereumGasPolicy
             {
                 Value = gasLimit - (ulong)reservoir,
                 StateReservoir = reservoir,
                 StateGasUsed = intrinsicGas.StateGasUsed,
                 StateGasSpill = 0,
             };
+            return true;
         }
 
-        return CreateAvailableFromIntrinsic(gasLimit, in intrinsicGas, spec);
+        return TryCreateAvailableFromIntrinsic(gasLimit, in intrinsicGas, spec, out available);
     }
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ClearExecutionGas(ref EthereumGasPolicy gas) => gas.Value = 0;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ulong GetRemainingGas(in EthereumGasPolicy gas) => gas.Value;
@@ -102,20 +105,6 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     private static void ConsumeRaw(ref EthereumGasPolicy gas, ulong cost) => gas.Value -= cost;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Consume(ref EthereumGasPolicy gas, ulong cost)
-    {
-        if (gas.Value < cost)
-        {
-            gas.Value = 0;
-            gas.OutOfGas = true;
-        }
-        else
-        {
-            ConsumeRaw(ref gas, cost);
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryConsume(ref EthereumGasPolicy gas, ulong cost)
     {
         if (gas.Value < cost) return false;
@@ -124,7 +113,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeStateGas(ref EthereumGasPolicy gas, long stateGasCost)
+    public static bool TryConsumeStateGas(ref EthereumGasPolicy gas, long stateGasCost)
     {
         long reservoir = gas.StateReservoir;
         if (reservoir >= stateGasCost)
@@ -135,11 +124,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         }
 
         ulong spillAmount = CalculateStateGasSpill(in gas, stateGasCost);
-        if (!TryConsume(ref gas, spillAmount))
-        {
-            gas.OutOfGas = true;
-            return false;
-        }
+        if (!TryConsume(ref gas, spillAmount)) return false;
 
         gas.StateReservoir = Math.Min(0, reservoir);
         gas.StateGasUsed += stateGasCost;
@@ -149,9 +134,9 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
 
     public static bool TryConsumeStateAndExecutionGas(ref EthereumGasPolicy gas, long stateGasCost, ulong executionGasCost) =>
         (executionGasCost <= 0 || UpdateGas(ref gas, executionGasCost)) &&
-        (stateGasCost <= 0 || ConsumeStateGas(ref gas, stateGasCost));
+        (stateGasCost <= 0 || TryConsumeStateGas(ref gas, stateGasCost));
 
-    public static bool ConsumeSelfDestructGas(ref EthereumGasPolicy gas)
+    public static bool TryConsumeSelfDestructGas(ref EthereumGasPolicy gas)
         => UpdateGas(ref gas, GasCostOf.SelfDestructEip150);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -219,17 +204,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         Math.Max(0, childGas.StateGasSpill - childGas.StateGasSpillRefunded);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsOutOfGas(in EthereumGasPolicy gas) => gas.OutOfGas;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void SetOutOfGas(ref EthereumGasPolicy gas)
-    {
-        gas.Value = 0;
-        gas.OutOfGas = true;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeAccountAccessGasWithDelegation(ref EthereumGasPolicy gas,
+    public static bool TryConsumeAccountAccessGasWithDelegation(ref EthereumGasPolicy gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
@@ -239,20 +214,20 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         if (!spec.UseHotAndColdStorage)
             return true;
 
-        bool notOutOfGas = ConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, address);
-        return notOutOfGas && (delegated is null || ConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, delegated));
+        bool notOutOfGas = TryConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, address);
+        return notOutOfGas && (delegated is null || TryConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, delegated));
     }
 
-    public static bool ConsumeAccountAccessGas(ref EthereumGasPolicy gas,
+    public static bool TryConsumeAccountAccessGas(ref EthereumGasPolicy gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         Address address,
         AccountAccessKind kind = AccountAccessKind.Default) =>
-        ConsumeAccountAccessGasCore<ColdAccountGasCost, DynamicStorageMode>(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
+        TryConsumeAccountAccessGasCore<ColdAccountGasCost, DynamicStorageMode>(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool ConsumeAccountAccessGasCore<TColdCost, TMode>(ref EthereumGasPolicy gas,
+    private static bool TryConsumeAccountAccessGasCore<TColdCost, TMode>(ref EthereumGasPolicy gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
@@ -293,19 +268,31 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     private static ulong ColdAccountAccessCost(IReleaseSpec spec) =>
         spec.IsEip8038Enabled ? Eip8038Constants.ColdAccountAccess : GasCostOf.ColdAccountAccess;
 
-    public static bool ConsumeStorageAccessGas(ref EthereumGasPolicy gas,
+    public static bool TryConsumeStorageAccessGas(ref EthereumGasPolicy gas,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         in StorageCell storageCell,
         StorageAccessType storageAccessType,
         IReleaseSpec spec) =>
-        ConsumeStorageAccessGasCore<DynamicStorageMode>(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
+        TryConsumeStorageAccessGasCore<DynamicStorageMode>(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeNetMeteredSStoreGas<Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+    public static bool TryConsumeNetMeteredSStoreGas<Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec)
         where Eip8038 : struct, IFlag =>
-        UpdateGas(ref gas, Eip8038.IsActive ? GasCostOf.Free : spec.GasCosts.NetMeteredSStoreCost);
+        Eip8038.IsActive || UpdateGas(ref gas, spec.GasCosts.NetMeteredSStoreCost);
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryConsumeExpBytes<Eip160>(ref EthereumGasPolicy gas, IReleaseSpec spec, ulong exponentByteSize)
+        where Eip160 : struct, IFlag =>
+        UpdateGas(ref gas, (Eip160.IsActive ? GasCostOf.ExpByteEip160 : GasCostOf.ExpByte) * exponentByteSize);
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryConsumeSLoadBaseGas<Eip2929>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+        where Eip2929 : struct, IFlag =>
+        Eip2929.IsActive || UpdateGas(ref gas, spec.GasCosts.SLoadCost);
 
     private readonly struct StorageMode<Eip2929, Eip8038> : IStorageMode
         where Eip2929 : struct, IFlag
@@ -319,25 +306,25 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeStorageAccessGas<Eip2929, Eip8038>(ref EthereumGasPolicy gas,
+    public static bool TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref EthereumGasPolicy gas,
         ref readonly StackAccessTracker accessTracker, bool isTracingAccess,
         in StorageCell storageCell, StorageAccessType storageAccessType, IReleaseSpec spec)
         where Eip2929 : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        ConsumeStorageAccessGasCore<StorageMode<Eip2929, Eip8038>>(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
+        TryConsumeStorageAccessGasCore<StorageMode<Eip2929, Eip8038>>(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeAccountAccessGas<Eip2929, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec,
+    public static bool TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker, bool isTracingAccess, Address address,
         AccountAccessKind kind = AccountAccessKind.Default)
         where Eip2929 : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        ConsumeAccountAccessGasCore<ColdAccountGasCost<Eip8038>, StorageMode<Eip2929, Eip8038>>(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
+        TryConsumeAccountAccessGasCore<ColdAccountGasCost<Eip8038>, StorageMode<Eip2929, Eip8038>>(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec, ulong initCodeWords)
+    public static bool TryConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec, ulong initCodeWords)
         where Eip8037 : struct, IFlag
         where TOpCreate : struct, EvmInstructions.IOpCreate
         where Eip3860 : struct, IFlag
@@ -375,7 +362,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool ConsumeStorageAccessGasCore<TMode>(ref EthereumGasPolicy gas,
+    private static bool TryConsumeStorageAccessGasCore<TMode>(ref EthereumGasPolicy gas,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         in StorageCell storageCell,
@@ -417,6 +404,10 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         in UInt256 position,
         in UInt256 length, ref EvmPooledMemory memory)
     {
+        ulong size = memory.Size;
+        if (length.IsUint64 && length.u0 <= size && position.IsUint64 && position.u0 <= size - length.u0)
+            return true;
+
         ulong memoryCost = memory.CalculateMemoryCost(in position, length, out bool outOfGas);
         if (memoryCost == 0L)
             return !outOfGas;
@@ -428,6 +419,10 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         in UInt256 position,
         ulong length, ref EvmPooledMemory memory)
     {
+        ulong size = memory.Size;
+        if (length <= size && position.IsUint64 && position.u0 <= size - length)
+            return true;
+
         ulong memoryCost = memory.CalculateMemoryCost(in position, length, out bool outOfGas);
         if (memoryCost == 0)
             return !outOfGas;
@@ -441,7 +436,6 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         if (GetRemainingGas(in gas) < gasCost)
         {
             gas.Value = 0;
-            gas.OutOfGas = true;
             return false;
         }
 
@@ -450,21 +444,21 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeStorageWrite<TEip8037, TIsSlotCreation>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+    public static bool TryConsumeStorageWrite<TEip8037, TIsSlotCreation>(ref EthereumGasPolicy gas, IReleaseSpec spec)
         where TEip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag =>
-        ConsumeStorageWriteCore<TEip8037, TIsSlotCreation, DynamicStorageMode>(ref gas, spec);
+        TryConsumeStorageWriteCore<TEip8037, TIsSlotCreation, DynamicStorageMode>(ref gas, spec);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeStorageWrite<Eip8037, TIsSlotCreation, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+    public static bool TryConsumeStorageWrite<Eip8037, TIsSlotCreation, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec)
         where Eip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        ConsumeStorageWriteCore<Eip8037, TIsSlotCreation, StorageMode<Eip8038>>(ref gas, spec);
+        TryConsumeStorageWriteCore<Eip8037, TIsSlotCreation, StorageMode<Eip8038>>(ref gas, spec);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool ConsumeStorageWriteCore<TEip8037, TIsSlotCreation, TMode>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+    private static bool TryConsumeStorageWriteCore<TEip8037, TIsSlotCreation, TMode>(ref EthereumGasPolicy gas, IReleaseSpec spec)
         where TEip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag
         where TMode : struct, IStorageMode
@@ -544,7 +538,6 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         if (gas.Value < childGas)
         {
             gas.Value = 0;
-            gas.OutOfGas = true;
             return false;
         }
 
@@ -661,30 +654,30 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         => GetCodeInsertExecutionRefund(codeInsertRefunds, spec);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeCallValueTransfer(ref EthereumGasPolicy gas)
+    public static bool TryConsumeCallValueTransfer(ref EthereumGasPolicy gas)
         => UpdateGas(ref gas, GasCostOf.CallValue);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeCallValueTransferEip2780(ref EthereumGasPolicy gas)
+    public static bool TryConsumeCallValueTransferEip2780(ref EthereumGasPolicy gas)
         => UpdateGas(ref gas, Eip8038Constants.CallValue);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeNewAccountCreation<TEip8037>(ref EthereumGasPolicy gas) where TEip8037 : struct, IFlag => TEip8037.IsActive switch
+    public static bool TryConsumeNewAccountCreation<TEip8037>(ref EthereumGasPolicy gas) where TEip8037 : struct, IFlag => TEip8037.IsActive switch
     {
-        true => ConsumeStateGas(ref gas, GasCostOf.NewAccountState),
+        true => TryConsumeStateGas(ref gas, GasCostOf.NewAccountState),
         false => UpdateGas(ref gas, GasCostOf.NewAccount)
     };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeLogEmission(ref EthereumGasPolicy gas, ulong topicCount, ulong dataSize)
+    public static bool TryConsumeLogEmission(ref EthereumGasPolicy gas, ulong topicCount, ulong dataSize)
     {
         ulong cost = GasCostOf.Log + topicCount * GasCostOf.LogTopic + dataSize * GasCostOf.LogData;
         return UpdateGas(ref gas, cost);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ConsumeDataCopyGas(ref EthereumGasPolicy gas, IReleaseSpec spec, bool isExternalCode, ulong words)
-        => Consume(ref gas, (isExternalCode ? spec.GasCosts.ExtCodeCost : GasCostOf.VeryLow) + GasCostOf.Memory * words);
+    public static bool TryConsumeDataCopyGas(ref EthereumGasPolicy gas, IReleaseSpec spec, bool isExternalCode, ulong words)
+        => UpdateGas(ref gas, (isExternalCode ? spec.GasCosts.ExtCodeCost : GasCostOf.VeryLow) + GasCostOf.Memory * words);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static EthereumGasPolicy Max(in EthereumGasPolicy a, in EthereumGasPolicy b) =>
@@ -773,12 +766,13 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EthereumGasPolicy CreateAvailableFromIntrinsic(ulong gasLimit, in EthereumGasPolicy intrinsicGas, IReleaseSpec spec)
+    public static bool TryCreateAvailableFromIntrinsic(ulong gasLimit, in EthereumGasPolicy intrinsicGas, IReleaseSpec spec, out EthereumGasPolicy available)
     {
         ulong intrinsicTotal = intrinsicGas.Value + (ulong)intrinsicGas.StateReservoir;
         if (gasLimit < intrinsicTotal)
         {
-            return new EthereumGasPolicy { Value = 0, OutOfGas = true };
+            available = default;
+            return false;
         }
 
         ulong evmGas = gasLimit - intrinsicTotal;
@@ -792,13 +786,14 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
             evmGas -= reservoir;
         }
 
-        return new EthereumGasPolicy
+        available = new EthereumGasPolicy
         {
             Value = evmGas,
             StateReservoir = (long)reservoir,
             StateGasUsed = intrinsicGas.StateReservoir,
             StateGasSpill = 0,
         };
+        return true;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -59,22 +59,27 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EthereumGasPolicy CreateSystemTransactionAvailableGas(ulong gasLimit, in EthereumGasPolicy intrinsicGas, IReleaseSpec spec)
+    public static bool TryCreateSystemTransactionAvailableGas(ulong gasLimit, in EthereumGasPolicy intrinsicGas, IReleaseSpec spec, out EthereumGasPolicy available)
     {
         if (spec.IsEip8037Enabled)
         {
             long reservoir = Math.Min((long)gasLimit, intrinsicGas.StateReservoir);
-            return new EthereumGasPolicy
+            available = new EthereumGasPolicy
             {
                 Value = gasLimit - (ulong)reservoir,
                 StateReservoir = reservoir,
                 StateGasUsed = intrinsicGas.StateGasUsed,
                 StateGasSpill = 0,
             };
+            return true;
         }
 
-        return CreateAvailableFromIntrinsic(gasLimit, in intrinsicGas, spec);
+        return TryCreateAvailableFromIntrinsic(gasLimit, in intrinsicGas, spec, out available);
     }
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ClearExecutionGas(ref EthereumGasPolicy gas) => gas.Value = 0;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ulong GetRemainingGas(in EthereumGasPolicy gas) => gas.Value;
@@ -113,20 +118,6 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     private static void ConsumeRaw(ref EthereumGasPolicy gas, ulong cost) => gas.Value -= cost;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Consume(ref EthereumGasPolicy gas, ulong cost)
-    {
-        if (gas.Value < cost)
-        {
-            gas.Value = 0;
-            gas.OutOfGas = true;
-        }
-        else
-        {
-            ConsumeRaw(ref gas, cost);
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryConsume(ref EthereumGasPolicy gas, ulong cost)
     {
         if (gas.Value < cost) return false;
@@ -135,7 +126,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeStateGas(ref EthereumGasPolicy gas, long stateGasCost)
+    public static bool TryConsumeStateGas(ref EthereumGasPolicy gas, long stateGasCost)
     {
         long reservoir = gas.StateReservoir;
         if (reservoir >= stateGasCost)
@@ -152,11 +143,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         }
 
         ulong spillAmount = CalculateStateGasSpill(in gas, stateGasCost);
-        if (!TryConsume(ref gas, spillAmount))
-        {
-            gas.OutOfGas = true;
-            return false;
-        }
+        if (!TryConsume(ref gas, spillAmount)) return false;
 
         gas.StateReservoir = Math.Min(0, reservoir);
         gas.StateGasUsed += stateGasCost;
@@ -166,9 +153,9 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
 
     public static bool TryConsumeStateAndExecutionGas(ref EthereumGasPolicy gas, long stateGasCost, ulong executionGasCost) =>
         (executionGasCost <= 0 || UpdateGas(ref gas, executionGasCost)) &&
-        (stateGasCost <= 0 || ConsumeStateGas(ref gas, stateGasCost));
+        (stateGasCost <= 0 || TryConsumeStateGas(ref gas, stateGasCost));
 
-    public static bool ConsumeSelfDestructGas(ref EthereumGasPolicy gas)
+    public static bool TryConsumeSelfDestructGas(ref EthereumGasPolicy gas)
         => UpdateGas(ref gas, GasCostOf.SelfDestructEip150);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -236,17 +223,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         Math.Max(0, childGas.StateGasSpill - childGas.StateGasSpillRefunded);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsOutOfGas(in EthereumGasPolicy gas) => gas.OutOfGas;
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void SetOutOfGas(ref EthereumGasPolicy gas)
-    {
-        gas.Value = 0;
-        gas.OutOfGas = true;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeAccountAccessGasWithDelegation(ref EthereumGasPolicy gas,
+    public static bool TryConsumeAccountAccessGasWithDelegation(ref EthereumGasPolicy gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
@@ -256,20 +233,20 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         if (!spec.UseHotAndColdStorage)
             return true;
 
-        bool notOutOfGas = ConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, address);
-        return notOutOfGas && (delegated is null || ConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, delegated));
+        bool notOutOfGas = TryConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, address);
+        return notOutOfGas && (delegated is null || TryConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, delegated));
     }
 
-    public static bool ConsumeAccountAccessGas(ref EthereumGasPolicy gas,
+    public static bool TryConsumeAccountAccessGas(ref EthereumGasPolicy gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         Address address,
         AccountAccessKind kind = AccountAccessKind.Default) =>
-        ConsumeAccountAccessGasCore<ColdAccountGasCost, DynamicStorageMode>(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
+        TryConsumeAccountAccessGasCore<ColdAccountGasCost, DynamicStorageMode>(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool ConsumeAccountAccessGasCore<TColdCost, TMode>(ref EthereumGasPolicy gas,
+    private static bool TryConsumeAccountAccessGasCore<TColdCost, TMode>(ref EthereumGasPolicy gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
@@ -311,19 +288,31 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     public static ulong GetColdAccountAccessCost(IReleaseSpec spec) =>
         spec.IsEip8038Enabled ? Eip8038Constants.ColdAccountAccess : GasCostOf.ColdAccountAccess;
 
-    public static bool ConsumeStorageAccessGas(ref EthereumGasPolicy gas,
+    public static bool TryConsumeStorageAccessGas(ref EthereumGasPolicy gas,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         in StorageCell storageCell,
         StorageAccessType storageAccessType,
         IReleaseSpec spec) =>
-        ConsumeStorageAccessGasCore<DynamicStorageMode>(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
+        TryConsumeStorageAccessGasCore<DynamicStorageMode>(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeNetMeteredSStoreGas<Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+    public static bool TryConsumeNetMeteredSStoreGas<Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec)
         where Eip8038 : struct, IFlag =>
-        UpdateGas(ref gas, Eip8038.IsActive ? GasCostOf.Free : spec.GasCosts.NetMeteredSStoreCost);
+        Eip8038.IsActive || UpdateGas(ref gas, spec.GasCosts.NetMeteredSStoreCost);
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryConsumeExpBytes<Eip160>(ref EthereumGasPolicy gas, IReleaseSpec spec, ulong exponentByteSize)
+        where Eip160 : struct, IFlag =>
+        UpdateGas(ref gas, (Eip160.IsActive ? GasCostOf.ExpByteEip160 : GasCostOf.ExpByte) * exponentByteSize);
+
+    /// <inheritdoc/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryConsumeSLoadBaseGas<Eip2929>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+        where Eip2929 : struct, IFlag =>
+        Eip2929.IsActive || UpdateGas(ref gas, spec.GasCosts.SLoadCost);
 
     private readonly struct StorageMode<Eip2929, Eip8038> : IStorageMode
         where Eip2929 : struct, IFlag
@@ -337,25 +326,25 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeStorageAccessGas<Eip2929, Eip8038>(ref EthereumGasPolicy gas,
+    public static bool TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref EthereumGasPolicy gas,
         ref readonly StackAccessTracker accessTracker, bool isTracingAccess,
         in StorageCell storageCell, StorageAccessType storageAccessType, IReleaseSpec spec)
         where Eip2929 : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        ConsumeStorageAccessGasCore<StorageMode<Eip2929, Eip8038>>(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
+        TryConsumeStorageAccessGasCore<StorageMode<Eip2929, Eip8038>>(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeAccountAccessGas<Eip2929, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec,
+    public static bool TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker, bool isTracingAccess, Address address,
         AccountAccessKind kind = AccountAccessKind.Default)
         where Eip2929 : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        ConsumeAccountAccessGasCore<ColdAccountGasCost<Eip8038>, StorageMode<Eip2929, Eip8038>>(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
+        TryConsumeAccountAccessGasCore<ColdAccountGasCost<Eip8038>, StorageMode<Eip2929, Eip8038>>(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec, ulong initCodeWords)
+    public static bool TryConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec, ulong initCodeWords)
         where Eip8037 : struct, IFlag
         where TOpCreate : struct, EvmInstructions.IOpCreate
         where Eip3860 : struct, IFlag
@@ -393,7 +382,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool ConsumeStorageAccessGasCore<TMode>(ref EthereumGasPolicy gas,
+    private static bool TryConsumeStorageAccessGasCore<TMode>(ref EthereumGasPolicy gas,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         in StorageCell storageCell,
@@ -435,6 +424,10 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         in UInt256 position,
         in UInt256 length, ref EvmPooledMemory memory)
     {
+        ulong size = memory.Size;
+        if (length.IsUint64 && length.u0 <= size && position.IsUint64 && position.u0 <= size - length.u0)
+            return true;
+
         ulong memoryCost = memory.CalculateMemoryCost(in position, length, out bool outOfGas);
         if (memoryCost == 0L)
             return !outOfGas;
@@ -446,6 +439,10 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         in UInt256 position,
         ulong length, ref EvmPooledMemory memory)
     {
+        ulong size = memory.Size;
+        if (length <= size && position.IsUint64 && position.u0 <= size - length)
+            return true;
+
         ulong memoryCost = memory.CalculateMemoryCost(in position, length, out bool outOfGas);
         if (memoryCost == 0)
             return !outOfGas;
@@ -459,7 +456,6 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         if (GetRemainingGas(in gas) < gasCost)
         {
             gas.Value = 0;
-            gas.OutOfGas = true;
             return false;
         }
 
@@ -468,21 +464,21 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeStorageWrite<TEip8037, TIsSlotCreation>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+    public static bool TryConsumeStorageWrite<TEip8037, TIsSlotCreation>(ref EthereumGasPolicy gas, IReleaseSpec spec)
         where TEip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag =>
-        ConsumeStorageWriteCore<TEip8037, TIsSlotCreation, DynamicStorageMode>(ref gas, spec);
+        TryConsumeStorageWriteCore<TEip8037, TIsSlotCreation, DynamicStorageMode>(ref gas, spec);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeStorageWrite<Eip8037, TIsSlotCreation, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+    public static bool TryConsumeStorageWrite<Eip8037, TIsSlotCreation, Eip8038>(ref EthereumGasPolicy gas, IReleaseSpec spec)
         where Eip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        ConsumeStorageWriteCore<Eip8037, TIsSlotCreation, StorageMode<Eip8038>>(ref gas, spec);
+        TryConsumeStorageWriteCore<Eip8037, TIsSlotCreation, StorageMode<Eip8038>>(ref gas, spec);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool ConsumeStorageWriteCore<TEip8037, TIsSlotCreation, TMode>(ref EthereumGasPolicy gas, IReleaseSpec spec)
+    private static bool TryConsumeStorageWriteCore<TEip8037, TIsSlotCreation, TMode>(ref EthereumGasPolicy gas, IReleaseSpec spec)
         where TEip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag
         where TMode : struct, IStorageMode
@@ -562,7 +558,6 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         if (gas.Value < childGas)
         {
             gas.Value = 0;
-            gas.OutOfGas = true;
             return false;
         }
 
@@ -679,30 +674,30 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         => GetCodeInsertExecutionRefund(codeInsertRefunds, spec);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeCallValueTransfer(ref EthereumGasPolicy gas)
+    public static bool TryConsumeCallValueTransfer(ref EthereumGasPolicy gas)
         => UpdateGas(ref gas, GasCostOf.CallValue);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeCallValueTransferEip2780(ref EthereumGasPolicy gas)
+    public static bool TryConsumeCallValueTransferEip2780(ref EthereumGasPolicy gas)
         => UpdateGas(ref gas, Eip8038Constants.CallValue);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeNewAccountCreation<TEip8037>(ref EthereumGasPolicy gas) where TEip8037 : struct, IFlag => TEip8037.IsActive switch
+    public static bool TryConsumeNewAccountCreation<TEip8037>(ref EthereumGasPolicy gas) where TEip8037 : struct, IFlag => TEip8037.IsActive switch
     {
-        true => ConsumeStateGas(ref gas, GasCostOf.NewAccountState),
+        true => TryConsumeStateGas(ref gas, GasCostOf.NewAccountState),
         false => UpdateGas(ref gas, GasCostOf.NewAccount)
     };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool ConsumeLogEmission(ref EthereumGasPolicy gas, ulong topicCount, ulong dataSize)
+    public static bool TryConsumeLogEmission(ref EthereumGasPolicy gas, ulong topicCount, ulong dataSize)
     {
         ulong cost = GasCostOf.Log + topicCount * GasCostOf.LogTopic + dataSize * GasCostOf.LogData;
         return UpdateGas(ref gas, cost);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ConsumeDataCopyGas(ref EthereumGasPolicy gas, IReleaseSpec spec, bool isExternalCode, ulong words)
-        => Consume(ref gas, (isExternalCode ? spec.GasCosts.ExtCodeCost : GasCostOf.VeryLow) + GasCostOf.Memory * words);
+    public static bool TryConsumeDataCopyGas(ref EthereumGasPolicy gas, IReleaseSpec spec, bool isExternalCode, ulong words)
+        => UpdateGas(ref gas, (isExternalCode ? spec.GasCosts.ExtCodeCost : GasCostOf.VeryLow) + GasCostOf.Memory * words);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static EthereumGasPolicy Max(in EthereumGasPolicy a, in EthereumGasPolicy b) =>
@@ -792,12 +787,13 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EthereumGasPolicy CreateAvailableFromIntrinsic(ulong gasLimit, in EthereumGasPolicy intrinsicGas, IReleaseSpec spec)
+    public static bool TryCreateAvailableFromIntrinsic(ulong gasLimit, in EthereumGasPolicy intrinsicGas, IReleaseSpec spec, out EthereumGasPolicy available)
     {
         ulong intrinsicTotal = intrinsicGas.Value + (ulong)intrinsicGas.StateReservoir;
         if (gasLimit < intrinsicTotal)
         {
-            return new EthereumGasPolicy { Value = 0, OutOfGas = true };
+            available = default;
+            return false;
         }
 
         ulong evmGas = gasLimit - intrinsicTotal;
@@ -811,13 +807,14 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
             evmGas -= reservoir;
         }
 
-        return new EthereumGasPolicy
+        available = new EthereumGasPolicy
         {
             Value = evmGas,
             StateReservoir = (long)reservoir,
             StateGasUsed = intrinsicGas.StateReservoir,
             StateGasSpill = 0,
         };
+        return true;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasCost.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasCost.cs
@@ -10,7 +10,7 @@ namespace Nethermind.Evm.GasPolicy;
 /// Compile-time descriptor of a fixed opcode gas charge.
 /// </summary>
 /// <remarks>
-/// Implemented by zero-size <c>struct</c> tags and consumed via <c>IGasPolicy.Consume&lt;TCost&gt;</c>.
+/// Implemented by zero-size <c>struct</c> tags and consumed via <c>IGasPolicy.UpdateGas&lt;TCost&gt;</c>.
 /// Because the EVM is monomorphized over <c>VirtualMachine&lt;TGasPolicy&gt;</c> and the tag is a type
 /// parameter, <see cref="GasCost"/> is a compile-time constant in the specialized method — the charge
 /// folds to the same code as a literal <c>cost</c> argument, without the caller passing a number.
@@ -25,7 +25,7 @@ public interface IGasCost
 /// Compile-time descriptor of a spec-dependent fixed opcode gas charge — the cost is read from the
 /// active <see cref="IReleaseSpec"/> rather than a literal, but it is still resolved inside the policy.
 /// </summary>
-/// <remarks>Consumed via <c>IGasPolicy.Consume&lt;TCost&gt;(ref gas, spec)</c>; the spec the opcode
+/// <remarks>Consumed via <c>IGasPolicy.UpdateGas&lt;TCost&gt;(ref gas, spec)</c>; the spec the opcode
 /// already has in hand is forwarded so the cost is computed from the price book without the caller
 /// passing a precomputed number.</remarks>
 public interface ISpecGasCost

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -19,10 +19,13 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static virtual TSelf CreateSystemTransactionIntrinsicGas(ulong blockGasLimit) => TSelf.FromULong(0);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual TSelf CreateSystemTransactionAvailableGas(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec) =>
-        TSelf.CreateAvailableFromIntrinsic(gasLimit, in intrinsicGas, spec);
+    static virtual bool TryCreateSystemTransactionAvailableGas(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec, out TSelf available) =>
+        TSelf.TryCreateAvailableFromIntrinsic(gasLimit, in intrinsicGas, spec, out available);
 
     static abstract ulong GetRemainingGas(in TSelf gas);
+
+    /// <summary>Zeros execution gas without changing state-gas accounting.</summary>
+    static abstract void ClearExecutionGas(ref TSelf gas);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong CombineBlockGas(ulong blockExecutionGas, ulong blockStateGas) => Math.Max(blockExecutionGas, blockStateGas);
@@ -84,38 +87,40 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
             : 0;
     }
 
-    static abstract void Consume(ref TSelf gas, ulong cost);
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool TryConsume(ref TSelf gas, ulong cost)
     {
         if (TSelf.GetRemainingGas(in gas) < cost) return false;
-        TSelf.Consume(ref gas, cost);
-        return true;
+        return TSelf.UpdateGas(ref gas, cost);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void Consume<TCost>(ref TSelf gas) where TCost : struct, IGasCost =>
-        TSelf.Consume(ref gas, TCost.GasCost);
+    static virtual bool UpdateGas<TCost>(ref TSelf gas) where TCost : struct, IGasCost =>
+        TSelf.UpdateGas(ref gas, TCost.GasCost);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void Consume<TCost>(ref TSelf gas, IReleaseSpec spec) where TCost : struct, ISpecGasCost =>
-        TSelf.Consume(ref gas, TCost.GasCost(spec));
+    static virtual bool UpdateGas<TCost>(ref TSelf gas, IReleaseSpec spec) where TCost : struct, ISpecGasCost =>
+        TSelf.UpdateGas(ref gas, TCost.GasCost(spec));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void ConsumeKeccak(ref TSelf gas, ulong words) =>
-        TSelf.Consume(ref gas, GasCostOf.Sha3 + GasCostOf.Sha3Word * words);
+    static virtual bool TryConsumeKeccak(ref TSelf gas, ulong words) =>
+        TSelf.UpdateGas(ref gas, GasCostOf.Sha3 + GasCostOf.Sha3Word * words);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void ConsumeMemoryCopy(ref TSelf gas, ulong words) =>
-        TSelf.Consume(ref gas, GasCostOf.VeryLow + GasCostOf.VeryLow * words);
+    static virtual bool TryConsumeMemoryCopy(ref TSelf gas, ulong words) =>
+        TSelf.UpdateGas(ref gas, GasCostOf.VeryLow + GasCostOf.VeryLow * words);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void ConsumeExpBytes(ref TSelf gas, IReleaseSpec spec, ulong exponentByteSize) =>
-        TSelf.Consume(ref gas, spec.GasCosts.ExpByteCost * exponentByteSize);
+    static virtual bool TryConsumeExpBytes(ref TSelf gas, IReleaseSpec spec, ulong exponentByteSize) =>
+        TSelf.UpdateGas(ref gas, spec.GasCosts.ExpByteCost * exponentByteSize);
+
+    /// <summary>Charges exponent bytes using the selected EIP-160 price.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static virtual bool TryConsumeExpBytes<Eip160>(ref TSelf gas, IReleaseSpec spec, ulong exponentByteSize)
+        where Eip160 : struct, IFlag => TSelf.TryConsumeExpBytes(ref gas, spec, exponentByteSize);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeCreateGas<TEip8037, TOpCreate>(ref TSelf gas, IReleaseSpec spec, ulong initCodeWords)
+    static virtual bool TryConsumeCreateGas<TEip8037, TOpCreate>(ref TSelf gas, IReleaseSpec spec, ulong initCodeWords)
         where TEip8037 : struct, IFlag
         where TOpCreate : struct, EvmInstructions.IOpCreate
     {
@@ -128,34 +133,39 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeCallBaseGas(ref TSelf gas, IReleaseSpec spec) =>
+    static virtual bool TryConsumeCallBaseGas(ref TSelf gas, IReleaseSpec spec) =>
         TSelf.UpdateGas(ref gas, spec.GasCosts.CallCost);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeSStoreResetGas(ref TSelf gas, IReleaseSpec spec) =>
+    static virtual bool TryConsumeSStoreResetGas(ref TSelf gas, IReleaseSpec spec) =>
         TSelf.UpdateGas(ref gas, spec.GasCosts.SStoreResetCost);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeNetMeteredSStoreGas(ref TSelf gas, IReleaseSpec spec) =>
+    static virtual bool TryConsumeNetMeteredSStoreGas(ref TSelf gas, IReleaseSpec spec) =>
         TSelf.UpdateGas(ref gas, spec.GasCosts.NetMeteredSStoreCost);
+
+    /// <summary>Charges the SLOAD base cost for the selected EIP-2929 mode.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static virtual bool TryConsumeSLoadBaseGas<Eip2929>(ref TSelf gas, IReleaseSpec spec)
+        where Eip2929 : struct, IFlag => TSelf.UpdateGas<SLoadGasCost>(ref gas, spec);
 
     /// <summary>Charges net-metered storage using the selected EIP-8038 mode.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeNetMeteredSStoreGas<Eip8038>(ref TSelf gas, IReleaseSpec spec)
-        where Eip8038 : struct, IFlag => TSelf.ConsumeNetMeteredSStoreGas(ref gas, spec);
+    static virtual bool TryConsumeNetMeteredSStoreGas<Eip8038>(ref TSelf gas, IReleaseSpec spec)
+        where Eip8038 : struct, IFlag => TSelf.TryConsumeNetMeteredSStoreGas(ref gas, spec);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeSSetFromCleanGas(ref TSelf gas) =>
+    static virtual bool TryConsumeSSetFromCleanGas(ref TSelf gas) =>
         TSelf.UpdateGas(ref gas, GasCostOf.SSet - GasCostOf.SReset);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumePrecompileGas(ref TSelf gas, IPrecompile precompile, ReadOnlyMemory<byte> inputData, IReleaseSpec spec)
+    static virtual bool TryConsumePrecompileGas(ref TSelf gas, IPrecompile precompile, ReadOnlyMemory<byte> inputData, IReleaseSpec spec)
     {
         ulong baseGasCost = precompile.BaseGasCost(spec);
         ulong dataGasCost = precompile.DataGasCost(inputData, spec);
         return baseGasCost <= ulong.MaxValue - dataGasCost && TSelf.UpdateGas(ref gas, baseGasCost + dataGasCost);
     }
-    static abstract bool ConsumeSelfDestructGas(ref TSelf gas);
+    static abstract bool TryConsumeSelfDestructGas(ref TSelf gas);
     static abstract void Refund(ref TSelf gas, in TSelf childGas);
 
     /// <summary>Repays outstanding EIP-8037 state-gas spill from the reservoir after a successful child merge.</summary>
@@ -168,8 +178,8 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static virtual void RepayStateGasSpill(ref TSelf gas) { }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeCreateStateGas(ref TSelf gas) =>
-        TSelf.ConsumeStateGas(ref gas, TSelf.GetCreateStateCost());
+    static virtual bool TryConsumeCreateStateGas(ref TSelf gas) =>
+        TSelf.TryConsumeStateGas(ref gas, TSelf.GetCreateStateCost());
 
     // Revert path: restore the child's state gas into the parent reservoir.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -181,25 +191,21 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void RevertRefundToHalt(ref TSelf parentGas, in TSelf childGas) { }
 
-    static abstract bool IsOutOfGas(in TSelf gas);
-
-    static abstract void SetOutOfGas(ref TSelf gasState);
-
-    static abstract bool ConsumeAccountAccessGasWithDelegation(ref TSelf gas,
+    static abstract bool TryConsumeAccountAccessGasWithDelegation(ref TSelf gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         Address address,
         Address? delegated);
 
-    static abstract bool ConsumeAccountAccessGas(ref TSelf gas,
+    static abstract bool TryConsumeAccountAccessGas(ref TSelf gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         Address address,
         AccountAccessKind kind = AccountAccessKind.Default);
 
-    static abstract bool ConsumeStorageAccessGas(ref TSelf gas,
+    static abstract bool TryConsumeStorageAccessGas(ref TSelf gas,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         in StorageCell storageCell,
@@ -208,21 +214,21 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     /// <summary>Charges storage access using the selected fork flags.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeStorageAccessGas<Eip2929, Eip8038>(ref TSelf gas,
+    static virtual bool TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref TSelf gas,
         ref readonly StackAccessTracker accessTracker, bool isTracingAccess,
         in StorageCell storageCell, StorageAccessType storageAccessType, IReleaseSpec spec)
         where Eip2929 : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        TSelf.ConsumeStorageAccessGas(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
+        TSelf.TryConsumeStorageAccessGas(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
 
     /// <summary>Charges account access using the selected fork flags.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeAccountAccessGas<Eip2929, Eip8038>(ref TSelf gas, IReleaseSpec spec,
+    static virtual bool TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref TSelf gas, IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker, bool isTracingAccess, Address address,
         AccountAccessKind kind = AccountAccessKind.Default)
         where Eip2929 : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        TSelf.ConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
+        TSelf.TryConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
 
     /// <summary>Reserves CALL gas using the selected EIP-150 mode.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -236,11 +242,11 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     /// <summary>Charges creation using the selected fork flags.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref TSelf gas, IReleaseSpec spec, ulong initCodeWords)
+    static virtual bool TryConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref TSelf gas, IReleaseSpec spec, ulong initCodeWords)
         where Eip8037 : struct, IFlag
         where TOpCreate : struct, EvmInstructions.IOpCreate
         where Eip3860 : struct, IFlag
-        where Eip8038 : struct, IFlag => TSelf.ConsumeCreateGas<Eip8037, TOpCreate>(ref gas, spec, initCodeWords);
+        where Eip8038 : struct, IFlag => TSelf.TryConsumeCreateGas<Eip8037, TOpCreate>(ref gas, spec, initCodeWords);
 
     static abstract bool UpdateMemoryCost(ref TSelf gas, in UInt256 position, in UInt256 length, ref EvmPooledMemory memory);
 
@@ -251,11 +257,12 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return TSelf.UpdateMemoryCost(ref gas, in position, in uint256Length, ref memory);
     }
 
+    /// <summary>Charges execution gas, returning false and exhausting it when the cost is unaffordable.</summary>
     static abstract bool UpdateGas(ref TSelf gas, ulong gasCost);
 
     // Pre-EIP-8037 fallback: state gas folded into execution gas.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeStateGas(ref TSelf gas, long stateGasCost) => TSelf.UpdateGas(ref gas, (ulong)stateGasCost);
+    static virtual bool TryConsumeStateGas(ref TSelf gas, long stateGasCost) => TSelf.UpdateGas(ref gas, (ulong)stateGasCost);
 
     // Execution gas charged first to prevent state-gas spill-then-halt from inflating
     // the reservoir via the error refund path.
@@ -263,17 +270,17 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     static abstract void UpdateGasUp(ref TSelf gas, ulong refund);
 
-    static abstract bool ConsumeStorageWrite<TEip8037, TIsSlotCreation>(ref TSelf gas, IReleaseSpec spec)
+    static abstract bool TryConsumeStorageWrite<TEip8037, TIsSlotCreation>(ref TSelf gas, IReleaseSpec spec)
         where TEip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag;
 
     /// <summary>Charges a storage write using the selected EIP-8038 mode.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeStorageWrite<Eip8037, TIsSlotCreation, Eip8038>(ref TSelf gas, IReleaseSpec spec)
+    static virtual bool TryConsumeStorageWrite<Eip8037, TIsSlotCreation, Eip8038>(ref TSelf gas, IReleaseSpec spec)
         where Eip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        TSelf.ConsumeStorageWrite<Eip8037, TIsSlotCreation>(ref gas, spec);
+        TSelf.TryConsumeStorageWrite<Eip8037, TIsSlotCreation>(ref gas, spec);
 
     // Pre-EIP-8037 fallback: refund into execution gas.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -319,10 +326,10 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static virtual ulong ApplyCodeInsertRefunds(ref TSelf gas, ulong codeInsertRefunds, IReleaseSpec spec, long stateGasFloor) =>
         TSelf.GetCodeInsertExecutionRefund(codeInsertRefunds, spec);
 
-    static abstract bool ConsumeCallValueTransfer(ref TSelf gas);
-    static abstract bool ConsumeCallValueTransferEip2780(ref TSelf gas);
-    static abstract bool ConsumeNewAccountCreation<TEip8037>(ref TSelf gas) where TEip8037 : struct, IFlag;
-    static abstract bool ConsumeLogEmission(ref TSelf gas, ulong topicCount, ulong dataSize);
+    static abstract bool TryConsumeCallValueTransfer(ref TSelf gas);
+    static abstract bool TryConsumeCallValueTransferEip2780(ref TSelf gas);
+    static abstract bool TryConsumeNewAccountCreation<TEip8037>(ref TSelf gas) where TEip8037 : struct, IFlag;
+    static abstract bool TryConsumeLogEmission(ref TSelf gas, ulong topicCount, ulong dataSize);
     static abstract TSelf Max(in TSelf a, in TSelf b);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -330,7 +337,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         TSelf.CalculateIntrinsicGas(tx, spec, blockGasLimit: 0);
     static abstract IntrinsicGas<TSelf> CalculateIntrinsicGas(Transaction tx, IReleaseSpec spec, ulong blockGasLimit);
 
-    static abstract TSelf CreateAvailableFromIntrinsic(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec);
+    static abstract bool TryCreateAvailableFromIntrinsic(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec, out TSelf available);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual TSelf CreateChildFrameGas(ref TSelf parentGas, ulong childExecutionGas) => TSelf.FromULong(childExecutionGas);
@@ -365,7 +372,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     }
 
     // EXTCODECOPY may need different categorization (state trie access) for some policies.
-    static abstract void ConsumeDataCopyGas(ref TSelf gas, IReleaseSpec spec, bool isExternalCode, ulong words);
+    static abstract bool TryConsumeDataCopyGas(ref TSelf gas, IReleaseSpec spec, bool isExternalCode, ulong words);
 }
 
 public readonly record struct IntrinsicGas<TGasPolicy>(TGasPolicy Standard, TGasPolicy FloorGas)

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/IGasPolicy.cs
@@ -24,8 +24,8 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static virtual TSelf CreateSystemTransactionIntrinsicGas(ulong blockGasLimit) => TSelf.FromULong(0);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual TSelf CreateSystemTransactionAvailableGas(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec) =>
-        TSelf.CreateAvailableFromIntrinsic(gasLimit, in intrinsicGas, spec);
+    static virtual bool TryCreateSystemTransactionAvailableGas(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec, out TSelf available) =>
+        TSelf.TryCreateAvailableFromIntrinsic(gasLimit, in intrinsicGas, spec, out available);
 
     static abstract ulong GetRemainingGas(in TSelf gas);
 
@@ -33,6 +33,9 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong GetColdAccountAccessCost(IReleaseSpec spec) =>
         spec.IsEip8038Enabled ? Eip8038Constants.ColdAccountAccess : GasCostOf.ColdAccountAccess;
+
+    /// <summary>Zeros execution gas without changing state-gas accounting.</summary>
+    static abstract void ClearExecutionGas(ref TSelf gas);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual ulong CombineBlockGas(ulong blockExecutionGas, ulong blockStateGas) => Math.Max(blockExecutionGas, blockStateGas);
@@ -94,38 +97,40 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
             : 0;
     }
 
-    static abstract void Consume(ref TSelf gas, ulong cost);
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual bool TryConsume(ref TSelf gas, ulong cost)
     {
         if (TSelf.GetRemainingGas(in gas) < cost) return false;
-        TSelf.Consume(ref gas, cost);
-        return true;
+        return TSelf.UpdateGas(ref gas, cost);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void Consume<TCost>(ref TSelf gas) where TCost : struct, IGasCost =>
-        TSelf.Consume(ref gas, TCost.GasCost);
+    static virtual bool UpdateGas<TCost>(ref TSelf gas) where TCost : struct, IGasCost =>
+        TSelf.UpdateGas(ref gas, TCost.GasCost);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void Consume<TCost>(ref TSelf gas, IReleaseSpec spec) where TCost : struct, ISpecGasCost =>
-        TSelf.Consume(ref gas, TCost.GasCost(spec));
+    static virtual bool UpdateGas<TCost>(ref TSelf gas, IReleaseSpec spec) where TCost : struct, ISpecGasCost =>
+        TSelf.UpdateGas(ref gas, TCost.GasCost(spec));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void ConsumeKeccak(ref TSelf gas, ulong words) =>
-        TSelf.Consume(ref gas, GasCostOf.Sha3 + GasCostOf.Sha3Word * words);
+    static virtual bool TryConsumeKeccak(ref TSelf gas, ulong words) =>
+        TSelf.UpdateGas(ref gas, GasCostOf.Sha3 + GasCostOf.Sha3Word * words);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void ConsumeMemoryCopy(ref TSelf gas, ulong words) =>
-        TSelf.Consume(ref gas, GasCostOf.VeryLow + GasCostOf.VeryLow * words);
+    static virtual bool TryConsumeMemoryCopy(ref TSelf gas, ulong words) =>
+        TSelf.UpdateGas(ref gas, GasCostOf.VeryLow + GasCostOf.VeryLow * words);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual void ConsumeExpBytes(ref TSelf gas, IReleaseSpec spec, ulong exponentByteSize) =>
-        TSelf.Consume(ref gas, spec.GasCosts.ExpByteCost * exponentByteSize);
+    static virtual bool TryConsumeExpBytes(ref TSelf gas, IReleaseSpec spec, ulong exponentByteSize) =>
+        TSelf.UpdateGas(ref gas, spec.GasCosts.ExpByteCost * exponentByteSize);
+
+    /// <summary>Charges exponent bytes using the selected EIP-160 price.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static virtual bool TryConsumeExpBytes<Eip160>(ref TSelf gas, IReleaseSpec spec, ulong exponentByteSize)
+        where Eip160 : struct, IFlag => TSelf.TryConsumeExpBytes(ref gas, spec, exponentByteSize);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeCreateGas<TEip8037, TOpCreate>(ref TSelf gas, IReleaseSpec spec, ulong initCodeWords)
+    static virtual bool TryConsumeCreateGas<TEip8037, TOpCreate>(ref TSelf gas, IReleaseSpec spec, ulong initCodeWords)
         where TEip8037 : struct, IFlag
         where TOpCreate : struct, EvmInstructions.IOpCreate
     {
@@ -138,34 +143,39 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeCallBaseGas(ref TSelf gas, IReleaseSpec spec) =>
+    static virtual bool TryConsumeCallBaseGas(ref TSelf gas, IReleaseSpec spec) =>
         TSelf.UpdateGas(ref gas, spec.GasCosts.CallCost);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeSStoreResetGas(ref TSelf gas, IReleaseSpec spec) =>
+    static virtual bool TryConsumeSStoreResetGas(ref TSelf gas, IReleaseSpec spec) =>
         TSelf.UpdateGas(ref gas, spec.GasCosts.SStoreResetCost);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeNetMeteredSStoreGas(ref TSelf gas, IReleaseSpec spec) =>
+    static virtual bool TryConsumeNetMeteredSStoreGas(ref TSelf gas, IReleaseSpec spec) =>
         TSelf.UpdateGas(ref gas, spec.GasCosts.NetMeteredSStoreCost);
+
+    /// <summary>Charges the SLOAD base cost for the selected EIP-2929 mode.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static virtual bool TryConsumeSLoadBaseGas<Eip2929>(ref TSelf gas, IReleaseSpec spec)
+        where Eip2929 : struct, IFlag => TSelf.UpdateGas<SLoadGasCost>(ref gas, spec);
 
     /// <summary>Charges net-metered storage using the selected EIP-8038 mode.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeNetMeteredSStoreGas<Eip8038>(ref TSelf gas, IReleaseSpec spec)
-        where Eip8038 : struct, IFlag => TSelf.ConsumeNetMeteredSStoreGas(ref gas, spec);
+    static virtual bool TryConsumeNetMeteredSStoreGas<Eip8038>(ref TSelf gas, IReleaseSpec spec)
+        where Eip8038 : struct, IFlag => TSelf.TryConsumeNetMeteredSStoreGas(ref gas, spec);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeSSetFromCleanGas(ref TSelf gas) =>
+    static virtual bool TryConsumeSSetFromCleanGas(ref TSelf gas) =>
         TSelf.UpdateGas(ref gas, GasCostOf.SSet - GasCostOf.SReset);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumePrecompileGas(ref TSelf gas, IPrecompile precompile, ReadOnlyMemory<byte> inputData, IReleaseSpec spec)
+    static virtual bool TryConsumePrecompileGas(ref TSelf gas, IPrecompile precompile, ReadOnlyMemory<byte> inputData, IReleaseSpec spec)
     {
         ulong baseGasCost = precompile.BaseGasCost(spec);
         ulong dataGasCost = precompile.DataGasCost(inputData, spec);
         return baseGasCost <= ulong.MaxValue - dataGasCost && TSelf.UpdateGas(ref gas, baseGasCost + dataGasCost);
     }
-    static abstract bool ConsumeSelfDestructGas(ref TSelf gas);
+    static abstract bool TryConsumeSelfDestructGas(ref TSelf gas);
     static abstract void Refund(ref TSelf gas, in TSelf childGas);
 
     /// <summary>Repays outstanding EIP-8037 state-gas spill from the reservoir after a successful child merge.</summary>
@@ -178,8 +188,8 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static virtual void RepayStateGasSpill(ref TSelf gas) { }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeCreateStateGas(ref TSelf gas) =>
-        TSelf.ConsumeStateGas(ref gas, TSelf.GetCreateStateCost());
+    static virtual bool TryConsumeCreateStateGas(ref TSelf gas) =>
+        TSelf.TryConsumeStateGas(ref gas, TSelf.GetCreateStateCost());
 
     // Revert path: restore the child's state gas into the parent reservoir.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -191,25 +201,21 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual void RevertRefundToHalt(ref TSelf parentGas, in TSelf childGas) { }
 
-    static abstract bool IsOutOfGas(in TSelf gas);
-
-    static abstract void SetOutOfGas(ref TSelf gasState);
-
-    static abstract bool ConsumeAccountAccessGasWithDelegation(ref TSelf gas,
+    static abstract bool TryConsumeAccountAccessGasWithDelegation(ref TSelf gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         Address address,
         Address? delegated);
 
-    static abstract bool ConsumeAccountAccessGas(ref TSelf gas,
+    static abstract bool TryConsumeAccountAccessGas(ref TSelf gas,
         IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         Address address,
         AccountAccessKind kind = AccountAccessKind.Default);
 
-    static abstract bool ConsumeStorageAccessGas(ref TSelf gas,
+    static abstract bool TryConsumeStorageAccessGas(ref TSelf gas,
         ref readonly StackAccessTracker accessTracker,
         bool isTracingAccess,
         in StorageCell storageCell,
@@ -218,21 +224,21 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     /// <summary>Charges storage access using the selected fork flags.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeStorageAccessGas<Eip2929, Eip8038>(ref TSelf gas,
+    static virtual bool TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref TSelf gas,
         ref readonly StackAccessTracker accessTracker, bool isTracingAccess,
         in StorageCell storageCell, StorageAccessType storageAccessType, IReleaseSpec spec)
         where Eip2929 : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        TSelf.ConsumeStorageAccessGas(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
+        TSelf.TryConsumeStorageAccessGas(ref gas, in accessTracker, isTracingAccess, in storageCell, storageAccessType, spec);
 
     /// <summary>Charges account access using the selected fork flags.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeAccountAccessGas<Eip2929, Eip8038>(ref TSelf gas, IReleaseSpec spec,
+    static virtual bool TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref TSelf gas, IReleaseSpec spec,
         ref readonly StackAccessTracker accessTracker, bool isTracingAccess, Address address,
         AccountAccessKind kind = AccountAccessKind.Default)
         where Eip2929 : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        TSelf.ConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
+        TSelf.TryConsumeAccountAccessGas(ref gas, spec, in accessTracker, isTracingAccess, address, kind);
 
     /// <summary>Reserves CALL gas using the selected EIP-150 mode.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -246,11 +252,11 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     /// <summary>Charges creation using the selected fork flags.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref TSelf gas, IReleaseSpec spec, ulong initCodeWords)
+    static virtual bool TryConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref TSelf gas, IReleaseSpec spec, ulong initCodeWords)
         where Eip8037 : struct, IFlag
         where TOpCreate : struct, EvmInstructions.IOpCreate
         where Eip3860 : struct, IFlag
-        where Eip8038 : struct, IFlag => TSelf.ConsumeCreateGas<Eip8037, TOpCreate>(ref gas, spec, initCodeWords);
+        where Eip8038 : struct, IFlag => TSelf.TryConsumeCreateGas<Eip8037, TOpCreate>(ref gas, spec, initCodeWords);
 
     static abstract bool UpdateMemoryCost(ref TSelf gas, in UInt256 position, in UInt256 length, ref EvmPooledMemory memory);
 
@@ -261,11 +267,12 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         return TSelf.UpdateMemoryCost(ref gas, in position, in uint256Length, ref memory);
     }
 
+    /// <summary>Charges execution gas, returning false and exhausting it when the cost is unaffordable.</summary>
     static abstract bool UpdateGas(ref TSelf gas, ulong gasCost);
 
     // Pre-EIP-8037 fallback: state gas folded into execution gas.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeStateGas(ref TSelf gas, long stateGasCost) => TSelf.UpdateGas(ref gas, (ulong)stateGasCost);
+    static virtual bool TryConsumeStateGas(ref TSelf gas, long stateGasCost) => TSelf.UpdateGas(ref gas, (ulong)stateGasCost);
 
     // Execution gas charged first to prevent state-gas spill-then-halt from inflating
     // the reservoir via the error refund path.
@@ -273,17 +280,17 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
 
     static abstract void UpdateGasUp(ref TSelf gas, ulong refund);
 
-    static abstract bool ConsumeStorageWrite<TEip8037, TIsSlotCreation>(ref TSelf gas, IReleaseSpec spec)
+    static abstract bool TryConsumeStorageWrite<TEip8037, TIsSlotCreation>(ref TSelf gas, IReleaseSpec spec)
         where TEip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag;
 
     /// <summary>Charges a storage write using the selected EIP-8038 mode.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static virtual bool ConsumeStorageWrite<Eip8037, TIsSlotCreation, Eip8038>(ref TSelf gas, IReleaseSpec spec)
+    static virtual bool TryConsumeStorageWrite<Eip8037, TIsSlotCreation, Eip8038>(ref TSelf gas, IReleaseSpec spec)
         where Eip8037 : struct, IFlag
         where TIsSlotCreation : struct, IFlag
         where Eip8038 : struct, IFlag =>
-        TSelf.ConsumeStorageWrite<Eip8037, TIsSlotCreation>(ref gas, spec);
+        TSelf.TryConsumeStorageWrite<Eip8037, TIsSlotCreation>(ref gas, spec);
 
     // Pre-EIP-8037 fallback: refund into execution gas.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -329,10 +336,10 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     static virtual ulong ApplyCodeInsertRefunds(ref TSelf gas, ulong codeInsertRefunds, IReleaseSpec spec, long stateGasFloor) =>
         TSelf.GetCodeInsertExecutionRefund(codeInsertRefunds, spec);
 
-    static abstract bool ConsumeCallValueTransfer(ref TSelf gas);
-    static abstract bool ConsumeCallValueTransferEip2780(ref TSelf gas);
-    static abstract bool ConsumeNewAccountCreation<TEip8037>(ref TSelf gas) where TEip8037 : struct, IFlag;
-    static abstract bool ConsumeLogEmission(ref TSelf gas, ulong topicCount, ulong dataSize);
+    static abstract bool TryConsumeCallValueTransfer(ref TSelf gas);
+    static abstract bool TryConsumeCallValueTransferEip2780(ref TSelf gas);
+    static abstract bool TryConsumeNewAccountCreation<TEip8037>(ref TSelf gas) where TEip8037 : struct, IFlag;
+    static abstract bool TryConsumeLogEmission(ref TSelf gas, ulong topicCount, ulong dataSize);
     static abstract TSelf Max(in TSelf a, in TSelf b);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -340,7 +347,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
         TSelf.CalculateIntrinsicGas(tx, spec, blockGasLimit: 0);
     static abstract IntrinsicGas<TSelf> CalculateIntrinsicGas(Transaction tx, IReleaseSpec spec, ulong blockGasLimit);
 
-    static abstract TSelf CreateAvailableFromIntrinsic(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec);
+    static abstract bool TryCreateAvailableFromIntrinsic(ulong gasLimit, in TSelf intrinsicGas, IReleaseSpec spec, out TSelf available);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static virtual TSelf CreateChildFrameGas(ref TSelf parentGas, ulong childExecutionGas) => TSelf.FromULong(childExecutionGas);
@@ -375,7 +382,7 @@ public interface IGasPolicy<TSelf> where TSelf : struct, IGasPolicy<TSelf>
     }
 
     // EXTCODECOPY may need different categorization (state trie access) for some policies.
-    static abstract void ConsumeDataCopyGas(ref TSelf gas, IReleaseSpec spec, bool isExternalCode, ulong words);
+    static abstract bool TryConsumeDataCopyGas(ref TSelf gas, IReleaseSpec spec, bool isExternalCode, ulong words);
 }
 
 public readonly record struct IntrinsicGas<TGasPolicy>(TGasPolicy Standard, TGasPolicy FloorGas)

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Bitwise.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Bitwise.cs
@@ -79,29 +79,31 @@ public static partial class EvmInstructions
         where TOpBitwise : struct, IOpBitwise
     {
         // Deduct the operation's gas cost.
-        TGasPolicy.Consume<TOpBitwise>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpBitwise>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        return BitwiseCore<TOpBitwise>(ref stack);
+        return BitwiseCore<TOpBitwise, OnFlag>(ref stack);
     }
 
     /// <summary>Gas-free body of <see cref="InstructionBitwise{TGasPolicy, TOpBitwise}"/>.</summary>
+    /// <remarks>When <typeparamref name="TCheckDepth"/> is inactive, the caller must have verified at least 2 stack items.</remarks>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static EvmExceptionType BitwiseCore<TOpBitwise>(ref EvmStack stack)
+    internal static EvmExceptionType BitwiseCore<TOpBitwise, TCheckDepth>(ref EvmStack stack)
         where TOpBitwise : struct, IOpBitwise
+        where TCheckDepth : struct, IFlag
     {
         if (!Vector256.IsHardwareAccelerated && typeof(TOpBitwise) == typeof(OpBitwiseEq))
-            return EqualsInSlot(ref stack);
+            return EqualsInSlot<TCheckDepth>(ref stack);
 
         if (!Vector128.IsHardwareAccelerated &&
             (typeof(TOpBitwise) == typeof(OpBitwiseAnd) ||
              typeof(TOpBitwise) == typeof(OpBitwiseOr) ||
              typeof(TOpBitwise) == typeof(OpBitwiseXor)))
-            return BitwiseScalar<TOpBitwise>(ref stack);
+            return BitwiseScalar<TOpBitwise, TCheckDepth>(ref stack);
 
         // One depth check, then one address computation: the popped slot sits one word above the
         // slot the result overwrites.
-        if (!stack.EnsureDepth(2)) goto StackUnderflow;
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(2)) goto StackUnderflow;
         ref byte topRef = ref stack.Pop1Peek32BytesUnchecked();
 
         EvmWord aVec = ReadUnaligned<EvmWord>(ref Add(ref topRef, EvmStack.WordSize));
@@ -123,9 +125,10 @@ public static partial class EvmInstructions
     /// same way. Comparing the slots removes that round trip.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static EvmExceptionType EqualsInSlot(ref EvmStack stack)
+    private static EvmExceptionType EqualsInSlot<TCheckDepth>(ref EvmStack stack)
+        where TCheckDepth : struct, IFlag
     {
-        if (!stack.EnsureDepth(2))
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(2))
             return EvmExceptionType.StackUnderflow;
 
         ref byte bBytes = ref stack.Pop1Peek32BytesUnchecked();
@@ -155,10 +158,11 @@ public static partial class EvmInstructions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static EvmExceptionType BitwiseScalar<TOpBitwise>(ref EvmStack stack)
+    private static EvmExceptionType BitwiseScalar<TOpBitwise, TCheckDepth>(ref EvmStack stack)
         where TOpBitwise : struct, IOpBitwise
+        where TCheckDepth : struct, IFlag
     {
-        if (!stack.EnsureDepth(2))
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(2))
             return EvmExceptionType.StackUnderflow;
 
         ref byte bBytes = ref stack.Pop1Peek32BytesUnchecked();
@@ -195,6 +199,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpBitwiseAnd : IOpBitwise
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static EvmWord Operation(in EvmWord a, in EvmWord b) => Vector256.BitwiseAnd(a, b);
     }
 
@@ -203,6 +208,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpBitwiseOr : IOpBitwise
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static EvmWord Operation(in EvmWord a, in EvmWord b) => Vector256.BitwiseOr(a, b);
     }
 
@@ -211,6 +217,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpBitwiseXor : IOpBitwise
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static EvmWord Operation(in EvmWord a, in EvmWord b) => Vector256.Xor(a, b);
     }
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -93,8 +94,7 @@ public static partial class EvmInstructions
     {
         vm.MetricsCounters.IncrementCalls();
 
-        // Clear previous return data.
-        vm.ReturnData = null;
+        Debug.Assert(vm.ReturnData is null, "Dispatch clears staged output before entering an opcode chain.");
 
         // Pop the gas limit for the call.
         if (!stack.PopUInt256(out UInt256 gasLimit)) goto StackUnderflow;
@@ -145,26 +145,26 @@ public static partial class EvmInstructions
             // EIP-2780 charges a flat value-move cost with no state read: the spec performs the
             // static gas check before any target access, so an OOG here must not touch the BAL.
             bool valueOutOfGas = TSpec.IsEip2780Enabled
-                ? !TGasPolicy.ConsumeCallValueTransferEip2780(ref gas)
-                : !TGasPolicy.ConsumeCallValueTransfer(ref gas);
+                ? !TGasPolicy.TryConsumeCallValueTransferEip2780(ref gas)
+                : !TGasPolicy.TryConsumeCallValueTransfer(ref gas);
             if (valueOutOfGas) goto OutOfGas;
         }
 
         // Update gas: call cost and memory expansion for input and output.
-        if (!TGasPolicy.ConsumeCallBaseGas(ref gas, spec) ||
+        if (!TGasPolicy.TryConsumeCallBaseGas(ref gas, spec) ||
             !TGasPolicy.UpdateMemoryCost(ref gas, in dataOffset, dataLength, ref vm.VmState.Memory) ||
             !TGasPolicy.UpdateMemoryCost(ref gas, in outputOffset, outputLength, ref vm.VmState.Memory))
             goto OutOfGas;
 
         // Charge gas for accessing the account's code (including delegation logic if applicable).
-        if (!TSpec.ConsumeAccountAccessGas<TGasPolicy>(ref gas, vm.Spec, in vm.VmState.AccessTracker,
-                vm.TxTracer.IsTracingAccess, codeSource)) goto OutOfGas;
+        if (!TSpec.TryConsumeAccountAccessGas<TGasPolicy>(ref gas, vm.Spec, in vm.VmState.AccessTracker,
+                vm.IsTracingAccess, codeSource)) goto OutOfGas;
 
         CodeInfo codeInfo = vm.CodeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation: false, vmSpec: spec, delegationAddress: out Address? delegated);
 
         if (TSpec.UseHotAndColdStorage &&
             delegated is not null &&
-            !TSpec.ConsumeAccountAccessGas<TGasPolicy>(ref gas, vm.Spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, delegated))
+            !TSpec.TryConsumeAccountAccessGas<TGasPolicy>(ref gas, vm.Spec, in vm.VmState.AccessTracker, vm.IsTracingAccess, delegated))
             goto OutOfGas;
 
         // Charge additional gas if the target account is new or considered empty.
@@ -178,7 +178,7 @@ public static partial class EvmInstructions
                 true => hasValueTransfer && state.IsDeadAccount(target),
             });
 
-        bool newAccountOutOfGas = chargesNewAccount && !TGasPolicy.ConsumeNewAccountCreation<TEip8037>(ref gas);
+        bool newAccountOutOfGas = chargesNewAccount && !TGasPolicy.TryConsumeNewAccountCreation<TEip8037>(ref gas);
 
         if (newAccountOutOfGas) goto OutOfGas;
 
@@ -200,7 +200,7 @@ public static partial class EvmInstructions
         // Add call stipend if value is being transferred.
         if (hasValueTransfer)
         {
-            if (vm.TxTracer.IsTracingRefunds)
+            if (vm.IsTracingRefunds)
                 vm.TxTracer.ReportExtraGasPressure(GasCostOf.CallStipend);
             gasLimitUl += GasCostOf.CallStipend;
         }
@@ -210,11 +210,11 @@ public static partial class EvmInstructions
             (hasValueTransfer && state.GetBalance(env.ExecutingAccount) < callValue))
         {
             // If the call cannot proceed, return an empty response and push zero on the stack.
-            vm.ReturnDataBuffer = Array.Empty<byte>();
-            EvmExceptionType pushResult = stack.PushZero<TTracingInst>();
+            vm.ReturnDataBuffer = default;
+            EvmExceptionType pushResult = stack.PushZero<TTracingInst, OnFlag>();
 
             // Optionally report memory changes for refund tracing.
-            if (vm.TxTracer.IsTracingRefunds)
+            if (vm.IsTracingRefunds)
             {
                 // Specific to Parity tracing: inspect 32 bytes from data offset.
                 ReadOnlyMemory<byte>? memoryTrace = vm.VmState.Memory.Inspect(in dataOffset, 32);
@@ -241,7 +241,7 @@ public static partial class EvmInstructions
         }
 
         // Fast-path for calls to externally owned accounts (non-contracts)
-        if (codeInfo.IsEmpty && !TTracingInst.IsActive && !vm.TxTracer.IsTracingActions)
+        if (codeInfo.IsEmpty && !TTracingInst.IsActive && !vm.IsTracingActions)
         {
             vm.ReturnDataBuffer = default;
             // Mutate balances only after the success byte is on the stack; this fast path has no snapshot to roll back a failed push.
@@ -262,7 +262,6 @@ public static partial class EvmInstructions
                 state.AddToBalanceAndCreateIfNotExists(target, TOpCall.ExecutionType, in callValue, spec);
             }
             vm.MetricsCounters.IncrementEmptyCalls();
-            vm.ReturnData = null;
             return EvmExceptionType.None;
         }
 

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.std.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.std.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -31,7 +32,8 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        if (TTracingInst.IsActive || vm.TxTracer.IsTracingActions || !vm.CanExecutePrecompileCallDirectly(precompile, codeSource))
+        Debug.Assert(vm.ReturnData is null, "Inline precompiles continue the current opcode chain.");
+        if (TTracingInst.IsActive || vm.IsTracingActions || !vm.CanExecutePrecompileCallDirectly(precompile, codeSource))
         {
             result = default;
             return false;
@@ -46,22 +48,20 @@ public static partial class EvmInstructions
         TGasPolicy childGas = TGasPolicy.CreateChildFrameGas(ref gas, gasLimitUl);
         IReleaseSpec spec = vm.Spec;
 
-        if (!TGasPolicy.ConsumePrecompileGas(ref childGas, precompile, callData, spec))
+        if (!TGasPolicy.TryConsumePrecompileGas(ref childGas, precompile, callData, spec))
         {
             TGasPolicy.RestoreChildStateGasOnHalt(ref gas, in childGas);
-            vm.ReturnDataBuffer = Array.Empty<byte>();
-            vm.ReturnData = null;
-            result = stack.PushZero<TTracingInst>();
+            vm.ReturnDataBuffer = default;
+            result = stack.PushZero<TTracingInst, OnFlag>();
             return true;
         }
 
         if (!(vm.TryRunPrecompileDirectly(precompile, callData, spec, out Result<byte[]> output) && output))
         {
-            TGasPolicy.SetOutOfGas(ref childGas);
+            TGasPolicy.ClearExecutionGas(ref childGas);
             TGasPolicy.RestoreChildStateGasOnHalt(ref gas, in childGas);
-            vm.ReturnDataBuffer = Array.Empty<byte>();
-            vm.ReturnData = null;
-            result = stack.PushZero<TTracingInst>();
+            vm.ReturnDataBuffer = default;
+            result = stack.PushZero<TTracingInst, OnFlag>();
             return true;
         }
 
@@ -85,7 +85,6 @@ public static partial class EvmInstructions
             }
         }
 
-        vm.ReturnData = null;
         result = stack.PushBytes<TTracingInst>(StatusCode.SuccessBytes.Span);
         return true;
     }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
@@ -34,7 +34,7 @@ public static partial class EvmInstructions
             goto StackUnderflow;
 
         ulong words = EvmCalculations.Div32Ceiling(in result, out bool outOfGas);
-        TGasPolicy.ConsumeDataCopyGas(ref gas, vm.Spec, isExternalCode: false, words);
+        if (!TGasPolicy.TryConsumeDataCopyGas(ref gas, vm.Spec, isExternalCode: false, words)) return EvmExceptionType.OutOfGas;
         if (outOfGas) goto OutOfGas;
 
         if (!result.IsZero)
@@ -96,7 +96,7 @@ public static partial class EvmInstructions
             goto StackUnderflow;
 
         ulong words = EvmCalculations.Div32Ceiling(in size, out bool outOfGas);
-        TGasPolicy.ConsumeDataCopyGas(ref gas, vm.Spec, isExternalCode: false, words);
+        if (!TGasPolicy.TryConsumeDataCopyGas(ref gas, vm.Spec, isExternalCode: false, words)) return EvmExceptionType.OutOfGas;
         if (outOfGas) goto OutOfGas;
 
         ReadOnlyMemory<byte> returnDataBuffer = vm.ReturnDataBuffer;
@@ -175,11 +175,11 @@ public static partial class EvmInstructions
 
         // Deduct gas cost: cost for external code access plus memory expansion cost.
         ulong words = EvmCalculations.Div32Ceiling(in result, out bool outOfGas);
-        TGasPolicy.ConsumeDataCopyGas(ref gas, spec, isExternalCode: true, words);
+        if (!TGasPolicy.TryConsumeDataCopyGas(ref gas, spec, isExternalCode: true, words)) return EvmExceptionType.OutOfGas;
         if (outOfGas) goto OutOfGas;
 
         // Charge gas for account access (considering hot/cold storage costs).
-        if (!TGasPolicy.ConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, address))
+        if (!TGasPolicy.TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in vm.VmState.AccessTracker, vm.IsTracingAccess, address))
             goto OutOfGas;
 
         // EIP-8038 charges an extra warm access for the second DB read EXTCODECOPY performs.
@@ -264,14 +264,14 @@ public static partial class EvmInstructions
     {
         IReleaseSpec spec = vm.Spec;
         // Deduct the gas cost for external code access.
-        TGasPolicy.Consume<ExtCodeSizeGasCost>(ref gas, spec);
+        if (!TGasPolicy.UpdateGas<ExtCodeSizeGasCost>(ref gas, spec)) return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);
 
         // Pop the account address from the stack.
         Address? address = stack.PopAddress(vm.AddressCache);
         if (address is null) goto StackUnderflow;
 
         // Charge gas for accessing the account's state.
-        if (!TGasPolicy.ConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, address))
+        if (!TGasPolicy.TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in vm.VmState.AccessTracker, vm.IsTracingAccess, address))
             goto OutOfGas;
 
         // EIP-8038 charges an extra warm access for the second DB read EXTCODESIZE performs.
@@ -309,7 +309,7 @@ public static partial class EvmInstructions
                 vm.OpCodeCount++;
                 programCounter++;
                 // Deduct very-low gas cost for the next operation (ISZERO, GT, or EQ).
-                TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+                if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);
 
                 // Determine if the account is a contract by checking the loaded CodeHash.
                 bool isCodeLengthNotZero = vm.WorldState.IsContract(address);
@@ -322,7 +322,7 @@ public static partial class EvmInstructions
                 // Push 1 if the condition is met (indicating contract presence or absence), else push 0.
                 return new OpcodeResult(programCounter, !isCodeLengthNotZero
                     ? stack.PushOne<TTracingInst>()
-                    : stack.PushZero<TTracingInst>());
+                    : stack.PushZero<TTracingInst, OnFlag>());
             }
         }
 
@@ -330,7 +330,7 @@ public static partial class EvmInstructions
         ReadOnlySpan<byte> accountCode = vm.CodeInfoRepository
             .GetCachedCodeInfo(address, followDelegation: false, spec, out _)
             .CodeSpan;
-        return new OpcodeResult(programCounter, stack.PushUInt32<TTracingInst>((uint)accountCode.Length));
+        return new OpcodeResult(programCounter, stack.PushUInt32<TTracingInst, OnFlag>((uint)accountCode.Length));
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
@@ -51,7 +51,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         ulong words = EvmCalculations.Div32Ceiling(in result, out bool outOfGas);
-        TGasPolicy.ConsumeDataCopyGas(ref gas, vm.Spec, isExternalCode: false, words);
+        if (!TGasPolicy.TryConsumeDataCopyGas(ref gas, vm.Spec, isExternalCode: false, words)) return EvmExceptionType.OutOfGas;
         if (outOfGas) goto OutOfGas;
 
         if (!result.IsZero)
@@ -91,7 +91,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         ulong words = EvmCalculations.Div32Ceiling(in size, out bool outOfGas);
-        TGasPolicy.ConsumeDataCopyGas(ref gas, vm.Spec, isExternalCode: false, words);
+        if (!TGasPolicy.TryConsumeDataCopyGas(ref gas, vm.Spec, isExternalCode: false, words)) goto OutOfGas;
         if (outOfGas) goto OutOfGas;
 
         // Ahead of the zero-length short-circuit: a zero-length read past the end still halts.
@@ -207,11 +207,11 @@ public static partial class EvmInstructions
 
         // Deduct gas cost: cost for external code access plus memory expansion cost.
         ulong words = EvmCalculations.Div32Ceiling(in result, out bool outOfGas);
-        TGasPolicy.ConsumeDataCopyGas(ref gas, spec, isExternalCode: true, words);
+        if (!TGasPolicy.TryConsumeDataCopyGas(ref gas, spec, isExternalCode: true, words)) return EvmExceptionType.OutOfGas;
         if (outOfGas) goto OutOfGas;
 
         // Charge gas for account access (considering hot/cold storage costs).
-        if (!TGasPolicy.ConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, address))
+        if (!TGasPolicy.TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in vm.VmState.AccessTracker, vm.IsTracingAccess, address))
             goto OutOfGas;
 
         // EIP-8038 charges an extra warm access for the second DB read EXTCODECOPY performs.
@@ -296,14 +296,14 @@ public static partial class EvmInstructions
     {
         IReleaseSpec spec = vm.Spec;
         // Deduct the gas cost for external code access.
-        TGasPolicy.Consume<ExtCodeSizeGasCost>(ref gas, spec);
+        if (!TGasPolicy.UpdateGas<ExtCodeSizeGasCost>(ref gas, spec)) return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);
 
         // Pop the account address from the stack.
         Address? address = stack.PopAddress(vm.AddressCache);
         if (address is null) goto StackUnderflow;
 
         // Charge gas for accessing the account's state.
-        if (!TGasPolicy.ConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, address))
+        if (!TGasPolicy.TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in vm.VmState.AccessTracker, vm.IsTracingAccess, address))
             goto OutOfGas;
 
         // EIP-8038 charges an extra warm access for the second DB read EXTCODESIZE performs.
@@ -341,7 +341,7 @@ public static partial class EvmInstructions
                 vm.OpCodeCount++;
                 programCounter++;
                 // Deduct very-low gas cost for the next operation (ISZERO, GT, or EQ).
-                TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+                if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);
 
                 // Determine if the account is a contract by checking the loaded CodeHash.
                 bool isCodeLengthNotZero = vm.WorldState.IsContract(address);
@@ -354,7 +354,7 @@ public static partial class EvmInstructions
                 // Push 1 if the condition is met (indicating contract presence or absence), else push 0.
                 return new OpcodeResult(programCounter, !isCodeLengthNotZero
                     ? stack.PushOne<TTracingInst>()
-                    : stack.PushZero<TTracingInst>());
+                    : stack.PushZero<TTracingInst, OnFlag>());
             }
         }
 
@@ -362,7 +362,7 @@ public static partial class EvmInstructions
         ReadOnlySpan<byte> accountCode = vm.CodeInfoRepository
             .GetCachedCodeInfo(address, followDelegation: false, spec, out _)
             .CodeSpan;
-        return new OpcodeResult(programCounter, stack.PushUInt32<TTracingInst>((uint)accountCode.Length));
+        return new OpcodeResult(programCounter, stack.PushUInt32<TTracingInst, OnFlag>((uint)accountCode.Length));
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.X86;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 
@@ -33,9 +34,9 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct the base gas cost for reading the program counter.
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         // The program counter pushed is adjusted by -1 to reflect the correct opcode location.
-        return stack.PushUInt32<TTracingInst>((uint)(programCounter - 1));
+        return stack.PushUInt32<TTracingInst, OnFlag>((uint)(programCounter - 1));
     }
 
     /// <summary>
@@ -53,7 +54,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
         // Deduct the gas cost specific for a jump destination marker.
-        TGasPolicy.Consume<JumpDestGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<JumpDestGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         return EvmExceptionType.None;
     }
@@ -93,14 +94,14 @@ public static partial class EvmInstructions
         where TSkipJumpDest : struct, IFlag
     {
         // Deduct the gas cost for performing a jump.
-        TGasPolicy.Consume<JumpGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<JumpGasCost>(ref gas)) return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);
         // Pop the jump destination from the stack.
         if (!stack.EnsureDepth(1)) goto StackUnderflow;
         // Validate the jump destination and update the program counter if valid.
-        nint destination = JumpDestination(ref stack.PopBytesByRefUnchecked(), vm.VmState.Env);
+        nint destination = JumpDestination(ref stack.PopBytesByRefUnchecked(), ref stack);
         if (destination < 0) goto InvalidJumpDestination;
-        programCounter = SkipJumpDest<TGasPolicy, TSkipJumpDest>(vm, ref gas, destination);
-        // Prefetch the cache line at the jump destination since hardware prefetcher can't predict jumps.
+        if (!SkipJumpDest<TGasPolicy, TSkipJumpDest>(vm, ref gas, destination, out programCounter))
+            return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);
         PrefetchCodeAtDestination(ref stack, programCounter);
 
         return new OpcodeResult(programCounter, EvmExceptionType.None);
@@ -148,7 +149,7 @@ public static partial class EvmInstructions
         where TSkipJumpDest : struct, IFlag
     {
         // Deduct the high gas cost for a conditional jump.
-        TGasPolicy.Consume<JumpIGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<JumpIGasCost>(ref gas)) return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);
         // The condition sits directly below the destination, so one depth check covers both.
         if (!stack.EnsureDepth(2)) goto StackUnderflow;
         ref byte condition = ref stack.Pop2BytesByRefUnchecked();
@@ -156,10 +157,10 @@ public static partial class EvmInstructions
         // Only a taken jump reads the destination, so an untaken one never decodes it.
         if (!EvmStack.IsSlotZero(ref condition))
         {
-            nint destination = JumpDestination(ref Unsafe.Add(ref condition, EvmStack.WordSize), vm.VmState.Env);
+            nint destination = JumpDestination(ref Unsafe.Add(ref condition, EvmStack.WordSize), ref stack);
             if (destination < 0) goto InvalidJumpDestination;
-            programCounter = SkipJumpDest<TGasPolicy, TSkipJumpDest>(vm, ref gas, destination);
-            // Prefetch the cache line at the jump destination since hardware prefetcher can't predict jumps.
+            if (!SkipJumpDest<TGasPolicy, TSkipJumpDest>(vm, ref gas, destination, out programCounter))
+                return new OpcodeResult(programCounter, EvmExceptionType.OutOfGas);
             PrefetchCodeAtDestination(ref stack, programCounter);
         }
 
@@ -171,21 +172,22 @@ public static partial class EvmInstructions
         return new OpcodeResult(programCounter, EvmExceptionType.InvalidJumpDestination);
     }
 
-    /// <summary>Charges the landed-on <c>JUMPDEST</c> and steps past it, returning the counter.</summary>
+    /// <summary>Steps past a landed-on <c>JUMPDEST</c> and returns whether its gas charge succeeded.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static nint SkipJumpDest<TGasPolicy, TSkipJumpDest>(VirtualMachine<TGasPolicy> vm, ref TGasPolicy gas, nint programCounter)
+    private static bool SkipJumpDest<TGasPolicy, TSkipJumpDest>(VirtualMachine<TGasPolicy> vm, ref TGasPolicy gas, nint destination, out nint programCounter)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TSkipJumpDest : struct, IFlag
     {
-        if (TSkipJumpDest.IsActive && !TGasPolicy.IsOutOfGas(in gas))
+        programCounter = destination;
+        if (TSkipJumpDest.IsActive)
         {
             // Count before charging so an out-of-gas JUMPDEST matches the dispatch loop's ordering.
             vm.OpCodeCount++;
-            TGasPolicy.Consume<JumpDestGasCost>(ref gas);
             programCounter++;
+            return TGasPolicy.UpdateGas<JumpDestGasCost>(ref gas);
         }
 
-        return programCounter;
+        return true;
     }
 
     /// <summary>
@@ -254,7 +256,7 @@ public static partial class EvmInstructions
         // If Shanghai DDoS protection is active, charge the appropriate gas cost.
         if (TSpec.UseShanghaiDDosProtection)
         {
-            if (!TGasPolicy.ConsumeSelfDestructGas(ref gas))
+            if (!TGasPolicy.TryConsumeSelfDestructGas(ref gas))
                 goto OutOfGas;
         }
 
@@ -264,7 +266,7 @@ public static partial class EvmInstructions
             goto StackUnderflow;
 
         // Charge gas for SELFDESTRUCT beneficiary access; if insufficient, signal out-of-gas.
-        if (!TSpec.ConsumeAccountAccessGas<TGasPolicy>(ref gas, spec, in vmState.AccessTracker, vm.TxTracer.IsTracingAccess, inheritor, AccountAccessKind.SelfDestructBeneficiary))
+        if (!TSpec.TryConsumeAccountAccessGas<TGasPolicy>(ref gas, spec, in vmState.AccessTracker, vm.IsTracingAccess, inheritor, AccountAccessKind.SelfDestructBeneficiary))
             goto OutOfGas;
 
         Address executingAccount = vmState.Env.ExecutingAccount;
@@ -277,7 +279,7 @@ public static partial class EvmInstructions
         // Retrieve the current balance for transfer.
         UInt256 result = state.GetBalance(executingAccount);
 
-        if (vm.TxTracer.IsTracingActions)
+        if (vm.IsTracingActions)
             vm.TxTracer.ReportSelfDestruct(executingAccount, result, inheritor);
 
         // Charge gas if transferring to a dead or non-existent account.
@@ -292,7 +294,7 @@ public static partial class EvmInstructions
         // charge execution first so an execution-gas OOG does not spill state gas.
         bool outOfGas = chargesNewAccount &&
             !((!TSpec.IsEip8038Enabled || TGasPolicy.UpdateGas(ref gas, Eip8038Constants.AccountWrite))
-              && TGasPolicy.ConsumeNewAccountCreation<TEip8037>(ref gas));
+              && TGasPolicy.TryConsumeNewAccountCreation<TEip8037>(ref gas));
 
         if (outOfGas) goto OutOfGas;
 
@@ -333,7 +335,7 @@ public static partial class EvmInstructions
     public static EvmExceptionType InstructionInvalid<TGasPolicy>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> _)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
-        TGasPolicy.Consume<HighGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<HighGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         return EvmExceptionType.BadInstruction;
     }
 
@@ -356,10 +358,10 @@ public static partial class EvmInstructions
     /// stack slot for the whole of the calling instruction.
     /// </remarks>
     /// <param name="slot">The stack slot holding the destination, big-endian.</param>
-    /// <param name="env">The current execution environment containing code information.</param>
+    /// <param name="stack">The current EVM stack, which carries the code length and jump-destination bitmap.</param>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static nint JumpDestination(ref byte slot, ExecutionEnvironment env)
+    private static nint JumpDestination(ref byte slot, ref EvmStack stack)
     {
         ref ulong parts = ref Unsafe.As<byte, ulong>(ref slot);
         ulong low = Unsafe.Add(ref parts, 3);
@@ -367,27 +369,26 @@ public static partial class EvmInstructions
         if ((parts | Unsafe.Add(ref parts, 1) | Unsafe.Add(ref parts, 2) | (uint)low) != 0)
             return -1;
 
-        // A value above int.MaxValue needs no test of its own: ValidateJump compares unsigned, so the
+        // A value above int.MaxValue needs no test of its own: the bound below compares unsigned, so the
         // sign-flipped index is far past any code length.
-        return JumpDestination((int)BinaryPrimitives.ReverseEndianness((uint)(low >> 32)), env);
+        return JumpDestination((int)BinaryPrimitives.ReverseEndianness((uint)(low >> 32)), ref stack);
     }
 
-    /// <inheritdoc cref="JumpDestination(ref byte, ExecutionEnvironment)"/>
-    private static nint JumpDestination(int jumpDestination, ExecutionEnvironment env) =>
-        env.CodeInfo.ValidateJump(jumpDestination) ? jumpDestination : -1;
+    /// <inheritdoc cref="JumpDestination(ref byte, ref EvmStack)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static nint JumpDestination(int jumpDestination, ref EvmStack stack) =>
+        (uint)jumpDestination < (uint)stack.CodeLength
+            && JumpDestinationAnalyzer.IsJumpDestination(stack.JumpDestinations, jumpDestination)
+            ? jumpDestination
+            : -1;
 
-    /// <summary>
-    /// Prefetches the cache line at the given program counter location.
-    /// Hardware prefetchers cannot predict jump destinations, so we explicitly prefetch
-    /// to reduce cache misses after non-sequential control flow.
-    /// </summary>
+    /// <summary>Prefetches the bytecode cache line at a taken jump's next instruction.</summary>
+    /// <remarks>Hints the target explicitly to reduce cache misses after non-sequential control flow.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static void PrefetchCodeAtDestination(ref EvmStack stack, nint programCounter)
     {
         if (Sse.IsSupported)
         {
-            // Prefetch the cache line containing the jump destination.
-            // Also prefetch the next cache line since code often spans multiple lines.
             ref byte code = ref stack.Code;
             nuint dest = (nuint)programCounter;
             nuint codeLength = (nuint)stack.CodeLength;
@@ -396,8 +397,7 @@ public static partial class EvmInstructions
             {
                 unsafe
                 {
-                    // Best-effort hint: PREFETCHT0 never faults. A GC relocation just
-                    // makes the hint useless, not unsafe.
+                    // PREFETCHT0 is a non-faulting hint; a GC relocation only makes the hint ineffective.
                     Sse.Prefetch0(Unsafe.AsPointer(ref Unsafe.Add(ref code, dest)));
                 }
             }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Create.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -84,8 +85,7 @@ public static partial class EvmInstructions
             goto StaticCallViolation;
         }
 
-        // Reset the return data buffer as contract creation does not use previous return data.
-        vm.ReturnData = null;
+        Debug.Assert(vm.ReturnData is null, "Dispatch clears staged output before entering an opcode chain.");
         ExecutionEnvironment env = vm.VmState.Env;
         IWorldState state = vm.WorldState;
 
@@ -108,7 +108,6 @@ public static partial class EvmInstructions
         {
             if (initCodeLength > spec.MaxInitCodeSize)
             {
-                TGasPolicy.SetOutOfGas(ref gas);
                 goto OutOfGas;
             }
         }
@@ -117,7 +116,7 @@ public static partial class EvmInstructions
         if (outOfGas)
             goto OutOfGas;
 
-        if (!TSpec.ConsumeCreateGas<TGasPolicy, TEip8037, TOpCreate>(ref gas, spec, initCodeWords))
+        if (!TSpec.TryConsumeCreateGas<TGasPolicy, TEip8037, TOpCreate>(ref gas, spec, initCodeWords))
             goto OutOfGas;
 
         // Update memory gas cost based on the required memory expansion for the init code.
@@ -128,8 +127,8 @@ public static partial class EvmInstructions
         // This guard ensures we do not create nested contract calls beyond EVM limits.
         if (env.CallDepth >= MaxCallDepth)
         {
-            vm.ReturnDataBuffer = Array.Empty<byte>();
-            return stack.PushZero<TTracingInst>();
+            vm.ReturnDataBuffer = default;
+            return stack.PushZero<TTracingInst, OnFlag>();
         }
 
         // Load the initialization code from memory based on the specified position and length.
@@ -140,16 +139,16 @@ public static partial class EvmInstructions
         UInt256 balance = state.GetBalance(env.ExecutingAccount);
         if (value > balance)
         {
-            vm.ReturnDataBuffer = Array.Empty<byte>();
-            return stack.PushZero<TTracingInst>();
+            vm.ReturnDataBuffer = default;
+            return stack.PushZero<TTracingInst, OnFlag>();
         }
 
         // Retrieve the nonce of the executing account to ensure it hasn't reached the maximum.
         ulong accountNonce = state.GetNonce(env.ExecutingAccount);
         if (accountNonce >= ulong.MaxValue)
         {
-            vm.ReturnDataBuffer = Array.Empty<byte>();
-            return stack.PushZero<TTracingInst>();
+            vm.ReturnDataBuffer = default;
+            return stack.PushZero<TTracingInst, OnFlag>();
         }
 
         // Compute the contract address:
@@ -169,7 +168,7 @@ public static partial class EvmInstructions
         bool isAliveAccount = !state.IsDeadAccount(contractAddress);
         bool chargeCreateStateGas = TEip8037.IsActive && !isAliveAccount;
 
-        if (chargeCreateStateGas && !TGasPolicy.ConsumeCreateStateGas(ref gas))
+        if (chargeCreateStateGas && !TGasPolicy.TryConsumeCreateStateGas(ref gas))
             goto OutOfGas;
 
         // Get remaining gas for the create operation.
@@ -201,8 +200,8 @@ public static partial class EvmInstructions
                 vm.CreditStateGasRefund<TEip8037>(ref gas, TGasPolicy.GetCreateStateCost());
             }
 
-            vm.ReturnDataBuffer = Array.Empty<byte>();
-            return stack.PushZero<TTracingInst>();
+            vm.ReturnDataBuffer = default;
+            return stack.PushZero<TTracingInst, OnFlag>();
         }
 
         state.ClearStorage(contractAddress);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Crypto.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Crypto.cs
@@ -30,7 +30,7 @@ public static partial class EvmInstructions
 
         // Deduct gas: base cost plus additional cost per 32-byte word.
         ulong words = EvmCalculations.Div32Ceiling(in b, out bool outOfGas);
-        TGasPolicy.ConsumeKeccak(ref gas, words);
+        if (!TGasPolicy.TryConsumeKeccak(ref gas, words)) return EvmExceptionType.OutOfGas;
         if (outOfGas) goto OutOfGas;
 
         VmState<TGasPolicy> vmState = vm.VmState;
@@ -44,7 +44,7 @@ public static partial class EvmInstructions
         // Compute the Keccak-256 hash.
         KeccakCache.ComputeTo(bytes, out ValueHash256 keccak);
         // Push the 256-bit hash result onto the stack.
-        return stack.Push32Bytes<TTracingInst>(in keccak);
+        return stack.Push32Bytes<TTracingInst, OnFlag>(in keccak);
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -168,7 +168,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct the gas cost as defined by the operation implementation.
-        TGasPolicy.Consume<TOpEnv>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpEnv>(ref gas)) return EvmExceptionType.OutOfGas;
 
         // Execute the operation and retrieve the result.
         Address result = TOpEnv.Operation(vm.VmState);
@@ -195,7 +195,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct the gas cost as defined by the operation implementation.
-        TGasPolicy.Consume<TOpEnv>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpEnv>(ref gas)) return EvmExceptionType.OutOfGas;
 
         // Execute the operation and retrieve the result.
         Address result = TOpEnv.Operation(vm);
@@ -220,7 +220,7 @@ public static partial class EvmInstructions
         where TOpEnv : struct, IOpEnvUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<TOpEnv>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpEnv>(ref gas)) return EvmExceptionType.OutOfGas;
 
         ref readonly UInt256 result = ref TOpEnv.Operation(vm.VmState);
 
@@ -243,7 +243,7 @@ public static partial class EvmInstructions
         where TOpEnv : struct, IOpBlkUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<TOpEnv>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpEnv>(ref gas)) return EvmExceptionType.OutOfGas;
 
         ref readonly UInt256 result = ref TOpEnv.Operation(vm);
 
@@ -266,11 +266,11 @@ public static partial class EvmInstructions
         where TOpEnv : struct, IOpEnvUInt32<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<TOpEnv>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpEnv>(ref gas)) return EvmExceptionType.OutOfGas;
 
         uint result = TOpEnv.Operation(vm.VmState);
 
-        return stack.PushUInt32<TTracingInst>(result);
+        return stack.PushUInt32<TTracingInst, OnFlag>(result);
     }
 
     [SkipLocalsInit]
@@ -278,11 +278,11 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         uint result = (uint)stack.CodeLength;
 
-        return stack.PushUInt32<TTracingInst>(result);
+        return stack.PushUInt32<TTracingInst, OnFlag>(result);
     }
 
     /// <summary>
@@ -301,11 +301,11 @@ public static partial class EvmInstructions
         where TOpEnv : struct, IOpEnvUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<TOpEnv>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpEnv>(ref gas)) return EvmExceptionType.OutOfGas;
 
         ulong result = TOpEnv.Operation(vm.VmState);
 
-        return stack.PushUInt64<TTracingInst>(result);
+        return stack.PushUInt64<TTracingInst, OnFlag>(result);
     }
 
     /// <summary>
@@ -324,11 +324,11 @@ public static partial class EvmInstructions
         where TOpEnv : struct, IOpBlkUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<TOpEnv>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpEnv>(ref gas)) return EvmExceptionType.OutOfGas;
 
         ulong result = TOpEnv.Operation(vm);
 
-        return stack.PushUInt64<TTracingInst>(result);
+        return stack.PushUInt64<TTracingInst, OnFlag>(result);
     }
 
     /// <summary>
@@ -347,11 +347,11 @@ public static partial class EvmInstructions
         where TOpEnv : struct, IOpEnv32Bytes<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<TOpEnv>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpEnv>(ref gas)) return EvmExceptionType.OutOfGas;
 
         ref readonly ValueHash256 result = ref TOpEnv.Operation(vm);
 
-        return stack.Push32Bytes<TTracingInst>(in result);
+        return stack.Push32Bytes<TTracingInst, OnFlag>(in result);
     }
 
     /// <summary>
@@ -373,8 +373,8 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
-        return stack.PushUInt32<TTracingInst>((uint)vm.ReturnDataBuffer.Length);
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
+        return stack.PushUInt32<TTracingInst, OnFlag>((uint)vm.ReturnDataBuffer.Length);
     }
 
     /// <summary>
@@ -449,8 +449,8 @@ public static partial class EvmInstructions
         if (!context.Header.ExcessBlobGas.HasValue) goto BadInstruction;
 
         // Charge the base gas cost for this opcode.
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
-        return stack.Push32Bytes<TTracingInst>(in context.BlobBaseFee);
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
+        return stack.Push32Bytes<TTracingInst, OnFlag>(in context.BlobBaseFee);
         // Jump forward to be unpredicted by the branch predictor.
     BadInstruction:
         return EvmExceptionType.BadInstruction;
@@ -548,16 +548,16 @@ public static partial class EvmInstructions
     {
         IReleaseSpec spec = vm.Spec;
         // Deduct gas cost for balance operation as per specification.
-        TGasPolicy.Consume<BalanceGasCost>(ref gas, spec);
+        if (!TGasPolicy.UpdateGas<BalanceGasCost>(ref gas, spec)) return EvmExceptionType.OutOfGas;
 
         Address? address = stack.PopAddress(vm.AddressCache);
         if (address is null) goto StackUnderflow;
 
         // Charge gas for account access. If insufficient gas remains, abort.
-        if (!TSpec.ConsumeAccountAccessGas<TGasPolicy>(ref gas, spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, address)) goto OutOfGas;
+        if (!TSpec.TryConsumeAccountAccessGas<TGasPolicy>(ref gas, spec, in vm.VmState.AccessTracker, vm.IsTracingAccess, address)) goto OutOfGas;
 
-        UInt256 result = vm.WorldState.GetBalance(address);
-        return PushBalance<TTracingInst>(ref stack, in result);
+        ref readonly UInt256 result = ref vm.WorldState.GetBalance(address);
+        return PushBalance<TTracingInst, OnFlag>(ref stack, in result);
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;
@@ -568,7 +568,9 @@ public static partial class EvmInstructions
     /// <summary>
     /// Pushes the balance of the executing account onto the stack.
     /// </summary>
+    /// <remarks>Keep the account lookup separately tierable for profile-guided inlining.</remarks>
     /// <typeparam name="TGasPolicy">The gas policy used for gas accounting.</typeparam>
+    /// <typeparam name="TCheck">Whether to check gas and stack capacity; dispatch establishes both when disabled.</typeparam>
     /// <param name="vm">The virtual machine instance.</param>
     /// <param name="stack">The execution stack.</param>
     /// <param name="gas">Reference to the gas state, updated by the operation's cost.</param>
@@ -576,22 +578,25 @@ public static partial class EvmInstructions
     /// <see cref="EvmExceptionType.None"/>
     /// </returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionSelfBalance<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static EvmExceptionType InstructionSelfBalance<TGasPolicy, TTracingInst, TCheck>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
+        where TCheck : struct, IFlag
     {
-        TGasPolicy.Consume<SelfBalanceGasCost>(ref gas);
+        if (TCheck.IsActive && !TGasPolicy.UpdateGas<SelfBalanceGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         // Get balance for currently executing account.
-        UInt256 result = vm.WorldState.GetBalance(vm.VmState.Env.ExecutingAccount);
-        return PushBalance<TTracingInst>(ref stack, in result);
+        ref readonly UInt256 result = ref vm.WorldState.GetBalance(vm.VmState.Env.ExecutingAccount);
+        return PushBalance<TTracingInst, TCheck>(ref stack, in result);
     }
 
     // Keep the 32-byte writer out of the already large state-access bodies.
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static EvmExceptionType PushBalance<TTracingInst>(ref EvmStack stack, in UInt256 value)
+    private static EvmExceptionType PushBalance<TTracingInst, TCheck>(ref EvmStack stack, in UInt256 value)
         where TTracingInst : struct, IFlag
-        => stack.PushUInt256<TTracingInst>(in value);
+        where TCheck : struct, IFlag
+        => stack.PushUInt256<TTracingInst, TCheck>(in value);
 
     /// <summary>
     /// Retrieves the code hash of an external account.
@@ -614,21 +619,21 @@ public static partial class EvmInstructions
         where TSpec : struct, IAccessSpec
     {
         IReleaseSpec spec = vm.Spec;
-        TGasPolicy.Consume<ExtCodeHashGasCost>(ref gas, spec);
+        if (!TGasPolicy.UpdateGas<ExtCodeHashGasCost>(ref gas, spec)) return EvmExceptionType.OutOfGas;
 
         Address? address = stack.PopAddress(vm.AddressCache);
         if (address is null) goto StackUnderflow;
         // Check if enough gas for account access and charge accordingly.
-        if (!TSpec.ConsumeAccountAccessGas<TGasPolicy>(ref gas, spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, address)) goto OutOfGas;
+        if (!TSpec.TryConsumeAccountAccessGas<TGasPolicy>(ref gas, spec, in vm.VmState.AccessTracker, vm.IsTracingAccess, address)) goto OutOfGas;
 
         IWorldState state = vm.WorldState;
         // For dead accounts, the specification requires pushing zero.
         if (state.IsDeadAccount(address))
         {
-            return stack.PushZero<TTracingInst>();
+            return stack.PushZero<TTracingInst, OnFlag>();
         }
         ValueHash256 hash = state.GetCodeHash(address);
-        return stack.Push32Bytes<TTracingInst>(in hash);
+        return stack.Push32Bytes<TTracingInst, OnFlag>(in hash);
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;
@@ -653,8 +658,8 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Charge the base gas cost for this opcode.
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
-        return stack.Push32Bytes<TTracingInst>(in vm.BlockExecutionContext.PrevRandao);
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
+        return stack.Push32Bytes<TTracingInst, OnFlag>(in vm.BlockExecutionContext.PrevRandao);
     }
 
     /// <summary>
@@ -674,13 +679,10 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct the base gas cost for reading gas.
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
-
-        // If gas falls below zero after cost deduction, signal out-of-gas error.
-        if (TGasPolicy.IsOutOfGas(in gas)) goto OutOfGas;
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) goto OutOfGas;
 
         // Push the remaining gas (as unsigned 64-bit) onto the stack.
-        return stack.PushUInt64<TTracingInst>(TGasPolicy.GetRemainingGas(in gas));
+        return stack.PushUInt64<TTracingInst, OnFlag>(TGasPolicy.GetRemainingGas(in gas));
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;
@@ -706,7 +708,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct the gas cost for blob hash operation.
-        TGasPolicy.Consume<BlobHashGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<BlobHashGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         // Pop the blob index from the stack.
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
@@ -722,7 +724,7 @@ public static partial class EvmInstructions
             return stack.PushBytes<TTracingInst>(versionedHash);
         }
 
-        return stack.PushZero<TTracingInst>();
+        return stack.PushZero<TTracingInst, OnFlag>();
         // Jump forward to be unpredicted by the branch predictor.
     StackUnderflow:
         return EvmExceptionType.StackUnderflow;
@@ -749,7 +751,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct the gas cost for block hash operation.
-        TGasPolicy.Consume<BlockHashGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<BlockHashGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         // Pop the block number from the stack.
         if (!stack.PopUInt256(out UInt256 a)) goto StackUnderflow;
@@ -763,8 +765,7 @@ public static partial class EvmInstructions
         // Push the block hash bytes if available; otherwise, push a 32-byte zero value.
         EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(blockHash is not null ? blockHash.Bytes : BytesZero32);
 
-        // If block hash tracing is enabled and a valid block hash was obtained, report it.
-        if (vm.TxTracer.IsTracingBlockHash && blockHash is not null)
+        if (DispatchFlags.ConstTracing && vm.TxTracer.IsTracingBlockHash && blockHash is not null)
         {
             vm.TxTracer.ReportBlockHash(blockHash);
         }
@@ -796,8 +797,8 @@ public static partial class EvmInstructions
         if (!slotNumber.HasValue) goto BadInstruction;
 
         // Charge the base gas cost for this opcode.
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
-        return stack.PushUInt64<TTracingInst>(slotNumber.Value);
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
+        return stack.PushUInt64<TTracingInst, OnFlag>(slotNumber.Value);
         // Jump forward to be unpredicted by the branch predictor.
     BadInstruction:
         return EvmExceptionType.BadInstruction;

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.FrameTx.cs
@@ -63,7 +63,7 @@ public static unsafe partial class EvmInstructions
         }
 
         // Charged immediately before the nonce increment that would create the sender.
-        if (plan.CreatesSender && !TGasPolicy.ConsumeStateGas(ref gas, TGasPolicy.GetNewAccountStateCost()))
+        if (plan.CreatesSender && !TGasPolicy.TryConsumeStateGas(ref gas, TGasPolicy.GetNewAccountStateCost()))
         {
             return EvmExceptionType.OutOfGas;
         }
@@ -96,14 +96,14 @@ public static unsafe partial class EvmInstructions
         FrameTxContext? ctx = vm.TxExecutionContext.FrameTxContext;
         if (ctx is null) return EvmExceptionType.BadInstruction;
 
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         if (!stack.PopUInt256(out UInt256 param)) return EvmExceptionType.StackUnderflow;
         if (param > 0x11U) return EvmExceptionType.BadInstruction;
 
         byte[]?[]? blobHashes = vm.TxExecutionContext.BlobVersionedHashes;
         return param.u0 switch
         {
-            0x00 => stack.PushUInt32<TTracingInst>((uint)TxType.FrameTx),
+            0x00 => stack.PushUInt32<TTracingInst, OnFlag>((uint)TxType.FrameTx),
             0x01 => stack.PushUInt256<TTracingInst>(ctx.Nonce),
             0x02 => stack.PushAddress<TTracingInst>(ctx.Sender),
             0x03 => stack.PushUInt256<TTracingInst>(ctx.MaxPriorityFeePerGas),
@@ -138,7 +138,7 @@ public static unsafe partial class EvmInstructions
         FrameTxContext? ctx = vm.TxExecutionContext.FrameTxContext;
         if (ctx is null) return EvmExceptionType.BadInstruction;
 
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         // Spec stack order: field on top, index second — the reverse of FRAMEPARAM and SIGPARAM.
         if (!stack.PopUInt256(out UInt256 field, out UInt256 index)) return EvmExceptionType.StackUnderflow;
         if (index >= (UInt256)ctx.RecentRootReferences.Length || field > 2) return EvmExceptionType.BadInstruction;
@@ -161,7 +161,7 @@ public static unsafe partial class EvmInstructions
         FrameTxContext? ctx = vm.TxExecutionContext.FrameTxContext;
         if (ctx is null) return EvmExceptionType.BadInstruction;
 
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         // Spec stack order: offset on top, frameIndex second (matching CALLDATALOAD).
         if (!stack.PopUInt256(out UInt256 offset, out UInt256 frameIndex)) return EvmExceptionType.StackUnderflow;
         if (frameIndex >= (UInt256)ctx.Frames.Length) return EvmExceptionType.BadInstruction;
@@ -169,7 +169,7 @@ public static unsafe partial class EvmInstructions
         ReadOnlySpan<byte> data = ctx.Frames[(int)frameIndex.u0].Data.Span;
         if (!offset.IsUint64 || offset.u0 >= (uint)data.Length)
         {
-            return stack.PushZero<TTracingInst>();
+            return stack.PushZero<TTracingInst, OnFlag>();
         }
 
         uint available = (uint)data.Length - (uint)offset.u0;
@@ -205,7 +205,7 @@ public static unsafe partial class EvmInstructions
         FrameTxContext? ctx = vm.TxExecutionContext.FrameTxContext;
         if (ctx is null) return EvmExceptionType.BadInstruction;
 
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         // Spec stack order: frameIndex on top, param second.
         if (!stack.PopUInt256(out UInt256 frameIndex, out UInt256 param)) return EvmExceptionType.StackUnderflow;
         if (frameIndex >= (UInt256)ctx.Frames.Length) return EvmExceptionType.BadInstruction;
@@ -217,12 +217,12 @@ public static unsafe partial class EvmInstructions
         {
             0x00 => stack.PushAddress<TTracingInst>(ctx.ResolvedTarget(index)),
             0x01 => stack.PushUInt256<TTracingInst>((UInt256)frame.ExecutionGasLimit),
-            0x02 => stack.PushUInt32<TTracingInst>(frame.Mode),
-            0x03 => stack.PushUInt32<TTracingInst>(frame.Flags),
+            0x02 => stack.PushUInt32<TTracingInst, OnFlag>(frame.Mode),
+            0x03 => stack.PushUInt32<TTracingInst, OnFlag>(frame.Flags),
             0x04 => stack.PushUInt256<TTracingInst>((UInt256)frame.Data.Length),
             0x05 => FrameStatus<TTracingInst>(ctx, index, ref stack),
-            0x06 => stack.PushUInt32<TTracingInst>(frame.AllowedApproveScope),
-            0x07 => stack.PushUInt32<TTracingInst>((uint)(frame.IsAtomicBatch ? 1 : 0)),
+            0x06 => stack.PushUInt32<TTracingInst, OnFlag>(frame.AllowedApproveScope),
+            0x07 => stack.PushUInt32<TTracingInst, OnFlag>((uint)(frame.IsAtomicBatch ? 1 : 0)),
             0x08 => stack.PushUInt256<TTracingInst>(frame.Value),
             0x09 => stack.PushUInt256<TTracingInst>((UInt256)frame.StateGasLimit),
             0x0A => FrameExecutionGasUsed<TTracingInst>(ctx, index, ref stack),
@@ -251,7 +251,7 @@ public static unsafe partial class EvmInstructions
         if (!ctx.IsFrameCompleted(index)) return EvmExceptionType.BadInstruction;
         // 0 failure, 1 success, 2 skipped by a failed atomic batch.
         uint status = ctx.WasFrameSkipped(index) ? 2u : ctx.HasFrameSucceeded(index) ? 1u : 0u;
-        return stack.PushUInt32<TTracingInst>(status);
+        return stack.PushUInt32<TTracingInst, OnFlag>(status);
     }
 
     /// <summary>SIGPARAM (0xb4): read a signature-scoped field.</summary>
@@ -271,15 +271,15 @@ public static unsafe partial class EvmInstructions
         int index = (int)signatureIndex.u0;
         TxFrameSignature signature = ctx.Signatures[index];
 
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         return param.u0 switch
         {
             0x00 => signature.Scheme == TxFrameSignature.SchemeArbitrary
                 ? EvmExceptionType.BadInstruction
                 : stack.PushAddress<TTracingInst>(ctx.ResolvedSigner(index)),
-            0x01 => stack.PushUInt32<TTracingInst>(signature.Scheme),
+            0x01 => stack.PushUInt32<TTracingInst, OnFlag>(signature.Scheme),
             0x02 => signature.Msg.IsEmpty
-                ? stack.PushZero<TTracingInst>()
+                ? stack.PushZero<TTracingInst, OnFlag>()
                 : stack.PushBytes<TTracingInst>(signature.Msg.Span),
             0x03 => signature.Scheme == TxFrameSignature.SchemeArbitrary
                 ? stack.PushUInt256<TTracingInst>((UInt256)signature.Signature.Length)

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math1Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math1Param.cs
@@ -53,23 +53,25 @@ public static partial class EvmInstructions
         where TOpMath : struct, IOpMath1Param
     {
         // Deduct the gas cost associated with the math operation.
-        TGasPolicy.Consume<TOpMath>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpMath>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        return Math1ParamCore<TOpMath>(ref stack);
+        return Math1ParamCore<TOpMath, OnFlag>(ref stack);
     }
 
     /// <summary>Gas-free body of <see cref="InstructionMath1Param{TGasPolicy, TOpMath}"/>.</summary>
+    /// <remarks>When <typeparamref name="TCheckDepth"/> is inactive, the caller must have verified at least 1 stack item.</remarks>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static EvmExceptionType Math1ParamCore<TOpMath>(ref EvmStack stack)
+    internal static EvmExceptionType Math1ParamCore<TOpMath, TCheckDepth>(ref EvmStack stack)
         where TOpMath : struct, IOpMath1Param
+        where TCheckDepth : struct, IFlag
     {
         // Folding a word down to a scalar through an EvmWord value makes the operand address-taken, so
         // targets with no 256-bit register home it on the frame and read it back limb by limb. Test the
         // slot where it lies instead.
         if (!Vector256.IsHardwareAccelerated && typeof(TOpMath) == typeof(OpIsZero))
         {
-            if (!stack.EnsureDepth(1))
+            if (TCheckDepth.IsActive && !stack.EnsureDepth(1))
                 return EvmExceptionType.StackUnderflow;
 
             ref byte slot = ref stack.PeekBytesByRefUnchecked();
@@ -79,7 +81,7 @@ public static partial class EvmInstructions
 
         if (!Vector128.IsHardwareAccelerated && typeof(TOpMath) == typeof(OpNot))
         {
-            if (!stack.EnsureDepth(1))
+            if (TCheckDepth.IsActive && !stack.EnsureDepth(1))
                 return EvmExceptionType.StackUnderflow;
 
             ref byte valueBytes = ref stack.PeekBytesByRefUnchecked();
@@ -94,7 +96,7 @@ public static partial class EvmInstructions
 
         // Peek at the top element of the stack without removing it.
         // This avoids an unnecessary pop/push sequence.
-        if (!stack.EnsureDepth(1)) goto StackUnderflow;
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(1)) goto StackUnderflow;
         ref byte bytesRef = ref stack.PeekBytesByRefUnchecked();
 
         // Read a 256-bit value from unaligned memory on the stack.
@@ -115,6 +117,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpNot : IOpMath1Param
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static EvmWord Operation(EvmWord value) => Vector256.OnesComplement(value);
     }
 
@@ -140,12 +143,10 @@ public static partial class EvmInstructions
     /// </remarks>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EvmExceptionType InstructionCountLeadingZeros<TGasPolicy>(ref EvmStack stack, ref TGasPolicy gas)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+    internal static EvmExceptionType CountLeadingZerosCore<TCheckDepth>(ref EvmStack stack)
+        where TCheckDepth : struct, IFlag
     {
-        TGasPolicy.Consume<LowGasCost>(ref gas);
-
-        if (!stack.EnsureDepth(1))
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(1))
             return EvmExceptionType.StackUnderflow;
 
         ref byte slot = ref stack.PeekBytesByRefUnchecked();
@@ -165,9 +166,18 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        if (!stack.EnsureDepth(2)) return EvmExceptionType.StackUnderflow;
+        return ByteCore<TTracingInst, OnFlag>(ref stack);
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType ByteCore<TTracingInst, TCheckDepth>(ref EvmStack stack)
+        where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
+    {
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(2)) return EvmExceptionType.StackUnderflow;
         ref byte topRef = ref stack.Pop1Peek32BytesUnchecked();
 
         ref ulong result = ref As<byte, ulong>(ref topRef);
@@ -215,7 +225,7 @@ public static partial class EvmInstructions
     public static EvmExceptionType InstructionSignExtend<TGasPolicy>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
     {
-        TGasPolicy.Consume<LowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<LowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         // The index and the word it applies to are adjacent, so one depth check covers both.
         if (!stack.EnsureDepth(2))

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
@@ -55,17 +55,19 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct the gas cost for the specific math operation.
-        TGasPolicy.Consume<TOpMath>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpMath>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        return Math2ParamCore<TOpMath, TTracingInst>(ref stack);
+        return Math2ParamCore<TOpMath, TTracingInst, OnFlag>(ref stack);
     }
 
     /// <summary>Gas-free body of <see cref="InstructionMath2Param{TGasPolicy, TOpMath, TTracingInst}"/>.</summary>
+    /// <remarks>When <typeparamref name="TCheckDepth"/> is inactive, the caller must have verified at least 2 stack items.</remarks>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static EvmExceptionType Math2ParamCore<TOpMath, TTracingInst>(ref EvmStack stack)
+    internal static EvmExceptionType Math2ParamCore<TOpMath, TTracingInst, TCheckDepth>(ref EvmStack stack)
         where TOpMath : struct, IOpMath2Param
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         // ADD and SUB run on the stack's own big-endian limbs on every target. Going through UInt256
         // costs three full-word endianness conversions around a vectorised carry chain that, on the
@@ -74,7 +76,7 @@ public static partial class EvmInstructions
         // is four dependent adds either way.
         if (typeof(TOpMath) == typeof(OpAdd))
         {
-            if (!stack.EnsureDepth(2)) goto StackUnderflow;
+            if (TCheckDepth.IsActive && !stack.EnsureDepth(2)) goto StackUnderflow;
             ref byte addTopRef = ref stack.Pop1Peek32BytesUnchecked();
 
             ref ulong top = ref As<byte, ulong>(ref addTopRef);
@@ -98,7 +100,7 @@ public static partial class EvmInstructions
 
         if (typeof(TOpMath) == typeof(OpSub))
         {
-            if (!stack.EnsureDepth(2)) goto StackUnderflow;
+            if (TCheckDepth.IsActive && !stack.EnsureDepth(2)) goto StackUnderflow;
             ref byte subtractTopRef = ref stack.Pop1Peek32BytesUnchecked();
 
             ref ulong subtrahend = ref As<byte, ulong>(ref subtractTopRef);
@@ -135,7 +137,7 @@ public static partial class EvmInstructions
             typeof(TOpMath) == typeof(OpSLt) ||
             typeof(TOpMath) == typeof(OpSGt))
         {
-            if (!stack.EnsureDepth(2)) goto StackUnderflow;
+            if (TCheckDepth.IsActive && !stack.EnsureDepth(2)) goto StackUnderflow;
             ref byte rawTopRef = ref stack.Pop1Peek32BytesUnchecked();
 
             ref ulong resultParts = ref As<byte, ulong>(ref rawTopRef);
@@ -149,7 +151,7 @@ public static partial class EvmInstructions
 
         // Pop a and peek the new top slot for in-place write; skips the push's overflow check
         // since the net stack delta (-1) cannot overflow a previously non-overflowing stack.
-        if (!stack.EnsureDepth(2)) goto StackUnderflow;
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(2)) goto StackUnderflow;
         ref byte topRef = ref stack.Pop1Peek32BytesUnchecked(out UInt256 a);
 
         EvmStack.ReadUInt256FromSlot(ref topRef, out UInt256 b);
@@ -204,6 +206,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpAdd : IOpMath2Param
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Operation(in UInt256 a, in UInt256 b, out UInt256 result)
             => UInt256.Add(in a, in b, out result);
     }
@@ -213,6 +216,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpSub : IOpMath2Param
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Operation(in UInt256 a, in UInt256 b, out UInt256 result)
             => UInt256.Subtract(in a, in b, out result);
     }
@@ -235,6 +239,7 @@ public static partial class EvmInstructions
     public struct OpDiv : IOpMath2Param
     {
         static ulong IGasCost.GasCost => GasCostOf.Low;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Operation(in UInt256 a, in UInt256 b, out UInt256 result)
         {
             if (b.IsZero)
@@ -290,6 +295,7 @@ public static partial class EvmInstructions
     public struct OpMod : IOpMath2Param
     {
         static ulong IGasCost.GasCost => GasCostOf.Low;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Operation(in UInt256 a, in UInt256 b, out UInt256 result)
         {
             if (b.IsZeroOrOne)
@@ -338,6 +344,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpLt : IOpMath2Param
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Operation(in UInt256 a, in UInt256 b, out UInt256 result) => result = a < b ? UInt256.One : default;
     }
 
@@ -347,6 +354,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpGt : IOpMath2Param
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Operation(in UInt256 a, in UInt256 b, out UInt256 result) => result = a > b ? UInt256.One : default;
     }
 
@@ -356,6 +364,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpSLt : IOpMath2Param
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Operation(in UInt256 a, in UInt256 b, out UInt256 result) => result = As<UInt256, Int256>(ref AsRef(in a))
                 .CompareTo(As<UInt256, Int256>(ref AsRef(in b))) < 0 ?
                 UInt256.One :
@@ -368,6 +377,7 @@ public static partial class EvmInstructions
     /// </summary>
     public struct OpSGt : IOpMath2Param
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Operation(in UInt256 a, in UInt256 b, out UInt256 result) => result = As<UInt256, Int256>(ref AsRef(in a))
                 .CompareTo(As<UInt256, Int256>(ref AsRef(in b))) > 0 ?
                 UInt256.One :
@@ -385,12 +395,13 @@ public static partial class EvmInstructions
     /// <see cref="EvmExceptionType.None"/> on success; or <see cref="EvmExceptionType.StackUnderflow"/> if not enough items on stack.
     /// </returns>
     [SkipLocalsInit]
-    public static EvmExceptionType InstructionExp<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
+    public static EvmExceptionType InstructionExp<TGasPolicy, TTracingInst, Eip160>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
+        where Eip160 : struct, IFlag
     {
         // Charge the fixed gas cost for exponentiation.
-        TGasPolicy.Consume<ExpGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<ExpGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         // Pop the base value and exponent from the stack.
         if (!stack.PopUInt256(out UInt256 a, out UInt256 exponent))
@@ -408,11 +419,11 @@ public static partial class EvmInstructions
 
         ulong expSize = (ulong)(32 - leadingZeros);
         // Deduct gas proportional to the number of 32-byte words needed to represent the exponent.
-        TGasPolicy.ConsumeExpBytes(ref gas, vm.Spec, expSize);
+        if (!TGasPolicy.TryConsumeExpBytes<Eip160>(ref gas, vm.Spec, expSize)) return EvmExceptionType.OutOfGas;
 
         if (a.IsZero)
         {
-            return stack.PushZero<TTracingInst>();
+            return stack.PushZero<TTracingInst, OnFlag>();
         }
         if (a.IsOne)
         {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math3Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math3Param.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics;
 using Nethermind.Core;
 using Nethermind.Evm.GasPolicy;
 
@@ -25,29 +24,31 @@ public static partial class EvmInstructions
         where TOpMath : struct, IOpMath3Param
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<TOpMath>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpMath>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        // Pop a and b, peek the third slot for in-place write; skips the push overflow check.
-        if (!stack.EnsureDepth(3)) goto StackUnderflow;
-        ref byte topRef = ref stack.Pop2Peek32BytesUnchecked(out UInt256 a, out UInt256 b);
+        if (!stack.EnsureDepth(3)) return EvmExceptionType.StackUnderflow;
+        return Math3ParamCore<TOpMath, TTracingInst>(ref stack);
+    }
 
-        EvmStack.ReadUInt256FromSlot(ref topRef, out UInt256 c);
-        if (c.IsZero)
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType Math3ParamCore<TOpMath, TTracingInst>(ref EvmStack stack)
+        where TOpMath : struct, IOpMath3Param
+        where TTracingInst : struct, IFlag
+    {
+        ref byte topRef = ref stack.Pop2Peek32BytesUnchecked();
+
+        if (!EvmStack.IsSlotZero(ref topRef))
         {
-            // c-slot already held c; overwrite with zero (matches PushZero semantics).
-            Unsafe.As<byte, Vector256<byte>>(ref topRef) = default;
-        }
-        else
-        {
+            EvmStack.ReadUInt256FromSlot(ref Unsafe.Add(ref topRef, EvmStack.WordSize), out UInt256 b);
+            EvmStack.ReadUInt256FromSlot(ref Unsafe.Add(ref topRef, 2 * EvmStack.WordSize), out UInt256 a);
+            EvmStack.ReadUInt256FromSlot(ref topRef, out UInt256 c);
             TOpMath.Operation(in a, in b, in c, out UInt256 result);
             EvmStack.WriteUInt256ToSlot(ref topRef, in result);
         }
 
         if (TTracingInst.IsActive) stack.ReportPushWord(ref topRef);
         return EvmExceptionType.None;
-    StackUnderflow:
-        // Jump forward to be unpredicted by the branch predictor
-        return EvmExceptionType.StackUnderflow;
     }
 
     public struct OpAddMod : IOpMath3Param

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Shifts.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Shifts.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
@@ -58,17 +59,18 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct gas cost specific to the shift operation.
-        TGasPolicy.Consume<TOpShift>(ref gas);
+        if (!TGasPolicy.UpdateGas<TOpShift>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        return ShiftCore<TOpShift, TTracingInst>(ref stack);
+        return ShiftCore<TOpShift, TTracingInst, OnFlag>(ref stack);
     }
 
     /// <summary>Gas-free body of <see cref="InstructionShift{TGasPolicy, TOpShift, TTracingInst}"/>.</summary>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static EvmExceptionType ShiftCore<TOpShift, TTracingInst>(ref EvmStack stack)
+    internal static EvmExceptionType ShiftCore<TOpShift, TTracingInst, TCheckDepth>(ref EvmStack stack)
         where TOpShift : struct, IOpShift
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
         // On x86 without a 256-bit register the JIT lowers the paired pop/push better than in-place
         // conversion. ARM64 is the other way round for every shift: it reverses a word in vector
@@ -84,7 +86,7 @@ public static partial class EvmInstructions
                 if (TTracingInst.IsActive)
                     return stack.PushUInt256<TTracingInst>(in UInt256.Zero);
 
-                return stack.PushZero<TTracingInst>();
+                return stack.PushZero<TTracingInst, OnFlag>();
             }
 
             TOpShift.Operation(in shift, in value, out UInt256 shifted);
@@ -94,10 +96,10 @@ public static partial class EvmInstructions
         if ((!Vector128.IsHardwareAccelerated || !X86Base.IsSupported) &&
             (typeof(TOpShift) == typeof(OpShl) || typeof(TOpShift) == typeof(OpShr)))
         {
-            return ShiftScalar<TOpShift, TTracingInst>(ref stack);
+            return ShiftScalar<TOpShift, TTracingInst, TCheckDepth>(ref stack);
         }
 
-        if (!stack.EnsureDepth(2)) goto StackUnderflow;
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(2)) goto StackUnderflow;
         ref byte topRef = ref stack.Pop1Peek32BytesUnchecked(out UInt256 a);
 
         // Direct limb access avoids the full 256-bit vector compare the JIT emits for `a >= 256`.
@@ -120,11 +122,12 @@ public static partial class EvmInstructions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static EvmExceptionType ShiftScalar<TOpShift, TTracingInst>(ref EvmStack stack)
+    private static EvmExceptionType ShiftScalar<TOpShift, TTracingInst, TCheckDepth>(ref EvmStack stack)
         where TOpShift : struct, IOpShift
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
-        if (!stack.EnsureDepth(2)) return EvmExceptionType.StackUnderflow;
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(2)) return EvmExceptionType.StackUnderflow;
         ref byte topRef = ref stack.Pop1Peek32BytesUnchecked();
 
         ref ulong value = ref As<byte, ulong>(ref topRef);
@@ -199,37 +202,58 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
+        return SarCore<TTracingInst, OnFlag>(ref stack);
+    }
+
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static EvmExceptionType SarCore<TTracingInst, TCheckDepth>(ref EvmStack stack)
+        where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
+    {
         if (X86Base.IsSupported)
         {
-            if (!stack.PopUInt256(out UInt256 shift, out UInt256 value)) goto StackUnderflow;
-
-            if (!shift.IsUint64 || shift.u0 >= 256)
+            UInt256 shift, value;
+            scoped ref byte slot = ref NullRef<byte>();
+            if (TCheckDepth.IsActive)
             {
-                if (As<UInt256, Int256>(ref value).Sign < 0)
-                    return stack.PushSignedInt256<TTracingInst>(in Int256.MinusOne);
-
-                if (TTracingInst.IsActive)
-                    return stack.PushUInt256<TTracingInst>(in UInt256.Zero);
-
-                return stack.PushZero<TTracingInst>();
+                if (!stack.PopUInt256(out shift, out value)) goto StackUnderflow;
+            }
+            else
+            {
+                slot = ref stack.Pop1Peek32BytesUnchecked(out shift);
+                EvmStack.ReadUInt256FromSlot(ref slot, out value);
             }
 
-            As<UInt256, Int256>(ref value).RightShift((int)shift, out Int256 shifted);
-            return stack.PushUInt256<TTracingInst>(in As<Int256, UInt256>(ref shifted));
+            UInt256 result;
+            if (!shift.IsUint64 || shift.u0 >= 256)
+                result = As<UInt256, Int256>(ref value).Sign < 0 ? UInt256.MaxValue : UInt256.Zero;
+            else
+            {
+                As<UInt256, Int256>(ref value).RightShift((int)shift, out Int256 shifted);
+                result = As<Int256, UInt256>(ref shifted);
+            }
+
+            if (TCheckDepth.IsActive) return stack.PushUInt256<TTracingInst>(in result);
+            Debug.Assert(!IsNullRef(ref slot), "The unchecked path peeked the destination slot.");
+            EvmStack.WriteUInt256ToSlot(ref slot, in result);
+            if (TTracingInst.IsActive) stack.ReportPushWord(ref slot);
+            return EvmExceptionType.None;
         }
 
-        return SarScalar<TTracingInst>(ref stack);
+        return SarScalar<TTracingInst, TCheckDepth>(ref stack);
     StackUnderflow:
         return EvmExceptionType.StackUnderflow;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static EvmExceptionType SarScalar<TTracingInst>(ref EvmStack stack)
+    private static EvmExceptionType SarScalar<TTracingInst, TCheckDepth>(ref EvmStack stack)
         where TTracingInst : struct, IFlag
+        where TCheckDepth : struct, IFlag
     {
-        if (!stack.EnsureDepth(2)) return EvmExceptionType.StackUnderflow;
+        if (TCheckDepth.IsActive && !stack.EnsureDepth(2)) return EvmExceptionType.StackUnderflow;
         ref byte topRef = ref stack.Pop1Peek32BytesUnchecked();
 
         ref ulong value = ref As<byte, ulong>(ref topRef);

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Spec.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Spec.cs
@@ -13,7 +13,7 @@ public static partial class EvmInstructions
 {
     internal interface IAccessSpec
     {
-        static abstract bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
+        static abstract bool TryConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
             ref readonly StackAccessTracker tracker, bool tracing, Address address, AccountAccessKind kind = AccountAccessKind.Default)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy>;
     }
@@ -23,10 +23,10 @@ public static partial class EvmInstructions
         where Eip8038 : struct, IEip8038Flag
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
+        public static bool TryConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
             ref readonly StackAccessTracker tracker, bool tracing, Address address, AccountAccessKind kind = AccountAccessKind.Default)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
-            TGasPolicy.ConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in tracker, tracing, address, kind);
+            TGasPolicy.TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in tracker, tracing, address, kind);
     }
 
     internal interface ICallSpec : IAccessSpec
@@ -55,10 +55,10 @@ public static partial class EvmInstructions
             where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
             TGasPolicy.TryReserveChildGas<Eip150>(ref gas, in requestedGas, spec, out childGas);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
+        public static bool TryConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
             ref readonly StackAccessTracker tracker, bool tracing, Address address, AccountAccessKind kind = AccountAccessKind.Default)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
-            TGasPolicy.ConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in tracker, tracing, address, kind);
+            TGasPolicy.TryConsumeAccountAccessGas<Eip2929, Eip8038>(ref gas, spec, in tracker, tracing, address, kind);
     }
 
     internal interface ICreateSpec
@@ -67,7 +67,7 @@ public static partial class EvmInstructions
         static abstract bool IsEip3860Enabled { get; }
         static abstract bool TryReserveChildGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec, out ulong childGas)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy>;
-        static abstract bool ConsumeCreateGas<TGasPolicy, Eip8037, TOpCreate>(ref TGasPolicy gas, IReleaseSpec spec, ulong words)
+        static abstract bool TryConsumeCreateGas<TGasPolicy, Eip8037, TOpCreate>(ref TGasPolicy gas, IReleaseSpec spec, ulong words)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy>
             where Eip8037 : struct, IFlag
             where TOpCreate : struct, IOpCreate;
@@ -86,11 +86,11 @@ public static partial class EvmInstructions
             where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
             TGasPolicy.TryReserveChildGas<Eip150>(ref gas, spec, out childGas);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ConsumeCreateGas<TGasPolicy, Eip8037, TOpCreate>(ref TGasPolicy gas, IReleaseSpec spec, ulong words)
+        public static bool TryConsumeCreateGas<TGasPolicy, Eip8037, TOpCreate>(ref TGasPolicy gas, IReleaseSpec spec, ulong words)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy>
             where Eip8037 : struct, IFlag
             where TOpCreate : struct, IOpCreate =>
-            TGasPolicy.ConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref gas, spec, words);
+            TGasPolicy.TryConsumeCreateGas<Eip8037, TOpCreate, Eip3860, Eip8038>(ref gas, spec, words);
     }
 
     internal interface ISelfDestructSpec : IAccessSpec
@@ -116,9 +116,9 @@ public static partial class EvmInstructions
         public static bool RemoveSelfdestructBurn { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip8246.IsActive; }
         public static bool IsEip8038Enabled { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Eip8038.IsActive; }
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
+        public static bool TryConsumeAccountAccessGas<TGasPolicy>(ref TGasPolicy gas, IReleaseSpec spec,
             ref readonly StackAccessTracker tracker, bool tracing, Address address, AccountAccessKind kind = AccountAccessKind.Default)
             where TGasPolicy : struct, IGasPolicy<TGasPolicy> =>
-            TAccess.ConsumeAccountAccessGas(ref gas, spec, in tracker, tracing, address, kind);
+            TAccess.TryConsumeAccountAccessGas(ref gas, spec, in tracker, tracing, address, kind);
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -14,25 +14,6 @@ namespace Nethermind.Evm;
 public static partial class EvmInstructions
 {
     /// <summary>
-    /// Pops a value from the EVM stack.
-    /// Deducts the base gas cost and returns an exception if the stack is underflowed.
-    /// </summary>
-    /// <param name="vm">The virtual machine instance.</param>
-    /// <param name="stack">The execution stack.</param>
-    /// <param name="gas">The gas state which is reduced by the operation's cost.</param>
-    /// <returns><see cref="EvmExceptionType.None"/> if successful; otherwise, <see cref="EvmExceptionType.StackUnderflow"/>.</returns>
-    [SkipLocalsInit]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EvmExceptionType InstructionPop<TGasPolicy>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
-        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
-    {
-        // Deduct the minimal gas cost for a POP operation.
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
-        // Pop from the stack; if nothing to pop, signal a stack underflow.
-        return stack.PopLimbo() ? EvmExceptionType.None : EvmExceptionType.StackUnderflow;
-    }
-
-    /// <summary>
     /// Interface for series of items based operations.
     /// The <c>Count</c> property specifies the expected number of items.
     /// </summary>
@@ -48,13 +29,14 @@ public static partial class EvmInstructions
         /// Pushes immediate data from the code onto the stack.
         /// If insufficient bytes are available, pads the value to the expected length.
         /// </summary>
-        /// <param name="length">The expected length of the data.</param>
+        /// <remarks>When TCheckCode is inactive, the caller must have verified that the complete immediate is available.</remarks>
         /// <param name="stack">The execution stack.</param>
         /// <param name="programCounter">The program counter.</param>
-        /// <param name="code">The code segment containing the immediate data.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        abstract static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
-            where TTracingInst : struct, IFlag;
+        abstract static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
+            where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag;
     }
 
     // Some push operations override the default Push method to handle fixed-size optimizations.
@@ -70,9 +52,11 @@ public static partial class EvmInstructions
         /// Push operation for zero
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
-        => stack.PushZero<TTracingInst>();
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
+        => stack.PushZero<TTracingInst, TCheckDepth>();
     }
 
     /// <summary>
@@ -88,14 +72,16 @@ public static partial class EvmInstructions
         /// If exactly one byte is available, it is pushed; otherwise, zero is pushed.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
             // Determine how many bytes can be used from the code.
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
-            return usedFromCode == Size ?
-                stack.PushByte<TTracingInst>(Unsafe.Add(ref stack.Code, programCounter)) :
-                stack.PushZero<TTracingInst>();
+            nint usedFromCode = stack.CodeLength - programCounter;
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
+                stack.PushByte<TTracingInst, TCheckDepth>(Unsafe.Add(ref stack.Code, programCounter)) :
+                stack.PushZero<TTracingInst, TCheckDepth>();
         }
     }
 
@@ -107,8 +93,10 @@ public static partial class EvmInstructions
         public static int Count => 2;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         => throw new NotSupportedException($"Use the {nameof(InstructionPush2)} opcode instead");
     }
 
@@ -122,16 +110,27 @@ public static partial class EvmInstructions
     {
         const int Size = sizeof(ushort);
         // Deduct a very low gas cost for the push operation.
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         // Retrieve the code segment containing immediate data.
         ref byte bytes = ref stack.Code;
         nint remainingCode = stack.CodeLength - programCounter;
         Instruction nextInstruction;
-        // Head < MaxStackSize - 1 preserves the StackOverflow a non-fused PUSH2 would raise
-        // at head == 1024 (even though the following JUMP/JUMPI would immediately pop it).
+        if (!TTracingInst.IsActive)
+        {
+            // A following jump or implicit STOP does not exempt PUSH2 from the stack limit.
+            if (stack.Head >= EvmStack.MaxStackSize - 1)
+            {
+                programCounter += Size;
+                return EvmExceptionType.StackOverflow;
+            }
+            if (remainingCode <= Size)
+            {
+                // Implicit STOP discards the stack, and no tracer or subsequent opcode can observe this push.
+                programCounter += Size;
+                return EvmExceptionType.None;
+            }
+        }
         if (!TTracingInst.IsActive &&
-            remainingCode > Size &&
-            stack.Head < EvmStack.MaxStackSize - 1 &&
             ((nextInstruction = (Instruction)Unsafe.Add(ref bytes, programCounter + Size))
                 is Instruction.JUMP or Instruction.JUMPI))
         {
@@ -141,13 +140,13 @@ public static partial class EvmInstructions
 
             if (nextInstruction == Instruction.JUMP)
             {
-                TGasPolicy.Consume<JumpGasCost>(ref gas);
                 vm.OpCodeCount++;
+                if (!TGasPolicy.UpdateGas<JumpGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
             }
             else
             {
-                TGasPolicy.Consume<JumpIGasCost>(ref gas);
                 vm.OpCodeCount++;
+                if (!TGasPolicy.UpdateGas<JumpIGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
                 if (!stack.EnsureDepth(1)) goto StackUnderflow;
                 if (EvmStack.IsSlotZero(ref stack.PopBytesByRefUnchecked()))
                 {
@@ -158,36 +157,33 @@ public static partial class EvmInstructions
             }
 
             // Validate the jump destination and update the program counter if valid.
-            nint jumpTarget = JumpDestination((int)destination, vm.VmState.Env);
+            nint jumpTarget = JumpDestination((int)destination, ref stack);
             if (jumpTarget < 0)
                 goto InvalidJumpDestination;
             // Skip the JUMPDEST byte we just validated, charging its gas and count here.
             programCounter = jumpTarget + 1;
-            // Prefetch the cache line at the jump destination
-            // since hardware prefetcher can't predict jumps.
             PrefetchCodeAtDestination(ref stack, programCounter);
-            TGasPolicy.Consume<JumpDestGasCost>(ref gas);
             vm.OpCodeCount++;
+            if (!TGasPolicy.UpdateGas<JumpDestGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
             goto Success;
         }
 
         ref byte start = ref Unsafe.Add(ref bytes, programCounter);
         EvmExceptionType result;
-        if (remainingCode >= Size)
+        if (!TTracingInst.IsActive || remainingCode >= Size)
         {
-            // Optimized push for exactly two bytes.
-            result = stack.Push2Bytes<TTracingInst>(ref start);
+            // The untraced prelude already checked capacity; only traced execution needs the push's depth check.
+            result = stack.Push2Bytes<TTracingInst, TTracingInst>(ref start);
         }
         else if (remainingCode == Op1.Count)
         {
-            // Directly push the single byte.
-            result = stack.PushByte<TTracingInst>(start);
+            result = stack.PushUInt32<TTracingInst, OnFlag>((uint)start << 8);
         }
         else
         {
             // Fallback when immediate data is incomplete.
-            result = stack.PushZero<TTracingInst>();
+            result = stack.PushZero<TTracingInst, OnFlag>();
         }
         programCounter += Size;
         return result;
@@ -210,15 +206,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 3-byte value (common case); otherwise padded push.
-                stack.Push3Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push3Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -232,15 +230,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 4-byte value (common case); otherwise padded push.
-                stack.Push4Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push4Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -254,15 +254,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 5-byte value (common case); otherwise padded push.
-                stack.Push5Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push5Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -276,15 +278,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 6-byte value (common case); otherwise padded push.
-                stack.Push6Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push6Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -298,15 +302,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 7-byte value (common case); otherwise padded push.
-                stack.Push7Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push7Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -320,15 +326,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 8-byte value (common case); otherwise padded push.
-                stack.Push8Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push8Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -342,14 +350,16 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
-                stack.Push9Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
+                stack.Push9Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -363,15 +373,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 10-byte value.
-                stack.Push10Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push10Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -385,15 +397,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 11-byte value.
-                stack.Push11Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push11Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -407,15 +421,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 12-byte value.
-                stack.Push12Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push12Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -429,15 +445,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 13-byte value.
-                stack.Push13Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push13Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -451,15 +469,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 14-byte value.
-                stack.Push14Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push14Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -473,15 +493,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 15-byte value.
-                stack.Push15Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push15Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -495,15 +517,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 16-byte value.
-                stack.Push16Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push16Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -517,15 +541,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 17-byte value.
-                stack.Push17Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push17Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -539,15 +565,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 18-byte value.
-                stack.Push18Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push18Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -561,15 +589,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 19-byte value.
-                stack.Push19Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push19Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -583,15 +613,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 20-byte value.
-                stack.Push20Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push20Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -605,15 +637,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 21-byte value.
-                stack.Push21Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push21Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -627,15 +661,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 22-byte value.
-                stack.Push22Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push22Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -649,15 +685,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 23-byte value.
-                stack.Push23Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push23Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -671,15 +709,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 24-byte value.
-                stack.Push24Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push24Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -693,15 +733,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 25-byte value.
-                stack.Push25Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push25Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -715,15 +757,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 26-byte value.
-                stack.Push26Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push26Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -737,15 +781,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 27-byte value.
-                stack.Push27Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push27Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -759,15 +805,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 28-byte value.
-                stack.Push28Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push28Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -781,15 +829,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 29-byte value.
-                stack.Push29Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push29Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -803,15 +853,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 30-byte value.
-                stack.Push30Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push30Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -825,15 +877,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 31-byte value.
-                stack.Push31Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push31Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -847,15 +901,17 @@ public static partial class EvmInstructions
 
         [SkipLocalsInit]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static EvmExceptionType Push<TTracingInst>(int length, ref EvmStack stack, nint programCounter)
+        public static EvmExceptionType Push<TTracingInst, TCheckDepth, TCheckCode>(ref EvmStack stack, nint programCounter)
             where TTracingInst : struct, IFlag
+            where TCheckDepth : struct, IFlag
+            where TCheckCode : struct, IFlag
         {
-            int usedFromCode = (int)Math.Min(stack.CodeLength - programCounter, (nint)length);
+            nint usedFromCode = stack.CodeLength - programCounter;
             ref byte start = ref Unsafe.Add(ref stack.Code, programCounter);
-            return usedFromCode == Size ?
+            return !TCheckCode.IsActive || usedFromCode >= Size ?
                 // Direct push of a 32-byte value.
-                stack.Push32Bytes<TTracingInst>(ref start) :
-                stack.PushBothPaddedBytes<TTracingInst>(ref start, usedFromCode, length);
+                stack.Push32Bytes<TTracingInst, TCheckDepth>(ref start) :
+                stack.PushBothPaddedBytes<TTracingInst, TCheckDepth>(ref start, (int)usedFromCode, Size);
         }
     }
 
@@ -871,8 +927,8 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<BaseGasCost>(ref gas);
-        return stack.PushZero<TTracingInst>();
+        if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
+        return stack.PushZero<TTracingInst, OnFlag>();
     }
 
     /// <summary>
@@ -894,9 +950,9 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct a very low gas cost for the push operation.
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         // Use the push method defined by the specific push operation.
-        EvmExceptionType result = TOpCount.Push<TTracingInst>(TOpCount.Count, ref stack, programCounter);
+        EvmExceptionType result = TOpCount.Push<TTracingInst, OnFlag, OnFlag>(ref stack, programCounter);
         // Advance the program counter by the number of bytes consumed.
         programCounter += TOpCount.Count;
         return result;
@@ -918,9 +974,9 @@ public static partial class EvmInstructions
         where TOpCount : struct, IOpCount
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        return stack.Dup<TTracingInst>(TOpCount.Count);
+        return stack.Dup<TTracingInst, OnFlag>(TOpCount.Count);
     }
 
     /// <summary>
@@ -941,9 +997,9 @@ public static partial class EvmInstructions
         where TOpCount : struct, IOpCount
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         // Swap the top element with the (n+1)th element; ensure adequate stack depth.
-        return stack.Swap<TTracingInst>(TOpCount.Count + 1);
+        return stack.Swap<TTracingInst, OnFlag>(TOpCount.Count + 1);
     }
 
     /// <summary>
@@ -956,11 +1012,11 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         return !TryDecodeSingle(ref stack, ref programCounter, out int depth)
             ? EvmExceptionType.BadInstruction
-            : stack.Dup<TTracingInst>(depth);
+            : stack.Dup<TTracingInst, OnFlag>(depth);
     }
 
     /// <summary>
@@ -973,11 +1029,11 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         return !TryDecodeSingle(ref stack, ref programCounter, out int depth)
             ? EvmExceptionType.BadInstruction
-            : stack.Swap<TTracingInst>(depth + 1);
+            : stack.Swap<TTracingInst, OnFlag>(depth + 1);
     }
 
     /// <summary>
@@ -990,7 +1046,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         return !TryDecodePair(ref stack, ref programCounter, out int n, out int m)
             ? EvmExceptionType.BadInstruction
@@ -1091,7 +1147,7 @@ public static partial class EvmInstructions
         if (!TGasPolicy.UpdateMemoryCost(ref gas, in position, length, ref vmState.Memory)) goto OutOfGas;
         // Deduct gas for the log entry itself, including per-topic and per-byte data costs.
         ulong dataSize = (ulong)length;
-        if (!TGasPolicy.ConsumeLogEmission(ref gas, topicsCount, dataSize)) goto OutOfGas;
+        if (!TGasPolicy.TryConsumeLogEmission(ref gas, topicsCount, dataSize)) goto OutOfGas;
 
         // Load the log data from memory.
         if (!vmState.Memory.TryLoad(in position, length, out ReadOnlyMemory<byte> data))

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -38,7 +38,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct the fixed gas cost for TLOAD.
-        TGasPolicy.Consume<TLoadGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<TLoadGasCost>(ref gas)) goto OutOfGas;
 
         // Attempt to pop the key (offset) from the stack; if unavailable, signal a stack underflow.
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
@@ -53,9 +53,8 @@ public static partial class EvmInstructions
         EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(value);
 
         // If storage tracing is enabled, record the operation.
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
-            if (TGasPolicy.IsOutOfGas(in gas)) goto OutOfGas;
             vm.TxTracer.LoadOperationTransientStorage(storageCell.Address, result, value);
         }
 
@@ -89,7 +88,7 @@ public static partial class EvmInstructions
         if (vmState.IsStatic) goto StaticCallViolation;
 
         // Deduct the gas cost for TSTORE.
-        TGasPolicy.Consume<TStoreGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<TStoreGasCost>(ref gas)) goto OutOfGas;
 
         // Pop the key (offset) from the stack; if unavailable, signal a stack underflow.
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
@@ -104,9 +103,8 @@ public static partial class EvmInstructions
         vm.WorldState.SetTransientState(in storageCell, !bytes.IsZero() ? bytes.ToArray() : BytesZero32);
 
         // If storage tracing is enabled, retrieve the current stored value and log the operation.
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
-            if (TGasPolicy.IsOutOfGas(in gas)) goto OutOfGas;
             ReadOnlySpan<byte> currentValue = vm.WorldState.GetTransientState(in storageCell);
             vm.TxTracer.SetOperationTransientStorage(storageCell.Address, result, bytes, currentValue);
         }
@@ -139,7 +137,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         // Single bounds check covering both the offset and the word.
         if (!stack.PopMemoryPositionAndWord256(out UInt256 result, out Span<byte> bytes)) goto StackUnderflow;
@@ -186,15 +184,12 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        // Pop the memory offset from the stack; if missing, signal a stack underflow.
-        if (!stack.PopMemoryPosition(out UInt256 result)) goto StackUnderflow;
-
-        // Pop a single byte from the stack; PopByte returns -1 on underflow.
-        int popped = stack.PopByte();
-        if (popped < 0) goto StackUnderflow;
-        byte data = (byte)popped;
+        if (!stack.EnsureDepth(2)) goto StackUnderflow;
+        ref byte word = ref stack.Pop2BytesByRefUnchecked();
+        EvmStack.ReadMemoryPositionFromSlot(ref Unsafe.Add(ref word, EvmStack.WordSize), out UInt256 result);
+        byte data = (byte)(Unsafe.As<byte, ulong>(ref Unsafe.Add(ref word, EvmStack.WordSize - sizeof(ulong))) >> 56);
 
         VmState<TGasPolicy> vmState = vm.VmState;
 
@@ -236,18 +231,16 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        // Pop the memory offset; if missing, signal a stack underflow.
-        if (!stack.PopMemoryPosition(out UInt256 result)) goto StackUnderflow;
+        if (!stack.EnsureDepth(1)) goto StackUnderflow;
+        EvmStack.ReadMemoryPositionFromSlot(ref stack.PeekBytesByRefUnchecked(), out UInt256 result);
 
         VmState<TGasPolicy> vmState = vm.VmState;
 
         // Update memory cost for a 32-byte load.
         if (!TGasPolicy.UpdateMemoryCost(ref gas, in result, 32UL, ref vmState.Memory))
-        {
             goto OutOfGas;
-        }
 
         ref byte wordBytes = ref vmState.Memory.Load32BytesAfterGas(in result);
 
@@ -257,8 +250,7 @@ public static partial class EvmInstructions
             vm.TxTracer.ReportMemoryChange(result, MemoryMarshal.CreateReadOnlySpan(ref wordBytes, EvmPooledMemory.WordSize));
         }
 
-        // Push the loaded bytes onto the stack.
-        return stack.Push32Bytes<TTracingInst>(ref wordBytes);
+        return stack.WriteRightPaddedBytes<TTracingInst>(ref stack.PeekBytesByRefUnchecked(), ref wordBytes, EvmStack.WordSize);
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;
@@ -289,7 +281,7 @@ public static partial class EvmInstructions
 
         // Calculate additional gas cost based on the length (using a division rounding-up method) and deduct the total cost.
         ulong words = EvmCalculations.Div32Ceiling(c, out bool outOfGas);
-        TGasPolicy.ConsumeMemoryCopy(ref gas, words);
+        if (!TGasPolicy.TryConsumeMemoryCopy(ref gas, words)) return EvmExceptionType.OutOfGas;
         if (outOfGas) goto OutOfGas;
 
         if (c.IsZero)
@@ -357,7 +349,7 @@ public static partial class EvmInstructions
         IReleaseSpec spec = vm.Spec;
 
         // For legacy metering: ensure there is enough gas for the SSTORE reset cost before reading storage.
-        if (!TGasPolicy.ConsumeSStoreResetGas(ref gas, spec))
+        if (!TGasPolicy.TryConsumeSStoreResetGas(ref gas, spec))
             goto OutOfGas;
 
         // Pop the key and then the new value for storage; signal underflow if unavailable.
@@ -373,7 +365,7 @@ public static partial class EvmInstructions
         // Construct the storage cell for the executing account.
         StorageCell storageCell = new(vmState.Env.ExecutingAccount, in result);
 
-        if (!TGasPolicy.ConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vmState.AccessTracker, vm.TxTracer.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
+        if (!TGasPolicy.TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vmState.AccessTracker, vm.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
             goto OutOfGas;
 
         // Retrieve the current value from persistent storage.
@@ -392,14 +384,14 @@ public static partial class EvmInstructions
             if (!newSameAsCurrent)
             {
                 vmState.Refund += sClearRefunds;
-                if (vm.TxTracer.IsTracingRefunds)
+                if (vm.IsTracingRefunds)
                     vm.TxTracer.ReportRefund(sClearRefunds);
             }
         }
         // When setting a non-zero value over an existing zero, apply the difference in gas costs.
         else if (currentIsZero)
         {
-            if (!TGasPolicy.ConsumeSSetFromCleanGas(ref gas))
+            if (!TGasPolicy.TryConsumeSSetFromCleanGas(ref gas))
                 goto OutOfGas;
         }
 
@@ -419,7 +411,7 @@ public static partial class EvmInstructions
             TraceSstore(vm, newIsZero, in storageCell, bytes);
         }
 
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
             vm.TxTracer.SetOperationStorage(storageCell.Address, result, bytes, currentValue);
         }
@@ -469,7 +461,7 @@ public static partial class EvmInstructions
         // In net metering with stipend fix, ensure extra gas pressure is reported and that sufficient gas remains.
         if (TUseNetGasStipendFix.IsActive)
         {
-            if (vm.TxTracer.IsTracingRefunds)
+            if (vm.IsTracingRefunds)
                 vm.TxTracer.ReportExtraGasPressure(GasCostOf.CallStipend - gasCosts.NetMeteredSStoreCost + 1);
             if (TGasPolicy.GetRemainingGas(in gas) <= GasCostOf.CallStipend)
                 goto OutOfGas;
@@ -490,7 +482,7 @@ public static partial class EvmInstructions
 
         // Charge gas based on whether this is a cold or warm storage access before reading
         // the slot; BAL records the read only once the access cost is covered.
-        if (!TGasPolicy.ConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vmState.AccessTracker, vm.TxTracer.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
+        if (!TGasPolicy.TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vmState.AccessTracker, vm.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
             goto OutOfGas;
 
         ReadOnlySpan<byte> currentValue = vm.WorldState.Get(in storageCell);
@@ -504,7 +496,7 @@ public static partial class EvmInstructions
 
         if (newSameAsCurrent)
         {
-            if (!TGasPolicy.ConsumeNetMeteredSStoreGas<Eip8038>(ref gas, spec))
+            if (!TGasPolicy.TryConsumeNetMeteredSStoreGas<Eip8038>(ref gas, spec))
                 goto OutOfGas;
         }
         else
@@ -518,25 +510,25 @@ public static partial class EvmInstructions
             {
                 if (currentIsZero)
                 {
-                    bool ssetOutOfGas = !TGasPolicy.ConsumeStorageWrite<TEip8037, OnFlag, Eip8038>(ref gas, spec);
+                    bool ssetOutOfGas = !TGasPolicy.TryConsumeStorageWrite<TEip8037, OnFlag, Eip8038>(ref gas, spec);
                     if (ssetOutOfGas) goto OutOfGas;
                 }
                 else
                 {
-                    if (!TGasPolicy.ConsumeStorageWrite<TEip8037, OffFlag, Eip8038>(ref gas, spec))
+                    if (!TGasPolicy.TryConsumeStorageWrite<TEip8037, OffFlag, Eip8038>(ref gas, spec))
                         goto OutOfGas;
 
                     if (newIsZero)
                     {
                         vmState.Refund += sClearRefunds;
-                        if (vm.TxTracer.IsTracingRefunds)
+                        if (vm.IsTracingRefunds)
                             vm.TxTracer.ReportRefund(sClearRefunds);
                     }
                 }
             }
             else
             {
-                if (!TGasPolicy.ConsumeNetMeteredSStoreGas<Eip8038>(ref gas, spec))
+                if (!TGasPolicy.TryConsumeNetMeteredSStoreGas<Eip8038>(ref gas, spec))
                     goto OutOfGas;
 
                 if (!originalIsZero)
@@ -545,14 +537,14 @@ public static partial class EvmInstructions
                     if (currentIsZero)
                     {
                         vmState.Refund -= sClearRefunds;
-                        if (vm.TxTracer.IsTracingRefunds)
+                        if (vm.IsTracingRefunds)
                             vm.TxTracer.ReportRefund(-sClearRefunds);
                     }
 
                     if (newIsZero)
                     {
                         vmState.Refund += sClearRefunds;
-                        if (vm.TxTracer.IsTracingRefunds)
+                        if (vm.IsTracingRefunds)
                             vm.TxTracer.ReportRefund(sClearRefunds);
                     }
                 }
@@ -575,7 +567,7 @@ public static partial class EvmInstructions
                     }
 
                     vmState.Refund += refundFromReversal;
-                    if (vm.TxTracer.IsTracingRefunds)
+                    if (vm.IsTracingRefunds)
                         vm.TxTracer.ReportRefund(refundFromReversal);
                 }
             }
@@ -597,7 +589,7 @@ public static partial class EvmInstructions
             TraceSstore(vm, newIsZero, in storageCell, bytes);
         }
 
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
             vm.TxTracer.SetOperationStorage(storageCell.Address, result, bytes, currentValue);
         }
@@ -645,7 +637,7 @@ public static partial class EvmInstructions
         vm.MetricsCounters.IncrementSLoad();
 
         // Deduct the gas cost for performing an SLOAD.
-        TGasPolicy.Consume<SLoadGasCost>(ref gas, spec);
+        if (!TGasPolicy.TryConsumeSLoadBaseGas<Eip2929>(ref gas, spec)) return EvmExceptionType.OutOfGas;
 
         // Pop the key from the stack; if unavailable, signal a stack underflow.
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
@@ -655,18 +647,18 @@ public static partial class EvmInstructions
         StorageCell storageCell = new(executingAccount, in result);
 
         // Charge additional gas based on whether the storage cell is hot or cold.
-        if (!TGasPolicy.ConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, in storageCell, StorageAccessType.SLOAD, spec))
+        if (!TGasPolicy.TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vm.VmState.AccessTracker, vm.IsTracingAccess, in storageCell, StorageAccessType.SLOAD, spec))
             goto OutOfGas;
 
         // Retrieve the persistent storage value and push it onto the stack. Zero slots come back
         // as a single zero byte; PushZero writes the word directly instead of packing the byte.
         ReadOnlySpan<byte> value = vm.WorldState.Get(in storageCell);
         EvmExceptionType pushResult = value.Length == 1 && value[0] == 0
-            ? stack.PushZero<TTracingInst>()
+            ? stack.PushZero<TTracingInst, OnFlag>()
             : stack.PushBytes<TTracingInst>(value);
 
         // Log the storage load operation if tracing is enabled.
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
             vm.TxTracer.LoadOperationStorage(executingAccount, result, value);
         }
@@ -686,32 +678,27 @@ public static partial class EvmInstructions
     /// </summary>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EvmExceptionType InstructionCallDataLoad<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
+    internal static EvmExceptionType CallDataLoadCore<TGasPolicy, TTracingInst>(ref EvmStack stack, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
-
-        // Pop the offset from which to load call data.
-        if (!stack.PopUInt256(out UInt256 result))
-            goto StackUnderflow;
+        ref byte slot = ref stack.PeekBytesByRefUnchecked();
+        EvmStack.ReadMemoryPositionFromSlot(ref slot, out UInt256 result);
 
         ReadOnlySpan<byte> inputData = vm.VmState.Env.InputData.Span;
 
         ulong offset = result.u0;
         if (!result.IsUint64 || offset >= (uint)inputData.Length)
         {
-            return stack.PushZero<TTracingInst>();
+            Unsafe.InitBlockUnaligned(ref slot, 0, EvmStack.WordSize);
+            if (TTracingInst.IsActive) vm.TxTracer.ReportStackPush(Bytes.ZeroByteSpan);
+            return EvmExceptionType.None;
         }
 
         uint available = (uint)inputData.Length - (uint)offset;
         uint copiedLength = available >= 32 ? 32u : available;
-        return stack.PushRightPaddedBytes<TTracingInst>(
+        return stack.WriteRightPaddedBytes<TTracingInst>(ref slot,
             ref Unsafe.Add(ref MemoryMarshal.GetReference(inputData), (nint)offset),
             copiedLength);
-
-        // Jump forward to be unpredicted by the branch predictor.
-    StackUnderflow:
-        return EvmExceptionType.StackUnderflow;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -38,7 +38,7 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         // Deduct the fixed gas cost for TLOAD.
-        TGasPolicy.Consume<TLoadGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<TLoadGasCost>(ref gas)) goto OutOfGas;
 
         // Attempt to pop the key (offset) from the stack; if unavailable, signal a stack underflow.
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
@@ -53,9 +53,8 @@ public static partial class EvmInstructions
         EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(value);
 
         // If storage tracing is enabled, record the operation.
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
-            if (TGasPolicy.IsOutOfGas(in gas)) goto OutOfGas;
             vm.TxTracer.LoadOperationTransientStorage(storageCell.Address, result, value);
         }
 
@@ -89,7 +88,7 @@ public static partial class EvmInstructions
         if (vmState.IsStatic) goto StaticCallViolation;
 
         // Deduct the gas cost for TSTORE.
-        TGasPolicy.Consume<TStoreGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<TStoreGasCost>(ref gas)) goto OutOfGas;
 
         // Pop the key (offset) from the stack; if unavailable, signal a stack underflow.
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
@@ -104,9 +103,8 @@ public static partial class EvmInstructions
         vm.WorldState.SetTransientState(in storageCell, !bytes.IsZero() ? bytes.ToArray() : BytesZero32);
 
         // If storage tracing is enabled, retrieve the current stored value and log the operation.
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
-            if (TGasPolicy.IsOutOfGas(in gas)) goto OutOfGas;
             ReadOnlySpan<byte> currentValue = vm.WorldState.GetTransientState(in storageCell);
             vm.TxTracer.SetOperationTransientStorage(storageCell.Address, result, bytes, currentValue);
         }
@@ -139,7 +137,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
         // Single bounds check covering both the offset and the word.
         if (!stack.PopMemoryPositionAndWord256(out UInt256 result, out Span<byte> bytes)) goto StackUnderflow;
@@ -186,15 +184,12 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        // Pop the memory offset from the stack; if missing, signal a stack underflow.
-        if (!stack.PopMemoryPosition(out UInt256 result)) goto StackUnderflow;
-
-        // Pop a single byte from the stack; PopByte returns -1 on underflow.
-        int popped = stack.PopByte();
-        if (popped < 0) goto StackUnderflow;
-        byte data = (byte)popped;
+        if (!stack.EnsureDepth(2)) goto StackUnderflow;
+        ref byte word = ref stack.Pop2BytesByRefUnchecked();
+        EvmStack.ReadMemoryPositionFromSlot(ref Unsafe.Add(ref word, EvmStack.WordSize), out UInt256 result);
+        byte data = (byte)(Unsafe.As<byte, ulong>(ref Unsafe.Add(ref word, EvmStack.WordSize - sizeof(ulong))) >> 56);
 
         VmState<TGasPolicy> vmState = vm.VmState;
 
@@ -236,18 +231,16 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
 
-        // Pop the memory offset; if missing, signal a stack underflow.
-        if (!stack.PopMemoryPosition(out UInt256 result)) goto StackUnderflow;
+        if (!stack.EnsureDepth(1)) goto StackUnderflow;
+        EvmStack.ReadMemoryPositionFromSlot(ref stack.PeekBytesByRefUnchecked(), out UInt256 result);
 
         VmState<TGasPolicy> vmState = vm.VmState;
 
         // Update memory cost for a 32-byte load.
         if (!TGasPolicy.UpdateMemoryCost(ref gas, in result, 32UL, ref vmState.Memory))
-        {
             goto OutOfGas;
-        }
 
         ref byte wordBytes = ref vmState.Memory.Load32BytesAfterGas(in result);
 
@@ -257,8 +250,7 @@ public static partial class EvmInstructions
             vm.TxTracer.ReportMemoryChange(result, MemoryMarshal.CreateReadOnlySpan(ref wordBytes, EvmPooledMemory.WordSize));
         }
 
-        // Push the loaded bytes onto the stack.
-        return stack.Push32Bytes<TTracingInst>(ref wordBytes);
+        return stack.WriteRightPaddedBytes<TTracingInst>(ref stack.PeekBytesByRefUnchecked(), ref wordBytes, EvmStack.WordSize);
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;
@@ -289,7 +281,7 @@ public static partial class EvmInstructions
 
         // Calculate additional gas cost based on the length (using a division rounding-up method) and deduct the total cost.
         ulong words = EvmCalculations.Div32Ceiling(c, out bool outOfGas);
-        TGasPolicy.ConsumeMemoryCopy(ref gas, words);
+        if (!TGasPolicy.TryConsumeMemoryCopy(ref gas, words)) return EvmExceptionType.OutOfGas;
         if (outOfGas) goto OutOfGas;
 
         if (c.IsZero)
@@ -357,7 +349,7 @@ public static partial class EvmInstructions
         IReleaseSpec spec = vm.Spec;
 
         // For legacy metering: ensure there is enough gas for the SSTORE reset cost before reading storage.
-        if (!TGasPolicy.ConsumeSStoreResetGas(ref gas, spec))
+        if (!TGasPolicy.TryConsumeSStoreResetGas(ref gas, spec))
             goto OutOfGas;
 
         // Pop the key and then the new value for storage; signal underflow if unavailable.
@@ -373,7 +365,7 @@ public static partial class EvmInstructions
         // Construct the storage cell for the executing account.
         StorageCell storageCell = new(vmState.Env.ExecutingAccount, in result);
 
-        if (!TGasPolicy.ConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vmState.AccessTracker, vm.TxTracer.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
+        if (!TGasPolicy.TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vmState.AccessTracker, vm.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
             goto OutOfGas;
 
         // Retrieve the current value from persistent storage.
@@ -392,14 +384,14 @@ public static partial class EvmInstructions
             if (!newSameAsCurrent)
             {
                 vmState.Refund += sClearRefunds;
-                if (vm.TxTracer.IsTracingRefunds)
+                if (vm.IsTracingRefunds)
                     vm.TxTracer.ReportRefund(sClearRefunds);
             }
         }
         // When setting a non-zero value over an existing zero, apply the difference in gas costs.
         else if (currentIsZero)
         {
-            if (!TGasPolicy.ConsumeSSetFromCleanGas(ref gas))
+            if (!TGasPolicy.TryConsumeSSetFromCleanGas(ref gas))
                 goto OutOfGas;
         }
 
@@ -419,7 +411,7 @@ public static partial class EvmInstructions
             TraceSstore(vm, newIsZero, in storageCell, bytes);
         }
 
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
             vm.TxTracer.SetOperationStorage(storageCell.Address, result, bytes, currentValue);
         }
@@ -469,7 +461,7 @@ public static partial class EvmInstructions
         // In net metering with stipend fix, ensure extra gas pressure is reported and that sufficient gas remains.
         if (TUseNetGasStipendFix.IsActive)
         {
-            if (vm.TxTracer.IsTracingRefunds)
+            if (vm.IsTracingRefunds)
                 vm.TxTracer.ReportExtraGasPressure(GasCostOf.CallStipend - gasCosts.NetMeteredSStoreCost + 1);
             if (TGasPolicy.GetRemainingGas(in gas) <= GasCostOf.CallStipend)
                 goto OutOfGas;
@@ -490,7 +482,7 @@ public static partial class EvmInstructions
 
         // Charge gas based on whether this is a cold or warm storage access before reading
         // the slot; BAL records the read only once the access cost is covered.
-        if (!TGasPolicy.ConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vmState.AccessTracker, vm.TxTracer.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
+        if (!TGasPolicy.TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vmState.AccessTracker, vm.IsTracingAccess, in storageCell, StorageAccessType.SSTORE, spec))
             goto OutOfGas;
 
         ReadOnlySpan<byte> currentValue = vm.WorldState.Get(in storageCell);
@@ -504,7 +496,7 @@ public static partial class EvmInstructions
 
         if (newSameAsCurrent)
         {
-            if (!TGasPolicy.ConsumeNetMeteredSStoreGas<Eip8038>(ref gas, spec))
+            if (!TGasPolicy.TryConsumeNetMeteredSStoreGas<Eip8038>(ref gas, spec))
                 goto OutOfGas;
         }
         else
@@ -518,7 +510,7 @@ public static partial class EvmInstructions
             {
                 if (currentIsZero)
                 {
-                    bool ssetOutOfGas = !TGasPolicy.ConsumeStorageWrite<TEip8037, OnFlag, Eip8038>(ref gas, spec);
+                    bool ssetOutOfGas = !TGasPolicy.TryConsumeStorageWrite<TEip8037, OnFlag, Eip8038>(ref gas, spec);
                     if (ssetOutOfGas) goto OutOfGas;
                     if (TEip8037.IsActive && vm.TxExecutionContext.FrameTxContext is { } chargeFrameCtx)
                     {
@@ -527,20 +519,20 @@ public static partial class EvmInstructions
                 }
                 else
                 {
-                    if (!TGasPolicy.ConsumeStorageWrite<TEip8037, OffFlag, Eip8038>(ref gas, spec))
+                    if (!TGasPolicy.TryConsumeStorageWrite<TEip8037, OffFlag, Eip8038>(ref gas, spec))
                         goto OutOfGas;
 
                     if (newIsZero)
                     {
                         vmState.Refund += sClearRefunds;
-                        if (vm.TxTracer.IsTracingRefunds)
+                        if (vm.IsTracingRefunds)
                             vm.TxTracer.ReportRefund(sClearRefunds);
                     }
                 }
             }
             else
             {
-                if (!TGasPolicy.ConsumeNetMeteredSStoreGas<Eip8038>(ref gas, spec))
+                if (!TGasPolicy.TryConsumeNetMeteredSStoreGas<Eip8038>(ref gas, spec))
                     goto OutOfGas;
 
                 if (!originalIsZero)
@@ -549,14 +541,14 @@ public static partial class EvmInstructions
                     if (currentIsZero)
                     {
                         vmState.Refund -= sClearRefunds;
-                        if (vm.TxTracer.IsTracingRefunds)
+                        if (vm.IsTracingRefunds)
                             vm.TxTracer.ReportRefund(-sClearRefunds);
                     }
 
                     if (newIsZero)
                     {
                         vmState.Refund += sClearRefunds;
-                        if (vm.TxTracer.IsTracingRefunds)
+                        if (vm.IsTracingRefunds)
                             vm.TxTracer.ReportRefund(sClearRefunds);
                     }
                 }
@@ -590,7 +582,7 @@ public static partial class EvmInstructions
                     }
 
                     vmState.Refund += refundFromReversal;
-                    if (vm.TxTracer.IsTracingRefunds)
+                    if (vm.IsTracingRefunds)
                         vm.TxTracer.ReportRefund(refundFromReversal);
                 }
             }
@@ -612,7 +604,7 @@ public static partial class EvmInstructions
             TraceSstore(vm, newIsZero, in storageCell, bytes);
         }
 
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
             vm.TxTracer.SetOperationStorage(storageCell.Address, result, bytes, currentValue);
         }
@@ -660,7 +652,7 @@ public static partial class EvmInstructions
         vm.MetricsCounters.IncrementSLoad();
 
         // Deduct the gas cost for performing an SLOAD.
-        TGasPolicy.Consume<SLoadGasCost>(ref gas, spec);
+        if (!TGasPolicy.TryConsumeSLoadBaseGas<Eip2929>(ref gas, spec)) return EvmExceptionType.OutOfGas;
 
         // Pop the key from the stack; if unavailable, signal a stack underflow.
         if (!stack.PopUInt256(out UInt256 result)) goto StackUnderflow;
@@ -670,18 +662,18 @@ public static partial class EvmInstructions
         StorageCell storageCell = new(executingAccount, in result);
 
         // Charge additional gas based on whether the storage cell is hot or cold.
-        if (!TGasPolicy.ConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, in storageCell, StorageAccessType.SLOAD, spec))
+        if (!TGasPolicy.TryConsumeStorageAccessGas<Eip2929, Eip8038>(ref gas, in vm.VmState.AccessTracker, vm.IsTracingAccess, in storageCell, StorageAccessType.SLOAD, spec))
             goto OutOfGas;
 
         // Retrieve the persistent storage value and push it onto the stack. Zero slots come back
         // as a single zero byte; PushZero writes the word directly instead of packing the byte.
         ReadOnlySpan<byte> value = vm.WorldState.Get(in storageCell);
         EvmExceptionType pushResult = value.Length == 1 && value[0] == 0
-            ? stack.PushZero<TTracingInst>()
+            ? stack.PushZero<TTracingInst, OnFlag>()
             : stack.PushBytes<TTracingInst>(value);
 
         // Log the storage load operation if tracing is enabled.
-        if (vm.TxTracer.IsTracingOpLevelStorage)
+        if (vm.IsTracingOpLevelStorage)
         {
             vm.TxTracer.LoadOperationStorage(executingAccount, result, value);
         }
@@ -701,32 +693,27 @@ public static partial class EvmInstructions
     /// </summary>
     [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static EvmExceptionType InstructionCallDataLoad<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
+    internal static EvmExceptionType CallDataLoadCore<TGasPolicy, TTracingInst>(ref EvmStack stack, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<VeryLowGasCost>(ref gas);
-
-        // Pop the offset from which to load call data.
-        if (!stack.PopUInt256(out UInt256 result))
-            goto StackUnderflow;
+        ref byte slot = ref stack.PeekBytesByRefUnchecked();
+        EvmStack.ReadMemoryPositionFromSlot(ref slot, out UInt256 result);
 
         ReadOnlySpan<byte> inputData = vm.VmState.Env.InputData.Span;
 
         ulong offset = result.u0;
         if (!result.IsUint64 || offset >= (uint)inputData.Length)
         {
-            return stack.PushZero<TTracingInst>();
+            Unsafe.InitBlockUnaligned(ref slot, 0, EvmStack.WordSize);
+            if (TTracingInst.IsActive) vm.TxTracer.ReportStackPush(Bytes.ZeroByteSpan);
+            return EvmExceptionType.None;
         }
 
         uint available = (uint)inputData.Length - (uint)offset;
         uint copiedLength = available >= 32 ? 32u : available;
-        return stack.PushRightPaddedBytes<TTracingInst>(
+        return stack.WriteRightPaddedBytes<TTracingInst>(ref slot,
             ref Unsafe.Add(ref MemoryMarshal.GetReference(inputData), (nint)offset),
             copiedLength);
-
-        // Jump forward to be unpredicted by the branch predictor.
-    StackUnderflow:
-        return EvmExceptionType.StackUnderflow;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.TxAssertions.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.TxAssertions.cs
@@ -27,7 +27,7 @@ public static partial class EvmInstructions
     {
         if (!TryGetPostTxView(vm, out TransactionDiffView view, out FrameTxContext ctx)) return EvmExceptionType.BadInstruction;
 
-        TGasPolicy.Consume<TxTraceGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<TxTraceGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         if (!stack.PopUInt256(out UInt256 param, out UInt256 index)) return EvmExceptionType.StackUnderflow;
         if (param > 0x15) return EvmExceptionType.BadInstruction;
 
@@ -84,7 +84,7 @@ public static partial class EvmInstructions
             return stack.PushUInt256<TTracingInst>(account.TryGetPreTxStorage(slot.Key, out UInt256 before) ? before : default);
         if (!account.TryGetStorageChange(slot.Key, out StorageChange? change)) return EvmExceptionType.BadInstruction;
         EvmWord after = change.Value.Value;
-        return stack.Push32Bytes<TTracingInst>(ref Unsafe.As<EvmWord, byte>(ref after));
+        return stack.Push32Bytes<TTracingInst, OnFlag>(ref Unsafe.As<EvmWord, byte>(ref after));
     }
 
     // 0x0A deployed address / 0x0B deployed code hash, indexed by deployment position.
@@ -96,7 +96,7 @@ public static partial class EvmInstructions
         if (param == 0x0A) return stack.PushAddress<TTracingInst>(address);
 
         ValueHash256 codeHash = view.Slice.GetAccountChanges(address)!.CodeChange!.Value.CodeHash;
-        return stack.Push32Bytes<TTracingInst>(in codeHash);
+        return stack.Push32Bytes<TTracingInst, OnFlag>(in codeHash);
     }
 
     // 0x0D address / 0x0E topic count / 0x0F..0x12 topics / 0x13 data length, indexed by event position.
@@ -108,7 +108,7 @@ public static partial class EvmInstructions
         switch (param)
         {
             case 0x0D: return stack.PushAddress<TTracingInst>(log.Address);
-            case 0x0E: return stack.PushUInt32<TTracingInst>((uint)log.Topics.Length);
+            case 0x0E: return stack.PushUInt32<TTracingInst, OnFlag>((uint)log.Topics.Length);
             case 0x13: return stack.PushUInt256<TTracingInst>((UInt256)(ulong)log.Data.Length);
             default:
                 int topic = param - 0x0F;
@@ -150,13 +150,13 @@ public static partial class EvmInstructions
         where TTracingInst : struct, IFlag
     {
         StorageCell cell = new(address, in key);
-        if (!TGasPolicy.ConsumeStorageAccessGas(ref gas, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, in cell, StorageAccessType.SLOAD, vm.Spec))
+        if (!TGasPolicy.TryConsumeStorageAccessGas(ref gas, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, in cell, StorageAccessType.SLOAD, vm.Spec))
             return EvmExceptionType.OutOfGas;
         if (param == 0x00 && account is not null && account.TryGetPreTxStorage(key, out UInt256 before))
             return stack.PushUInt256<TTracingInst>(before);
         // "after", or an unmodified slot's "before": the current live value.
         ReadOnlySpan<byte> value = vm.WorldState.Get(in cell);
-        EvmExceptionType pushResult = value.Length == 1 && value[0] == 0 ? stack.PushZero<TTracingInst>() : stack.PushBytes<TTracingInst>(value);
+        EvmExceptionType pushResult = value.Length == 1 && value[0] == 0 ? stack.PushZero<TTracingInst, OnFlag>() : stack.PushBytes<TTracingInst>(value);
 
         // Reported like SLOAD, so a trace over a failed assertion shows the slot it read.
         if (vm.TxTracer.IsTracingOpLevelStorage)
@@ -172,7 +172,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        if (!TGasPolicy.ConsumeAccountAccessGas(ref gas, vm.Spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, address))
+        if (!TGasPolicy.TryConsumeAccountAccessGas(ref gas, vm.Spec, in vm.VmState.AccessTracker, vm.TxTracer.IsTracingAccess, address))
             return EvmExceptionType.OutOfGas;
         IWorldState state = vm.WorldState;
         switch (param)
@@ -184,12 +184,12 @@ public static partial class EvmInstructions
             case 0x04:
                 {
                     ValueHash256 hash = account?.CodeChange is not null ? view.GetPreTxCodeHash(address, account) : state.GetCodeHash(address);
-                    return stack.Push32Bytes<TTracingInst>(in hash);
+                    return stack.Push32Bytes<TTracingInst, OnFlag>(in hash);
                 }
             default:
                 {
                     ValueHash256 hash = state.GetCodeHash(address);
-                    return stack.Push32Bytes<TTracingInst>(in hash);
+                    return stack.Push32Bytes<TTracingInst, OnFlag>(in hash);
                 }
         }
     }
@@ -199,7 +199,7 @@ public static partial class EvmInstructions
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
-        TGasPolicy.Consume<TxTraceGasCost>(ref gas);
+        if (!TGasPolicy.UpdateGas<TxTraceGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
         return param switch
         {
             0x06 => in3.IsZero ? stack.PushUInt256<TTracingInst>((UInt256)(ulong)(view.TryGetSlotRun(address, out _, out int slots) ? slots : 0)) : EvmExceptionType.BadInstruction,
@@ -210,7 +210,7 @@ public static partial class EvmInstructions
             0x09 => view.TryGetAddressEventGlobalIndex(address, in in3, out int global)
                 ? stack.PushUInt256<TTracingInst>((UInt256)(ulong)global)
                 : EvmExceptionType.BadInstruction,
-            _ => in3.IsZero ? stack.PushUInt32<TTracingInst>(ChangeFlags(account)) : EvmExceptionType.BadInstruction, // 0x0A
+            _ => in3.IsZero ? stack.PushUInt32<TTracingInst, OnFlag>(ChangeFlags(account)) : EvmExceptionType.BadInstruction, // 0x0A
         };
     }
 

--- a/src/Nethermind/Nethermind.Evm/SpecFlags.std.cs
+++ b/src/Nethermind/Nethermind.Evm/SpecFlags.std.cs
@@ -24,6 +24,8 @@ internal static partial class SpecFlags
 
     public static bool Eip158(IReleaseSpec spec) => spec.ClearEmptyAccountWhenTouched;
 
+    public static bool Eip160(IReleaseSpec spec) => spec.UseExpDDosProtection;
+
     public static bool Eip2200(IReleaseSpec spec) => spec.UseNetGasMeteringWithAStipendFix;
 
     public static bool Eip2929(IReleaseSpec spec) => spec.UseHotAndColdStorage;

--- a/src/Nethermind/Nethermind.Evm/SpecFlags.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/SpecFlags.zkevm.cs
@@ -24,6 +24,9 @@ internal static partial class SpecFlags
     public const bool ConstEip158 = true;
 
     /// <inheritdoc cref="ConstEip150"/>
+    public const bool ConstEip160 = true;
+
+    /// <inheritdoc cref="ConstEip150"/>
     public const bool ConstEip2200 = true;
 
     /// <inheritdoc cref="ConstEip150"/>
@@ -41,6 +44,8 @@ internal static partial class SpecFlags
     public static bool Eip150(IReleaseSpec spec) => ConstEip150;
 
     public static bool Eip158(IReleaseSpec spec) => ConstEip158;
+
+    public static bool Eip160(IReleaseSpec spec) => ConstEip160;
 
     public static bool Eip2200(IReleaseSpec spec) => ConstEip2200;
 
@@ -82,6 +87,7 @@ internal static partial class SpecFlags
 
         Check(spec.Use63Over64Rule, ConstEip150, "EIP-150");
         Check(spec.ClearEmptyAccountWhenTouched, ConstEip158, "EIP-158");
+        Check(spec.UseExpDDosProtection, ConstEip160, "EIP-160");
         Check(spec.UseNetGasMeteringWithAStipendFix, ConstEip2200, "EIP-2200");
         Check(spec.UseHotAndColdStorage, ConstEip2929, "EIP-2929");
         Check(spec.IsEip3860Enabled, ConstEip3860, "EIP-3860");

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/SystemTransactionProcessor.cs
@@ -10,6 +10,7 @@ using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Evm.State;
 using System;
+using System.Diagnostics;
 
 namespace Nethermind.Evm.TransactionProcessing;
 
@@ -107,10 +108,13 @@ public class SystemTransactionProcessor<TGasPolicy>(
     {
         if (tx is SystemCall)
         {
-            gasAvailable = TGasPolicy.CreateSystemTransactionAvailableGas(tx.GasLimit, intrinsicGas.Standard, spec);
-            return TransactionResult.Ok;
+            return TGasPolicy.TryCreateSystemTransactionAvailableGas(tx.GasLimit, intrinsicGas.Standard, spec, out gasAvailable)
+                ? TransactionResult.Ok
+                : TransactionResult.GasLimitBelowIntrinsicGas;
         }
 
+        Debug.Assert(TGasPolicy.GetStateReservoir(intrinsicGas.Standard) == 0,
+            "System transactions other than SystemCall bypass minimum-gas validation and must have no intrinsic state reservoir.");
         return base.CalculateAvailableGas(tx, spec, in intrinsicGas, out gasAvailable);
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -354,7 +354,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 && tx.To is not null && tx.SenderAddress != tx.To
                 && WorldState.IsDeadAccount(tx.To))
             {
-                topFrameOutOfGas = !TGasPolicy.ConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost());
+                topFrameOutOfGas = !TGasPolicy.TryConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost());
             }
 
             if (topFrameOutOfGas && spec.IsEip8037Enabled)
@@ -456,7 +456,7 @@ namespace Nethermind.Evm.TransactionProcessing
             if (spec.IsEip8037Enabled && hasValueTransfer && !senderIsRecipient
                 && WorldState.IsDeadAccount(recipient))
             {
-                newAccountOutOfGas = !TGasPolicy.ConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost());
+                newAccountOutOfGas = !TGasPolicy.TryConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost());
             }
 
             // Self-send: sender account is already touched/warmed by gas charging and any
@@ -474,7 +474,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             // Forfeit after the action start is traced: a halted frame reports the gas it would have received.
             if (newAccountOutOfGas)
-                TGasPolicy.Consume(ref gasAvailable, TGasPolicy.GetRemainingGas(in gasAvailable));
+                TGasPolicy.ClearExecutionGas(ref gasAvailable);
 
             JournalCollection<LogEntry>? logs = null;
             if (spec.IsEip7708Enabled && hasValueTransfer && !senderIsRecipient && !newAccountOutOfGas)
@@ -699,11 +699,10 @@ namespace Nethermind.Evm.TransactionProcessing
                 : TransactionResult.Ok;
         }
 
-        protected virtual TransactionResult CalculateAvailableGas(Transaction tx, IReleaseSpec spec, in IntrinsicGas<TGasPolicy> intrinsicGas, out TGasPolicy gasAvailable)
-        {
-            gasAvailable = TGasPolicy.CreateAvailableFromIntrinsic(tx.GasLimit, intrinsicGas.Standard, spec);
-            return TransactionResult.Ok;
-        }
+        protected virtual TransactionResult CalculateAvailableGas(Transaction tx, IReleaseSpec spec, in IntrinsicGas<TGasPolicy> intrinsicGas, out TGasPolicy gasAvailable) =>
+            TGasPolicy.TryCreateAvailableFromIntrinsic(tx.GasLimit, intrinsicGas.Standard, spec, out gasAvailable)
+                ? TransactionResult.Ok
+                : TransactionResult.GasLimitBelowIntrinsicGas;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private bool ProcessDelegations(
@@ -755,7 +754,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
                     if (spec.IsEip8037Enabled)
                     {
-                        if (!accountExists && !TGasPolicy.ConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost()))
+                        if (!accountExists && !TGasPolicy.TryConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost()))
                         {
                             return false;
                         }
@@ -772,7 +771,7 @@ namespace Nethermind.Evm.TransactionProcessing
                         if (!clearsDelegation)
                         {
                             if (!delegatedBefore && delegationSetFor!.Add(authority)
-                                && !TGasPolicy.ConsumeStateGas(ref gasAvailable, TGasPolicy.GetPerAuthBaseStateCost()))
+                                && !TGasPolicy.TryConsumeStateGas(ref gasAvailable, TGasPolicy.GetPerAuthBaseStateCost()))
                             {
                                 return false;
                             }
@@ -1062,7 +1061,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return opcodeGasPrice;
         }
 
-        protected virtual bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
+        protected bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
             tx.TryCalculatePremiumPerGas(baseFee, out premiumPerGas);
 
         protected virtual TransactionResult ValidateSender(Transaction tx, BlockHeader header, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts)
@@ -1264,7 +1263,7 @@ namespace Nethermind.Evm.TransactionProcessing
                     {
                         // EIP-8037: load delegated-recipient target code only after the
                         // target's normal EIP-2929 warm/cold account-access charge succeeds.
-                        topFrameOutOfGas = !TGasPolicy.ConsumeAccountAccessGas(
+                        topFrameOutOfGas = !TGasPolicy.TryConsumeAccountAccessGas(
                             ref gasAvailable,
                             spec,
                             in accessTracker,
@@ -1304,7 +1303,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return TransactionResult.Ok;
         }
 
-        protected virtual bool ShouldValidate(ExecutionOptions opts) => !opts.HasFlag(ExecutionOptions.SkipValidation);
+        protected bool ShouldValidate(ExecutionOptions opts) => !opts.HasFlag(ExecutionOptions.SkipValidation);
 
         private int ExecuteEvmCall<TTracingInst>(
             Transaction tx,
@@ -1337,7 +1336,7 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 TraceHaltedTopFrameAction(tx, env, tracer, in gasAvailable);
                 substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracing);
-                TGasPolicy.SetOutOfGas(ref gasAvailable);
+                TGasPolicy.ClearExecutionGas(ref gasAvailable);
                 TGasPolicy oogIntrinsicGasStandard = gas.Standard;
                 gasConsumed = CompleteEip8037Halt(tx, spec, opts, ref gasAvailable, VirtualMachine.TxExecutionContext.GasPrice, in oogIntrinsicGasStandard, floorGasLong, postIntrinsicStateReservoir);
                 goto Complete;
@@ -1383,12 +1382,12 @@ namespace Nethermind.Evm.TransactionProcessing
 
             using (VmState<TGasPolicy> state = VmState<TGasPolicy>.RentTopLevel(gasAvailable, executionType, env, in accessedItems, in snapshot))
             {
-                if (spec.IsEip8037Enabled && topLevelCreateStateGasCharged && !TGasPolicy.ConsumeCreateStateGas(ref state.Gas))
+                if (spec.IsEip8037Enabled && topLevelCreateStateGasCharged && !TGasPolicy.TryConsumeCreateStateGas(ref state.Gas))
                 {
                     TraceHaltedTopFrameAction(tx, env, tracer, in gasAvailable);
                     substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracing);
                     gasAvailable = state.Gas;
-                    TGasPolicy.SetOutOfGas(ref gasAvailable);
+                    TGasPolicy.ClearExecutionGas(ref gasAvailable);
                     WorldState.Restore(snapshot);
                     TGasPolicy createStateOogIntrinsicGasStandard = gas.Standard;
                     gasConsumed = CompleteEip8037Halt(tx, spec, opts, ref gasAvailable, VirtualMachine.TxExecutionContext.GasPrice, in createStateOogIntrinsicGasStandard, floorGasLong, postIntrinsicStateReservoir);
@@ -1477,7 +1476,7 @@ namespace Nethermind.Evm.TransactionProcessing
             };
             if (spec.ChargeForTopLevelCreate)
             {
-                TGasPolicy.SetOutOfGas(ref gasAvailable);
+                TGasPolicy.ClearExecutionGas(ref gasAvailable);
             }
             WorldState.Restore(snapshot);
             VirtualMachineStatics.RestoreRipemdTouch(WorldState, spec, substate.ShouldRestoreRipemdTouch);
@@ -1548,7 +1547,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return RefundOnTopLevelHalt(tx, spec, opts, in gas, in gasPrice, in intrinsicGasStandard, floorGas, codeInsertExecutionRefund);
         }
 
-        protected virtual GasConsumed RefundOnFail(
+        protected GasConsumed RefundOnFail(
             Transaction tx,
             IReleaseSpec spec,
             ExecutionOptions opts,
@@ -1590,7 +1589,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 TGasPolicy.RefundStateGas(ref gasAfterCollision, refundedTopLevelCreateStateGas, stateGasFloor, trackSpillRefund: false);
             }
 
-            TGasPolicy.SetOutOfGas(ref gasAfterCollision);
+            TGasPolicy.ClearExecutionGas(ref gasAfterCollision);
             ulong preRefundGas = TGasPolicy.GetPreRefundGas(in gasAfterCollision, tx.GasLimit);
             ulong spentGas = Math.Max(preRefundGas, floorGas);
             long blockStateGas = TGasPolicy.GetStateGasUsed(in gasAfterCollision);
@@ -1600,7 +1599,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return RefundFailedEip8037Gas(tx, spec, opts, in gasPrice, spentGas, blockGas, blockStateGas);
         }
 
-        protected virtual GasConsumed RefundOnTopLevelHalt(
+        protected GasConsumed RefundOnTopLevelHalt(
             Transaction tx,
             IReleaseSpec spec,
             ExecutionOptions opts,
@@ -1649,7 +1648,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return new GasConsumed(spentGas, spentGas, blockGas, (ulong)blockStateGas, spentGas, gasRefund);
         }
 
-        protected virtual bool DeployContract(IReleaseSpec spec, Address codeOwner, in TransactionSubstate substate, in StackAccessTracker accessedItems, ref TGasPolicy unspentGas)
+        protected bool DeployContract(IReleaseSpec spec, Address codeOwner, in TransactionSubstate substate, in StackAccessTracker accessedItems, ref TGasPolicy unspentGas)
         {
             if (!CodeDepositHandler.CalculateCost(spec, substate.Output.Length, in unspentGas, out ulong executionDepositCost, out long stateDepositCost))
                 return false;
@@ -1836,7 +1835,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return (spentGas, Math.Min((long)(spentGas / (ulong)quotient), totalToRefund));
         }
 
-        protected virtual ulong CalculateClaimableRefund(ulong spentGas, ulong totalRefund, IReleaseSpec spec)
+        protected ulong CalculateClaimableRefund(ulong spentGas, ulong totalRefund, IReleaseSpec spec)
             => RefundHelper.CalculateClaimableRefund(spentGas, totalRefund, spec);
 
         private static (ulong blockGas, long blockStateGas) CalculateBlockGas(

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -372,7 +372,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 && tx.To is not null && tx.SenderAddress != tx.To
                 && WorldState.IsDeadAccount(tx.To))
             {
-                topFrameOutOfGas = !TGasPolicy.ConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost());
+                topFrameOutOfGas = !TGasPolicy.TryConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost());
             }
 
             if (topFrameOutOfGas && spec.IsEip8037Enabled)
@@ -474,7 +474,7 @@ namespace Nethermind.Evm.TransactionProcessing
             if (spec.IsEip8037Enabled && hasValueTransfer && !senderIsRecipient
                 && WorldState.IsDeadAccount(recipient))
             {
-                newAccountOutOfGas = !TGasPolicy.ConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost());
+                newAccountOutOfGas = !TGasPolicy.TryConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost());
             }
 
             // Self-send: sender account is already touched/warmed by gas charging and any
@@ -492,7 +492,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
             // Forfeit after the action start is traced: a halted frame reports the gas it would have received.
             if (newAccountOutOfGas)
-                TGasPolicy.Consume(ref gasAvailable, TGasPolicy.GetRemainingGas(in gasAvailable));
+                TGasPolicy.ClearExecutionGas(ref gasAvailable);
 
             JournalCollection<LogEntry>? logs = null;
             if (spec.IsEip7708Enabled && hasValueTransfer && !senderIsRecipient && !newAccountOutOfGas)
@@ -717,11 +717,10 @@ namespace Nethermind.Evm.TransactionProcessing
                 : TransactionResult.Ok;
         }
 
-        protected virtual TransactionResult CalculateAvailableGas(Transaction tx, IReleaseSpec spec, in IntrinsicGas<TGasPolicy> intrinsicGas, out TGasPolicy gasAvailable)
-        {
-            gasAvailable = TGasPolicy.CreateAvailableFromIntrinsic(tx.GasLimit, intrinsicGas.Standard, spec);
-            return TransactionResult.Ok;
-        }
+        protected virtual TransactionResult CalculateAvailableGas(Transaction tx, IReleaseSpec spec, in IntrinsicGas<TGasPolicy> intrinsicGas, out TGasPolicy gasAvailable) =>
+            TGasPolicy.TryCreateAvailableFromIntrinsic(tx.GasLimit, intrinsicGas.Standard, spec, out gasAvailable)
+                ? TransactionResult.Ok
+                : TransactionResult.GasLimitBelowIntrinsicGas;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private bool ProcessDelegations(
@@ -773,7 +772,7 @@ namespace Nethermind.Evm.TransactionProcessing
 
                     if (spec.IsEip8037Enabled)
                     {
-                        if (!accountExists && !TGasPolicy.ConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost()))
+                        if (!accountExists && !TGasPolicy.TryConsumeStateGas(ref gasAvailable, TGasPolicy.GetNewAccountStateCost()))
                         {
                             return false;
                         }
@@ -790,7 +789,7 @@ namespace Nethermind.Evm.TransactionProcessing
                         if (!clearsDelegation)
                         {
                             if (!delegatedBefore && delegationSetFor!.Add(authority)
-                                && !TGasPolicy.ConsumeStateGas(ref gasAvailable, TGasPolicy.GetPerAuthBaseStateCost()))
+                                && !TGasPolicy.TryConsumeStateGas(ref gasAvailable, TGasPolicy.GetPerAuthBaseStateCost()))
                             {
                                 return false;
                             }
@@ -1080,7 +1079,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return opcodeGasPrice;
         }
 
-        protected virtual bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
+        protected bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
             tx.TryCalculatePremiumPerGas(baseFee, out premiumPerGas);
 
         protected virtual TransactionResult ValidateSender(Transaction tx, BlockHeader header, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts)
@@ -1282,7 +1281,7 @@ namespace Nethermind.Evm.TransactionProcessing
                     {
                         // EIP-8037: load delegated-recipient target code only after the
                         // target's normal EIP-2929 warm/cold account-access charge succeeds.
-                        topFrameOutOfGas = !TGasPolicy.ConsumeAccountAccessGas(
+                        topFrameOutOfGas = !TGasPolicy.TryConsumeAccountAccessGas(
                             ref gasAvailable,
                             spec,
                             in accessTracker,
@@ -1322,7 +1321,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return TransactionResult.Ok;
         }
 
-        protected virtual bool ShouldValidate(ExecutionOptions opts) => !opts.HasFlag(ExecutionOptions.SkipValidation);
+        protected bool ShouldValidate(ExecutionOptions opts) => !opts.HasFlag(ExecutionOptions.SkipValidation);
 
         private int ExecuteEvmCall<TTracingInst>(
             Transaction tx,
@@ -1355,7 +1354,7 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 TraceHaltedTopFrameAction(tx, env, tracer, in gasAvailable);
                 substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracing);
-                TGasPolicy.SetOutOfGas(ref gasAvailable);
+                TGasPolicy.ClearExecutionGas(ref gasAvailable);
                 TGasPolicy oogIntrinsicGasStandard = gas.Standard;
                 gasConsumed = CompleteEip8037Halt(tx, spec, opts, ref gasAvailable, VirtualMachine.TxExecutionContext.GasPrice, in oogIntrinsicGasStandard, floorGasLong, postIntrinsicStateReservoir);
                 goto Complete;
@@ -1401,12 +1400,12 @@ namespace Nethermind.Evm.TransactionProcessing
 
             using (VmState<TGasPolicy> state = VmState<TGasPolicy>.RentTopLevel(gasAvailable, executionType, env, in accessedItems, in snapshot))
             {
-                if (spec.IsEip8037Enabled && topLevelCreateStateGasCharged && !TGasPolicy.ConsumeCreateStateGas(ref state.Gas))
+                if (spec.IsEip8037Enabled && topLevelCreateStateGasCharged && !TGasPolicy.TryConsumeCreateStateGas(ref state.Gas))
                 {
                     TraceHaltedTopFrameAction(tx, env, tracer, in gasAvailable);
                     substate = new TransactionSubstate(EvmExceptionType.OutOfGas, tracer.IsTracing);
                     gasAvailable = state.Gas;
-                    TGasPolicy.SetOutOfGas(ref gasAvailable);
+                    TGasPolicy.ClearExecutionGas(ref gasAvailable);
                     WorldState.Restore(snapshot);
                     TGasPolicy createStateOogIntrinsicGasStandard = gas.Standard;
                     gasConsumed = CompleteEip8037Halt(tx, spec, opts, ref gasAvailable, VirtualMachine.TxExecutionContext.GasPrice, in createStateOogIntrinsicGasStandard, floorGasLong, postIntrinsicStateReservoir);
@@ -1495,7 +1494,7 @@ namespace Nethermind.Evm.TransactionProcessing
             };
             if (spec.ChargeForTopLevelCreate)
             {
-                TGasPolicy.SetOutOfGas(ref gasAvailable);
+                TGasPolicy.ClearExecutionGas(ref gasAvailable);
             }
             WorldState.Restore(snapshot);
             VirtualMachineStatics.RestoreRipemdTouch(WorldState, spec, substate.ShouldRestoreRipemdTouch);
@@ -1566,7 +1565,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return RefundOnTopLevelHalt(tx, spec, opts, in gas, in gasPrice, in intrinsicGasStandard, floorGas, codeInsertExecutionRefund);
         }
 
-        protected virtual GasConsumed RefundOnFail(
+        protected GasConsumed RefundOnFail(
             Transaction tx,
             IReleaseSpec spec,
             ExecutionOptions opts,
@@ -1608,7 +1607,7 @@ namespace Nethermind.Evm.TransactionProcessing
                 TGasPolicy.RefundStateGas(ref gasAfterCollision, refundedTopLevelCreateStateGas, stateGasFloor, trackSpillRefund: false);
             }
 
-            TGasPolicy.SetOutOfGas(ref gasAfterCollision);
+            TGasPolicy.ClearExecutionGas(ref gasAfterCollision);
             ulong preRefundGas = TGasPolicy.GetPreRefundGas(in gasAfterCollision, tx.GasLimit);
             ulong spentGas = Math.Max(preRefundGas, floorGas);
             long blockStateGas = TGasPolicy.GetStateGasUsed(in gasAfterCollision);
@@ -1618,7 +1617,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return RefundFailedEip8037Gas(tx, spec, opts, in gasPrice, spentGas, blockGas, blockStateGas);
         }
 
-        protected virtual GasConsumed RefundOnTopLevelHalt(
+        protected GasConsumed RefundOnTopLevelHalt(
             Transaction tx,
             IReleaseSpec spec,
             ExecutionOptions opts,
@@ -1667,7 +1666,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return new GasConsumed(spentGas, spentGas, blockGas, (ulong)blockStateGas, spentGas, gasRefund);
         }
 
-        protected virtual bool DeployContract(IReleaseSpec spec, Address codeOwner, in TransactionSubstate substate, in StackAccessTracker accessedItems, ref TGasPolicy unspentGas)
+        protected bool DeployContract(IReleaseSpec spec, Address codeOwner, in TransactionSubstate substate, in StackAccessTracker accessedItems, ref TGasPolicy unspentGas)
         {
             if (!CodeDepositHandler.CalculateCost(spec, substate.Output.Length, in unspentGas, out ulong executionDepositCost, out long stateDepositCost))
                 return false;
@@ -1854,7 +1853,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return (spentGas, Math.Min((long)(spentGas / (ulong)quotient), totalToRefund));
         }
 
-        protected virtual ulong CalculateClaimableRefund(ulong spentGas, ulong totalRefund, IReleaseSpec spec)
+        protected ulong CalculateClaimableRefund(ulong spentGas, ulong totalRefund, IReleaseSpec spec)
             => RefundHelper.CalculateClaimableRefund(spentGas, totalRefund, spec);
 
         private static (ulong blockGas, long blockStateGas) CalculateBlockGas(

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Dispatch.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Dispatch.cs
@@ -218,18 +218,36 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TCancelable : struct, IFlag
         where TContinuable : struct, IFlag
     {
-        VirtualMachine<TGasPolicy> vm = state.Vm;
-
         // Only a traced run reads the opcode out of the bytecode. The read costs two dependent loads.
         if (TTracingInst.IsActive)
         {
             Instruction instruction = (Instruction)Unsafe.Add(ref stack.Code, pc);
-            vm.StartInstructionTrace(instruction, TGasPolicy.GetRemainingGas(in gas), (int)pc, in stack);
+            state.Vm.StartInstructionTrace(instruction, TGasPolicy.GetRemainingGas(in gas), (int)pc, in stack);
         }
 
         pc++;
         opCodeCount++;
-        EvmExceptionType exceptionType = TOpcode.Execute(ref stack, ref gas, vm, ref pc);
+        EvmExceptionType exceptionType;
+        if (TOpcode.HasCheckedBody)
+        {
+            if (!TOpcode.TryConsumeGas(ref gas))
+                return ExitCheckedOpcode(ref state, pc, opCodeCount, EvmExceptionType.OutOfGas);
+            if (TOpcode.StackInputs != 0 && !stack.EnsureDepth(TOpcode.StackInputs))
+                return ExitCheckedOpcode(ref state, pc, opCodeCount, EvmExceptionType.StackUnderflow);
+            if (TOpcode.StackGrowth > 0 && stack.Head >= EvmStack.MaxStackSize - TOpcode.StackGrowth)
+                return ExitCheckedOpcode(ref state, pc, opCodeCount, EvmExceptionType.StackOverflow);
+            // Only untraced PUSH bodies opt in: no subsequent opcode can observe the final stack value.
+            if (TOpcode.PushSize >= 0 && pc + TOpcode.PushSize >= stack.CodeLength)
+                return ExitCheckedOpcode(ref state, pc + TOpcode.PushSize, opCodeCount, EvmExceptionType.None);
+
+            EvmExceptionType checkedResult = TOpcode.Execute(ref stack, ref gas, TOpcode.UsesVm ? state.Vm : null!, ref pc);
+            Debug.Assert(checkedResult == EvmExceptionType.None, "HasCheckedBody must not fail after dispatch validates its preconditions.");
+            exceptionType = EvmExceptionType.None;
+        }
+        else
+        {
+            exceptionType = TOpcode.Execute(ref stack, ref gas, state.Vm, ref pc);
+        }
 
         if (!TContinuable.IsActive)
             goto Exit;
@@ -238,29 +256,25 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         // Its load chain then overlaps the rest of the handler. Zero means the counter ran off the end of
         // the code. No table entry is null, so zero cannot mean anything else.
         nint next = 0;
-        if ((nuint)pc < (nuint)stack.CodeLength)
+        if ((TOpcode.HasCheckedBody && TOpcode.PushSize >= 0) || (nuint)pc < (nuint)stack.CodeLength)
             next = (nint)state.OpcodeHandlers[Unsafe.Add(ref stack.Code, pc)];
 
-        if (ShouldExitFrame(exceptionType, TGasPolicy.IsOutOfGas(in gas)))
+        if (!TOpcode.HasCheckedBody && exceptionType != EvmExceptionType.None)
             goto Exit;
 
-        Debug.Assert(vm.ReturnData is null,
+        Debug.Assert(state.Vm.ReturnData is null,
             "A handler that stages ReturnData must report a non-None status, or dispatch will continue past the halt");
 
         if (TTracingInst.IsActive)
-            vm.EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));
+            state.Vm.EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));
 
-        // Reaching here means ShouldExitFrame said no, so the status is None and gas is left: the exit
+        // Reaching here means the halt check passed, so the status is None and gas is valid: the exit
         // block returns exactly that, and one copy of it is smaller than two.
-        if (next == 0)
+        if (!(TOpcode.HasCheckedBody && TOpcode.PushSize >= 0) && next == 0)
             goto Exit;
 
         if (TCancelable.IsActive && (opCodeCount & CancellationCheckMask) == 0)
-        {
-            state.OpCodeCount = opCodeCount;
-            state.FinalProgramCounter = pc;
-            return EvmExceptionType.None;
-        }
+            goto Exit;
 
         // Keep the target in a real local so InlineIL can place it above the outgoing arguments.
         IL.EnsureLocal(in next);
@@ -286,12 +300,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
     Exit:
         state.OpCodeCount = opCodeCount;
         state.FinalProgramCounter = pc;
-        if (TGasPolicy.IsOutOfGas(in gas))
-        {
-            TGasPolicy.SetOutOfGas(ref gas);
-            return EvmExceptionType.OutOfGas;
-        }
+        return exceptionType;
+    }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static EvmExceptionType ExitCheckedOpcode(ref DispatchState state, nint pc, int opCodeCount, EvmExceptionType exceptionType)
+    {
+        state.OpCodeCount = opCodeCount;
+        state.FinalProgramCounter = pc;
         return exceptionType;
     }
 
@@ -322,7 +338,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             : EvmInstructions.InstructionJumpIfAndSkipJumpDest(ref stack, ref gas, vm, pc);
         pc = result.ProgramCounter;
 
-        if (ShouldExitFrame(result.Exception, TGasPolicy.IsOutOfGas(in gas)))
+        if (result.Exception != EvmExceptionType.None)
             goto Exit;
 
         Debug.Assert(vm.ReturnData is null,
@@ -400,12 +416,6 @@ public unsafe partial class VirtualMachine<TGasPolicy>
     Exit:
         state.OpCodeCount = opCodeCount;
         state.FinalProgramCounter = pc;
-        if (TGasPolicy.IsOutOfGas(in gas))
-        {
-            TGasPolicy.SetOutOfGas(ref gas);
-            return EvmExceptionType.OutOfGas;
-        }
-
         return result.Exception;
     }
 }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.ExecutionHandlers.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.ExecutionHandlers.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -12,19 +13,29 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 {
     private ExecutionHandlers? _executionHandlers;
 
-    private ExecutionHandlers GetExecutionHandlers() =>
-        _executionHandlers ??= GetOpcodeTable().GetExecutionHandlers(Spec);
+    [MethodImpl(ExecutionHandlersInlining)]
+    private ExecutionHandlers GetExecutionHandlers()
+    {
+        Debug.Assert(_executionHandlers is not null, "PrepareOpcodes resolves frame handlers before execution.");
+#if DEBUG
+        Debug.Assert(ReferenceEquals(_executionHandlers.Spec, Spec), "Frame handlers must belong to the current block spec.");
+#endif
+        return _executionHandlers!;
+    }
 
     /// <summary>Frame operations selected once for the same spec as the opcode tables.</summary>
     private sealed class ExecutionHandlers(IReleaseSpec spec)
     {
+#if DEBUG
+        public readonly IReleaseSpec Spec = spec;
+#endif
         // All targets have these managed signatures; the table captures no VM or transaction state.
         public readonly delegate*<VirtualMachine<TGasPolicy>, VmState<TGasPolicy>, void> InitializeFrame =
-            spec.ClearEmptyAccountWhenTouched ? &InitializeFrameCore<OnFlag> : &InitializeFrameCore<OffFlag>;
+            SpecFlags.Eip158(spec) ? &InitializeFrameCore<OnFlag> : &InitializeFrameCore<OffFlag>;
         public readonly delegate*<VirtualMachine<TGasPolicy>, VmState<TGasPolicy>, void> TransferLog =
             spec.IsEip7708Enabled ? &AddTransferLogCore<OnFlag> : &AddTransferLogCore<OffFlag>;
         public readonly delegate*<VirtualMachine<TGasPolicy>, VmState<TGasPolicy>, CallResult> RunPrecompile =
-            spec.ClearEmptyAccountWhenTouched ? &RunPrecompileCore<OnFlag> : &RunPrecompileCore<OffFlag>;
+            SpecFlags.Eip158(spec) ? &RunPrecompileCore<OnFlag> : &RunPrecompileCore<OffFlag>;
         public readonly delegate*<VirtualMachine<TGasPolicy>, ref TGasPolicy, long, bool, void> CreditStateGasRefund =
             spec.IsEip8037Enabled ? &CreditStateGasRefundCore<OnFlag> : &CreditStateGasRefundCore<OffFlag>;
     }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 
@@ -18,6 +22,15 @@ public unsafe partial class VirtualMachine<TGasPolicy>
     /// </remarks>
     private interface IOpcodeBody
     {
+        /// <summary>Whether dispatch owns the gas/depth guards and Execute cannot fail.</summary>
+        static virtual bool HasCheckedBody => false;
+        static virtual bool UsesVm => false;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static virtual bool TryConsumeGas(ref TGasPolicy gas) => false;
+        static virtual int StackInputs => 0;
+        static virtual int StackGrowth => 0;
+        static virtual int PushSize => -1;
+
         static abstract EvmExceptionType Execute(
             ref EvmStack stack,
             ref TGasPolicy gas,
@@ -73,19 +86,21 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         lookup[(int)Instruction.SMOD] = OpcodeHandler<Math2Opcode<EvmInstructions.OpSMod, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.ADDMOD] = OpcodeHandler<Math3Opcode<EvmInstructions.OpAddMod, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.MULMOD] = OpcodeHandler<Math3Opcode<EvmInstructions.OpMulMod, TTracingInst>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.EXP] = OpcodeHandler<ExpOpcode<TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.EXP] = SpecFlags.Eip160(spec)
+            ? OpcodeHandler<ExpOpcode<TTracingInst, OnFlag>, TTracingInst, TCancelable>()
+            : OpcodeHandler<ExpOpcode<TTracingInst, OffFlag>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.SIGNEXTEND] = OpcodeHandler<SignExtendOpcode, TTracingInst, TCancelable>();
 
         lookup[(int)Instruction.LT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpLt, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.GT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpGt, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.SLT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpSLt, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.SGT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpSGt, TTracingInst>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.EQ] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseEq>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.ISZERO] = OpcodeHandler<Math1Opcode<EvmInstructions.OpIsZero>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.AND] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseAnd>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.OR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseOr>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.XOR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseXor>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.NOT] = OpcodeHandler<Math1Opcode<EvmInstructions.OpNot>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.EQ] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseEq, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.ISZERO] = OpcodeHandler<Math1Opcode<EvmInstructions.OpIsZero, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.AND] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseAnd, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.OR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseOr, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.XOR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseXor, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.NOT] = OpcodeHandler<Math1Opcode<EvmInstructions.OpNot, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.BYTE] = OpcodeHandler<ByteOpcode<TTracingInst>, TTracingInst, TCancelable>();
 
         if (spec.ShiftOpcodesEnabled)
@@ -496,34 +511,97 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TOpMath : struct, EvmInstructions.IOpMath2Param
         where TTracingInst : struct, IFlag
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionMath2Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas);
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpMath>(ref gas);
+        public static int StackInputs => 2;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            if (!HasCheckedBody)
+                return EvmInstructions.InstructionMath2Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas);
+
+            return EvmInstructions.Math2ParamCore<TOpMath, TTracingInst, OffFlag>(ref stack);
+        }
     }
 
     private readonly struct Math3Opcode<TOpMath, TTracingInst> : IOpcodeBody
         where TOpMath : struct, EvmInstructions.IOpMath3Param
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpMath>(ref gas);
+        public static int StackInputs => 3;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionMath3Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody
+                ? EvmInstructions.Math3ParamCore<TOpMath, TTracingInst>(ref stack)
+                : EvmInstructions.InstructionMath3Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas, vm);
     }
 
-    private readonly struct Math1Opcode<TOpMath> : IOpcodeBody where TOpMath : struct, EvmInstructions.IOpMath1Param
+    private readonly struct Math1Opcode<TOpMath, TTracingInst> : IOpcodeBody
+        where TOpMath : struct, EvmInstructions.IOpMath1Param
+        where TTracingInst : struct, IFlag
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionMath1Param<TGasPolicy, TOpMath>(ref stack, ref gas, vm);
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpMath>(ref gas);
+        public static int StackInputs => 1;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            if (!HasCheckedBody)
+                return EvmInstructions.InstructionMath1Param<TGasPolicy, TOpMath>(ref stack, ref gas, vm);
+
+            return EvmInstructions.Math1ParamCore<TOpMath, OffFlag>(ref stack);
+        }
     }
 
-    private readonly struct BitwiseOpcode<TOpBitwise> : IOpcodeBody where TOpBitwise : struct, EvmInstructions.IOpBitwise
+    private readonly struct BitwiseOpcode<TOpBitwise, TTracingInst> : IOpcodeBody
+        where TOpBitwise : struct, EvmInstructions.IOpBitwise
+        where TTracingInst : struct, IFlag
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionBitwise<TGasPolicy, TOpBitwise>(ref stack, ref gas, vm);
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpBitwise>(ref gas);
+        public static int StackInputs => 2;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            if (!HasCheckedBody)
+                return EvmInstructions.InstructionBitwise<TGasPolicy, TOpBitwise>(ref stack, ref gas, vm);
+
+            return EvmInstructions.BitwiseCore<TOpBitwise, OffFlag>(ref stack);
+        }
     }
 
-    private readonly struct ExpOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
+    private readonly struct ExpOpcode<TTracingInst, Eip160> : IOpcodeBody
+        where TTracingInst : struct, IFlag
+        where Eip160 : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionExp<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            EvmInstructions.InstructionExp<TGasPolicy, TTracingInst, Eip160>(ref stack, ref gas, vm);
     }
 
     private readonly struct SignExtendOpcode : IOpcodeBody
@@ -534,28 +612,65 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct CountLeadingZerosOpcode : IOpcodeBody
     {
+        public static bool HasCheckedBody => true;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.LowGasCost>(ref gas);
+        public static int StackInputs => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionCountLeadingZeros<TGasPolicy>(ref stack, ref gas);
+            EvmInstructions.CountLeadingZerosCore<OffFlag>(ref stack);
     }
 
     private readonly struct ByteOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackInputs => 2;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionByte<TGasPolicy, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? EvmInstructions.ByteCore<TTracingInst, OffFlag>(ref stack)
+                : EvmInstructions.InstructionByte<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct ShiftOpcode<TOpShift, TTracingInst> : IOpcodeBody
         where TOpShift : struct, EvmInstructions.IOpShift
         where TTracingInst : struct, IFlag
     {
+        // ShiftCore's x86 Vector128 paired pop/push path retains its own checks and fallible status.
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive &&
+                !(Vector128.IsHardwareAccelerated && !Vector256.IsHardwareAccelerated && X86Base.IsSupported);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpShift>(ref gas);
+        public static int StackInputs => 2;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionShift<TGasPolicy, TOpShift, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? EvmInstructions.ShiftCore<TOpShift, TTracingInst, OffFlag>(ref stack)
+                : EvmInstructions.InstructionShift<TGasPolicy, TOpShift, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct SarOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackInputs => 2;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionSar<TGasPolicy, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? EvmInstructions.SarCore<TTracingInst, OffFlag>(ref stack)
+                : EvmInstructions.InstructionSar<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct KeccakOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -568,64 +683,144 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TOpEnv : struct, EvmInstructions.IOpEnvAddress<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnvAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.Push20Bytes<TTracingInst, OffFlag>(ref MemoryMarshal.GetReference(TOpEnv.Operation(vm.VmState).Bytes))
+                : EvmInstructions.InstructionEnvAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct Env32BytesOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnv32Bytes<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnv32Bytes<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.Push32Bytes<TTracingInst, OffFlag>(in TOpEnv.Operation(vm))
+                : EvmInstructions.InstructionEnv32Bytes<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct EnvUInt256Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnvUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt256<TTracingInst, OffFlag>(TOpEnv.Operation(vm.VmState))
+                : EvmInstructions.InstructionEnvUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct EnvUInt32Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt32<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnvUInt32<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt32<TTracingInst, OffFlag>(TOpEnv.Operation(vm.VmState))
+                : EvmInstructions.InstructionEnvUInt32<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct EnvUInt64Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnvUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt64<TTracingInst, OffFlag>(TOpEnv.Operation(vm.VmState))
+                : EvmInstructions.InstructionEnvUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct BlkAddressOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkAddress<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionBlkAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.Push20Bytes<TTracingInst, OffFlag>(ref MemoryMarshal.GetReference(TOpEnv.Operation(vm).Bytes))
+                : EvmInstructions.InstructionBlkAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct BlkUInt256Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionBlkUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt256<TTracingInst, OffFlag>(TOpEnv.Operation(vm))
+                : EvmInstructions.InstructionBlkUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct BlkUInt64Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionBlkUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt64<TTracingInst, OffFlag>(TOpEnv.Operation(vm))
+                : EvmInstructions.InstructionBlkUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct BalanceOpcode<TTracingInst, TSpec> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -637,8 +832,13 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct CallDataLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody => true;
+        public static bool UsesVm => true;
+        public static int StackInputs => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionCallDataLoad<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            EvmInstructions.CallDataLoadCore<TGasPolicy, TTracingInst>(ref stack, vm);
     }
 
     private readonly struct CallDataCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -649,8 +849,18 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct CodeSizeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionCodeSize<TGasPolicy, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? stack.PushUInt32<TTracingInst, OffFlag>((uint)stack.CodeLength)
+                : EvmInstructions.InstructionCodeSize<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct CodeCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -683,8 +893,19 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct ReturnDataSizeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionReturnDataSize<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt32<TTracingInst, OffFlag>((uint)vm.ReturnDataBuffer.Length)
+                : EvmInstructions.InstructionReturnDataSize<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct ReturnDataCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -708,14 +929,36 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct PrevRandaoOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionPrevRandao<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.Push32Bytes<TTracingInst, OffFlag>(in vm.BlockExecutionContext.PrevRandao)
+                : EvmInstructions.InstructionPrevRandao<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct SelfBalanceOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.SelfBalanceGasCost>(ref gas);
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionSelfBalance<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? EvmInstructions.InstructionSelfBalance<TGasPolicy, TTracingInst, OffFlag>(ref stack, ref gas, vm)
+                : EvmInstructions.InstructionSelfBalance<TGasPolicy, TTracingInst, OnFlag>(ref stack, ref gas, vm);
     }
 
     private readonly struct BlobHashOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -738,8 +981,17 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct PopOpcode : IOpcodeBody
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionPop(ref stack, ref gas, vm);
+        public static bool HasCheckedBody => true;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackInputs => 1;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            stack.Head--;
+            return EvmExceptionType.None;
+        }
     }
 
     private readonly struct MLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -819,14 +1071,34 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct ProgramCounterOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionProgramCounter<TGasPolicy, TTracingInst>(ref stack, ref gas, vm, programCounter);
+            HasCheckedBody ? stack.PushUInt32<TTracingInst, OffFlag>((uint)(programCounter - 1))
+                : EvmInstructions.InstructionProgramCounter<TGasPolicy, TTracingInst>(ref stack, ref gas, vm, programCounter);
     }
 
     private readonly struct GasOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionGas<TGasPolicy, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? stack.PushUInt64<TTracingInst, OffFlag>(TGasPolicy.GetRemainingGas(in gas))
+                : EvmInstructions.InstructionGas<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct JumpDestOpcode : IOpcodeBody
@@ -855,8 +1127,21 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct Push0Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static int PushSize => 0;
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionPush0<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody
+                ? stack.PushZero<TTracingInst, OffFlag>()
+                : EvmInstructions.InstructionPush0<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct Push2Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -869,24 +1154,67 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionPush<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, ref programCounter);
+        public static int PushSize => TOpCount.Count;
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            if (!HasCheckedBody)
+                return EvmInstructions.InstructionPush<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, ref programCounter);
+
+            _ = TOpCount.Push<TTracingInst, OffFlag, OffFlag>(ref stack, programCounter);
+            programCounter += TOpCount.Count;
+            return EvmExceptionType.None;
+        }
     }
 
     private readonly struct DupOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackInputs => TOpCount.Count;
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionDup<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody
+                ? stack.Dup<TTracingInst, OffFlag>(TOpCount.Count)
+                : EvmInstructions.InstructionDup<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct SwapOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackInputs => TOpCount.Count + 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionSwap<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody
+                ? stack.Swap<TTracingInst, OffFlag>(TOpCount.Count + 1)
+                : EvmInstructions.InstructionSwap<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct LogOpcode<TOpCount> : IOpcodeBody where TOpCount : struct, EvmInstructions.IOpCount

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 
@@ -18,6 +22,15 @@ public unsafe partial class VirtualMachine<TGasPolicy>
     /// </remarks>
     private interface IOpcodeBody
     {
+        /// <summary>Whether dispatch owns the gas/depth guards and Execute cannot fail.</summary>
+        static virtual bool HasCheckedBody => false;
+        static virtual bool UsesVm => false;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static virtual bool TryConsumeGas(ref TGasPolicy gas) => false;
+        static virtual int StackInputs => 0;
+        static virtual int StackGrowth => 0;
+        static virtual int PushSize => -1;
+
         static abstract EvmExceptionType Execute(
             ref EvmStack stack,
             ref TGasPolicy gas,
@@ -73,19 +86,21 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         lookup[(int)Instruction.SMOD] = OpcodeHandler<Math2Opcode<EvmInstructions.OpSMod, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.ADDMOD] = OpcodeHandler<Math3Opcode<EvmInstructions.OpAddMod, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.MULMOD] = OpcodeHandler<Math3Opcode<EvmInstructions.OpMulMod, TTracingInst>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.EXP] = OpcodeHandler<ExpOpcode<TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.EXP] = SpecFlags.Eip160(spec)
+            ? OpcodeHandler<ExpOpcode<TTracingInst, OnFlag>, TTracingInst, TCancelable>()
+            : OpcodeHandler<ExpOpcode<TTracingInst, OffFlag>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.SIGNEXTEND] = OpcodeHandler<SignExtendOpcode, TTracingInst, TCancelable>();
 
         lookup[(int)Instruction.LT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpLt, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.GT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpGt, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.SLT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpSLt, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.SGT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpSGt, TTracingInst>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.EQ] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseEq>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.ISZERO] = OpcodeHandler<Math1Opcode<EvmInstructions.OpIsZero>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.AND] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseAnd>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.OR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseOr>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.XOR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseXor>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.NOT] = OpcodeHandler<Math1Opcode<EvmInstructions.OpNot>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.EQ] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseEq, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.ISZERO] = OpcodeHandler<Math1Opcode<EvmInstructions.OpIsZero, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.AND] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseAnd, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.OR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseOr, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.XOR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseXor, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.NOT] = OpcodeHandler<Math1Opcode<EvmInstructions.OpNot, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.BYTE] = OpcodeHandler<ByteOpcode<TTracingInst>, TTracingInst, TCancelable>();
 
         if (spec.ShiftOpcodesEnabled)
@@ -521,34 +536,97 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TOpMath : struct, EvmInstructions.IOpMath2Param
         where TTracingInst : struct, IFlag
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionMath2Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas);
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpMath>(ref gas);
+        public static int StackInputs => 2;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            if (!HasCheckedBody)
+                return EvmInstructions.InstructionMath2Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas);
+
+            return EvmInstructions.Math2ParamCore<TOpMath, TTracingInst, OffFlag>(ref stack);
+        }
     }
 
     private readonly struct Math3Opcode<TOpMath, TTracingInst> : IOpcodeBody
         where TOpMath : struct, EvmInstructions.IOpMath3Param
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpMath>(ref gas);
+        public static int StackInputs => 3;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionMath3Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody
+                ? EvmInstructions.Math3ParamCore<TOpMath, TTracingInst>(ref stack)
+                : EvmInstructions.InstructionMath3Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas, vm);
     }
 
-    private readonly struct Math1Opcode<TOpMath> : IOpcodeBody where TOpMath : struct, EvmInstructions.IOpMath1Param
+    private readonly struct Math1Opcode<TOpMath, TTracingInst> : IOpcodeBody
+        where TOpMath : struct, EvmInstructions.IOpMath1Param
+        where TTracingInst : struct, IFlag
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionMath1Param<TGasPolicy, TOpMath>(ref stack, ref gas, vm);
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpMath>(ref gas);
+        public static int StackInputs => 1;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            if (!HasCheckedBody)
+                return EvmInstructions.InstructionMath1Param<TGasPolicy, TOpMath>(ref stack, ref gas, vm);
+
+            return EvmInstructions.Math1ParamCore<TOpMath, OffFlag>(ref stack);
+        }
     }
 
-    private readonly struct BitwiseOpcode<TOpBitwise> : IOpcodeBody where TOpBitwise : struct, EvmInstructions.IOpBitwise
+    private readonly struct BitwiseOpcode<TOpBitwise, TTracingInst> : IOpcodeBody
+        where TOpBitwise : struct, EvmInstructions.IOpBitwise
+        where TTracingInst : struct, IFlag
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionBitwise<TGasPolicy, TOpBitwise>(ref stack, ref gas, vm);
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpBitwise>(ref gas);
+        public static int StackInputs => 2;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            if (!HasCheckedBody)
+                return EvmInstructions.InstructionBitwise<TGasPolicy, TOpBitwise>(ref stack, ref gas, vm);
+
+            return EvmInstructions.BitwiseCore<TOpBitwise, OffFlag>(ref stack);
+        }
     }
 
-    private readonly struct ExpOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
+    private readonly struct ExpOpcode<TTracingInst, Eip160> : IOpcodeBody
+        where TTracingInst : struct, IFlag
+        where Eip160 : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionExp<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            EvmInstructions.InstructionExp<TGasPolicy, TTracingInst, Eip160>(ref stack, ref gas, vm);
     }
 
     private readonly struct SignExtendOpcode : IOpcodeBody
@@ -559,28 +637,65 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct CountLeadingZerosOpcode : IOpcodeBody
     {
+        public static bool HasCheckedBody => true;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.LowGasCost>(ref gas);
+        public static int StackInputs => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionCountLeadingZeros<TGasPolicy>(ref stack, ref gas);
+            EvmInstructions.CountLeadingZerosCore<OffFlag>(ref stack);
     }
 
     private readonly struct ByteOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackInputs => 2;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionByte<TGasPolicy, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? EvmInstructions.ByteCore<TTracingInst, OffFlag>(ref stack)
+                : EvmInstructions.InstructionByte<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct ShiftOpcode<TOpShift, TTracingInst> : IOpcodeBody
         where TOpShift : struct, EvmInstructions.IOpShift
         where TTracingInst : struct, IFlag
     {
+        // ShiftCore's x86 Vector128 paired pop/push path retains its own checks and fallible status.
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive &&
+                !(Vector128.IsHardwareAccelerated && !Vector256.IsHardwareAccelerated && X86Base.IsSupported);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpShift>(ref gas);
+        public static int StackInputs => 2;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionShift<TGasPolicy, TOpShift, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? EvmInstructions.ShiftCore<TOpShift, TTracingInst, OffFlag>(ref stack)
+                : EvmInstructions.InstructionShift<TGasPolicy, TOpShift, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct SarOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackInputs => 2;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionSar<TGasPolicy, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? EvmInstructions.SarCore<TTracingInst, OffFlag>(ref stack)
+                : EvmInstructions.InstructionSar<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct KeccakOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -593,64 +708,144 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TOpEnv : struct, EvmInstructions.IOpEnvAddress<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnvAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.Push20Bytes<TTracingInst, OffFlag>(ref MemoryMarshal.GetReference(TOpEnv.Operation(vm.VmState).Bytes))
+                : EvmInstructions.InstructionEnvAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct Env32BytesOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnv32Bytes<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnv32Bytes<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.Push32Bytes<TTracingInst, OffFlag>(in TOpEnv.Operation(vm))
+                : EvmInstructions.InstructionEnv32Bytes<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct EnvUInt256Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnvUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt256<TTracingInst, OffFlag>(TOpEnv.Operation(vm.VmState))
+                : EvmInstructions.InstructionEnvUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct EnvUInt32Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt32<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnvUInt32<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt32<TTracingInst, OffFlag>(TOpEnv.Operation(vm.VmState))
+                : EvmInstructions.InstructionEnvUInt32<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct EnvUInt64Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionEnvUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt64<TTracingInst, OffFlag>(TOpEnv.Operation(vm.VmState))
+                : EvmInstructions.InstructionEnvUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct BlkAddressOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkAddress<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionBlkAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.Push20Bytes<TTracingInst, OffFlag>(ref MemoryMarshal.GetReference(TOpEnv.Operation(vm).Bytes))
+                : EvmInstructions.InstructionBlkAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct BlkUInt256Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionBlkUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt256<TTracingInst, OffFlag>(TOpEnv.Operation(vm))
+                : EvmInstructions.InstructionBlkUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct BlkUInt64Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<TOpEnv>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionBlkUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt64<TTracingInst, OffFlag>(TOpEnv.Operation(vm))
+                : EvmInstructions.InstructionBlkUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct BalanceOpcode<TTracingInst, TSpec> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -662,8 +857,13 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct CallDataLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody => true;
+        public static bool UsesVm => true;
+        public static int StackInputs => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionCallDataLoad<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            EvmInstructions.CallDataLoadCore<TGasPolicy, TTracingInst>(ref stack, vm);
     }
 
     private readonly struct CallDataCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -674,8 +874,18 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct CodeSizeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionCodeSize<TGasPolicy, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? stack.PushUInt32<TTracingInst, OffFlag>((uint)stack.CodeLength)
+                : EvmInstructions.InstructionCodeSize<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct CodeCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -708,8 +918,19 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct ReturnDataSizeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionReturnDataSize<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.PushUInt32<TTracingInst, OffFlag>((uint)vm.ReturnDataBuffer.Length)
+                : EvmInstructions.InstructionReturnDataSize<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct ReturnDataCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -733,14 +954,36 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct PrevRandaoOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionPrevRandao<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? stack.Push32Bytes<TTracingInst, OffFlag>(in vm.BlockExecutionContext.PrevRandao)
+                : EvmInstructions.InstructionPrevRandao<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct SelfBalanceOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        public static bool UsesVm => true;
+        public static int StackGrowth => 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.SelfBalanceGasCost>(ref gas);
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionSelfBalance<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody ? EvmInstructions.InstructionSelfBalance<TGasPolicy, TTracingInst, OffFlag>(ref stack, ref gas, vm)
+                : EvmInstructions.InstructionSelfBalance<TGasPolicy, TTracingInst, OnFlag>(ref stack, ref gas, vm);
     }
 
     private readonly struct BlobHashOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -832,8 +1075,17 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct PopOpcode : IOpcodeBody
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionPop(ref stack, ref gas, vm);
+        public static bool HasCheckedBody => true;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackInputs => 1;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            stack.Head--;
+            return EvmExceptionType.None;
+        }
     }
 
     private readonly struct MLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -913,14 +1165,34 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct ProgramCounterOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionProgramCounter<TGasPolicy, TTracingInst>(ref stack, ref gas, vm, programCounter);
+            HasCheckedBody ? stack.PushUInt32<TTracingInst, OffFlag>((uint)(programCounter - 1))
+                : EvmInstructions.InstructionProgramCounter<TGasPolicy, TTracingInst>(ref stack, ref gas, vm, programCounter);
     }
 
     private readonly struct GasOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionGas<TGasPolicy, TTracingInst>(ref stack, ref gas);
+            HasCheckedBody ? stack.PushUInt64<TTracingInst, OffFlag>(TGasPolicy.GetRemainingGas(in gas))
+                : EvmInstructions.InstructionGas<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
     private readonly struct JumpDestOpcode : IOpcodeBody
@@ -949,8 +1221,21 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     private readonly struct Push0Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
+        public static int PushSize => 0;
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.BaseGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionPush0<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody
+                ? stack.PushZero<TTracingInst, OffFlag>()
+                : EvmInstructions.InstructionPush0<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct Push2Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
@@ -963,24 +1248,67 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
     {
-        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionPush<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, ref programCounter);
+        public static int PushSize => TOpCount.Count;
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackGrowth => 1;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        {
+            if (!HasCheckedBody)
+                return EvmInstructions.InstructionPush<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, ref programCounter);
+
+            _ = TOpCount.Push<TTracingInst, OffFlag, OffFlag>(ref stack, programCounter);
+            programCounter += TOpCount.Count;
+            return EvmExceptionType.None;
+        }
     }
 
     private readonly struct DupOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackInputs => TOpCount.Count;
+        public static int StackGrowth => 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionDup<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody
+                ? stack.Dup<TTracingInst, OffFlag>(TOpCount.Count)
+                : EvmInstructions.InstructionDup<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct SwapOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
     {
+        public static bool HasCheckedBody
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => !TTracingInst.IsActive;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryConsumeGas(ref TGasPolicy gas) => TGasPolicy.UpdateGas<GasPolicy.VeryLowGasCost>(ref gas);
+        public static int StackInputs => TOpCount.Count + 1;
+
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
-            EvmInstructions.InstructionSwap<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
+            HasCheckedBody
+                ? stack.Swap<TTracingInst, OffFlag>(TOpCount.Count + 1)
+                : EvmInstructions.InstructionSwap<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
     }
 
     private readonly struct LogOpcode<TOpCount> : IOpcodeBody where TOpCount : struct, EvmInstructions.IOpCount

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -68,20 +68,6 @@ public static class VirtualMachineStatics
     internal static readonly Address Ripemd160Address = Address.FromNumber(3);
 
     /// <summary>
-    /// Whether the dispatch loop must leave the frame after an instruction: the handler returned a status
-    /// other than <see cref="EvmExceptionType.None"/>, or the gas policy ran out of gas.
-    /// </summary>
-    /// <remarks>
-    /// This folds both conditions into one branch on the per-opcode hot path. The exit path checks the gas
-    /// policy first so out-of-gas retains priority over a handler status. The subtraction keeps the fold
-    /// correct for any value of <see cref="EvmExceptionType.None"/>, which is hand-numbered; the OR only
-    /// ever sets bit 0, so it cannot cancel a nonzero difference. While <c>None</c> is zero it folds away.
-    /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static bool ShouldExitFrame(EvmExceptionType status, bool outOfGas) =>
-        (((int)status - (int)EvmExceptionType.None) | Unsafe.BitCast<bool, byte>(outOfGas)) != 0;
-
-    /// <summary>
     /// Restores the RIPEMD-160 empty-account touch after a world-state snapshot rollback.
     /// </summary>
     /// <remarks>
@@ -121,9 +107,9 @@ public partial class VirtualMachine<TGasPolicy>(
 
     private ICodeInfoRepository _codeInfoRepository = null!;
 
-    private ReadOnlyMemory<byte> _returnDataBuffer = Array.Empty<byte>();
+    private ReadOnlyMemory<byte> _returnDataBuffer;
     protected VmState<TGasPolicy> _currentState = null!;
-    protected ReadOnlyMemory<byte>? _previousCallResult;
+    protected (Address? CreatedAddress, bool? Success) _previousCallResult;
     protected UInt256 _previousCallOutputDestination;
 
     public ILogger Logger => _logger;
@@ -136,12 +122,13 @@ public partial class VirtualMachine<TGasPolicy>(
     public PoppedAddressCache AddressCache { get; } = new();
     public IBlockhashProvider BlockHashProvider => _blockHashProvider;
     protected VmStateStack<TGasPolicy> StateStack => _stateStack;
-    // Both are fixed per execution, so they are cached once in ExecuteTransaction rather than dispatched
-    // through the tracer each time: IsTracingActions is read at several hot CALL/precompile sites, and
-    // IsCancelable picks both the dispatch table and the generic instantiation that runs on it, which have
-    // to agree.
-    private bool _isTracingActionsCached;
+    // Tracer capabilities are fixed for one execution. IsCancelable also selects both
+    // the dispatch table and its matching loop specialization.
+    internal bool IsTracingActions { get => DispatchFlags.Tracing(field); private set; }
+    internal bool IsTracingRefunds { get => DispatchFlags.Tracing(field); private set; }
     private bool _isCancelableCached;
+    internal bool IsTracingAccess { get => DispatchFlags.Tracing(field); private set; }
+    internal bool IsTracingOpLevelStorage { get => DispatchFlags.Tracing(field); private set; }
 
     private BlockExecutionContext _blockExecutionContext;
     public virtual void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
@@ -191,8 +178,11 @@ public partial class VirtualMachine<TGasPolicy>(
     {
         // Initialize dependencies for transaction tracing and state access.
         _txTracer = txTracer;
-        _isTracingActionsCached = txTracer.IsTracingActions;
+        IsTracingActions = txTracer.IsTracingActions;
+        IsTracingRefunds = txTracer.IsTracingRefunds;
         _isCancelableCached = txTracer.IsCancelable;
+        IsTracingAccess = txTracer.IsTracingAccess;
+        IsTracingOpLevelStorage = txTracer.IsTracingOpLevelStorage;
         DispatchFlags.Validate(txTracer);
         _worldState = worldState;
 
@@ -205,9 +195,9 @@ public partial class VirtualMachine<TGasPolicy>(
         _codeInfoRepository = TxExecutionContext.CodeInfoRepository;
         _currentState = vmState;
         using FrameCleanupScope _ = new(this, vmState);
-        _previousCallResult = null;
+        _previousCallResult = default;
         _previousCallOutputDestination = UInt256.Zero;
-        ReadOnlySpan<byte> previousCallOutput = ReadOnlySpan<byte>.Empty;
+        nuint previousCallOutputLength = 0;
 
         // Main execution loop: processes call frames until the top-level transaction completes.
         while (true)
@@ -215,7 +205,7 @@ public partial class VirtualMachine<TGasPolicy>(
             // For non-continuation frames, clear any previously stored return data.
             if (!_currentState.IsContinuation)
             {
-                ReturnDataBuffer = Array.Empty<byte>();
+                ReturnDataBuffer = default;
             }
 
             Exception? failure;
@@ -227,7 +217,7 @@ public partial class VirtualMachine<TGasPolicy>(
                 // If the current state represents a precompiled contract, handle it separately.
                 if (_currentState.IsPrecompile)
                 {
-                    callResult = ExecutePrecompile(_currentState, _isTracingActionsCached, out failure, out substateError);
+                    callResult = ExecutePrecompile(_currentState, IsTracingActions, out failure, out substateError);
                     if (failure is not null)
                     {
                         // Jump to the failure handler if a precompile error occurred.
@@ -239,7 +229,7 @@ public partial class VirtualMachine<TGasPolicy>(
                     if (!_currentState.IsContinuation)
                     {
                         // Report frame start before the EIP-7708 transfer log so it attaches to the frame being entered
-                        if (_isTracingActionsCached) TraceTransactionActionStart(_currentState);
+                        if (IsTracingActions) TraceTransactionActionStart(_currentState);
                         AddTransferLog(_currentState);
                     }
 
@@ -248,7 +238,7 @@ public partial class VirtualMachine<TGasPolicy>(
                     {
                         callResult = ExecuteCall<TTracingInst>(
                             _previousCallResult,
-                            previousCallOutput,
+                            previousCallOutputLength,
                             _previousCallOutputDestination);
                     }
                     else
@@ -259,14 +249,14 @@ public partial class VirtualMachine<TGasPolicy>(
                     // If the call did not finish with a return, set up the next call frame and continue.
                     if (!callResult.IsReturn)
                     {
-                        PrepareNextCallFrame(in callResult, ref previousCallOutput);
+                        PrepareNextCallFrame(in callResult, ref previousCallOutputLength);
                         continue;
                     }
 
                     // Handle exceptions raised during the call execution.
                     if (callResult.IsException)
                     {
-                        TransactionSubstate substate = HandleException(in callResult, ref previousCallOutput, out bool terminate);
+                        TransactionSubstate substate = HandleException(in callResult, ref previousCallOutputLength, out bool terminate);
                         if (terminate)
                         {
                             _currentState = null!;
@@ -280,7 +270,7 @@ public partial class VirtualMachine<TGasPolicy>(
                 // If the current execution state is the top-level call, finalize tracing and return the result.
                 if (_currentState.IsTopLevel)
                 {
-                    if (_isTracingActionsCached)
+                    if (IsTracingActions)
                     {
                         TraceTransactionActionEnd(_currentState, callResult);
                     }
@@ -308,12 +298,12 @@ public partial class VirtualMachine<TGasPolicy>(
 
                         // Refund the remaining gas from the completed call frame (success path).
                         TGasPolicy.Refund(ref _currentState.Gas, in previousState.Gas);
-                        ulong gasAvailableForCodeDeposit = TGasPolicy.GetRemainingGas(previousState.Gas);
 
                         // Process contract creation calls differently from regular calls.
                         if (isCreate)
                         {
-                            PrepareCreateData(previousState, ref previousCallOutput);
+                            ulong gasAvailableForCodeDeposit = TGasPolicy.GetRemainingGas(previousState.Gas);
+                            PrepareCreateData(previousState, ref previousCallOutputLength);
                             HandleCreate(
                                 in callResult,
                                 previousState,
@@ -323,7 +313,7 @@ public partial class VirtualMachine<TGasPolicy>(
                         else
                         {
                             // Process a standard call return.
-                            previousCallOutput = HandleRegularReturn<TTracingInst>(in callResult, previousState);
+                            previousCallOutputLength = HandleRegularReturn<TTracingInst>(in callResult, previousState);
                         }
 
                         // Commit the changes from the completed call frame if execution was successful.
@@ -355,7 +345,7 @@ public partial class VirtualMachine<TGasPolicy>(
                             CreditStateGasRefund(ref _currentState.Gas, TGasPolicy.GetNewAccountStateCost());
                         }
                         // Revert state changes for the previous call frame when a revert condition is signaled.
-                        HandleRevert(previousState, callResult, ref previousCallOutput);
+                        HandleRevert(previousState, callResult, ref previousCallOutputLength);
                     }
                 }
 #pragma warning restore IDE0063
@@ -373,7 +363,7 @@ public partial class VirtualMachine<TGasPolicy>(
 
             // Failure handling: attempts to process and possibly finalize the transaction after an error.
         Failure:
-            TransactionSubstate failSubstate = HandleFailure<TTracingInst>(failure, substateError, ref previousCallOutput, out bool shouldExit);
+            TransactionSubstate failSubstate = HandleFailure<TTracingInst>(failure, substateError, ref previousCallOutputLength, out bool shouldExit);
             if (shouldExit)
             {
                 _currentState = null!;
@@ -417,38 +407,37 @@ public partial class VirtualMachine<TGasPolicy>(
         }
     }
 
-    protected void PrepareCreateData(VmState<TGasPolicy> previousState, ref ReadOnlySpan<byte> previousCallOutput)
+    protected void PrepareCreateData(VmState<TGasPolicy> previousState, ref nuint previousCallOutputLength)
     {
-        _previousCallResult = previousState.Env.ExecutingAccount.Bytes.ToArray();
+        _previousCallResult = (previousState.Env.ExecutingAccount, true);
         _previousCallOutputDestination = UInt256.Zero;
-        ReturnDataBuffer = Array.Empty<byte>();
-        previousCallOutput = ReadOnlySpan<byte>.Empty;
+        ReturnDataBuffer = default;
+        previousCallOutputLength = 0;
     }
 
-    protected ReadOnlySpan<byte> HandleRegularReturn<TTracingInst>(scoped in CallResult callResult, VmState<TGasPolicy> previousState)
+    protected nuint HandleRegularReturn<TTracingInst>(scoped in CallResult callResult, VmState<TGasPolicy> previousState)
         where TTracingInst : struct, IFlag
     {
         ReturnDataBuffer = callResult.Output;
-        _previousCallResult = callResult.PrecompileSuccess.HasValue
-            ? (callResult.PrecompileSuccess.Value ? StatusCode.SuccessBytes : StatusCode.FailureBytes)
-            : StatusCode.SuccessBytes;
-        ReadOnlySpan<byte> previousCallOutput = ReturnDataBuffer.Span[..Math.Min(ReturnDataBuffer.Length, (int)previousState.OutputLength)];
+        _previousCallResult = (null, callResult.PrecompileSuccess != false);
+        nuint previousCallOutputLength = (nuint)Math.Min(ReturnDataBuffer.Length, (int)previousState.OutputLength);
         _previousCallOutputDestination = (ulong)previousState.OutputDestination;
         if (previousState.IsPrecompile)
         {
             // parity induced if else for vmtrace
             if (TTracingInst.IsActive)
             {
-                _txTracer.ReportMemoryChange(_previousCallOutputDestination, in previousCallOutput);
+                ReadOnlySpan<byte> output = ReturnDataBuffer.Span[..(int)previousCallOutputLength];
+                _txTracer.ReportMemoryChange(_previousCallOutputDestination, in output);
             }
         }
 
-        if (_isTracingActionsCached)
+        if (IsTracingActions)
         {
             _txTracer.ReportActionEnd(TGasPolicy.GetRemainingGas(previousState.Gas), ReturnDataBuffer);
         }
 
-        return previousCallOutput;
+        return previousCallOutputLength;
     }
     /// <summary>
     /// Handles the code deposit for a contract creation operation.
@@ -533,7 +522,7 @@ public partial class VirtualMachine<TGasPolicy>(
             {
                 _currentState.Gas = gasAfterCodeDeposit;
                 _codeInfoRepository.InsertCode(code, callCodeOwner, spec);
-                if (_isTracingActionsCached)
+                if (IsTracingActions)
                 {
                     _txTracer.ReportActionEnd(TGasPolicy.GetRemainingGas(previousState.Gas) - codeDepositGasCost, callCodeOwner, code);
                 }
@@ -542,7 +531,8 @@ public partial class VirtualMachine<TGasPolicy>(
 
         if (!chargedCodeDeposit && (spec.FailOnOutOfGasCodeDeposit || invalidCode))
         {
-            TGasPolicy.Consume(ref _currentState.Gas, gasAvailableForCodeDeposit);
+            bool charged = TGasPolicy.UpdateGas(ref _currentState.Gas, gasAvailableForCodeDeposit);
+            Debug.Assert(charged, "Refund already merged the child's remaining gas into the parent.");
             // Code deposit failure is an exceptional halt of the child CREATE frame.
             // Refund already merged the child's state gas (reservoir, stateGasUsed) into the parent,
             // but halt semantics require restoring the full initial state reservoir and discarding
@@ -562,15 +552,15 @@ public partial class VirtualMachine<TGasPolicy>(
             }
             RestoreRipemdTouch(_worldState, spec, _shouldRestoreRipemdTouch);
 
-            _previousCallResult = BytesZero;
+            _previousCallResult = (null, false);
             previousStateSucceeded = false;
 
-            if (_isTracingActionsCached)
+            if (IsTracingActions)
             {
                 _txTracer.ReportActionError(invalidCode ? EvmExceptionType.InvalidCode : EvmExceptionType.OutOfGas);
             }
         }
-        else if (!chargedCodeDeposit && _isTracingActionsCached)
+        else if (!chargedCodeDeposit && IsTracingActions)
         {
             _txTracer.ReportActionEnd(0UL, callCodeOwner, code);
         }
@@ -589,10 +579,10 @@ public partial class VirtualMachine<TGasPolicy>(
     /// The result of the call that triggered the revert, containing output data and flags
     /// indicating precompile success.
     /// </param>
-    /// <param name="previousCallOutput">
-    /// A reference to the output data buffer that will be updated with the reverted call's output.
+    /// <param name="previousCallOutputLength">
+    /// The bounded number of reverted output bytes to copy into parent memory.
     /// </param>
-    protected void HandleRevert(VmState<TGasPolicy> previousState, in CallResult callResult, ref ReadOnlySpan<byte> previousCallOutput)
+    protected void HandleRevert(VmState<TGasPolicy> previousState, in CallResult callResult, ref nuint previousCallOutputLength)
     {
         // Restore the world state to the snapshot taken before the execution of the call.
         _worldState.Restore(previousState.Snapshot);
@@ -604,15 +594,15 @@ public partial class VirtualMachine<TGasPolicy>(
         // Set the return data buffer to the output bytes from the failed call.
         ReturnDataBuffer = outputBytes;
 
-        _previousCallResult = StatusCode.FailureBytes;
+        _previousCallResult = (null, false);
 
-        previousCallOutput = ReturnDataBuffer.Span[..Math.Min(ReturnDataBuffer.Length, (int)previousState.OutputLength)];
+        previousCallOutputLength = (nuint)Math.Min(ReturnDataBuffer.Length, (int)previousState.OutputLength);
 
         // Record the output destination address for subsequent operations.
         _previousCallOutputDestination = (ulong)previousState.OutputDestination;
 
         // If transaction tracing is enabled, report the revert action along with the available gas and output bytes.
-        if (_isTracingActionsCached)
+        if (IsTracingActions)
         {
             _txTracer.ReportActionRevert(TGasPolicy.GetRemainingGas(previousState.Gas), outputBytes);
         }
@@ -627,14 +617,14 @@ public partial class VirtualMachine<TGasPolicy>(
     /// A type parameter representing tracing instructions. It must be a struct implementing <see cref="IFlag"/>.
     /// </typeparam>
     /// <param name="failure">The exception that caused the failure during execution.</param>
-    /// <param name="previousCallOutput">
-    /// A reference to the previous call's output; it will be reset upon failure.
+    /// <param name="previousCallOutputLength">
+    /// The pending output copy length, reset upon failure.
     /// </param>
     /// <returns>
     /// A <see cref="TransactionSubstate"/> if the failure occurs in the top-level call; otherwise, <c>null</c>
     /// to indicate that execution should continue with the parent call frame.
     /// </returns>
-    protected TransactionSubstate HandleFailure<TTracingInst>(Exception failure, string? substateError, scoped ref ReadOnlySpan<byte> previousCallOutput, out bool shouldExit)
+    protected TransactionSubstate HandleFailure<TTracingInst>(Exception failure, string? substateError, scoped ref nuint previousCallOutputLength, out bool shouldExit)
         where TTracingInst : struct, IFlag
     {
         // Log the exception if trace logging is enabled.
@@ -663,7 +653,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
 
         // If action-level tracing is enabled, report the error associated with the action.
-        if (txTracer.IsTracingActions)
+        if (IsTracingActions)
         {
             txTracer.ReportActionError(errorType);
         }
@@ -682,7 +672,7 @@ public partial class VirtualMachine<TGasPolicy>(
             };
         }
 
-        _previousCallResult = StatusCode.FailureBytes;
+        _previousCallResult = (null, false);
         bool failedCreate = _currentState.ExecutionType.IsAnyCreate();
         // Captured before the pop: the parent refunds NEW_ACCOUNT for the failed *CALL's uncreated recipient.
         bool childNewAccountCharged = _currentState.NewAccountCharged;
@@ -690,8 +680,8 @@ public partial class VirtualMachine<TGasPolicy>(
 
         // Reset output destination and return data.
         _previousCallOutputDestination = UInt256.Zero;
-        ReturnDataBuffer = Array.Empty<byte>();
-        previousCallOutput = ReadOnlySpan<byte>.Empty;
+        ReturnDataBuffer = default;
+        previousCallOutputLength = 0;
 
         PopAndRestoreParentState();
         if (failedCreate && childCreateStateGasCharged)
@@ -808,10 +798,10 @@ public partial class VirtualMachine<TGasPolicy>(
     /// <param name="callResult">
     /// The result object from the current call, which contains the state to be executed next.
     /// </param>
-    /// <param name="previousCallOutput">
-    /// A reference to the buffer holding the previous call's output, which is cleared in preparation for the new call.
+    /// <param name="previousCallOutputLength">
+    /// The pending memory-copy length, cleared before entering the new frame.
     /// </param>
-    protected void PrepareNextCallFrame(in CallResult callResult, ref ReadOnlySpan<byte> previousCallOutput)
+    protected void PrepareNextCallFrame(in CallResult callResult, ref nuint previousCallOutputLength)
     {
         Debug.Assert(callResult.StateToExecute is not null, "A non-returning call result must carry its next frame.");
         // Push the current execution state onto the state stack so it can be restored later.
@@ -821,13 +811,9 @@ public partial class VirtualMachine<TGasPolicy>(
         _currentState = callResult.StateToExecute;
 
         // Clear the previous call result as the execution context is moving to a new frame.
-        _previousCallResult = null;
+        _previousCallResult = default;
 
-        // Reset the return data buffer to ensure no residual data persists across call frames.
-        ReturnDataBuffer = Array.Empty<byte>();
-
-        // Clear the previous call output, preparing for new output data in the next call frame.
-        previousCallOutput = ReadOnlySpan<byte>.Empty;
+        previousCallOutputLength = 0;
     }
 
     /// <summary>
@@ -838,20 +824,20 @@ public partial class VirtualMachine<TGasPolicy>(
     /// <param name="callResult">
     /// The result object that contains the exception type and any output data from the failed call.
     /// </param>
-    /// <param name="previousCallOutput">
-    /// A reference to the previous call's output, which is reset on exception.
+    /// <param name="previousCallOutputLength">
+    /// The pending output copy length, reset on exception.
     /// </param>
     /// <returns>
     /// A <see cref="TransactionSubstate"/> instance if the failure occurred in a top-level call,
     /// otherwise <c>null</c> to indicate that execution should continue in the parent frame.
     /// </returns>
-    protected TransactionSubstate HandleException(scoped in CallResult callResult, scoped ref ReadOnlySpan<byte> previousCallOutput, out bool shouldExit)
+    protected TransactionSubstate HandleException(scoped in CallResult callResult, scoped ref nuint previousCallOutputLength, out bool shouldExit)
     {
         // Cache the tracer to minimize repeated field accesses.
         ITxTracer txTracer = _txTracer;
 
         // Report the error for action-level tracing if enabled.
-        if (txTracer.IsTracingActions)
+        if (IsTracingActions)
         {
             txTracer.ReportActionError(callResult.ExceptionType);
         }
@@ -873,7 +859,7 @@ public partial class VirtualMachine<TGasPolicy>(
             };
         }
 
-        _previousCallResult = StatusCode.FailureBytes;
+        _previousCallResult = (null, false);
         bool failedCreate = _currentState.ExecutionType.IsAnyCreate();
         // Captured before the pop: the parent refunds NEW_ACCOUNT for the halted *CALL's uncreated recipient.
         bool childNewAccountCharged = _currentState.NewAccountCharged;
@@ -881,8 +867,8 @@ public partial class VirtualMachine<TGasPolicy>(
 
         // Reset output destination and clear return data.
         _previousCallOutputDestination = UInt256.Zero;
-        ReturnDataBuffer = Array.Empty<byte>();
-        previousCallOutput = ReadOnlySpan<byte>.Empty;
+        ReturnDataBuffer = default;
+        previousCallOutputLength = 0;
 
         PopAndRestoreParentState();
         if (failedCreate && childCreateStateGasCharged)
@@ -918,7 +904,7 @@ public partial class VirtualMachine<TGasPolicy>(
     /// A <see cref="CallResult"/> containing the results of the precompile execution. In case of a failure,
     /// returns the default value of <see cref="CallResult"/>.
     /// </returns>
-    protected virtual CallResult ExecutePrecompile(VmState<TGasPolicy> currentState, bool isTracingActions, out Exception? failure, out string? substateError)
+    protected CallResult ExecutePrecompile(VmState<TGasPolicy> currentState, bool isTracingActions, out Exception? failure, out string? substateError)
     {
         // Report the precompile action if tracing is enabled.
         if (isTracingActions)
@@ -958,7 +944,7 @@ public partial class VirtualMachine<TGasPolicy>(
             }
 
             // Otherwise, if no exception but precompile did not succeed, exhaust the remaining gas.
-            TGasPolicy.SetOutOfGas(ref currentState.Gas);
+            TGasPolicy.ClearExecutionGas(ref currentState.Gas);
         }
 
         // If execution reaches here, the precompile operation is considered successful.
@@ -1147,7 +1133,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
 
         // The policy reads the precompile's own base/data cost (with the overflow guard inside).
-        if (!TGasPolicy.ConsumePrecompileGas(ref gas, precompile, callData, spec))
+        if (!TGasPolicy.TryConsumePrecompileGas(ref gas, precompile, callData, spec))
         {
             return new(default, precompileSuccess: false, shouldRevert: true, EvmExceptionType.OutOfGas);
         }
@@ -1227,11 +1213,10 @@ public partial class VirtualMachine<TGasPolicy>(
     /// The current EVM state containing the execution environment, gas, memory, and stack information.
     /// </param>
     /// <param name="previousCallResult">
-    /// An optional read-only memory buffer containing the output of a previous call; if provided, its bytes
-    /// will be pushed onto the stack for further processing.
+    /// The pending call status or created address to push onto the resumed frame's stack.
     /// </param>
-    /// <param name="previousCallOutput">
-    /// Output from the previous call used for updating the memory state.
+    /// <param name="previousCallOutputLength">
+    /// The bounded number of return bytes to copy into parent memory.
     /// </param>
     /// <param name="previousCallOutputDestination">
     /// The memory destination address where the previous call's output should be stored.
@@ -1246,8 +1231,8 @@ public partial class VirtualMachine<TGasPolicy>(
     /// </remarks>
     [SkipLocalsInit]
     protected unsafe CallResult ExecuteCall<TTracingInst>(
-        ReadOnlyMemory<byte>? previousCallResult,
-        ReadOnlySpan<byte> previousCallOutput,
+        in (Address? CreatedAddress, bool? Success) previousCallResult,
+        nuint previousCallOutputLength,
         scoped in UInt256 previousCallOutputDestination)
         where TTracingInst : struct, IFlag
     {
@@ -1274,7 +1259,11 @@ public partial class VirtualMachine<TGasPolicy>(
 
         // Initialize the internal stacks for the current call frame.
         EvmStack stack;
-        if (TTracingInst.IsActive)
+        if (vmState.IsContinuation)
+        {
+            vmState.RestoreStack<TTracingInst>(_txTracer, codeSpan, out stack);
+        }
+        else if (TTracingInst.IsActive)
         {
             vmState.InitializeStacks(_txTracer, codeSpan, out stack);
         }
@@ -1287,10 +1276,24 @@ public partial class VirtualMachine<TGasPolicy>(
         // gas/state-gas accounting without needing interpreter-wide exception handling.
         ref TGasPolicy gas = ref vmState.Gas;
 
-        // If a previous call result exists, push its bytes onto the stack.
-        if (previousCallResult is not null)
+        // If a previous call result exists, push it onto the stack.
+        if (previousCallResult.Success.HasValue)
         {
-            EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(previousCallResult.Value.Span);
+            EvmExceptionType pushResult;
+            if (previousCallResult.CreatedAddress is { } createdAddress)
+            {
+                pushResult = stack.PushAddress<TTracingInst>(createdAddress);
+            }
+            else if (TTracingInst.IsActive)
+            {
+                pushResult = previousCallResult.Success.GetValueOrDefault()
+                    ? stack.PushOne<TTracingInst>()
+                    : stack.PushZero<TTracingInst, OnFlag>();
+            }
+            else
+            {
+                pushResult = stack.PushUInt32<TTracingInst, OnFlag>(previousCallResult.Success.GetValueOrDefault() ? 1u : 0u);
+            }
             if (pushResult != EvmExceptionType.None) return new(pushResult);
 
             // Report the remaining gas if tracing instructions are enabled.
@@ -1300,19 +1303,10 @@ public partial class VirtualMachine<TGasPolicy>(
             }
         }
 
-        // If there is previous call output, update the memory cost and save the output.
-        if (previousCallOutput.Length > 0)
+        // CALL already expanded this range; returned output is clipped to the requested length.
+        if (previousCallOutputLength > 0)
         {
-            // Use a local variable for the destination to simplify passing it by reference.
-            UInt256 localPreviousDest = previousCallOutputDestination;
-
-            // Attempt to update the memory cost; if insufficient gas is available, jump to the out-of-gas handler.
-            if (!TGasPolicy.UpdateMemoryCost(ref gas, in localPreviousDest, (ulong)previousCallOutput.Length, ref vmState.Memory))
-            {
-                goto OutOfGas;
-            }
-
-            vmState.Memory.SaveAfterGas(in localPreviousDest, previousCallOutput);
+            vmState.Memory.SaveAfterGas(in previousCallOutputDestination, ReturnDataBuffer.Span[..(int)previousCallOutputLength]);
         }
 
         // Dispatch the bytecode interpreter.
@@ -1330,10 +1324,6 @@ public partial class VirtualMachine<TGasPolicy>(
     Empty:
         // Return an empty CallResult if there is no machine code to execute.
         return CallResult.Empty();
-
-    OutOfGas:
-        // Return an out-of-gas CallResult if updating the memory cost fails.
-        return new(EvmExceptionType.OutOfGas);
     }
 
     /// <summary>Runs the frame's bytecode through the opcode dispatch loop.</summary>
@@ -1355,13 +1345,20 @@ public partial class VirtualMachine<TGasPolicy>(
         {
             if (TTracingInst.IsActive)
                 EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));
-            UpdateCurrentState((int)programCounter, in gas, (int)stack.Head);
+            int stackHead = (int)stack.Head;
+            VmState<TGasPolicy> state = VmState;
+            state.ProgramCounter = (int)programCounter;
+            state.DataStackHead = stackHead;
         }
         else
         {
             goto ReturnFailure;
         }
 
+        Debug.Assert((exceptionType == EvmExceptionType.Suspend) == (ReturnData is VmState<TGasPolicy>),
+            "CALL/CREATE stage a child frame exactly when they return Suspend.");
+        if (exceptionType == EvmExceptionType.Suspend)
+            return new CallResult(Unsafe.As<VmState<TGasPolicy>>(ReturnData!));
         if (exceptionType == EvmExceptionType.Revert)
             goto Revert;
         if (ReturnData is not null)
@@ -1370,29 +1367,24 @@ public partial class VirtualMachine<TGasPolicy>(
         return CallResult.Empty();
 
     DataReturn:
-        // A nested frame is the common outcome here, and it is the cheaper test: an array `isinst` needs
-        // the general helper, while a class one has a specialized fast path. Order them accordingly.
-        return ReturnData switch
-        {
-            VmState<TGasPolicy> state => new CallResult(state),
-            byte[] data => new CallResult(data, null),
-            _ => new CallResult(ReturnDataBuffer, null),
-        };
+        Debug.Assert(ReturnData is byte[], "RETURN stages a byte array before stopping dispatch.");
+        return new CallResult(Unsafe.As<byte[]>(ReturnData), null);
 
     Revert:
-        Debug.Assert(ReturnData is byte[], "REVERT must provide return data.");
-        return new CallResult((byte[])ReturnData, null, shouldRevert: true, exceptionType);
+        Debug.Assert(ReturnData is byte[], "REVERT stages a byte array before stopping dispatch.");
+        return new CallResult(Unsafe.As<byte[]>(ReturnData), null, shouldRevert: true, exceptionType);
 
     ReturnFailure:
-        // EIP-8037: write gas back so RestoreChildStateGasOnHalt can read the child frame's state gas.
-        _currentState.Gas = gas;
+        if (exceptionType == EvmExceptionType.OutOfGas)
+            TGasPolicy.ClearExecutionGas(ref gas);
+
         return GetFailureReturn(TGasPolicy.GetRemainingGas(in gas), exceptionType);
     }
 
 
     private CallResult GetFailureReturn(ulong gasAvailable, EvmExceptionType exceptionType)
     {
-        if (_txTracer.IsTracingInstructions) EndInstructionTraceError(gasAvailable, exceptionType);
+        if (DispatchFlags.ConstTracing && _txTracer.IsTracingInstructions) EndInstructionTraceError(gasAvailable, exceptionType);
 
         return exceptionType switch
         {
@@ -1405,15 +1397,6 @@ public partial class VirtualMachine<TGasPolicy>(
             EvmExceptionType.AccessViolation => new(exceptionType),
             _ => throw new ArgumentOutOfRangeException(nameof(exceptionType), exceptionType, "")
         };
-    }
-
-    private void UpdateCurrentState(int pc, in TGasPolicy gas, int stackHead)
-    {
-        VmState<TGasPolicy> state = VmState;
-
-        state.ProgramCounter = pc;
-        state.Gas = gas;
-        state.DataStackHead = stackHead;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1452,8 +1435,7 @@ public partial class VirtualMachine<TGasPolicy>(
     {
         VmState.AccessTracker.Logs.Add(logEntry);
 
-        // Optionally report the log if tracing is enabled.
-        if (TxTracer.IsTracingLogs)
+        if (DispatchFlags.ConstTracing && TxTracer.IsTracingLogs)
         {
             TxTracer.ReportLog(logEntry);
         }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -68,20 +68,6 @@ public static class VirtualMachineStatics
     internal static readonly Address Ripemd160Address = Address.FromNumber(3);
 
     /// <summary>
-    /// Whether the dispatch loop must leave the frame after an instruction: the handler returned a status
-    /// other than <see cref="EvmExceptionType.None"/>, or the gas policy ran out of gas.
-    /// </summary>
-    /// <remarks>
-    /// This folds both conditions into one branch on the per-opcode hot path. The exit path checks the gas
-    /// policy first so out-of-gas retains priority over a handler status. The subtraction keeps the fold
-    /// correct for any value of <see cref="EvmExceptionType.None"/>, which is hand-numbered; the OR only
-    /// ever sets bit 0, so it cannot cancel a nonzero difference. While <c>None</c> is zero it folds away.
-    /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static bool ShouldExitFrame(EvmExceptionType status, bool outOfGas) =>
-        (((int)status - (int)EvmExceptionType.None) | Unsafe.BitCast<bool, byte>(outOfGas)) != 0;
-
-    /// <summary>
     /// Restores the RIPEMD-160 empty-account touch after a world-state snapshot rollback.
     /// </summary>
     /// <remarks>
@@ -121,9 +107,9 @@ public partial class VirtualMachine<TGasPolicy>(
 
     private ICodeInfoRepository _codeInfoRepository = null!;
 
-    private ReadOnlyMemory<byte> _returnDataBuffer = Array.Empty<byte>();
+    private ReadOnlyMemory<byte> _returnDataBuffer;
     protected VmState<TGasPolicy> _currentState = null!;
-    protected ReadOnlyMemory<byte>? _previousCallResult;
+    protected (Address? CreatedAddress, bool? Success) _previousCallResult;
     protected UInt256 _previousCallOutputDestination;
 
     public ILogger Logger => _logger;
@@ -136,12 +122,13 @@ public partial class VirtualMachine<TGasPolicy>(
     public PoppedAddressCache AddressCache { get; } = new();
     public IBlockhashProvider BlockHashProvider => _blockHashProvider;
     protected VmStateStack<TGasPolicy> StateStack => _stateStack;
-    // Both are fixed per execution, so they are cached once in ExecuteTransaction rather than dispatched
-    // through the tracer each time: IsTracingActions is read at several hot CALL/precompile sites, and
-    // IsCancelable picks both the dispatch table and the generic instantiation that runs on it, which have
-    // to agree.
-    private bool _isTracingActionsCached;
+    // Tracer capabilities are fixed for one execution. IsCancelable also selects both
+    // the dispatch table and its matching loop specialization.
+    internal bool IsTracingActions { get => DispatchFlags.Tracing(field); private set; }
+    internal bool IsTracingRefunds { get => DispatchFlags.Tracing(field); private set; }
     private bool _isCancelableCached;
+    internal bool IsTracingAccess { get => DispatchFlags.Tracing(field); private set; }
+    internal bool IsTracingOpLevelStorage { get => DispatchFlags.Tracing(field); private set; }
 
     private BlockExecutionContext _blockExecutionContext;
     public virtual void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
@@ -191,8 +178,11 @@ public partial class VirtualMachine<TGasPolicy>(
     {
         // Initialize dependencies for transaction tracing and state access.
         _txTracer = txTracer;
-        _isTracingActionsCached = txTracer.IsTracingActions;
+        IsTracingActions = txTracer.IsTracingActions;
+        IsTracingRefunds = txTracer.IsTracingRefunds;
         _isCancelableCached = txTracer.IsCancelable;
+        IsTracingAccess = txTracer.IsTracingAccess;
+        IsTracingOpLevelStorage = txTracer.IsTracingOpLevelStorage;
         DispatchFlags.Validate(txTracer);
         _worldState = worldState;
 
@@ -205,9 +195,9 @@ public partial class VirtualMachine<TGasPolicy>(
         _codeInfoRepository = TxExecutionContext.CodeInfoRepository;
         _currentState = vmState;
         using FrameCleanupScope _ = new(this, vmState);
-        _previousCallResult = null;
+        _previousCallResult = default;
         _previousCallOutputDestination = UInt256.Zero;
-        ReadOnlySpan<byte> previousCallOutput = ReadOnlySpan<byte>.Empty;
+        nuint previousCallOutputLength = 0;
 
         // Main execution loop: processes call frames until the top-level transaction completes.
         while (true)
@@ -215,7 +205,7 @@ public partial class VirtualMachine<TGasPolicy>(
             // For non-continuation frames, clear any previously stored return data.
             if (!_currentState.IsContinuation)
             {
-                ReturnDataBuffer = Array.Empty<byte>();
+                ReturnDataBuffer = default;
             }
 
             Exception? failure;
@@ -227,7 +217,7 @@ public partial class VirtualMachine<TGasPolicy>(
                 // If the current state represents a precompiled contract, handle it separately.
                 if (_currentState.IsPrecompile)
                 {
-                    callResult = ExecutePrecompile(_currentState, _isTracingActionsCached, out failure, out substateError);
+                    callResult = ExecutePrecompile(_currentState, IsTracingActions, out failure, out substateError);
                     if (failure is not null)
                     {
                         // Jump to the failure handler if a precompile error occurred.
@@ -239,7 +229,7 @@ public partial class VirtualMachine<TGasPolicy>(
                     if (!_currentState.IsContinuation)
                     {
                         // Report frame start before the EIP-7708 transfer log so it attaches to the frame being entered
-                        if (_isTracingActionsCached) TraceTransactionActionStart(_currentState);
+                        if (IsTracingActions) TraceTransactionActionStart(_currentState);
                         AddTransferLog(_currentState);
                     }
 
@@ -248,7 +238,7 @@ public partial class VirtualMachine<TGasPolicy>(
                     {
                         callResult = ExecuteCall<TTracingInst>(
                             _previousCallResult,
-                            previousCallOutput,
+                            previousCallOutputLength,
                             _previousCallOutputDestination);
                     }
                     else
@@ -259,14 +249,14 @@ public partial class VirtualMachine<TGasPolicy>(
                     // If the call did not finish with a return, set up the next call frame and continue.
                     if (!callResult.IsReturn)
                     {
-                        PrepareNextCallFrame(in callResult, ref previousCallOutput);
+                        PrepareNextCallFrame(in callResult, ref previousCallOutputLength);
                         continue;
                     }
 
                     // Handle exceptions raised during the call execution.
                     if (callResult.IsException)
                     {
-                        TransactionSubstate substate = HandleException(in callResult, ref previousCallOutput, out bool terminate);
+                        TransactionSubstate substate = HandleException(in callResult, ref previousCallOutputLength, out bool terminate);
                         if (terminate)
                         {
                             _currentState = null!;
@@ -280,7 +270,7 @@ public partial class VirtualMachine<TGasPolicy>(
                 // If the current execution state is the top-level call, finalize tracing and return the result.
                 if (_currentState.IsTopLevel)
                 {
-                    if (_isTracingActionsCached)
+                    if (IsTracingActions)
                     {
                         TraceTransactionActionEnd(_currentState, callResult);
                     }
@@ -308,12 +298,12 @@ public partial class VirtualMachine<TGasPolicy>(
 
                         // Refund the remaining gas from the completed call frame (success path).
                         TGasPolicy.Refund(ref _currentState.Gas, in previousState.Gas);
-                        ulong gasAvailableForCodeDeposit = TGasPolicy.GetRemainingGas(previousState.Gas);
 
                         // Process contract creation calls differently from regular calls.
                         if (isCreate)
                         {
-                            PrepareCreateData(previousState, ref previousCallOutput);
+                            ulong gasAvailableForCodeDeposit = TGasPolicy.GetRemainingGas(previousState.Gas);
+                            PrepareCreateData(previousState, ref previousCallOutputLength);
                             HandleCreate(
                                 in callResult,
                                 previousState,
@@ -323,7 +313,7 @@ public partial class VirtualMachine<TGasPolicy>(
                         else
                         {
                             // Process a standard call return.
-                            previousCallOutput = HandleRegularReturn<TTracingInst>(in callResult, previousState);
+                            previousCallOutputLength = HandleRegularReturn<TTracingInst>(in callResult, previousState);
                         }
 
                         // Commit the changes from the completed call frame if execution was successful.
@@ -355,7 +345,7 @@ public partial class VirtualMachine<TGasPolicy>(
                             CreditStateGasRefund(ref _currentState.Gas, TGasPolicy.GetNewAccountStateCost());
                         }
                         // Revert state changes for the previous call frame when a revert condition is signaled.
-                        HandleRevert(previousState, callResult, ref previousCallOutput);
+                        HandleRevert(previousState, callResult, ref previousCallOutputLength);
                     }
                 }
 #pragma warning restore IDE0063
@@ -373,7 +363,7 @@ public partial class VirtualMachine<TGasPolicy>(
 
             // Failure handling: attempts to process and possibly finalize the transaction after an error.
         Failure:
-            TransactionSubstate failSubstate = HandleFailure<TTracingInst>(failure, substateError, ref previousCallOutput, out bool shouldExit);
+            TransactionSubstate failSubstate = HandleFailure<TTracingInst>(failure, substateError, ref previousCallOutputLength, out bool shouldExit);
             if (shouldExit)
             {
                 _currentState = null!;
@@ -417,38 +407,37 @@ public partial class VirtualMachine<TGasPolicy>(
         }
     }
 
-    protected void PrepareCreateData(VmState<TGasPolicy> previousState, ref ReadOnlySpan<byte> previousCallOutput)
+    protected void PrepareCreateData(VmState<TGasPolicy> previousState, ref nuint previousCallOutputLength)
     {
-        _previousCallResult = previousState.Env.ExecutingAccount.Bytes.ToArray();
+        _previousCallResult = (previousState.Env.ExecutingAccount, true);
         _previousCallOutputDestination = UInt256.Zero;
-        ReturnDataBuffer = Array.Empty<byte>();
-        previousCallOutput = ReadOnlySpan<byte>.Empty;
+        ReturnDataBuffer = default;
+        previousCallOutputLength = 0;
     }
 
-    protected ReadOnlySpan<byte> HandleRegularReturn<TTracingInst>(scoped in CallResult callResult, VmState<TGasPolicy> previousState)
+    protected nuint HandleRegularReturn<TTracingInst>(scoped in CallResult callResult, VmState<TGasPolicy> previousState)
         where TTracingInst : struct, IFlag
     {
         ReturnDataBuffer = callResult.Output;
-        _previousCallResult = callResult.PrecompileSuccess.HasValue
-            ? (callResult.PrecompileSuccess.Value ? StatusCode.SuccessBytes : StatusCode.FailureBytes)
-            : StatusCode.SuccessBytes;
-        ReadOnlySpan<byte> previousCallOutput = ReturnDataBuffer.Span[..Math.Min(ReturnDataBuffer.Length, (int)previousState.OutputLength)];
+        _previousCallResult = (null, callResult.PrecompileSuccess != false);
+        nuint previousCallOutputLength = (nuint)Math.Min(ReturnDataBuffer.Length, (int)previousState.OutputLength);
         _previousCallOutputDestination = (ulong)previousState.OutputDestination;
         if (previousState.IsPrecompile)
         {
             // parity induced if else for vmtrace
             if (TTracingInst.IsActive)
             {
-                _txTracer.ReportMemoryChange(_previousCallOutputDestination, in previousCallOutput);
+                ReadOnlySpan<byte> output = ReturnDataBuffer.Span[..(int)previousCallOutputLength];
+                _txTracer.ReportMemoryChange(_previousCallOutputDestination, in output);
             }
         }
 
-        if (_isTracingActionsCached)
+        if (IsTracingActions)
         {
             _txTracer.ReportActionEnd(TGasPolicy.GetRemainingGas(previousState.Gas), ReturnDataBuffer);
         }
 
-        return previousCallOutput;
+        return previousCallOutputLength;
     }
     /// <summary>
     /// Handles the code deposit for a contract creation operation.
@@ -533,7 +522,7 @@ public partial class VirtualMachine<TGasPolicy>(
             {
                 _currentState.Gas = gasAfterCodeDeposit;
                 _codeInfoRepository.InsertCode(code, callCodeOwner, spec);
-                if (_isTracingActionsCached)
+                if (IsTracingActions)
                 {
                     _txTracer.ReportActionEnd(TGasPolicy.GetRemainingGas(previousState.Gas) - codeDepositGasCost, callCodeOwner, code);
                 }
@@ -542,7 +531,8 @@ public partial class VirtualMachine<TGasPolicy>(
 
         if (!chargedCodeDeposit && (spec.FailOnOutOfGasCodeDeposit || invalidCode))
         {
-            TGasPolicy.Consume(ref _currentState.Gas, gasAvailableForCodeDeposit);
+            bool charged = TGasPolicy.UpdateGas(ref _currentState.Gas, gasAvailableForCodeDeposit);
+            Debug.Assert(charged, "Refund already merged the child's remaining gas into the parent.");
             // Code deposit failure is an exceptional halt of the child CREATE frame.
             // Refund already merged the child's state gas (reservoir, stateGasUsed) into the parent,
             // but halt semantics require restoring the full initial state reservoir and discarding
@@ -563,15 +553,15 @@ public partial class VirtualMachine<TGasPolicy>(
             }
             RestoreRipemdTouch(_worldState, spec, _shouldRestoreRipemdTouch);
 
-            _previousCallResult = BytesZero;
+            _previousCallResult = (null, false);
             previousStateSucceeded = false;
 
-            if (_isTracingActionsCached)
+            if (IsTracingActions)
             {
                 _txTracer.ReportActionError(invalidCode ? EvmExceptionType.InvalidCode : EvmExceptionType.OutOfGas);
             }
         }
-        else if (!chargedCodeDeposit && _isTracingActionsCached)
+        else if (!chargedCodeDeposit && IsTracingActions)
         {
             _txTracer.ReportActionEnd(0UL, callCodeOwner, code);
         }
@@ -590,10 +580,10 @@ public partial class VirtualMachine<TGasPolicy>(
     /// The result of the call that triggered the revert, containing output data and flags
     /// indicating precompile success.
     /// </param>
-    /// <param name="previousCallOutput">
-    /// A reference to the output data buffer that will be updated with the reverted call's output.
+    /// <param name="previousCallOutputLength">
+    /// The bounded number of reverted output bytes to copy into parent memory.
     /// </param>
-    protected void HandleRevert(VmState<TGasPolicy> previousState, in CallResult callResult, ref ReadOnlySpan<byte> previousCallOutput)
+    protected void HandleRevert(VmState<TGasPolicy> previousState, in CallResult callResult, ref nuint previousCallOutputLength)
     {
         // Restore the world state to the snapshot taken before the execution of the call.
         _worldState.Restore(previousState.Snapshot);
@@ -606,15 +596,15 @@ public partial class VirtualMachine<TGasPolicy>(
         // Set the return data buffer to the output bytes from the failed call.
         ReturnDataBuffer = outputBytes;
 
-        _previousCallResult = StatusCode.FailureBytes;
+        _previousCallResult = (null, false);
 
-        previousCallOutput = ReturnDataBuffer.Span[..Math.Min(ReturnDataBuffer.Length, (int)previousState.OutputLength)];
+        previousCallOutputLength = (nuint)Math.Min(ReturnDataBuffer.Length, (int)previousState.OutputLength);
 
         // Record the output destination address for subsequent operations.
         _previousCallOutputDestination = (ulong)previousState.OutputDestination;
 
         // If transaction tracing is enabled, report the revert action along with the available gas and output bytes.
-        if (_isTracingActionsCached)
+        if (IsTracingActions)
         {
             _txTracer.ReportActionRevert(TGasPolicy.GetRemainingGas(previousState.Gas), outputBytes);
         }
@@ -629,14 +619,14 @@ public partial class VirtualMachine<TGasPolicy>(
     /// A type parameter representing tracing instructions. It must be a struct implementing <see cref="IFlag"/>.
     /// </typeparam>
     /// <param name="failure">The exception that caused the failure during execution.</param>
-    /// <param name="previousCallOutput">
-    /// A reference to the previous call's output; it will be reset upon failure.
+    /// <param name="previousCallOutputLength">
+    /// The pending output copy length, reset upon failure.
     /// </param>
     /// <returns>
     /// A <see cref="TransactionSubstate"/> if the failure occurs in the top-level call; otherwise, <c>null</c>
     /// to indicate that execution should continue with the parent call frame.
     /// </returns>
-    protected TransactionSubstate HandleFailure<TTracingInst>(Exception failure, string? substateError, scoped ref ReadOnlySpan<byte> previousCallOutput, out bool shouldExit)
+    protected TransactionSubstate HandleFailure<TTracingInst>(Exception failure, string? substateError, scoped ref nuint previousCallOutputLength, out bool shouldExit)
         where TTracingInst : struct, IFlag
     {
         // Log the exception if trace logging is enabled.
@@ -665,7 +655,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
 
         // If action-level tracing is enabled, report the error associated with the action.
-        if (txTracer.IsTracingActions)
+        if (IsTracingActions)
         {
             txTracer.ReportActionError(errorType);
         }
@@ -684,7 +674,7 @@ public partial class VirtualMachine<TGasPolicy>(
             };
         }
 
-        _previousCallResult = StatusCode.FailureBytes;
+        _previousCallResult = (null, false);
         bool failedCreate = _currentState.ExecutionType.IsAnyCreate();
         // Captured before the pop: the parent refunds NEW_ACCOUNT for the failed *CALL's uncreated recipient.
         bool childNewAccountCharged = _currentState.NewAccountCharged;
@@ -692,8 +682,8 @@ public partial class VirtualMachine<TGasPolicy>(
 
         // Reset output destination and return data.
         _previousCallOutputDestination = UInt256.Zero;
-        ReturnDataBuffer = Array.Empty<byte>();
-        previousCallOutput = ReadOnlySpan<byte>.Empty;
+        ReturnDataBuffer = default;
+        previousCallOutputLength = 0;
 
         PopAndRestoreParentState();
         if (failedCreate && childCreateStateGasCharged)
@@ -811,10 +801,10 @@ public partial class VirtualMachine<TGasPolicy>(
     /// <param name="callResult">
     /// The result object from the current call, which contains the state to be executed next.
     /// </param>
-    /// <param name="previousCallOutput">
-    /// A reference to the buffer holding the previous call's output, which is cleared in preparation for the new call.
+    /// <param name="previousCallOutputLength">
+    /// The pending memory-copy length, cleared before entering the new frame.
     /// </param>
-    protected void PrepareNextCallFrame(in CallResult callResult, ref ReadOnlySpan<byte> previousCallOutput)
+    protected void PrepareNextCallFrame(in CallResult callResult, ref nuint previousCallOutputLength)
     {
         Debug.Assert(callResult.StateToExecute is not null, "A non-returning call result must carry its next frame.");
         // Push the current execution state onto the state stack so it can be restored later.
@@ -824,13 +814,9 @@ public partial class VirtualMachine<TGasPolicy>(
         _currentState = callResult.StateToExecute;
 
         // Clear the previous call result as the execution context is moving to a new frame.
-        _previousCallResult = null;
+        _previousCallResult = default;
 
-        // Reset the return data buffer to ensure no residual data persists across call frames.
-        ReturnDataBuffer = Array.Empty<byte>();
-
-        // Clear the previous call output, preparing for new output data in the next call frame.
-        previousCallOutput = ReadOnlySpan<byte>.Empty;
+        previousCallOutputLength = 0;
     }
 
     /// <summary>
@@ -841,20 +827,20 @@ public partial class VirtualMachine<TGasPolicy>(
     /// <param name="callResult">
     /// The result object that contains the exception type and any output data from the failed call.
     /// </param>
-    /// <param name="previousCallOutput">
-    /// A reference to the previous call's output, which is reset on exception.
+    /// <param name="previousCallOutputLength">
+    /// The pending output copy length, reset on exception.
     /// </param>
     /// <returns>
     /// A <see cref="TransactionSubstate"/> instance if the failure occurred in a top-level call,
     /// otherwise <c>null</c> to indicate that execution should continue in the parent frame.
     /// </returns>
-    protected TransactionSubstate HandleException(scoped in CallResult callResult, scoped ref ReadOnlySpan<byte> previousCallOutput, out bool shouldExit)
+    protected TransactionSubstate HandleException(scoped in CallResult callResult, scoped ref nuint previousCallOutputLength, out bool shouldExit)
     {
         // Cache the tracer to minimize repeated field accesses.
         ITxTracer txTracer = _txTracer;
 
         // Report the error for action-level tracing if enabled.
-        if (txTracer.IsTracingActions)
+        if (IsTracingActions)
         {
             txTracer.ReportActionError(callResult.ExceptionType);
         }
@@ -876,7 +862,7 @@ public partial class VirtualMachine<TGasPolicy>(
             };
         }
 
-        _previousCallResult = StatusCode.FailureBytes;
+        _previousCallResult = (null, false);
         bool failedCreate = _currentState.ExecutionType.IsAnyCreate();
         // Captured before the pop: the parent refunds NEW_ACCOUNT for the halted *CALL's uncreated recipient.
         bool childNewAccountCharged = _currentState.NewAccountCharged;
@@ -884,8 +870,8 @@ public partial class VirtualMachine<TGasPolicy>(
 
         // Reset output destination and clear return data.
         _previousCallOutputDestination = UInt256.Zero;
-        ReturnDataBuffer = Array.Empty<byte>();
-        previousCallOutput = ReadOnlySpan<byte>.Empty;
+        ReturnDataBuffer = default;
+        previousCallOutputLength = 0;
 
         PopAndRestoreParentState();
         if (failedCreate && childCreateStateGasCharged)
@@ -921,7 +907,7 @@ public partial class VirtualMachine<TGasPolicy>(
     /// A <see cref="CallResult"/> containing the results of the precompile execution. In case of a failure,
     /// returns the default value of <see cref="CallResult"/>.
     /// </returns>
-    protected virtual CallResult ExecutePrecompile(VmState<TGasPolicy> currentState, bool isTracingActions, out Exception? failure, out string? substateError)
+    protected CallResult ExecutePrecompile(VmState<TGasPolicy> currentState, bool isTracingActions, out Exception? failure, out string? substateError)
     {
         // Report the precompile action if tracing is enabled.
         if (isTracingActions)
@@ -961,7 +947,7 @@ public partial class VirtualMachine<TGasPolicy>(
             }
 
             // Otherwise, if no exception but precompile did not succeed, exhaust the remaining gas.
-            TGasPolicy.SetOutOfGas(ref currentState.Gas);
+            TGasPolicy.ClearExecutionGas(ref currentState.Gas);
         }
 
         // If execution reaches here, the precompile operation is considered successful.
@@ -1150,7 +1136,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
 
         // The policy reads the precompile's own base/data cost (with the overflow guard inside).
-        if (!TGasPolicy.ConsumePrecompileGas(ref gas, precompile, callData, spec))
+        if (!TGasPolicy.TryConsumePrecompileGas(ref gas, precompile, callData, spec))
         {
             return new(default, precompileSuccess: false, shouldRevert: true, EvmExceptionType.OutOfGas);
         }
@@ -1230,11 +1216,10 @@ public partial class VirtualMachine<TGasPolicy>(
     /// The current EVM state containing the execution environment, gas, memory, and stack information.
     /// </param>
     /// <param name="previousCallResult">
-    /// An optional read-only memory buffer containing the output of a previous call; if provided, its bytes
-    /// will be pushed onto the stack for further processing.
+    /// The pending call status or created address to push onto the resumed frame's stack.
     /// </param>
-    /// <param name="previousCallOutput">
-    /// Output from the previous call used for updating the memory state.
+    /// <param name="previousCallOutputLength">
+    /// The bounded number of return bytes to copy into parent memory.
     /// </param>
     /// <param name="previousCallOutputDestination">
     /// The memory destination address where the previous call's output should be stored.
@@ -1249,8 +1234,8 @@ public partial class VirtualMachine<TGasPolicy>(
     /// </remarks>
     [SkipLocalsInit]
     protected unsafe CallResult ExecuteCall<TTracingInst>(
-        ReadOnlyMemory<byte>? previousCallResult,
-        ReadOnlySpan<byte> previousCallOutput,
+        in (Address? CreatedAddress, bool? Success) previousCallResult,
+        nuint previousCallOutputLength,
         scoped in UInt256 previousCallOutputDestination)
         where TTracingInst : struct, IFlag
     {
@@ -1277,7 +1262,11 @@ public partial class VirtualMachine<TGasPolicy>(
 
         // Initialize the internal stacks for the current call frame.
         EvmStack stack;
-        if (TTracingInst.IsActive)
+        if (vmState.IsContinuation)
+        {
+            vmState.RestoreStack<TTracingInst>(_txTracer, codeSpan, out stack);
+        }
+        else if (TTracingInst.IsActive)
         {
             vmState.InitializeStacks(_txTracer, codeSpan, out stack);
         }
@@ -1290,10 +1279,24 @@ public partial class VirtualMachine<TGasPolicy>(
         // gas/state-gas accounting without needing interpreter-wide exception handling.
         ref TGasPolicy gas = ref vmState.Gas;
 
-        // If a previous call result exists, push its bytes onto the stack.
-        if (previousCallResult is not null)
+        // If a previous call result exists, push it onto the stack.
+        if (previousCallResult.Success.HasValue)
         {
-            EvmExceptionType pushResult = stack.PushBytes<TTracingInst>(previousCallResult.Value.Span);
+            EvmExceptionType pushResult;
+            if (previousCallResult.CreatedAddress is { } createdAddress)
+            {
+                pushResult = stack.PushAddress<TTracingInst>(createdAddress);
+            }
+            else if (TTracingInst.IsActive)
+            {
+                pushResult = previousCallResult.Success.GetValueOrDefault()
+                    ? stack.PushOne<TTracingInst>()
+                    : stack.PushZero<TTracingInst, OnFlag>();
+            }
+            else
+            {
+                pushResult = stack.PushUInt32<TTracingInst, OnFlag>(previousCallResult.Success.GetValueOrDefault() ? 1u : 0u);
+            }
             if (pushResult != EvmExceptionType.None) return new(pushResult);
 
             // Report the remaining gas if tracing instructions are enabled.
@@ -1303,19 +1306,10 @@ public partial class VirtualMachine<TGasPolicy>(
             }
         }
 
-        // If there is previous call output, update the memory cost and save the output.
-        if (previousCallOutput.Length > 0)
+        // CALL already expanded this range; returned output is clipped to the requested length.
+        if (previousCallOutputLength > 0)
         {
-            // Use a local variable for the destination to simplify passing it by reference.
-            UInt256 localPreviousDest = previousCallOutputDestination;
-
-            // Attempt to update the memory cost; if insufficient gas is available, jump to the out-of-gas handler.
-            if (!TGasPolicy.UpdateMemoryCost(ref gas, in localPreviousDest, (ulong)previousCallOutput.Length, ref vmState.Memory))
-            {
-                goto OutOfGas;
-            }
-
-            vmState.Memory.SaveAfterGas(in localPreviousDest, previousCallOutput);
+            vmState.Memory.SaveAfterGas(in previousCallOutputDestination, ReturnDataBuffer.Span[..(int)previousCallOutputLength]);
         }
 
         // Dispatch the bytecode interpreter.
@@ -1333,10 +1327,6 @@ public partial class VirtualMachine<TGasPolicy>(
     Empty:
         // Return an empty CallResult if there is no machine code to execute.
         return CallResult.Empty();
-
-    OutOfGas:
-        // Return an out-of-gas CallResult if updating the memory cost fails.
-        return new(EvmExceptionType.OutOfGas);
     }
 
     /// <summary>Runs the frame's bytecode through the opcode dispatch loop.</summary>
@@ -1358,13 +1348,20 @@ public partial class VirtualMachine<TGasPolicy>(
         {
             if (TTracingInst.IsActive)
                 EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));
-            UpdateCurrentState((int)programCounter, in gas, (int)stack.Head);
+            int stackHead = (int)stack.Head;
+            VmState<TGasPolicy> state = VmState;
+            state.ProgramCounter = (int)programCounter;
+            state.DataStackHead = stackHead;
         }
         else
         {
             goto ReturnFailure;
         }
 
+        Debug.Assert((exceptionType == EvmExceptionType.Suspend) == (ReturnData is VmState<TGasPolicy>),
+            "CALL/CREATE stage a child frame exactly when they return Suspend.");
+        if (exceptionType == EvmExceptionType.Suspend)
+            return new CallResult(Unsafe.As<VmState<TGasPolicy>>(ReturnData!));
         if (exceptionType == EvmExceptionType.Revert)
             goto Revert;
         if (ReturnData is not null)
@@ -1373,29 +1370,24 @@ public partial class VirtualMachine<TGasPolicy>(
         return CallResult.Empty();
 
     DataReturn:
-        // A nested frame is the common outcome here, and it is the cheaper test: an array `isinst` needs
-        // the general helper, while a class one has a specialized fast path. Order them accordingly.
-        return ReturnData switch
-        {
-            VmState<TGasPolicy> state => new CallResult(state),
-            byte[] data => new CallResult(data, null),
-            _ => new CallResult(ReturnDataBuffer, null),
-        };
+        Debug.Assert(ReturnData is byte[], "RETURN stages a byte array before stopping dispatch.");
+        return new CallResult(Unsafe.As<byte[]>(ReturnData), null);
 
     Revert:
-        Debug.Assert(ReturnData is byte[], "REVERT must provide return data.");
-        return new CallResult((byte[])ReturnData, null, shouldRevert: true, exceptionType);
+        Debug.Assert(ReturnData is byte[], "REVERT stages a byte array before stopping dispatch.");
+        return new CallResult(Unsafe.As<byte[]>(ReturnData), null, shouldRevert: true, exceptionType);
 
     ReturnFailure:
-        // EIP-8037: write gas back so RestoreChildStateGasOnHalt can read the child frame's state gas.
-        _currentState.Gas = gas;
+        if (exceptionType == EvmExceptionType.OutOfGas)
+            TGasPolicy.ClearExecutionGas(ref gas);
+
         return GetFailureReturn(TGasPolicy.GetRemainingGas(in gas), exceptionType);
     }
 
 
     private CallResult GetFailureReturn(ulong gasAvailable, EvmExceptionType exceptionType)
     {
-        if (_txTracer.IsTracingInstructions) EndInstructionTraceError(gasAvailable, exceptionType);
+        if (DispatchFlags.ConstTracing && _txTracer.IsTracingInstructions) EndInstructionTraceError(gasAvailable, exceptionType);
 
         return exceptionType switch
         {
@@ -1408,15 +1400,6 @@ public partial class VirtualMachine<TGasPolicy>(
             EvmExceptionType.AccessViolation => new(exceptionType),
             _ => throw new ArgumentOutOfRangeException(nameof(exceptionType), exceptionType, "")
         };
-    }
-
-    private void UpdateCurrentState(int pc, in TGasPolicy gas, int stackHead)
-    {
-        VmState<TGasPolicy> state = VmState;
-
-        state.ProgramCounter = pc;
-        state.Gas = gas;
-        state.DataStackHead = stackHead;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1455,8 +1438,7 @@ public partial class VirtualMachine<TGasPolicy>(
     {
         VmState.AccessTracker.Logs.Add(logEntry);
 
-        // Optionally report the log if tracing is enabled.
-        if (TxTracer.IsTracingLogs)
+        if (DispatchFlags.ConstTracing && TxTracer.IsTracingLogs)
         {
             TxTracer.ReportLog(logEntry);
         }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.std.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.std.cs
@@ -10,6 +10,8 @@ namespace Nethermind.Evm;
 
 public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct, IGasPolicy<TGasPolicy>
 {
+    private const MethodImplOptions ExecutionHandlersInlining = MethodImplOptions.AggressiveInlining;
+
     // Weak keys: transient state-override specs in eth_simulateV1 must not be retained forever by this
     // process-wide cache.
     private static readonly ConditionalWeakTable<IReleaseSpec, OpcodeTable> _opcodeTablesBySpec = [];
@@ -18,7 +20,6 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
     private OpcodeTable GetOpcodeTable() =>
         _opcodeTablesBySpec.GetValue(Spec, static _ => new OpcodeTable());
 
-    // How often the non-traced table is rebuilt, and when the rebuilding stops.
     private const long OpcodeRefreshInterval = 10_000;
     private const long OpcodeRefreshLimit = 500_000;
 
@@ -26,10 +27,8 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Every 10,000 transactions, until 500,000 have run. A captured function pointer keeps pointing at the
-    /// code it was taken from, so a table built during warm-up dispatches through tier-0 entry stubs for the
-    /// life of the process; rebuilding it occasionally re-captures whatever the JIT has promoted since. The
-    /// cadence stops once tiering has settled, and a rebuild is only a table of pointers.
+    /// Startup heuristic for re-capturing opcode entry points as the runtime warms up.
+    /// The transaction limits bound rebuild overhead; they do not detect JIT tier changes.
     /// </remarks>
     private partial bool ShouldRefreshOpcodes()
     {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.warmup.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.warmup.cs
@@ -33,8 +33,6 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         VirtualMachine<TGasPolicy> vm = new(hashProvider, specProvider, LimboLogs.Instance);
         ILogManager lm = new OneLoggerLogManager(NullLogger.Instance);
 
-        byte[] bytecode = new byte[64];
-        bytecode.AsSpan().Fill((byte)Instruction.JUMPDEST);
         byte[] address = new byte[20];
         address[^1] = 0x1;
         Address addressOne = new(address);
@@ -47,26 +45,13 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         vm.SetBlockExecutionContext(new BlockExecutionContext(header, spec));
         vm.SetTxExecutionContext(new TxExecutionContext(addressOne, codeInfoRepository, null, 0));
 
-        using ExecutionEnvironment env = ExecutionEnvironment.Rent(
-            codeInfo: new CodeInfo(bytecode),
-            executingAccount: addressOne,
-            caller: addressOne,
-            codeSource: addressOne,
-            callDepth: 0,
-            value: 0,
-            inputData: default);
+        vm._worldState = state;
+        vm._codeInfoRepository = codeInfoRepository;
 
-        using (VmState<TGasPolicy> vmState = VmState<TGasPolicy>.RentTopLevel(TGasPolicy.FromULong(ulong.MaxValue), ExecutionType.TRANSACTION, env, new StackAccessTracker(), state.TakeSnapshot()))
-        {
-            vm.VmState = vmState;
-            vm._worldState = state;
-            vm._codeInfoRepository = codeInfoRepository;
-
-            WarmUpOpcodeHandlers<OffFlag, OffFlag>(vm, state, vmState);
-            WarmUpOpcodeHandlers<OffFlag, OnFlag>(vm, state, vmState);
-            WarmUpOpcodeHandlers<OnFlag, OffFlag>(vm, state, vmState);
-            WarmUpOpcodeHandlers<OnFlag, OnFlag>(vm, state, vmState);
-        }
+        WarmUpOpcodeHandlers<OffFlag, OffFlag>(vm, state, addressOne);
+        WarmUpOpcodeHandlers<OffFlag, OnFlag>(vm, state, addressOne);
+        WarmUpOpcodeHandlers<OnFlag, OffFlag>(vm, state, addressOne);
+        WarmUpOpcodeHandlers<OnFlag, OnFlag>(vm, state, addressOne);
 
         TransactionProcessor<TGasPolicy> processor = new(BlobBaseFeeCalculator.Instance, specProvider, state, vm, codeInfoRepository, lm);
         processor.SetBlockExecutionContext(new BlockExecutionContext(header, spec));
@@ -163,7 +148,7 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
     private static void WarmUpOpcodeHandlers<TTracingInst, TCancelable>(
         VirtualMachine<TGasPolicy> vm,
         IWorldState state,
-        VmState<TGasPolicy> vmState)
+        Address address)
         where TTracingInst : struct, IFlag
         where TCancelable : struct, IFlag
     {
@@ -173,33 +158,43 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
         vm._txTracer = txTracer;
         // This drives RunByteCode directly, so it resolves the table itself rather than through a transaction.
         vm.PrepareOpcodes<TTracingInst, TCancelable>();
-        byte[] code = new byte[EvmStack.WordSize + 2];
-        vmState.InitializeStacks(txTracer, code, out EvmStack stack);
+        CodeInfo[] codeInfos = new CodeInfo[byte.MaxValue + 1];
+        for (int i = 0; i < codeInfos.Length; i++)
+            codeInfos[i] = CreateWarmUpCodeInfo((Instruction)i);
 
         for (int repeat = 0; repeat < WarmUpIterations; repeat++)
         {
             for (int i = 0; i <= byte.MaxValue; i++)
             {
-                code.AsSpan().Clear();
-                Instruction instruction = (Instruction)i;
-                code[0] = (byte)instruction;
-                if (instruction is Instruction.JUMP or Instruction.JUMPI)
-                    code[1] = (byte)Instruction.JUMPDEST;
-                else if (instruction is Instruction.DUPN or Instruction.SWAPN or Instruction.EXCHANGE)
-                    code[1] = 0x80;
+                CodeInfo codeInfo = codeInfos[i];
+                using ExecutionEnvironment env = ExecutionEnvironment.Rent(
+                    codeInfo, address, address, address, 0, 0, default);
+                using StackAccessTracker accessTracker = new();
+                using VmState<TGasPolicy> vmState = VmState<TGasPolicy>.RentTopLevel(
+                    TGasPolicy.FromULong(ulong.MaxValue), ExecutionType.TRANSACTION, env, accessTracker, state.TakeSnapshot());
+                vm.VmState = vmState;
+                vmState.InitializeStacks(txTracer, codeInfo.CodeSpan, out EvmStack stack);
 
                 for (int stackItem = 0; stackItem < 20; stackItem++)
                     stack.PushOne<TTracingInst>();
 
-                vmState.ProgramCounter = 0;
-                vmState.Gas = TGasPolicy.FromULong(ulong.MaxValue);
                 CallResult callResult = vm.RunByteCode<TTracingInst, TCancelable>(ref stack, ref vmState.Gas);
                 callResult.StateToExecute?.Dispose();
 
                 state.Reset(resetBlockChanges: true);
-                stack.Head = 0;
             }
         }
+    }
+
+    private static CodeInfo CreateWarmUpCodeInfo(Instruction instruction)
+    {
+        byte[] code = new byte[EvmStack.WordSize + 2];
+        code[0] = (byte)instruction;
+        if (instruction is Instruction.JUMP or Instruction.JUMPI)
+            code[1] = (byte)Instruction.JUMPDEST;
+        else if (instruction is Instruction.DUPN or Instruction.SWAPN or Instruction.EXCHANGE)
+            code[1] = 0x80;
+        return new CodeInfo(code);
     }
 
     private class WarmupBlockhashProvider(ISpecProvider specProvider) : IBlockhashProvider

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.zkevm.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.zkevm.cs
@@ -13,6 +13,9 @@ namespace Nethermind.Evm;
 
 public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct, IGasPolicy<TGasPolicy>
 {
+    // Keeping this call boundary reduces guest execution cost.
+    private const MethodImplOptions ExecutionHandlersInlining = MethodImplOptions.NoInlining;
+
     // Cache the dispatch tables in plain per-TGasPolicy statics: the guest executes a single fork, and
     // ConditionalWeakTable (used by the std build) relies on GC dependent-handles the zkEVM guest can't map.
     private static readonly OpcodeTable _opcodeTable = new();
@@ -58,7 +61,7 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
             snapshot: in snapshot,
             newAccountCharged: newAccountCharged);
 
-        CallResult callResult = ExecutePrecompile(child, _isTracingActionsCached, out Exception? failure, out _);
+        CallResult callResult = ExecutePrecompile(child, isTracingActions: false, out Exception? failure, out _);
 
         if (failure is not null)
         {
@@ -71,8 +74,8 @@ public unsafe partial class VirtualMachine<TGasPolicy> where TGasPolicy : struct
             if (child.NewAccountCharged)
                 CreditStateGasRefund(ref parent.Gas, TGasPolicy.GetNewAccountStateCost());
             child.Dispose();
-            ReturnDataBuffer = Array.Empty<byte>();
-            return stack.PushZero<TTracingInst>();
+            ReturnDataBuffer = default;
+            return stack.PushZero<TTracingInst, OnFlag>();
         }
 
         bool reverted = callResult.ShouldRevert;

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -256,7 +256,7 @@ public class VmState<TGasPolicy> : IDisposable
             DataStack = dataStack = AllocateStacks();
         }
 
-        stack = new(DataStackHead, ref As32AlignedRef(dataStack), codeSpan);
+        stack = new(DataStackHead, ref As32AlignedRef(dataStack), codeSpan, Env.CodeInfo);
     }
 
     public void InitializeStacks(ITxTracer txTracer, ReadOnlySpan<byte> codeSpan, out EvmStack stack)
@@ -268,7 +268,18 @@ public class VmState<TGasPolicy> : IDisposable
             DataStack = dataStack = AllocateStacks();
         }
 
-        stack = new(DataStackHead, txTracer, ref As32AlignedRef(dataStack), codeSpan);
+        stack = new(DataStackHead, txTracer, ref As32AlignedRef(dataStack), codeSpan, Env.CodeInfo);
+    }
+
+    internal void RestoreStack<TTracingInst>(ITxTracer txTracer, ReadOnlySpan<byte> codeSpan, out EvmStack stack)
+        where TTracingInst : struct, IFlag
+    {
+        Debug.Assert(IsContinuation && !_isDisposed && DataStack is not null,
+            "A resumed frame retains its initialized stack until disposal.");
+        ref byte dataStack = ref As32AlignedRef(DataStack);
+        stack = TTracingInst.IsActive
+            ? new(DataStackHead, txTracer, ref dataStack, codeSpan, Env.CodeInfo)
+            : new(DataStackHead, ref dataStack, codeSpan, Env.CodeInfo);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -266,7 +266,7 @@ public class VmState<TGasPolicy> : IDisposable
             DataStack = dataStack = AllocateStacks();
         }
 
-        stack = new(DataStackHead, ref As32AlignedRef(dataStack), codeSpan);
+        stack = new(DataStackHead, ref As32AlignedRef(dataStack), codeSpan, Env.CodeInfo);
     }
 
     public void InitializeStacks(ITxTracer txTracer, ReadOnlySpan<byte> codeSpan, out EvmStack stack)
@@ -278,7 +278,18 @@ public class VmState<TGasPolicy> : IDisposable
             DataStack = dataStack = AllocateStacks();
         }
 
-        stack = new(DataStackHead, txTracer, ref As32AlignedRef(dataStack), codeSpan);
+        stack = new(DataStackHead, txTracer, ref As32AlignedRef(dataStack), codeSpan, Env.CodeInfo);
+    }
+
+    internal void RestoreStack<TTracingInst>(ITxTracer txTracer, ReadOnlySpan<byte> codeSpan, out EvmStack stack)
+        where TTracingInst : struct, IFlag
+    {
+        Debug.Assert(IsContinuation && !_isDisposed && DataStack is not null,
+            "A resumed frame retains its initialized stack until disposal.");
+        ref byte dataStack = ref As32AlignedRef(DataStack);
+        stack = TTracingInst.IsActive
+            ? new(DataStackHead, txTracer, ref dataStack, codeSpan, Env.CodeInfo)
+            : new(DataStackHead, ref dataStack, codeSpan, Env.CodeInfo);
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -106,6 +106,18 @@ public class JsonRpcServiceTests
             (Action<IEthRpcModule>)(static module => module.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())))
             .SetName("Extra argument");
         yield return new TestCaseData(
+            nameof(IEthRpcModule.eth_getBlockByNumber),
+            """["",false]""",
+            "missing value for required argument 0",
+            (Action<IEthRpcModule>)(static module => module.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())))
+            .SetName("Required argument marked missing before another");
+        yield return new TestCaseData(
+            nameof(IEthRpcModule.eth_getBlockByNumber),
+            """["",false,"extra"]""",
+            "Invalid params",
+            (Action<IEthRpcModule>)(static module => module.DidNotReceive().eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())))
+            .SetName("Extra argument alongside a missing marker");
+        yield return new TestCaseData(
             nameof(IEthRpcModule.eth_getBalance),
             """["cf1dc766fc2c62bef0b67a8de666c8e67acf35f6","0x1036640"]""",
             "hex string without 0x prefix",
@@ -501,6 +513,22 @@ public class JsonRpcServiceTests
     }
 
     [Test]
+    public void Missing_marker_on_an_optional_argument_binds_its_default([Values(false, true)] bool rawUtf8)
+    {
+        IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        ethRpcModule
+            .eth_getBlockByNumber(Arg.Any<BlockParameter>(), Arg.Any<bool>())
+            .ReturnsForAnyArgs(_ => ResultWrapper<BlockForRpc>.Success(new BlockForRpc(Build.A.Block.WithNumber(2).TestObject, true, specProvider)));
+
+        RpcTest.AssertSuccess<BlockForRpc>(rawUtf8
+            ? TestRawRequest(ethRpcModule, "eth_getBlockByNumber", """["0x1b4",""]""")
+            : TestRequest(ethRpcModule, "eth_getBlockByNumber", "0x1b4", ""));
+
+        ethRpcModule.Received().eth_getBlockByNumber(Arg.Any<BlockParameter>(), false);
+    }
+
+    [Test]
     public void Eth_getTransactionReceipt_properly_fails_given_wrong_parameters()
     {
         IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();
@@ -510,6 +538,11 @@ public class JsonRpcServiceTests
 
     [TestCase("eth_getBlockByNumber", new object?[] { }, "missing value for required argument 0", TestName = "FirstArgOmitted")]
     [TestCase("eth_feeHistory", new object?[] { "0x1", "latest" }, "missing value for required argument 2", TestName = "LaterArgOmitted")]
+    [TestCase("eth_getBlockByNumber", new object?[] { "", false }, "missing value for required argument 0", TestName = "FirstArgMarkedMissingBeforeAnother")]
+    [TestCase("eth_getProof", new object?[] { "0x7F0d15C7FAae65896648C8273B6d7E43f58Fa842", "", "latest" }, "missing value for required argument 1", TestName = "LaterArgMarkedMissingBeforeAnother")]
+    [TestCase("eth_feeHistory", new object?[] { "", "latest" }, "missing value for required argument 0", TestName = "MarkedMissingArgIsNamedAheadOfOmittedTrailingOnes")]
+    [TestCase("eth_getBlockByNumber", new object?[] { "", false, "" }, "Invalid params", TestName = "ExtraArgumentWinsOverAMarkedMissingOne")]
+    [TestCase("eth_getBlockByNumber", new object?[] { "0x1", false, "" }, "Invalid params", TestName = "ExtraTrailingMarkerIsAnExtraArgument")]
     public void MissingRequiredArgument_ReturnsGethStyleError(string method, object?[] parameters, string expectedMessage)
     {
         IEthRpcModule ethRpcModule = Substitute.For<IEthRpcModule>();

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -317,6 +317,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             providedParametersUtf8,
             out int providedParametersLength,
             out int missingParamsCount,
+            out int missingRequiredParameterIndex,
             out ExceptionDispatchInfo? parameterDeserializationException,
             out returnParametersToPool);
 
@@ -325,6 +326,7 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
             methodName,
             in requestId,
             providedParametersLength,
+            missingRequiredParameterIndex,
             ref missingParamsCount);
         if (validationError is not null)
         {
@@ -356,13 +358,14 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         returnParametersToPool = false;
 
         int providedParametersLength = providedParameters.ValueKind == JsonValueKind.Array ? providedParameters.GetArrayLength() : 0;
-        int missingParamsCount = CountMissingJsonElementParameters(expectedParameters, providedParameters, providedParametersLength);
+        int missingParamsCount = CountMissingJsonElementParameters(expectedParameters, providedParameters, providedParametersLength, out int missingRequiredParameterIndex);
 
         JsonRpcErrorResponse? validationError = ValidateMissingParameters(
             expectedParameters,
             methodName,
             in requestId,
             providedParametersLength,
+            missingRequiredParameterIndex,
             ref missingParamsCount);
         if (validationError is not null)
         {
@@ -383,16 +386,26 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
     private static int CountMissingJsonElementParameters(
         ExpectedParameter[] expectedParameters,
         JsonElement providedParameters,
-        int providedParametersLength)
+        int providedParametersLength,
+        out int missingRequiredParameterIndex)
     {
         int missingParamsCount = expectedParameters.Length - providedParametersLength;
         int initialMissingParamsCount = missingParamsCount;
+        missingRequiredParameterIndex = -1;
 
         if (providedParametersLength > 0)
         {
+            int index = 0;
             foreach (JsonElement item in providedParameters.EnumerateArray())
             {
-                UpdateMissingParamsCount(item, ref missingParamsCount, initialMissingParamsCount);
+                bool isMissing = IsMissingParameterMarker(item);
+                missingParamsCount = isMissing ? missingParamsCount + 1 : initialMissingParamsCount;
+                if (isMissing)
+                {
+                    TrackMissingRequiredParameter(expectedParameters, index, ref missingRequiredParameterIndex);
+                }
+
+                index++;
             }
         }
 
@@ -448,44 +461,39 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         string methodName,
         in JsonRpcId requestId,
         int providedParametersLength,
+        int missingRequiredParameterIndex,
         ref int missingParamsCount)
     {
+        // The JSON element deserializer walks every provided element against expectedParameters, so an
+        // over-long request has to be rejected here rather than indexing past the end.
+        if (providedParametersLength > expectedParameters.Length || missingParamsCount < 0)
+        {
+            return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", null, in requestId);
+        }
+
+        if (missingRequiredParameterIndex >= 0)
+        {
+            return GetErrorResponse(methodName, ErrorCodes.InvalidParams,
+                $"missing value for required argument {missingRequiredParameterIndex}", null, in requestId);
+        }
+
         int explicitNullableParamsCount = 0;
 
-        if (missingParamsCount != 0)
+        for (int i = 0; i < missingParamsCount; i++)
         {
-            bool hasIncorrectParameters = true;
-            int firstMissingRequiredIndex = -1;
-            if (missingParamsCount > 0)
+            int parameterIndex = expectedParameters.Length - missingParamsCount + i;
+
+            // Preserve compatibility for calls that pass trailing nullable defaults as null or "".
+            bool isExplicit = providedParametersLength >= parameterIndex + 1;
+            if (expectedParameters[parameterIndex].IsNullable && isExplicit)
             {
-                hasIncorrectParameters = false;
-                for (int i = 0; i < missingParamsCount; i++)
-                {
-                    int parameterIndex = expectedParameters.Length - missingParamsCount + i;
-                    bool nullable = expectedParameters[parameterIndex].IsNullable;
-
-                    // Preserve compatibility for calls that pass trailing nullable defaults as null or "".
-                    bool isExplicit = providedParametersLength >= parameterIndex + 1;
-                    if (nullable && isExplicit)
-                    {
-                        explicitNullableParamsCount += 1;
-                    }
-
-                    if (!expectedParameters[parameterIndex].IsOptional && !nullable)
-                    {
-                        hasIncorrectParameters = true;
-                        firstMissingRequiredIndex = parameterIndex;
-                        break;
-                    }
-                }
+                explicitNullableParamsCount += 1;
             }
 
-            if (hasIncorrectParameters)
+            if (RequiresExplicitValue(in expectedParameters[parameterIndex]))
             {
-                string message = firstMissingRequiredIndex >= 0
-                    ? $"missing value for required argument {firstMissingRequiredIndex}"
-                    : "Invalid params";
-                return GetErrorResponse(methodName, ErrorCodes.InvalidParams, message, null, in requestId);
+                return GetErrorResponse(methodName, ErrorCodes.InvalidParams,
+                    $"missing value for required argument {parameterIndex}", null, in requestId);
             }
         }
 
@@ -515,15 +523,24 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         reader.TokenType == JsonTokenType.Null
         || (reader.TokenType == JsonTokenType.String && reader.ValueTextEquals(ReadOnlySpan<byte>.Empty));
 
-    private static void UpdateMissingParamsCount(JsonElement item, ref int missingParamsCount, int initialMissingParamsCount)
+    private static bool IsMissingParameterMarker(JsonElement item) =>
+        item.ValueKind == JsonValueKind.Null
+        || (item.ValueKind == JsonValueKind.String && item.ValueEquals(ReadOnlySpan<byte>.Empty));
+
+    private static bool RequiresExplicitValue(in ExpectedParameter parameter) =>
+        !parameter.IsOptional && !parameter.IsNullable;
+
+    /// <summary>
+    /// Records <paramref name="index"/> as the first argument where a missing-argument marker landed on a
+    /// parameter that requires an explicit value, leaving an already recorded index untouched.
+    /// </summary>
+    private static void TrackMissingRequiredParameter(ExpectedParameter[] expectedParameters, int index, ref int missingRequiredParameterIndex)
     {
-        if (item.ValueKind == JsonValueKind.Null || (item.ValueKind == JsonValueKind.String && item.ValueEquals(ReadOnlySpan<byte>.Empty)))
+        if (missingRequiredParameterIndex < 0
+            && index < expectedParameters.Length
+            && RequiresExplicitValue(in expectedParameters[index]))
         {
-            missingParamsCount++;
-        }
-        else
-        {
-            missingParamsCount = initialMissingParamsCount;
+            missingRequiredParameterIndex = index;
         }
     }
 
@@ -799,11 +816,13 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         ReadOnlyMemory<byte> providedParametersUtf8,
         out int providedParametersLength,
         out int missingParamsCount,
+        out int missingRequiredParameterIndex,
         out ExceptionDispatchInfo? parameterDeserializationException,
         out bool returnParametersToPool)
     {
         providedParametersLength = 0;
         missingParamsCount = 0;
+        missingRequiredParameterIndex = -1;
         parameterDeserializationException = null;
         returnParametersToPool = false;
 
@@ -832,6 +851,11 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
 
             bool isMissing = IsMissingParameterMarker(in reader);
             trailingMissingParamsCount = isMissing ? trailingMissingParamsCount + 1 : 0;
+            if (isMissing)
+            {
+                TrackMissingRequiredParameter(expectedParameters, providedParametersLength, ref missingRequiredParameterIndex);
+            }
+
             Utf8JsonReader parameterReader = reader;
             try
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.StoringBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BaseEngineModuleTests.StoringBlockImprovementContextFactory.cs
@@ -33,7 +33,7 @@ public partial class BaseEngineModuleTests
             {
                 if (_skipDuplicatedContext
                     && CreatedContexts.Count > 0
-                    && CreatedContexts[^1].CurrentBestBlock == blockImprovementContext.CurrentBestBlock)
+                    && CreatedContexts[^1].Best.CurrentBestBlock == blockImprovementContext.Best.CurrentBestBlock)
                 {
                     return blockImprovementContext;
                 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeCallSpy.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/BlockTreeCallSpy.cs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Concurrent;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Find;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
@@ -9,13 +11,23 @@ using Nethermind.Core.Test.Builders;
 namespace Nethermind.Merge.Plugin.Test;
 
 /// <summary>
-/// Counts <see cref="IBlockFinder.FindHeader"/> calls on a real block tree.
+/// Records every height-hinted header lookup made against a real block tree, the shape
+/// <see cref="IBlockFinderExtensions.FindParentHeader"/> issues when it passes the parent's height.
 /// </summary>
+/// <remarks>
+/// The spy decorates the container's singleton block tree, which background components share and probe on
+/// their own threads - under the flat layout the persistence pipeline resolves the finalized state root that
+/// way. Recording is therefore thread-safe, and assertions have to key on the specific lookup under test
+/// rather than on a total call count that any of those threads can bump at any moment.
+/// </remarks>
 internal sealed class BlockTreeCallSpy(IBlockTree inner) : BlockTreeTestDouble(inner)
 {
-    public int FindHeaderCalls { get; private set; }
+    private readonly ConcurrentDictionary<(ValueHash256 Hash, ulong Number), byte> _parentProbes = new();
 
-    public void ResetCounters() => FindHeaderCalls = 0;
+    public void Reset() => _parentProbes.Clear();
+
+    public bool WasProbedAsParent(Hash256 blockHash, ulong blockNumber) =>
+        _parentProbes.ContainsKey((blockHash.ValueHash256, blockNumber));
 
     public static (IBlockTree Proxy, BlockTreeCallSpy Spy) Wrap(IBlockTree inner)
     {
@@ -25,13 +37,11 @@ internal sealed class BlockTreeCallSpy(IBlockTree inner) : BlockTreeTestDouble(i
 
     public override BlockHeader? FindHeader(Hash256 blockHash, BlockTreeLookupOptions options, ulong? blockNumber = null)
     {
-        FindHeaderCalls++;
-        return base.FindHeader(blockHash, options, blockNumber);
-    }
+        if (blockNumber is not null)
+        {
+            _parentProbes.TryAdd((blockHash.ValueHash256, blockNumber.Value), 0);
+        }
 
-    public override BlockHeader? FindHeader(ulong blockNumber, BlockTreeLookupOptions options)
-    {
-        FindHeaderCalls++;
-        return base.FindHeader(blockNumber, options);
+        return base.FindHeader(blockHash, options, blockNumber);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.DelayBlockImprovementContextFactory.cs
@@ -48,6 +48,7 @@ public partial class EngineModuleTests
 
     private class DelayBlockImprovementContext : IBlockImprovementContext
     {
+        private volatile BlockProductionSnapshot _best;
         private readonly SharedCancellationTokenSource _improvementCancellation;
         private CancellationTokenSource? _timeOutCancellation;
         private CancellationTokenSource? _linkedCancellation;
@@ -62,7 +63,7 @@ public partial class EngineModuleTests
             SharedCancellationTokenSource cts,
             Action<CancellationToken>? onBuildStarted = null)
         {
-            CurrentBestBlock = currentBestBlock;
+            _best = new(currentBestBlock, UInt256.Zero);
             StartDateTime = startDateTime;
             _improvementCancellation = cts;
             _timeOutCancellation = new CancellationTokenSource(timeout);
@@ -84,15 +85,14 @@ public partial class EngineModuleTests
             Block? block = await blockProducer.BuildBlock(parentHeader, NullBlockTracer.Instance, payloadAttributes, IBlockProducer.Flags.None, cancellationToken);
             if (block is not null)
             {
-                CurrentBestBlock = block;
+                _best = new(block, UInt256.Zero);
             }
 
-            return CurrentBestBlock;
+            return _best.CurrentBestBlock;
         }
 
         public Task<Block?> ImprovementTask { get; }
-        public Block? CurrentBestBlock { get; private set; }
-        public UInt256 BlockFees { get; }
+        public BlockProductionSnapshot Best => _best;
         public bool Disposed { get; private set; }
         public DateTimeOffset StartDateTime { get; }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.GetPayloadCandidateConsistency.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.GetPayloadCandidateConsistency.cs
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Threading;
+using Nethermind.Int256;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.Specs.Forks;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+public partial class EngineModuleTests
+{
+    [TestCase(3)]
+    [TestCase(4)]
+    [TestCase(5)]
+    [TestCase(6)]
+    public async Task GetPayload_describes_one_candidate_when_improvement_swaps_the_block_midway(int version)
+    {
+        IReleaseSpec spec = version switch
+        {
+            3 => Cancun.Instance,
+            4 => Prague.Instance,
+            5 => Osaka.Instance,
+            _ => Amsterdam.Instance
+        };
+        // More candidates than any response should read, so no two reads can alias to one block.
+        Block[] candidates = [BuildCandidate(blobCount: 1, spec), BuildCandidate(blobCount: 2, spec), BuildCandidate(blobCount: 3, spec), BuildCandidate(blobCount: 4, spec)];
+        AlternatingBlockImprovementContextFactory factory = new(candidates);
+        using MergeTestBlockchain chain = await CreateBlockchain(releaseSpec: spec, configurer: builder =>
+            builder.AddSingleton<IBlockImprovementContextFactory>(factory));
+
+        string payloadId = chain.PayloadPreparationService.StartPreparingPayload(chain.BlockTree.Head!.Header, new PayloadAttributes
+        {
+            Timestamp = chain.BlockTree.Head.Timestamp + 1,
+            PrevRandao = TestItem.KeccakH,
+            SuggestedFeeRecipient = TestItem.AddressF,
+            Withdrawals = [],
+            ParentBeaconBlockRoot = TestItem.KeccakE
+        })!;
+
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+        byte[] id = Bytes.FromHexString(payloadId);
+        (Hash256 blockHash, byte[][] commitments, byte[][]? requests, UInt256 blockValue) = version switch
+        {
+            3 => Parts((await rpc.engine_getPayloadV3(id)).Data!),
+            4 => Parts((await rpc.engine_getPayloadV4(id)).Data!),
+            5 => Parts((await rpc.engine_getPayloadV5(id)).Data!),
+            _ => Parts((await rpc.engine_getPayloadV6(id)).Data!)
+        };
+
+        Block? served = Array.Find(candidates, c => c.Hash == blockHash);
+        Assert.That(served, Is.Not.Null, "payload is not one of the candidates");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(factory.Created!.Reads, Is.LessThanOrEqualTo(candidates.Length), "reads wrapped around, so two reads may have aliased to one candidate");
+            // A bundle from another candidate breaks engine_getPayloadV3 item 3 (commitments must match the payload's blob versioned hashes).
+            Assert.That(commitments, Is.EqualTo(new BlobsBundleV1(served).Commitments), "blobs bundle came from another candidate");
+            if (version >= 4)
+            {
+                Assert.That(requests, Is.EqualTo(served.ExecutionRequests), "execution requests came from another candidate");
+            }
+
+            Assert.That(blockValue, Is.EqualTo(AlternatingBlockImprovementContext.FeesOf(Array.IndexOf(candidates, served))), "blockValue came from another candidate");
+        }
+    }
+
+    private static (Hash256, byte[][], byte[][]?, UInt256) Parts(GetPayloadV3Result r) => (r.ExecutionPayload.BlockHash, r.BlobsBundle.Commitments, null, r.BlockValue);
+    private static (Hash256, byte[][], byte[][]?, UInt256) Parts(GetPayloadV4Result r) => (r.ExecutionPayload.BlockHash, r.BlobsBundle.Commitments, r.ExecutionRequests, r.BlockValue);
+    private static (Hash256, byte[][], byte[][]?, UInt256) Parts(GetPayloadV5Result r) => (r.ExecutionPayload.BlockHash, r.BlobsBundle.Commitments, r.ExecutionRequests, r.BlockValue);
+    private static (Hash256, byte[][], byte[][]?, UInt256) Parts(GetPayloadV6Result r) => (r.ExecutionPayload.BlockHash, r.BlobsBundle.Commitments, r.ExecutionRequests, r.BlockValue);
+
+    private static Block BuildCandidate(int blobCount, IReleaseSpec spec)
+    {
+        Transaction[] txs = new Transaction[blobCount];
+        for (int i = 0; i < blobCount; i++)
+        {
+            txs[i] = Build.A.Transaction
+                .WithShardBlobTxTypeAndFields(1, spec: spec)
+                .WithNonce((ulong)i)
+                .SignedAndResolved(TestItem.PrivateKeyA)
+                .TestObject;
+        }
+
+        Block block = Build.A.Block.WithTransactions(txs).WithGasUsed((ulong)blobCount).TestObject;
+        block.ExecutionRequests = [[(byte)blobCount]];
+        return block;
+    }
+
+    private class AlternatingBlockImprovementContextFactory(Block[] candidates) : IBlockImprovementContextFactory
+    {
+        public AlternatingBlockImprovementContext? Created { get; private set; }
+
+        public IBlockImprovementContext StartBlockImprovementContext(Block currentBestBlock, BlockHeader parentHeader,
+            PayloadAttributes payloadAttributes, DateTimeOffset startDateTime, UInt256 currentBlockFees, SharedCancellationTokenSource cts) =>
+            Created = new AlternatingBlockImprovementContext(candidates, startDateTime);
+    }
+
+    /// <summary>
+    /// Advances to the next candidate on every read, so a response built from more than one read mixes candidates.
+    /// </summary>
+    private class AlternatingBlockImprovementContext(Block[] candidates, DateTimeOffset startDateTime) : IBlockImprovementContext
+    {
+        private int _reads;
+
+        public static UInt256 FeesOf(int candidate) => (UInt256)(candidate + 1);
+
+        /// <summary>How many times the candidate was read; above the candidate count, reads alias.</summary>
+        public int Reads => Volatile.Read(ref _reads);
+
+        public BlockProductionSnapshot Best
+        {
+            get
+            {
+                int candidate = (Interlocked.Increment(ref _reads) - 1) % candidates.Length;
+                return new(candidates[candidate], FeesOf(candidate));
+            }
+        }
+        public Task<Block?> ImprovementTask { get; } = new TaskCompletionSource<Block?>(TaskCreationOptions.RunContinuationsAsynchronously).Task;
+        public bool Disposed { get; private set; }
+        public DateTimeOffset StartDateTime { get; } = startDateTime;
+
+        public void CancelOngoingImprovements() { }
+        public void Dispose() => Disposed = true;
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.MockBlockImprovementContextFactory.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.MockBlockImprovementContextFactory.cs
@@ -26,8 +26,7 @@ public partial class EngineModuleTests
         public void CancelOngoingImprovements() { }
 
         public Task<Block?> ImprovementTask { get; } = Task.FromResult((Block?)currentBestBlock);
-        public Block? CurrentBestBlock { get; } = currentBestBlock;
-        public UInt256 BlockFees { get; }
+        public BlockProductionSnapshot Best { get; } = new(currentBestBlock, UInt256.Zero);
         public bool Disposed { get; private set; }
         public DateTimeOffset StartDateTime { get; } = startDateTime;
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -503,7 +503,7 @@ public partial class EngineModuleTests
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
 
         List<int?> transactionsLength = improvementContextFactory.SnapshotCreatedContexts()
-            .Select(c => c.CurrentBestBlock?.Transactions.Length).ToList();
+            .Select(c => c.Best.CurrentBestBlock?.Transactions.Length).ToList();
 
         using (Assert.EnterMultipleScope())
         {
@@ -561,7 +561,7 @@ public partial class EngineModuleTests
 
         StoringBlockImprovementContextFactory improvementContextFactory = (StoringBlockImprovementContextFactory)chain.Container.Resolve<IBlockImprovementContextFactory>();
         List<int?> transactionsLength = improvementContextFactory.SnapshotCreatedContexts()
-            .Select(c => c.CurrentBestBlock?.Transactions.Length).ToList();
+            .Select(c => c.Best.CurrentBestBlock?.Transactions.Length).ToList();
 
         Assert.That(transactionsLength, Is.EqualTo(new[] { 1, 2 }));
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V1.cs
@@ -1710,16 +1710,20 @@ public partial class EngineModuleTests
             Assert.That(chain.BlockTree.IsMainChain(a3.BlockHash), Is.False, "precondition: a3's marker was flipped to b3");
         }
 
-        // Count FindHeader calls made by the repeated FCU only. Safe=Keccak.Zero skips its
-        // ValidateBlockHash lookup. Baseline: 1 to resolve head, 1 for finalized validation,
-        // 1 for IsOnMainChainBehindFinalized (FindFinalizedHeader), plus the IsInconsistent walk
-        // (1 under the optimization, 2 without).
-        spy!.ResetCounters();
+        // Watch the parent probes of the repeated FCU only. The walk steps a3 -> a2 and has to stop
+        // there; continuing would step a2 -> a1. Only the walk passes a height, so a probe of a1 at
+        // H=1 is its unambiguous signature - the finalized hash a1 is resolved without one.
+        spy!.Reset();
         ForkchoiceStateV1 repeated = new(headBlockHash: a3.BlockHash, finalizedBlockHash: a1.BlockHash, safeBlockHash: Keccak.Zero);
         ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(repeated);
         Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
 
-        Assert.That(spy.FindHeaderCalls, Is.EqualTo(4), "walk must stop at the first main-chain ancestor (a2) rather than continue to a1");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(spy.WasProbedAsParent(a2.BlockHash, a2.BlockNumber), Is.True, "the walk has to step a3 -> a2");
+            Assert.That(spy.WasProbedAsParent(a1.BlockHash, a1.BlockNumber), Is.False,
+                "walk must stop at the first main-chain ancestor (a2) rather than continue to a1");
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/BlockImprovementContext.cs
@@ -20,6 +20,7 @@ public class BlockImprovementContext : IBlockImprovementContext
     private CancellationTokenSource? _timeOutCancellation;
     private CancellationTokenSource? _linkedCancellation;
     private readonly FeesTracer _feesTracer = new();
+    private volatile BlockProductionSnapshot _best;
 
     public BlockImprovementContext(Block currentBestBlock,
         IBlockProducer blockProducer,
@@ -32,8 +33,7 @@ public class BlockImprovementContext : IBlockImprovementContext
     {
         _improvementCancellation = cts;
         _timeOutCancellation = new CancellationTokenSource(timeout);
-        CurrentBestBlock = currentBestBlock;
-        BlockFees = currentBlockFees;
+        _best = new(currentBestBlock, currentBlockFees);
         StartDateTime = startDateTime;
 
         _linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, _timeOutCancellation.Token);
@@ -46,8 +46,7 @@ public class BlockImprovementContext : IBlockImprovementContext
 
     public Task<Block?> ImprovementTask { get; }
 
-    public Block? CurrentBestBlock { get; private set; }
-    public UInt256 BlockFees { get; private set; }
+    public BlockProductionSnapshot Best => _best;
 
     private Block? SetCurrentBestBlock(Task<Block?> task)
     {
@@ -57,18 +56,18 @@ public class BlockImprovementContext : IBlockImprovementContext
             if (block is not null)
             {
                 UInt256 fees = _feesTracer.Fees;
-                if (CurrentBestBlock is null ||
-                    fees > BlockFees ||
-                    (fees == BlockFees && block.GasUsed > CurrentBestBlock.GasUsed))
+                BlockProductionSnapshot best = _best;
+                if (best.CurrentBestBlock is null ||
+                    fees > best.BlockFees ||
+                    (fees == best.BlockFees && block.GasUsed > best.CurrentBestBlock.GasUsed))
                 {
                     // Only update block if block has actually improved.
-                    CurrentBestBlock = block;
-                    BlockFees = fees;
+                    _best = new(block, fees);
                 }
             }
         }
 
-        return CurrentBestBlock;
+        return _best.CurrentBestBlock;
     }
 
     public bool Disposed { get; private set; }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/Boost/BoostBlockImprovementContext.cs
@@ -24,6 +24,7 @@ public class BoostBlockImprovementContext : IBlockImprovementContext
     private readonly SharedCancellationTokenSource _improvementCancellation;
     private CancellationTokenSource? _timeOutCancellation;
     private CancellationTokenSource? _linkedCancellation;
+    private volatile BlockProductionSnapshot _best;
 
     public BoostBlockImprovementContext(Block currentBestBlock,
         IBlockProducer blockProducer,
@@ -40,7 +41,7 @@ public class BoostBlockImprovementContext : IBlockImprovementContext
         _improvementCancellation = cts;
         _timeOutCancellation = new CancellationTokenSource(timeout);
         _linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(cts.Token, _timeOutCancellation.Token);
-        CurrentBestBlock = currentBestBlock;
+        _best = new(currentBestBlock, UInt256.Zero);
         StartDateTime = startDateTime;
         ImprovementTask = StartImprovingBlock(blockProducer, parentHeader, payloadAttributes, _linkedCancellation.Token);
     }
@@ -59,18 +60,16 @@ public class BoostBlockImprovementContext : IBlockImprovementContext
         Block? block = await blockProducer.BuildBlock(parentHeader, _feesTracer, payloadAttributes, IBlockProducer.Flags.None, cancellationToken);
         if (block is not null)
         {
-            CurrentBestBlock = block;
-            BlockFees = _feesTracer.Fees;
+            _best = new(block, _feesTracer.Fees);
             _stateReader.TryGetAccount(parentHeader, feeRecipient, out account);
             await _boostRelay.SendPayload(new BoostExecutionPayloadV1 { Block = ExecutionPayload.Create(block), Profit = account.Balance - balanceBefore }, cancellationToken);
         }
 
-        return CurrentBestBlock;
+        return _best.CurrentBestBlock;
     }
 
     public Task<Block?> ImprovementTask { get; }
-    public Block? CurrentBestBlock { get; private set; }
-    public UInt256 BlockFees { get; private set; }
+    public BlockProductionSnapshot Best => _best;
     public bool Disposed { get; private set; }
     public DateTimeOffset StartDateTime { get; }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/IPayloadPreparationService.cs
@@ -11,6 +11,7 @@ namespace Nethermind.Merge.Plugin.BlockProduction
     {
         string? StartPreparingPayload(BlockHeader parentHeader, PayloadAttributes payloadAttributes);
 
+        /// <summary>Returns an immutable snapshot of the best candidate, or <c>null</c> for an unknown payload.</summary>
         ValueTask<IBlockProductionContext?> GetPayload(string payloadId, bool skipCancel = false);
         void CancelBlockProduction(string payloadId);
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/NoBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/NoBlockImprovementContext.cs
@@ -9,8 +9,7 @@ using Nethermind.Int256;
 
 namespace Nethermind.Merge.Plugin.BlockProduction;
 
-public class NoBlockImprovementContext(Block? currentBestBlock, UInt256 blockFees, DateTimeOffset startDateTime)
-    : NoBlockProductionContext(currentBestBlock, blockFees), IBlockImprovementContext
+public class NoBlockImprovementContext(Block? currentBestBlock, UInt256 blockFees, DateTimeOffset startDateTime) : IBlockImprovementContext
 {
     void IDisposable.Dispose() { }
 
@@ -18,6 +17,7 @@ public class NoBlockImprovementContext(Block? currentBestBlock, UInt256 blockFee
 
     public bool Disposed => true;
 
+    public BlockProductionSnapshot Best { get; } = new(currentBestBlock, blockFees);
     public Task<Block?> ImprovementTask { get; } = Task.FromResult(currentBestBlock);
     public DateTimeOffset StartDateTime { get; } = startDateTime;
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/BlockProduction/PayloadPreparationService.cs
@@ -153,7 +153,7 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
                     return currentContext;
                 }
 
-                IBlockImprovementContext newContext = CreateBlockImprovementContext(id, parentHeader, payloadAttributes, currentBestBlock, startDateTime, currentContext.BlockFees, cts);
+                IBlockImprovementContext newContext = CreateBlockImprovementContext(id, parentHeader, payloadAttributes, currentBestBlock, startDateTime, currentBlockFees, cts);
                 if (!cts.IsCancellationRequested)
                 {
                     currentContext.Dispose();
@@ -180,7 +180,7 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
             {
                 if (!token.IsCancellationRequested)
                 {
-                    LogProductionResult(b, currentBestBlock, blockImprovementContext.BlockFees, Stopwatch.GetElapsedTime(startTimestamp));
+                    LogProductionResult(b, currentBestBlock, blockImprovementContext.Best.BlockFees, Stopwatch.GetElapsedTime(startTimestamp));
                 }
             },
             TaskContinuationOptions.RunContinuationsAsynchronously);
@@ -211,8 +211,8 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
 
             if (!token.IsCancellationRequested || !blockImprovementContext.Disposed) // if GetPayload wasn't called for this item or it wasn't cleared
             {
-                Block newBestBlock = blockImprovementContext.CurrentBestBlock ?? currentBestBlock;
-                ImproveBlock(payloadId, parentHeader, payloadAttributes, newBestBlock, startDateTime, blockImprovementContext.BlockFees, cts);
+                BlockProductionSnapshot best = blockImprovementContext.Best;
+                ImproveBlock(payloadId, parentHeader, payloadAttributes, best.CurrentBestBlock ?? currentBestBlock, startDateTime, best.BlockFees, cts);
             }
             else
             {
@@ -321,7 +321,7 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
                 DateTimeOffset now = DateTimeOffset.UtcNow;
                 if (payload.Value.StartDateTime + _cleanupOldPayloadDelay <= now)
                 {
-                    if (_logger.IsDebug) _logger.Info($"A new payload to remove: {payload.Key}, Current time {now:t}, Payload timestamp: {payload.Value.CurrentBestBlock?.Timestamp}");
+                    if (_logger.IsDebug) _logger.Info($"A new payload to remove: {payload.Key}, Current time {now:t}, Payload timestamp: {payload.Value.Best.CurrentBestBlock?.Timestamp}");
 
                     if (_payloadStorage.TryRemove(payload.Key, out IBlockImprovementContext? context))
                     {
@@ -387,7 +387,7 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
         {
             try
             {
-                bool currentBestBlockIsEmpty = blockContext.CurrentBestBlock?.Transactions.Length == 0;
+                bool currentBestBlockIsEmpty = blockContext.Best.CurrentBestBlock?.Transactions.Length == 0;
                 if (currentBestBlockIsEmpty && !blockContext.ImprovementTask.IsCompleted)
                 {
                     // Inform current improvement that we need results now
@@ -409,7 +409,7 @@ public class PayloadPreparationService : IPayloadPreparationService, IDisposable
                     }
                 }
 
-                return blockContext;
+                return blockContext.Best;
             }
             finally
             {

--- a/src/Nethermind/Nethermind.Shutter/ShutterBlockImprovementContext.cs
+++ b/src/Nethermind/Nethermind.Shutter/ShutterBlockImprovementContext.cs
@@ -47,12 +47,12 @@ public class ShutterBlockImprovementContext : IBlockImprovementContext
 {
     public Task<Block?> ImprovementTask { get; }
 
-    public Block? CurrentBestBlock { get; private set; }
+    public BlockProductionSnapshot Best => _best;
 
     public bool Disposed { get; private set; }
     public DateTimeOffset StartDateTime { get; }
 
-    public UInt256 BlockFees => 0;
+    private volatile BlockProductionSnapshot _best;
 
     private readonly SharedCancellationTokenSource _improvementCancellation;
     private readonly CancellationToken _improvementToken;
@@ -89,7 +89,7 @@ public class ShutterBlockImprovementContext : IBlockImprovementContext
 
         _improvementCancellation = cts;
         _improvementToken = cts.Token;
-        CurrentBestBlock = currentBestBlock;
+        _best = new(currentBestBlock, UInt256.Zero);
         StartDateTime = startDateTime;
         _logger = logManager.GetClassLogger<ShutterBlockImprovementContext>();
         _blockProducer = blockProducer;
@@ -125,20 +125,20 @@ public class ShutterBlockImprovementContext : IBlockImprovementContext
         {
             if (_logger.IsWarn) _logger.Warn($"Could not calculate Shutter building slot: {e}");
             await BuildBlock();
-            return CurrentBestBlock;
+            return _best.CurrentBestBlock;
         }
 
         bool includedShutterTxs = await TryBuildShutterBlock(slot);
         if (includedShutterTxs)
         {
-            return CurrentBestBlock;
+            return _best.CurrentBestBlock;
         }
 
         long waitTime = _shutterConfig.MaxKeyDelay - offset;
         if (waitTime <= 0)
         {
             if (_logger.IsWarn) _logger.Warn($"Cannot await Shutter decryption keys for slot {slot}, offset of {offset}ms is too late.");
-            return CurrentBestBlock;
+            return _best.CurrentBestBlock;
         }
         waitTime = Math.Min(waitTime, 2 * (long)_slotLength.TotalMilliseconds);
 
@@ -158,13 +158,13 @@ public class ShutterBlockImprovementContext : IBlockImprovementContext
             Metrics.ShutterKeysMissed++;
             if (_logger.IsWarn) _logger.Warn($"Shutter decryption keys not received in time for slot {slot}.");
 
-            return CurrentBestBlock;
+            return _best.CurrentBestBlock;
         }
 
         // should succeed after waiting for transactions
         await TryBuildShutterBlock(slot);
 
-        return CurrentBestBlock;
+        return _best.CurrentBestBlock;
     }
 
     private async Task<bool> TryBuildShutterBlock(ulong slot)
@@ -179,7 +179,7 @@ public class ShutterBlockImprovementContext : IBlockImprovementContext
         Block? result = await _blockProducer.BuildBlock(_parentHeader, null, _payloadAttributes, IBlockProducer.Flags.None, _linkedCancellation?.Token ?? default);
         if (result is not null)
         {
-            CurrentBestBlock = result;
+            _best = new(result, UInt256.Zero);
         }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotCompactorTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotCompactorTests.cs
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
@@ -14,6 +18,7 @@ using Nethermind.State.Flat.PersistedSnapshots;
 using Nethermind.State.Flat.Persistence.BloomFilter;
 using Nethermind.State.Flat.PersistedSnapshots.Storage;
 using Nethermind.Trie;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
@@ -38,6 +43,27 @@ public class PersistedSnapshotCompactorTests
     {
         _memArena.Dispose();
         try { Directory.Delete(_memArenaDir, recursive: true); } catch { /* best-effort */ }
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task EnqueueAsync_FailedHandoff_ReturnsBatchToPool(bool disposed)
+    {
+        using FlatTestContainer tier = new();
+        using CancellationTokenSource cancellation = new();
+        ArrayPool<StateId> pool = Substitute.For<ArrayPool<StateId>>();
+        StateId[] rented = new StateId[1];
+        pool.Rent(1).Returns(rented);
+        using ArrayPoolList<StateId> batch = new(pool, 1) { new StateId(1, Keccak.EmptyTreeHash) };
+
+        if (disposed)
+            await tier.Compactor.DisposeAsync();
+        else
+            await cancellation.CancelAsync();
+
+        Type exceptionType = disposed ? typeof(ObjectDisposedException) : typeof(OperationCanceledException);
+        Assert.That(async () => await tier.Compactor.EnqueueAsync(batch, 0, cancellation.Token), Throws.InstanceOf(exceptionType));
+        pool.Received(1).Return(rented, Arg.Any<bool>());
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Threading;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Nethermind.Config;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
@@ -39,6 +41,7 @@ public class PersistenceManagerTests
         _config = new FlatDbConfig
         {
             CompactSize = 16,
+            CompactionOffset = 0,
             MinReorgDepth = 64,
             MaxInMemoryBaseSnapshotCount = 128 + 32,
             MaxReorgDepth = 256,
@@ -51,7 +54,7 @@ public class PersistenceManagerTests
         // SnapshotRepository owns both tiers over a real temp-dir-backed persisted store, wired the
         // production way through FlatWorldStateModule; the container pairs it with its loader (load on
         // build, teardown on dispose).
-        _tier = new FlatTestContainer();
+        _tier = new FlatTestContainer(_config);
         _snapshotRepository = _tier.Repository;
         _persistence = Substitute.For<IPersistence>();
 
@@ -63,7 +66,7 @@ public class PersistenceManagerTests
 
         _persistenceManager = new PersistenceManager(
             _config,
-            ScheduleHelper.CreateWithOffset(_config, 0),
+            _tier.Resolve<ICompactionSchedule>(),
             _finalizedStateProvider,
             _persistence,
             _snapshotRepository,
@@ -89,10 +92,11 @@ public class PersistenceManagerTests
         return new StateId(blockNumber, new ValueHash256(bytes));
     }
 
-    private Snapshot CreateSnapshot(StateId from, StateId to, bool compacted = false)
+    private Snapshot CreateSnapshot(StateId from, StateId to, bool compacted = false, Action<Snapshot>? populate = null)
     {
         Snapshot snapshot = _resourcePool.CreateSnapshot(from, to, ResourcePool.Usage.ReadOnlyProcessingEnv);
         snapshot.Content.Accounts[TestItem.AddressA] = new Account(1, 100);
+        populate?.Invoke(snapshot);
 
         if (compacted)
         {
@@ -471,6 +475,66 @@ public class PersistenceManagerTests
             Assert.That(_snapshotRepository.TryLeaseInMemoryState(baseB, SnapshotTier.InMemoryBase, out _), Is.False, "baseB removed from the in-memory tier");
             Assert.That(_snapshotRepository.TryLeaseInMemoryState(compactedTo, SnapshotTier.InMemoryCompacted, out _), Is.False, "boundary compacted removed");
         });
+    }
+
+    [TestCase(1)]
+    [TestCase(8)]
+    public async Task AddToPersistence_RepeatedForks_ReleasesConvertedCompactedSnapshots(int forkCount)
+    {
+        // Keep the conversion threshold reached while each fork stays below a full compaction boundary.
+        for (int i = 0; i < _config.MaxInMemoryBaseSnapshotCount; i++)
+            CreateSnapshot(Block0, CreateStateId(3, (byte)i));
+
+        ISnapshotCompactor compactor = _tier.Resolve<ISnapshotCompactor>();
+        List<Snapshot> convertedCompacts = [];
+        List<int> compactedCountsAtHandoff = [];
+        StateId latest = Block0;
+        _persistedSnapshotCompactor
+            .EnqueueAsync(Arg.Any<ArrayPoolList<StateId>>(), Arg.Any<ulong>(), Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                using ArrayPoolList<StateId> batch = call.Arg<ArrayPoolList<StateId>>();
+                if (batch[0] == latest)
+                    compactedCountsAtHandoff.Add(_snapshotRepository.CompactedSnapshotCount);
+                return ValueTask.CompletedTask;
+            });
+
+        for (int i = 1; i <= forkCount; i++)
+        {
+            StateId setup = CreateStateId(1, (byte)i);
+            latest = CreateStateId(2, (byte)i);
+            Account setupAccount = new(1, (UInt256)i);
+            CreateSnapshot(Block0, setup, populate: snapshot => snapshot.Content.Accounts[TestItem.AddressB] = setupAccount);
+            CreateSnapshot(setup, latest);
+
+            Assert.That(compactor.DoCompactSnapshot(latest), Is.True);
+            Assert.That(_snapshotRepository.TryLeaseInMemoryState(latest, SnapshotTier.InMemoryCompacted, out Snapshot? compacted), Is.True);
+            using (compacted)
+            {
+                convertedCompacts.Add(compacted!);
+                await _persistenceManager.AddToPersistence(latest);
+
+                Assert.That(compacted!.TryGetAccount(TestItem.AddressB, out Account? account), Is.True);
+                Assert.That(account, Is.EqualTo(setupAccount), "an active reader must survive conversion");
+            }
+        }
+
+        using AssembledSnapshotResult assembled = _snapshotRepository.AssembleSnapshots(latest, Block0, 2);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_snapshotRepository.SnapshotCount, Is.EqualTo(_config.MaxInMemoryBaseSnapshotCount));
+            Assert.That(_snapshotRepository.CompactedSnapshotCount, Is.Zero, "converted forks must not retain compacted snapshots");
+            Assert.That(compactedCountsAtHandoff, Has.Count.EqualTo(forkCount));
+            Assert.That(compactedCountsAtHandoff, Is.All.Zero, "compacted snapshots must be released before the potentially blocking handoff");
+            Assert.That(assembled.InMemory.Count, Is.Zero);
+            Assert.That(assembled.Persisted.Count, Is.EqualTo(2), "the persisted bases must still cover the fork");
+            foreach (Snapshot compacted in convertedCompacts)
+            {
+                bool retained = compacted.TryAcquire();
+                if (retained) compacted.Dispose();
+                Assert.That(retained, Is.False, "compacted data must be released after the last reader exits");
+            }
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/IPersistedSnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/IPersistedSnapshotCompactor.cs
@@ -13,14 +13,18 @@ public interface IPersistedSnapshotCompactor : IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// Takes ownership of <paramref name="batch"/> and disposes it once the batch has been
-    /// processed (or drained on cancellation). Asynchronously awaits a free slot when the internal
-    /// queue is full, providing backpressure to the block-processing pipeline without blocking a
-    /// thread.
+    /// processed, rejected during enqueue, or drained on cancellation. Asynchronously awaits a free
+    /// slot when the internal queue is full, providing backpressure to the block-processing pipeline
+    /// without blocking a thread.
     /// </remarks>
     /// <param name="batch">The converted states to compact; ownership transfers to the compactor.</param>
     /// <param name="persistedBlockNumber">The current persistence point (RocksDB persisted state block).
     /// Compaction windows are clamped to not reach below it — snapshots below are already in RocksDB,
     /// so merging them would be wasted work.</param>
     /// <param name="cancellationToken">Releases the backpressure wait when the producer is shutting down.</param>
+    /// <exception cref="ObjectDisposedException">The compactor has been disposed. This check precedes cancellation;
+    /// <paramref name="batch"/> is returned to its pool before the exception is propagated.</exception>
+    /// <exception cref="OperationCanceledException"><paramref name="cancellationToken"/> was canceled before or while
+    /// waiting to enqueue; <paramref name="batch"/> is returned to its pool before the exception is propagated.</exception>
     ValueTask EnqueueAsync(ArrayPoolList<StateId> batch, ulong persistedBlockNumber, CancellationToken cancellationToken);
 }

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotCompactor.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotCompactor.cs
@@ -66,15 +66,15 @@ public class PersistedSnapshotCompactor(
     /// <inheritdoc/>
     public async ValueTask EnqueueAsync(ArrayPoolList<StateId> batch, ulong persistedBlockNumber, CancellationToken cancellationToken)
     {
-        // Fire-and-forget: EnsureStarted returns the long-running compactor task, which must not be awaited.
-        _ = EnsureStarted();
         try
         {
+            // Fire-and-forget: EnsureStarted returns the long-running compactor task, which must not be awaited.
+            _ = EnsureStarted();
             // Awaits a free slot on the bounded queue, providing backpressure without blocking a thread;
             // the caller's token releases the wait on shutdown.
             await _compactPersistedJobs.Writer.WriteAsync((batch, persistedBlockNumber), cancellationToken);
         }
-        catch (OperationCanceledException)
+        catch
         {
             // The batch never entered the channel, so dispose the handoff we still own.
             batch.Dispose();
@@ -87,6 +87,8 @@ public class PersistedSnapshotCompactor(
         // Guard against concurrent EnqueueAsync callers spawning duplicate worker sets.
         lock (_startLock)
         {
+            ObjectDisposedException.ThrowIf(_disposed != 0, this);
+
             _compactPersistedTask ??= RunPersistedCompactor(_shutdownToken);
             if (_boundaryCompactorTasks is null)
             {
@@ -214,7 +216,11 @@ public class PersistedSnapshotCompactor(
 
     public async ValueTask DisposeAsync()
     {
-        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        lock (_startLock)
+        {
+            if (_disposed != 0) return;
+            _disposed = 1;
+        }
         // Complete and drain the persisted stage first so any boundary jobs it produces are written
         // before the boundary channel is completed; on process exit the shared token has already
         // cancelled both stages, so these awaits return promptly instead of draining.

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -364,10 +364,11 @@ public class PersistenceManager(
             loader.ConvertAndRegister(baseSnap);
             Metrics.PersistedSnapshotConvertTime.Observe(Stopwatch.GetTimestamp() - sw);
 
+            snapshotRepository.RemoveAndReleaseInMemoryKnownState(baseSnap.To, SnapshotTier.InMemoryCompacted);
+            snapshotRepository.RemoveAndReleaseInMemoryKnownState(baseSnap.To, SnapshotTier.InMemoryBase);
+
             ArrayPoolList<StateId> single = new(1) { baseSnap.To };
             await compactor.EnqueueAsync(single, GetCurrentPersistedStateId().BlockNumber, _cts.Token);
-
-            snapshotRepository.RemoveAndReleaseInMemoryKnownState(baseSnap.To, SnapshotTier.InMemoryBase);
         }
         finally
         {

--- a/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StateProviderTests.cs
@@ -83,6 +83,35 @@ public class StateProviderTests(bool useFlat)
     }
 
     [Test]
+    public void Cold_account_read_tracks_writes_and_rollback([Values] bool exists)
+    {
+        using Context ctx = new(useFlat);
+        IWorldState provider = ctx.WorldState;
+        BlockHeader baseBlock;
+        using (provider.BeginScope(IWorldState.PreGenesis))
+        {
+            if (exists) provider.CreateAccount(_address1, 1);
+            provider.Commit(Frontier.Instance);
+            provider.CommitTree(0);
+            baseBlock = Build.A.BlockHeader.WithStateRoot(provider.StateRoot).TestObject;
+        }
+
+        using IDisposable scope = provider.BeginScope(baseBlock);
+        Assert.That(provider.AccountExists(_address1), Is.EqualTo(exists));
+        Snapshot snapshot = provider.TakeSnapshot();
+        if (exists) provider.AddToBalance(_address1, 2, Frontier.Instance);
+        else provider.CreateAccount(_address1, 3);
+        Assert.That(provider.GetBalance(_address1), Is.EqualTo((UInt256)3));
+
+        provider.Restore(snapshot);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(provider.AccountExists(_address1), Is.EqualTo(exists));
+            Assert.That(provider.GetBalance(_address1), Is.EqualTo(exists ? UInt256.One : UInt256.Zero));
+        }
+    }
+
+    [Test]
     public void Eip_158_touch_zero_value_system_account_is_not_deleted()
     {
         using Context ctx = new(useFlat);

--- a/src/Nethermind/Nethermind.State/OverridableEnv/OverridableCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/OverridableCodeInfoRepository.cs
@@ -23,7 +23,8 @@ public class OverridableCodeInfoRepository(ICodeInfoRepository codeInfoRepositor
     public CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec, out Address? delegationAddress)
     {
         delegationAddress = null;
-        if (_precompileOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, Address initialAddr) precompile)) return precompile.codeInfo;
+        // Moved precompiles are rare, so skip the hash lookup when there are none.
+        if (_precompileOverrides.Count != 0 && _precompileOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, Address initialAddr) precompile)) return precompile.codeInfo;
 
         if (_codeOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, ValueHash256 codeHash) result))
         {

--- a/src/Nethermind/Nethermind.State/OverridableEnv/OverridableCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/OverridableCodeInfoRepository.cs
@@ -24,7 +24,8 @@ public class OverridableCodeInfoRepository(ICodeInfoRepository codeInfoRepositor
     public CodeInfo GetCachedCodeInfo(Address codeSource, bool followDelegation, IReleaseSpec vmSpec, out Address? delegationAddress)
     {
         delegationAddress = null;
-        if (_precompileOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, Address initialAddr) precompile)) return precompile.codeInfo;
+        // Moved precompiles are rare, so skip the hash lookup when there are none.
+        if (_precompileOverrides.Count != 0 && _precompileOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, Address initialAddr) precompile)) return precompile.codeInfo;
 
         if (_codeOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, ValueHash256 codeHash) result))
         {

--- a/src/Nethermind/Nethermind.State/StateProvider.cs
+++ b/src/Nethermind/Nethermind.State/StateProvider.cs
@@ -66,10 +66,8 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     private IWorldStateScopeProvider.ICodeDb CodeDb =>
         _codeDb ?? throw new InvalidOperationException("Code storage can only be used within a world-state scope.");
 
-    // Invalidates the guest front cache when a restore/commit/reset recycles the change stacks; elided on
-    // mainline, which has no front cache (no implementing declaration).
-    partial void InvalidateFrontCache();
-#if ZK_EVM
+    // Invalidates the front cache when a restore/commit/reset recycles the change stacks.
+    private void InvalidateFrontCache() => _epoch++;
     // Single-entry cache in front of _intraTxCache: the EVM accesses the same
     // account many times in a row. Pushes write the new value through when the
     // cached address matches, so a hit needs no staleness probe. Invalidated
@@ -79,12 +77,9 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
     private int _cachedEpoch = -1;
     private int _epoch;
 
-    partial void InvalidateFrontCache() => _epoch++;
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsFrontCacheHit(Address address) =>
         _cachedEpoch == _epoch && _cachedAddress is not null && _cachedAddress.Equals(address);
-#endif
 
     public void RecalculateStateRoot()
     {
@@ -938,7 +933,6 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
 
     internal Account? GetThroughCache(Address address)
     {
-#if ZK_EVM
         if (IsFrontCacheHit(address))
         {
             return _cachedAccount;
@@ -949,12 +943,10 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
             _cachedEpoch = _epoch;
             return _cachedAccount = _changes[head].Account;
         }
-        return GetAndAddToCache(address);
-#else
-        return _intraTxCache.TryGetValue(address, out int head)
-            ? _changes[head].Account
-            : GetAndAddToCache(address);
-#endif
+        Account? account = GetAndAddToCache(address);
+        _cachedAddress = address;
+        _cachedEpoch = _epoch;
+        return _cachedAccount = account;
     }
 
     private void PushJustCache(Address address, Account account)
@@ -995,11 +987,9 @@ internal partial class StateProvider(ILogManager logManager, LocalMetrics metric
         int prevIdx = exists ? head : -1;
         head = _changes.Count;
         _changes.Add(new Change(address, touchedAccount, changeType, prevIdx));
-#if ZK_EVM
         // Keep the front cache coherent: a push almost always follows a read of the same account.
         if (IsFrontCacheHit(address))
             _cachedAccount = touchedAccount;
-#endif
     }
 
     public ArrayPoolList<AddressAsKey>? ChangedAddresses()

--- a/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
+++ b/src/Nethermind/Nethermind.State/WorldStateDecorator.cs
@@ -20,17 +20,17 @@ public abstract class WorldStateDecorator(IWorldState state) : IWorldState
 {
     protected readonly IWorldState State = state;
 
-    public virtual Hash256 StateRoot => State.StateRoot;
-    public virtual bool IsInScope => State.IsInScope;
-    public virtual IWorldStateScopeProvider ScopeProvider => State.ScopeProvider;
+    public Hash256 StateRoot => State.StateRoot;
+    public bool IsInScope => State.IsInScope;
+    public IWorldStateScopeProvider ScopeProvider => State.ScopeProvider;
 
-    public virtual IDisposable BeginScope(BlockHeader? baseBlock)
+    public IDisposable BeginScope(BlockHeader? baseBlock)
         => State.BeginScope(baseBlock);
 
-    public virtual Task HintBal(ReadOnlyBlockAccessList bal)
+    public Task HintBal(ReadOnlyBlockAccessList bal)
         => State.HintBal(bal);
 
-    public virtual bool HasStateForBlock(BlockHeader? baseBlock)
+    public bool HasStateForBlock(BlockHeader? baseBlock)
         => State.HasStateForBlock(baseBlock);
 
     public virtual bool TryGetAccount(Address address, out AccountStruct account)
@@ -84,10 +84,10 @@ public abstract class WorldStateDecorator(IWorldState state) : IWorldState
     public virtual void Restore(Snapshot snapshot)
         => State.Restore(snapshot);
 
-    public virtual void WarmUp(AccessList? accessList, CancellationToken cancellationToken = default)
+    public void WarmUp(AccessList? accessList, CancellationToken cancellationToken = default)
         => State.WarmUp(accessList, cancellationToken);
 
-    public virtual void WarmUp(Address address)
+    public void WarmUp(Address address)
         => State.WarmUp(address);
 
     public virtual void ClearStorage(Address address)
@@ -132,7 +132,7 @@ public abstract class WorldStateDecorator(IWorldState state) : IWorldState
     public virtual void Commit(IReleaseSpec releaseSpec, IWorldStateTracer tracer, bool isGenesis = false, bool commitRoots = true)
         => State.Commit(releaseSpec, tracer, isGenesis, commitRoots);
 
-    public virtual void CommitTree(ulong blockNumber)
+    public void CommitTree(ulong blockNumber)
         => State.CommitTree(blockNumber);
 
     public virtual ArrayPoolList<AddressAsKey>? GetAccountChanges()

--- a/src/Nethermind/Nethermind.Taiko/TaikoPayloadPreparationService.cs
+++ b/src/Nethermind/Nethermind.Taiko/TaikoPayloadPreparationService.cs
@@ -71,7 +71,7 @@ public class TaikoPayloadPreparationService(
                 }
 
                 // ignore TryAdd failure (it can only happen if payloadId is already in the dictionary)
-                return new NoBlockProductionContext(block, UInt256.Zero);
+                return new BlockProductionSnapshot(block, UInt256.Zero);
             },
             (payloadId, existing) =>
             {


### PR DESCRIPTION
## Changes

Merges `master` into `eip8141-frame-txs-devnet7` to clear the DIRTY/CONFLICTING state on the umbrella PR #12526 (the branch had fallen 5 master commits behind). Three conflicts, plus a follow-on API port driven by master #13189 ("Reduce EVM opcode dispatch and call-frame overhead"), which rewrote the `IGasPolicy` consume API and the stack-push API under the frame-only opcode files.

Conflict resolutions:
- `IGasPolicy.cs` / `EthereumGasPolicy.cs`: both sides added different members at the same spot; kept both (union). `IndependentStatePool` / `OutOfGas` frame fields retained.
- `EvmInstructions.CodeCopy.cs`: RETURNDATACOPY routed through the frame's `BoundedDataCopyCore`; its body now uses master's `TryConsumeDataCopyGas`.

#13189 API port across `EvmInstructions.FrameTx.cs` and `EvmInstructions.TxAssertions.cs` (frame-only, auto-merged but referencing changed APIs):
- Stack pushes gained a `TCheckDepth` type argument. Frame sites pass `OnFlag`, which reproduces exactly the always-check-depth behavior of the removed single-parameter overloads (verified against the pre-merge `PushUInt32<TTracingInst>` body).
- `Consume<TGasCost>` (void) became `UpdateGas<TGasCost>` (bool) with an `OutOfGas` short-circuit, matching master's own opcode idiom (`if (!TGasPolicy.UpdateGas<BaseGasCost>(ref gas)) return OutOfGas`, e.g. `EvmInstructions.ControlFlow.cs`). Base cost is charged before the opcode's only effect (the push), so the short-circuit is consensus-equivalent.
- `ConsumeStateGas` / `ConsumeStorageAccessGas` / `ConsumeAccountAccessGas` renamed to the `TryConsume*` family; those sites already checked the bool return.

## For review

The #13189 port touches consensus-critical frame opcode gas metering. The mapping is behavior-preserving by construction, but a frame-EVM owner review of the `Consume<T>` -> `UpdateGas<T>` short-circuit and the `OnFlag` depth-check choice is welcome.

## Types of changes

- [x] Housekeeping (merge / no functional change intended)

## Testing

- `Nethermind.slnx` release build: 0 warnings, 0 errors.
- `Nethermind.Evm.Test` frame/Eip8037/ReturnData/CodeCopy/TxParam subset: 616 passed, 0 failed.
- `Nethermind.Blockchain.Test` FrameTxBlockGas/TransactionsExecutor/FrameTx: 81 passed, 0 failed.
- `dotnet format whitespace` clean on the touched Evm project.
