### PR TITLE
refactor(rpc): tighten the over-long parameter guard and its test

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcServiceTests.cs
@@ -525,7 +525,7 @@ public class JsonRpcServiceTests
             ? TestRawRequest(ethRpcModule, "eth_getBlockByNumber", """["0x1b4",""]""")
             : TestRequest(ethRpcModule, "eth_getBlockByNumber", "0x1b4", ""));
 
-        ethRpcModule.Received().eth_getBlockByNumber(Arg.Any<BlockParameter>(), false);
+        ethRpcModule.Received().eth_getBlockByNumber(new BlockParameter(0x1b4), false);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcService.cs
@@ -464,9 +464,10 @@ public sealed class JsonRpcService(IRpcModuleProvider rpcModuleProvider, ILogMan
         int missingRequiredParameterIndex,
         ref int missingParamsCount)
     {
-        // The JSON element deserializer walks every provided element against expectedParameters, so an
-        // over-long request has to be rejected here rather than indexing past the end.
-        if (providedParametersLength > expectedParameters.Length || missingParamsCount < 0)
+        // Both paths funnel over-length here: the JSON element deserializer would otherwise index past
+        // expectedParameters, and the utf8 one signals the same shape by reporting a length of
+        // expectedParameters.Length + 1 rather than the true element count.
+        if (providedParametersLength > expectedParameters.Length)
         {
             return GetErrorResponse(methodName, ErrorCodes.InvalidParams, "Invalid params", null, in requestId);
         }


### PR DESCRIPTION
Follow-up to #13235, applying three low findings from its review that arrived after the merge. No behaviour change.

## Changes

- Drops the `|| missingParamsCount < 0` disjunct from `ValidateMissingParameters`. It is unreachable: the only producer of a negative count is the utf8 over-long branch, which also reports `providedParametersLength` as `expectedParameters.Length + 1`, so the length check always fires first. Keeping it hid which path signals over-length.
- Rewrites the guard's comment to state the sentinel contract that safety now rests on — the utf8 deserializer reports `expectedParameters.Length + 1` rather than a true element count, so a change reporting the real length there would silently defeat the guard.
- Tightens `Missing_marker_on_an_optional_argument_binds_its_default`: `Arg.Any<BlockParameter>()` also matched `null`, so argument 0 binding its (null) default instead of parsing `0x1b4` would have gone unnoticed — which is exactly the bug #13196 describes. It now asserts `new BlockParameter(0x1b4)`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

No new cases — one existing assertion is tightened.

I checked that the tightened matcher is not vacuous: swapping the expectation to `new BlockParameter(0x1b5)` fails both `[Values]` cases, so it now pins argument 0 and argument 1 independently.

`Nethermind.JsonRpc.Test` 1986 passed / 22 pre-existing skips.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
