### PR TITLE
Fix BAL fetcher after peer allocation disposal migration

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/BalFetcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/BalFetcherTests.cs
@@ -26,12 +26,20 @@ namespace Nethermind.Synchronization.Test.FastSync;
 
 public class BalFetcherTests
 {
+    public enum FetchOutcome
+    {
+        Success,
+        Failure,
+        Cancellation,
+    }
+
     private const int BlockCount = 300;
     private const int AllocateTimeoutMs = 5;
 
     private readonly Dictionary<ValueHash256, byte[]> _balByHash = [];
     private int _largestRequest;
     private int _responseLimit;
+    private int _disposedAllocations;
     private IBlockTree _blockTree = null!;
     private MemDb _balDb = null!;
     private BlockAccessListStore _balStore = null!;
@@ -44,6 +52,7 @@ public class BalFetcherTests
         _balByHash.Clear();
         _largestRequest = 0;
         _responseLimit = int.MaxValue;
+        _disposedAllocations = 0;
         _blockTree = Substitute.For<IBlockTree>();
         _balDb = new MemDb();
         _balStore = new BlockAccessListStore(_balDb);
@@ -92,7 +101,7 @@ public class BalFetcherTests
         BlockHeader from = Block(10, bal: null);
         BlockHeader b11 = Block(11, [0x01, 0x02]);
         _pool.Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(SyncPeerAllocation.FailedAllocation);
+            .Returns(new SyncPeerAllocation(AllocationContexts.State));
 
         bool result = await _fetcher.EnsureRange(from, b11, default);
 
@@ -100,6 +109,32 @@ public class BalFetcherTests
         Assert.That(_balStore.Exists(11, b11.Hash!), Is.False);
 
         await _pool.Received().Allocate(Arg.Any<IPeerAllocationStrategy>(), AllocationContexts.State, AllocateTimeoutMs, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Disposes_allocation_after_fetch([Values(FetchOutcome.Success, FetchOutcome.Failure, FetchOutcome.Cancellation)] FetchOutcome outcome)
+    {
+        BlockHeader from = Block(10, bal: null);
+        BlockHeader b11 = Block(11, [0x01, 0x02]);
+        PeerInfo peer = Snap2Peer(outcome);
+        AllocatePeer(peer);
+
+        if (outcome == FetchOutcome.Cancellation)
+        {
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await _fetcher.EnsureRange(from, b11, default));
+        }
+        else
+        {
+            bool result = await _fetcher.EnsureRange(from, b11, default);
+            Assert.That(result, Is.EqualTo(outcome == FetchOutcome.Success));
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            int expectedDisposals = outcome == FetchOutcome.Failure ? 50 : 1;
+            Assert.That(_disposedAllocations, Is.EqualTo(expectedDisposals));
+            Assert.That(peer.IsAllocated(AllocationContexts.State), Is.False);
+        }
     }
 
     [Test]
@@ -229,15 +264,24 @@ public class BalFetcherTests
 
     private void AllocatePeer(PeerInfo peer) =>
         _pool.Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(ci => new SyncPeerAllocation(peer, (AllocationContexts)ci[1]));
+            .Returns(ci =>
+            {
+                AllocationContexts contexts = ci.Arg<AllocationContexts>();
+                SyncPeerAllocation allocation = new(contexts, null, () => _disposedAllocations++);
+                allocation.AllocatePeer(peer);
+                return allocation;
+            });
 
-    private PeerInfo Snap2Peer()
+    private PeerInfo Snap2Peer(FetchOutcome outcome = FetchOutcome.Success)
     {
         ISnapSyncPeer snap = Substitute.For<ISnapSyncPeer>();
         snap.SnapProtocolVersion.Returns(SnapVersions.Snap2);
         snap.GetBlockAccessLists(Arg.Any<IReadOnlyList<ValueHash256>>(), Arg.Any<CancellationToken>())
             .Returns(ci =>
             {
+                if (outcome == FetchOutcome.Failure) throw new InvalidOperationException("fetch failed");
+                if (outcome == FetchOutcome.Cancellation) throw new OperationCanceledException();
+
                 IReadOnlyList<ValueHash256> requested = ci.Arg<IReadOnlyList<ValueHash256>>();
                 _largestRequest = Math.Max(_largestRequest, requested.Count);
                 int served = Math.Min(requested.Count, _responseLimit);

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/BalFetcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/BalFetcher.cs
@@ -69,15 +69,10 @@ public class BalFetcher(
                     return false;
                 }
 
-                SyncPeerAllocation allocation = await peerPool.Allocate(PeerStrategy, AllocationContexts.State, _allocateTimeoutMs, token);
                 int stored;
-                try
+                using (SyncPeerAllocation allocation = await peerPool.Allocate(PeerStrategy, AllocationContexts.State, _allocateTimeoutMs, token))
                 {
                     stored = allocation.Current is null ? 0 : await FetchFromPeer(allocation.Current, missing, token);
-                }
-                finally
-                {
-                    peerPool.Free(allocation);
                 }
 
                 if (stored == 0)


### PR DESCRIPTION
## Changes

Complete the migration from #13094 for the BAL-fetcher call sites added by #12945. `BalFetcher` still calls the removed `ISyncPeerPool.Free`, which breaks master builds and downstream PR builds.

Use a scoped allocation so the peer is released before retry bookkeeping, including when fetching throws or is cancelled. Update the BAL test allocation setup to the new API and cover success, failure and cancellation cleanup.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Release build of `Nethermind.Synchronization.Test`: 0 warnings, 0 errors. `BalFetcherTests`: 13/13 passed, including exact allocation-disposal counts on success, repeated failure and cancellation. `PeerInfoAllocationTests`: 30/30 passed. `git diff --check` passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
