### PR TITLE
test(eip8141): sweep attempts-per-head (M) alongside K_retry

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
@@ -103,9 +103,9 @@ public class FrameTxProducerRetryMeasurement
             .Op(Instruction.APPROVE)
             .Done;
 
-    [TestCase(true, 236_285ul, TestName = "control: a prefix that approves is included and paid for")]
+    [TestCase(true, 322_800ul, TestName = "control: a prefix that approves is included and paid for")]
     [TestCase(false, 300_000ul, TestName = "never approves, at the default MAX_VERIFY_GAS")]
-    [TestCase(false, 236_285ul, TestName = "never approves, at a measured private-pool prefix")]
+    [TestCase(false, 322_800ul, TestName = "never approves, at a measured private-pool prefix")]
     public async Task ProducerRetriesAFailingPrefix(bool approves, ulong verifyGas)
     {
         await BuildChain(approves ? Approves() : NeverApproves());
@@ -182,7 +182,7 @@ public class FrameTxProducerRetryMeasurement
 
     private static IEnumerable<TestCaseData> RetryCases()
     {
-        foreach (ulong verifyGas in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 500_000ul })
+        foreach (ulong verifyGas in new ulong[] { 100_000ul, 300_000ul, 322_800ul, 500_000ul })
         {
             foreach (int kRetry in new int[] { 1, 2, 4, 8 })
             {
@@ -198,6 +198,83 @@ public class FrameTxProducerRetryMeasurement
     [TestCaseSource(nameof(RetryCases))]
     public async Task ProducerRetriesAreBoundedByKRetry(ulong verifyGas, int kRetry)
     {
+        (int blocksOffered, int attempts, _, ulong firstBurn, ulong burned, UInt256 beneficiaryDelta) =
+            await RunNeverApprovingSweep(verifyGas, kRetry, mPerHead: 1, attemptCap: kRetry);
+
+        Emit($"case=k_retry_sweep k_retry={kRetry} budget={verifyGas} "
+             + $"blocks_offered={blocksOffered} execution_attempts={attempts} "
+             + $"burn_first_attempt={firstBurn} burn_total={burned} "
+             + $"amplification={(firstBurn == 0 ? 0 : (double)burned / firstBurn):F2} "
+             + $"beneficiary_delta={beneficiaryDelta}");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(attempts, Is.EqualTo(kRetry),
+                "the producer must re-execute the prefix exactly K_retry times before the pool evicts it");
+            Assert.That(firstBurn, Is.GreaterThan((ulong)(verifyGas * BudgetBurnFloor)),
+                "each attempt must burn the whole verification budget, or the amplification is measured against the wrong unit");
+            Assert.That(burned, Is.GreaterThan((ulong)(firstBurn * (ulong)kRetry * BudgetBurnFloor)),
+                "total unpaid burn must scale with K_retry, which is the quantity this sweep exists to report");
+            Assert.That(beneficiaryDelta, Is.EqualTo(UInt256.Zero),
+                "the work was paid for after all, so it is not unpaid burn");
+        }
+    }
+
+    /// <summary>
+    /// Measures unpaid verification burn as a function of both K_retry (distinct chain heads survived)
+    /// and M (production attempts spent against the same head before it advances).
+    /// </summary>
+    /// <remarks>
+    /// The pool's eviction budget counts one unit per distinct chain head, not per production attempt:
+    /// repeated attempts against an unchanged head are free until the head advances, so total unpaid
+    /// burn scales with K_retry times M, not K_retry alone. M is a modelled sweep input here, not a
+    /// measured one. At <c>kRetry == 1</c>, M has no effect (eviction happens on the first attempt
+    /// regardless), so those rows are a documented control rather than a distinct measurement.
+    /// </remarks>
+    [Test]
+    public async Task ProducerRetriesAreBoundedByKRetryAndAttemptsPerHead(
+        [Values(1, 2, 4, 8)] int kRetry,
+        [Values(1, 8, 32, 128)] int mPerHead)
+    {
+        const ulong verifyGas = 300_000ul;
+        // (kRetry - 1) full heads of mPerHead free attempts each, plus one attempt on the head that
+        // brings the failed-heads tally to kRetry and evicts.
+        int attemptCap = (kRetry - 1) * mPerHead + 1;
+
+        (int blocksOffered, int attempts, int headsFailed, ulong firstBurn, ulong burned, UInt256 beneficiaryDelta) =
+            await RunNeverApprovingSweep(verifyGas, kRetry, mPerHead, attemptCap);
+
+        Emit($"case=k_retry_two_axis k_retry={kRetry} m_per_head={mPerHead} m_basis=modelled budget={verifyGas} "
+             + $"blocks_offered={blocksOffered} execution_attempts={attempts} "
+             + $"burn_first_attempt={firstBurn} burn_total={burned} "
+             + $"amplification={(firstBurn == 0 ? 0 : (double)burned / firstBurn):F2} "
+             + $"beneficiary_delta={beneficiaryDelta}");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(headsFailed, Is.EqualTo(kRetry),
+                "the transaction must fail on exactly K_retry distinct heads before eviction");
+            Assert.That(blocksOffered, Is.EqualTo(attemptCap),
+                "total attempts must equal (K_retry - 1) full heads of M attempts plus one on the evicting head");
+            Assert.That(attempts, Is.EqualTo(blocksOffered),
+                "the producer must re-execute the prefix once per attempt, regardless of which head it targets");
+            Assert.That(firstBurn, Is.GreaterThan((ulong)(verifyGas * BudgetBurnFloor)),
+                "each attempt must burn the whole verification budget, or the amplification is measured against the wrong unit");
+            Assert.That(burned, Is.GreaterThan((ulong)(firstBurn * (ulong)blocksOffered * BudgetBurnFloor)),
+                "total unpaid burn must scale with attempts, which is K_retry times M, not K_retry alone");
+            Assert.That(beneficiaryDelta, Is.EqualTo(UInt256.Zero),
+                "the work was paid for after all, so it is not unpaid burn");
+        }
+    }
+
+    /// <summary>
+    /// Runs a never-approving frame tx through repeated production attempts against a modelled
+    /// per-head eviction budget, until the pool evicts it. Shared by both sweeps above; the single-axis
+    /// sweep is the case <paramref name="mPerHead"/> == 1.
+    /// </summary>
+    private async Task<(int BlocksOffered, int Attempts, int HeadsFailed, ulong FirstBurn, ulong Burned, UInt256 BeneficiaryDelta)>
+        RunNeverApprovingSweep(ulong verifyGas, int kRetry, int mPerHead, int attemptCap)
+    {
         await BuildChain(NeverApproves());
 
         CountingAdapter adapter = new(new BuildUpTransactionProcessorAdapter(_transactionProcessor));
@@ -205,11 +282,22 @@ public class FrameTxProducerRetryMeasurement
         IBlockAccessListManager balManager = Substitute.For<IBlockAccessListManager>();
         balManager.Enabled.Returns(false);
 
-        // Stands in for the pool's eviction decision: the transaction survives kRetry failed attempts and is
-        // evicted on the kRetry-th, which is what the plan's K_retry counts.
-        int evictionRequests = 0;
+        // Reproduces the pool's real per-head bookkeeping: the failed-heads tally advances only the
+        // first time a given head generation is seen, so repeated attempts against the same head spend
+        // no further budget.
+        long headGeneration = 0;
+        long lastCountedGeneration = -1;
+        int headsFailed = 0;
         ITxPool txPool = Substitute.For<ITxPool>();
-        txPool.EvictTransaction(Arg.Any<Transaction>()).Returns(_ => ++evictionRequests >= kRetry);
+        txPool.EvictTransaction(Arg.Any<Transaction>()).Returns(_ =>
+        {
+            if (lastCountedGeneration != headGeneration)
+            {
+                lastCountedGeneration = headGeneration;
+                headsFailed++;
+            }
+            return headsFailed >= kRetry;
+        });
 
         BlockProcessor.BlockProductionTransactionsExecutor executor =
             new(adapter, _stateProvider, picker, LimboLogs.Instance, balManager, txPool);
@@ -217,11 +305,12 @@ public class FrameTxProducerRetryMeasurement
         Transaction tx = FrameTx(verifyGas);
         UInt256 beneficiaryBefore = _stateProvider.GetBalance(Beneficiary);
 
+        int attemptsAtCurrentHead = 0;
         int blocksOffered = 0;
-        for (int i = 0; i < Attempts && evictionRequests < kRetry; i++)
+        while (blocksOffered < attemptCap && headsFailed < kRetry)
         {
             Block block = Build.A.Block
-                .WithNumber(1 + i)
+                .WithNumber(1 + blocksOffered)
                 .WithBaseFeePerGas(UInt256.Zero)
                 .WithBeneficiary(Beneficiary)
                 .WithGasLimit(BlockGasLimit)
@@ -235,10 +324,17 @@ public class FrameTxProducerRetryMeasurement
             executor.ProcessTransactions(block, ProcessingOptions.ProducingBlock, receiptsTracer, CancellationToken.None);
             receiptsTracer.EndBlockTrace();
             blocksOffered++;
+            attemptsAtCurrentHead++;
 
             if (block.Header.TxRoot != Keccak.EmptyTreeHash)
             {
-                Assert.Fail($"a prefix that never approves was built into block {1 + i}");
+                Assert.Fail($"a prefix that never approves was built into block {blocksOffered}");
+            }
+
+            if (attemptsAtCurrentHead >= mPerHead)
+            {
+                headGeneration++;
+                attemptsAtCurrentHead = 0;
             }
         }
 
@@ -246,23 +342,8 @@ public class FrameTxProducerRetryMeasurement
         foreach (ulong b in adapter.BurnedPerAttempt) burned += b;
         ulong firstBurn = adapter.BurnedPerAttempt.Count > 0 ? adapter.BurnedPerAttempt[0] : 0;
 
-        Emit($"case=k_retry_sweep k_retry={kRetry} budget={verifyGas} "
-             + $"blocks_offered={blocksOffered} execution_attempts={adapter.Attempts} "
-             + $"burn_first_attempt={firstBurn} burn_total={burned} "
-             + $"amplification={(firstBurn == 0 ? 0 : (double)burned / firstBurn):F2} "
-             + $"beneficiary_delta={_stateProvider.GetBalance(Beneficiary) - beneficiaryBefore}");
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(adapter.Attempts, Is.EqualTo(kRetry),
-                "the producer must re-execute the prefix exactly K_retry times before the pool evicts it");
-            Assert.That(firstBurn, Is.GreaterThan((ulong)(verifyGas * BudgetBurnFloor)),
-                "each attempt must burn the whole verification budget, or the amplification is measured against the wrong unit");
-            Assert.That(burned, Is.GreaterThan((ulong)(firstBurn * (ulong)kRetry * BudgetBurnFloor)),
-                "total unpaid burn must scale with K_retry, which is the quantity this sweep exists to report");
-            Assert.That(_stateProvider.GetBalance(Beneficiary) - beneficiaryBefore, Is.EqualTo(UInt256.Zero),
-                "the work was paid for after all, so it is not unpaid burn");
-        }
+        return (blocksOffered, adapter.Attempts, headsFailed, firstBurn, burned,
+            _stateProvider.GetBalance(Beneficiary) - beneficiaryBefore);
     }
 
     private static Transaction FrameTx(ulong verifyGas)


### PR DESCRIPTION
## Stacked on and blocked by #13258

~~This targets `daniil/frame-evict-kretry`~~ Retargeted to `eip8141-frame-txs-devnet7` now that #13258 merged.

## Why

`ProducerRetriesAreBoundedByKRetry` has always assumed one build attempt spends one retry-budget unit. #13258 makes eviction count distinct chain heads instead: repeated attempts against an unchanged head are free until the head advances. That means unpaid burn scales with `K_retry × M` (M = attempts spent per head before it advances), not `K_retry` alone — and M is not small: the payload-improvement loop's rebuild cadence can plausibly produce tens-to-100+ same-head attempts in a slot's tail.

## What this adds

`ProducerRetriesAreBoundedByKRetryAndAttemptsPerHead`, sweeping `K_retry ∈ {1,2,4,8}` against a modelled `m_per_head ∈ {1,8,32,128}` at a fixed budget. `m_per_head=1` reproduces the old test's implicit assumption; `m_per_head=128` shows the old model understates real unpaid burn by up to ~112x at K_retry=8 (8x assumed vs. 897x actual attempts). At `kRetry == 1` the M axis is inert (eviction happens on the first attempt regardless), so those four rows are a documented control, not a distinct measurement — the row now emits `m_effective` to make that explicit rather than relying on the docstring alone.

**Scope-down, stated plainly:** this reproduces the eviction budget's head-keyed bookkeeping algorithm directly (a local head-generation counter matching the real one's semantics) rather than driving a real `TxPool`. Wiring a real pool into this fixture needs chain-head-info and comparer plumbing this test project doesn't otherwise carry, and the algorithm's own correctness is #13258's own regression test's job, not this harness's — this harness only needs the externally observable behavior to drive a real burn measurement. The mechanism it models (`TrySpendEvictionRetry`/`_frameEvictionAttempts` in `TxPool.cs`) is real production code, gated behind `FrameTxEvictionRetryBudget > 1`; that config defaults to `1`, so under shipped defaults `attemptCap` is `1` and the whole M axis is inert today. The 897-attempt / ~112x headline is what an operator raising that budget to 8 would see, not current default behavior — which is itself a solid argument for keeping the default at `1`.

`amplification` in both sweeps is a closed form of `(kRetry, mPerHead)`, not an independent measurement (per-attempt burn is deterministic) — both emit `amplification_basis=closed_form`, and `k_basis=modelled`/`m_basis=modelled` mark the two swept inputs to the same substitute mock.

Test-only, no production code. 39/39 passing in the fixture (3 + 20 + 16).