### PR TITLE
Dispose the pooled lists that trie path recovery abandons

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Tasks/WaitAnyWhereTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Tasks/WaitAnyWhereTests.cs
@@ -67,17 +67,32 @@ public class WaitAnyWhereTests
 
         Disposable result = await Wait.AnyWhere(r => r is not null, Task.FromResult(winner), pending.Task);
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(result, Is.SameAs(winner));
-            Assert.That(straggler.Disposed, Is.False);
-        });
+        Assert.That(result, Is.SameAs(winner));
 
         // The straggler produces its result only after the winner has already been forwarded.
         pending.SetResult(straggler);
 
         Assert.That(() => straggler.Disposed, Is.True.After(1000, 10));
         Assert.That(winner.Disposed, Is.False);
+    }
+
+    [Test]
+    public void Result_of_a_task_abandoned_by_a_failure_is_disposed()
+    {
+        Disposable straggler = new();
+        TaskCompletionSource<Disposable> pending = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<Disposable> anyWhere = Wait.AnyWhere(
+            r => r is not null,
+            Task.FromException<Disposable>(new InvalidOperationException()),
+            pending.Task);
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => anyWhere);
+
+        // The straggler produces its result only after the failure has already unwound the call.
+        pending.SetResult(straggler);
+
+        Assert.That(() => straggler.Disposed, Is.True.After(1000, 10));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Tasks/WaitAnyWhereTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Tasks/WaitAnyWhereTests.cs
@@ -77,22 +77,60 @@ public class WaitAnyWhereTests
     }
 
     [Test]
-    public void Result_of_a_task_abandoned_by_a_failure_is_disposed()
+    public void Result_of_a_task_abandoned_by_a_failure_is_disposed([Values] bool cancelled)
     {
         Disposable straggler = new();
         TaskCompletionSource<Disposable> pending = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        Task<Disposable> failed = cancelled
+            ? Task.FromCanceled<Disposable>(new CancellationToken(true))
+            : Task.FromException<Disposable>(new InvalidOperationException());
         Task<Disposable> anyWhere = Wait.AnyWhere(
             r => r is not null,
-            Task.FromException<Disposable>(new InvalidOperationException()),
+            failed,
             pending.Task);
 
-        Assert.ThrowsAsync<InvalidOperationException>(() => anyWhere);
+        Assert.ThrowsAsync(cancelled ? typeof(TaskCanceledException) : typeof(InvalidOperationException), () => anyWhere);
 
         // The straggler produces its result only after the failure has already unwound the call.
         pending.SetResult(straggler);
 
         Assert.That(() => straggler.Disposed, Is.True.After(1000, 10));
+    }
+
+    [Test]
+    public void Throwing_predicate_disposes_current_and_abandoned_results()
+    {
+        Disposable current = new();
+        Disposable straggler = new();
+        TaskCompletionSource<Disposable> pending = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Task<Disposable> anyWhere = Wait.AnyWhere(
+            _ => throw new InvalidOperationException(), Task.FromResult(current), pending.Task);
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => anyWhere);
+        Assert.That(current.Disposed, Is.True);
+
+        pending.SetResult(straggler);
+
+        Assert.That(() => straggler.Disposed, Is.True.After(1000, 10));
+    }
+
+    [Test]
+    public async Task Disposable_results_typed_as_object_are_disposed([Values] bool rejected)
+    {
+        Disposable discarded = new();
+        object accepted = new();
+        TaskCompletionSource<object> pending = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (rejected) pending.SetResult(discarded);
+
+        object result = await Wait.AnyWhere(
+            r => ReferenceEquals(r, accepted), pending.Task, Task.FromResult(accepted));
+
+        Assert.That(result, Is.SameAs(accepted));
+        if (!rejected) pending.SetResult(discarded);
+
+        Assert.That(() => discarded.Disposed, Is.True.After(1000, 10));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Core.Test/Tasks/WaitAnyWhereTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Tasks/WaitAnyWhereTests.cs
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Core.Tasks;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test.Tasks;
+
+public class WaitAnyWhereTests
+{
+    [Test]
+    public async Task Forwarded_result_is_left_to_the_caller()
+    {
+        Disposable forwarded = new();
+
+        Disposable result = await Wait.AnyWhere(r => r is not null, Task.FromResult(forwarded));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(forwarded));
+            Assert.That(forwarded.Disposed, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Rejected_result_is_disposed()
+    {
+        Disposable rejected = new();
+        Disposable accepted = new();
+
+        Disposable result = await Wait.AnyWhere(
+            r => ReferenceEquals(r, accepted),
+            Task.FromResult(rejected),
+            Task.FromResult(accepted));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(accepted));
+            Assert.That(rejected.Disposed, Is.True);
+            Assert.That(accepted.Disposed, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Last_rejected_result_is_forwarded_undisposed()
+    {
+        Disposable onlyResult = new();
+
+        Disposable result = await Wait.AnyWhere(_ => false, Task.FromResult(onlyResult));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(onlyResult));
+            Assert.That(onlyResult.Disposed, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task Result_of_a_task_abandoned_in_flight_is_disposed()
+    {
+        Disposable winner = new();
+        Disposable straggler = new();
+        TaskCompletionSource<Disposable> pending = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Disposable result = await Wait.AnyWhere(r => r is not null, Task.FromResult(winner), pending.Task);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.SameAs(winner));
+            Assert.That(straggler.Disposed, Is.False);
+        });
+
+        // The straggler produces its result only after the winner has already been forwarded.
+        pending.SetResult(straggler);
+
+        Assert.That(() => straggler.Disposed, Is.True.After(1000, 10));
+        Assert.That(winner.Disposed, Is.False);
+    }
+
+    [Test]
+    public async Task Non_disposable_results_are_forwarded_unchanged()
+    {
+        byte[] accepted = [1];
+
+        byte[]? result = await Wait.AnyWhere(
+            r => r is not null,
+            Task.FromResult<byte[]?>(null),
+            Task.FromResult<byte[]?>(accepted));
+
+        Assert.That(result, Is.SameAs(accepted));
+    }
+
+    private sealed class Disposable : IDisposable
+    {
+        private int _disposeCount;
+
+        public bool Disposed => Volatile.Read(ref _disposeCount) > 0;
+
+        public void Dispose() => Interlocked.Increment(ref _disposeCount);
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Tasks/Wait.cs
+++ b/src/Nethermind/Nethermind.Core/Tasks/Wait.cs
@@ -34,6 +34,7 @@ public static class Wait
                 Task<T> resolved = await Task.WhenAny<T>(taskSet);
                 T result = await resolved;
 
+                // Kept in the set until forwarded, so a throwing `cond` still discards this result.
                 if (cond(result) || taskSet.Count == 1)
                 {
                     taskSet.Remove(resolved);

--- a/src/Nethermind/Nethermind.Core/Tasks/Wait.cs
+++ b/src/Nethermind/Nethermind.Core/Tasks/Wait.cs
@@ -20,40 +20,36 @@ public static class Wait
     /// <returns></returns>
     /// <remarks>
     /// Only the forwarded result reaches the caller; every other result stays owned by this method.
-    /// When <typeparamref name="T"/> is <see cref="IDisposable"/> those results are disposed — one
-    /// rejected by <paramref name="cond"/> as soon as it is seen, and the results of the tasks still
-    /// in flight once a result is forwarded once they complete. Forwarding does not wait for those,
-    /// so their disposal happens after this method returns.
+    /// Results implementing <see cref="IDisposable"/> are disposed when rejected by <paramref name="cond"/>.
+    /// Tasks abandoned on return or failure have their results disposed when they complete.
+    /// This method does not wait for abandoned tasks, so their disposal may happen after it returns.
     /// </remarks>
     public static async Task<T> AnyWhere<T>(Func<T, bool> cond, params IEnumerable<Task<T>> tasks)
     {
         HashSet<Task<T>> taskSet = [.. tasks];
-        while (taskSet.Count != 0)
+        try
         {
-            Task<T> resolved = await Task.WhenAny<T>(taskSet);
-            taskSet.Remove(resolved);
-
-            T result = await resolved;
-
-            if (cond(result))
+            while (taskSet.Count != 0)
             {
-                // Its ok, then immediately return.
-                DiscardRemaining(taskSet);
-                return result;
+                Task<T> resolved = await Task.WhenAny<T>(taskSet);
+                T result = await resolved;
+
+                if (cond(result) || taskSet.Count == 1)
+                {
+                    taskSet.Remove(resolved);
+                    return result;
+                }
+
+                taskSet.Remove(resolved);
+                Discard(result);
             }
 
-            if (taskSet.Count == 0)
-            {
-                // No more tasks, just return the last one.
-                return result;
-            }
-
-            Discard(result);
-
-            // Otherwise, we try WhenAny again.
+            throw new UnreachableException();
         }
-
-        throw new UnreachableException();
+        finally
+        {
+            DiscardRemaining(taskSet);
+        }
     }
 
     private static void Discard<T>(T result)
@@ -63,8 +59,6 @@ public static class Wait
 
     private static void DiscardRemaining<T>(HashSet<Task<T>> tasks)
     {
-        if (!typeof(IDisposable).IsAssignableFrom(typeof(T))) return;
-
         foreach (Task<T> task in tasks)
         {
             _ = task.ContinueWith(static abandoned =>

--- a/src/Nethermind/Nethermind.Core/Tasks/Wait.cs
+++ b/src/Nethermind/Nethermind.Core/Tasks/Wait.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nethermind.Core.Tasks;
@@ -17,6 +18,13 @@ public static class Wait
     /// <param name="tasks"></param>
     /// <typeparam name="T"></typeparam>
     /// <returns></returns>
+    /// <remarks>
+    /// Only the forwarded result reaches the caller; every other result stays owned by this method.
+    /// When <typeparamref name="T"/> is <see cref="IDisposable"/> those results are disposed — one
+    /// rejected by <paramref name="cond"/> as soon as it is seen, and the results of the tasks still
+    /// in flight once a result is forwarded once they complete. Forwarding does not wait for those,
+    /// so their disposal happens after this method returns.
+    /// </remarks>
     public static async Task<T> AnyWhere<T>(Func<T, bool> cond, params IEnumerable<Task<T>> tasks)
     {
         HashSet<Task<T>> taskSet = [.. tasks];
@@ -30,6 +38,7 @@ public static class Wait
             if (cond(result))
             {
                 // Its ok, then immediately return.
+                DiscardRemaining(taskSet);
                 return result;
             }
 
@@ -39,9 +48,31 @@ public static class Wait
                 return result;
             }
 
+            Discard(result);
+
             // Otherwise, we try WhenAny again.
         }
 
         throw new UnreachableException();
+    }
+
+    private static void Discard<T>(T result)
+    {
+        if (result is IDisposable disposable) disposable.Dispose();
+    }
+
+    private static void DiscardRemaining<T>(HashSet<Task<T>> tasks)
+    {
+        if (!typeof(IDisposable).IsAssignableFrom(typeof(T))) return;
+
+        foreach (Task<T> task in tasks)
+        {
+            _ = task.ContinueWith(static abandoned =>
+            {
+                if (abandoned.IsCompletedSuccessfully) Discard(abandoned.Result);
+                // Observe a failure too, so abandoning it does not raise UnobservedTaskException.
+                else _ = abandoned.Exception;
+            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
@@ -131,15 +131,14 @@ public class RecoveryTests
     }
 
     [Test]
-    public async Task cannot_recover_eth66_partial_path()
+    public void cannot_recover_eth66_partial_path()
     {
         // The first node resolves and is collected, then its child is unavailable, so the walk gives up mid-path.
         TrieNode extension = new(new ExtensionData { Key = [3], Value = TestItem.KeccakB });
         _returnedRlp = extension.RlpEncode(Substitute.For<ITrieNodeResolver>(), ref _path).ToArray()!;
         _hash = Keccak.Compute(_returnedRlp);
 
-        IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_nodeDataDataRecovery, _peerEth66);
-        Assert.That(response, Is.Null);
+        AssertFailedRecoveryReturnsBuffer(_nodeDataDataRecovery, _peerEth66);
     }
 
     [Test]
@@ -175,12 +174,11 @@ public class RecoveryTests
     }
 
     [Test]
-    public async Task cannot_recover_eth67_unassemblable_proofs()
+    public void cannot_recover_eth67_unassemblable_proofs()
     {
         // Proofs that hash to nothing on the queried path leave the assembled node list empty.
         _returnedRlp = [5, 6, 7];
-        IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_snapRecovery, _peerEth67);
-        Assert.That(response, Is.Null);
+        AssertFailedRecoveryReturnsBuffer(_snapRecovery, _peerEth67);
     }
 
     [Test]
@@ -190,6 +188,31 @@ public class RecoveryTests
             .Returns(_ => Task.FromResult<IByteArrayList>(new ByteArrayListAdapter(new ArrayPoolList<byte[]>(1) { new byte[] { 5, 6, 7 } })));
         IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_nodeDataDataRecovery, _peerEth67);
         Assert.That(response, Is.Null);
+    }
+
+    private void AssertFailedRecoveryReturnsBuffer(IPathRecovery recovery, PeerInfo peer)
+    {
+        (TreePath, byte[])[] expected = SafeArrayPool<(TreePath, byte[])>.Shared.Rent(1);
+        SafeArrayPool<(TreePath, byte[])>.Shared.Return(expected);
+
+        Task<IOwnedReadOnlyList<(TreePath, byte[])>?> task = Recover(recovery, peer);
+        // Completed mocks keep all rentals on this thread, where the pool reuses its last returned array.
+        Assert.That(task.IsCompletedSuccessfully, Is.True);
+        using IOwnedReadOnlyList<(TreePath, byte[])>? response = task.GetAwaiter().GetResult();
+
+        (TreePath, byte[])[] actual = SafeArrayPool<(TreePath, byte[])>.Shared.Rent(1);
+        try
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(response, Is.Null);
+                Assert.That(actual, Is.SameAs(expected), "Recovery must return its rented node buffer.");
+            }
+        }
+        finally
+        {
+            SafeArrayPool<(TreePath, byte[])>.Shared.Return(actual);
+        }
     }
 
     private Task<IOwnedReadOnlyList<(TreePath, byte[])>?> Recover(IPathRecovery recovery, params PeerInfo[] peers)

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
@@ -163,6 +163,15 @@ public class RecoveryTests
     }
 
     [Test]
+    public async Task cannot_recover_eth67_unassemblable_proofs()
+    {
+        // Proofs that hash to nothing on the queried path leave the assembled node list empty.
+        _returnedRlp = [5, 6, 7];
+        IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_snapRecovery, _peerEth67);
+        Assert.That(response, Is.Null);
+    }
+
+    [Test]
     public async Task cannot_recover_eth67_hash_mismatch()
     {
         _snapSyncPeer.GetTrieNodes(Arg.Any<GetTrieNodesRequest>(), Arg.Any<CancellationToken>())

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
@@ -131,14 +131,15 @@ public class RecoveryTests
     }
 
     [Test]
-    public void cannot_recover_eth66_partial_path()
+    public async Task cannot_recover_eth66_partial_path()
     {
         // The first node resolves and is collected, then its child is unavailable, so the walk gives up mid-path.
         TrieNode extension = new(new ExtensionData { Key = [3], Value = TestItem.KeccakB });
         _returnedRlp = extension.RlpEncode(Substitute.For<ITrieNodeResolver>(), ref _path).ToArray()!;
         _hash = Keccak.Compute(_returnedRlp);
 
-        AssertFailedRecoveryReturnsBuffer(_nodeDataDataRecovery, _peerEth66);
+        IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_nodeDataDataRecovery, _peerEth66);
+        Assert.That(response, Is.Null);
     }
 
     [Test]
@@ -174,11 +175,12 @@ public class RecoveryTests
     }
 
     [Test]
-    public void cannot_recover_eth67_unassemblable_proofs()
+    public async Task cannot_recover_eth67_unassemblable_proofs()
     {
         // Proofs that hash to nothing on the queried path leave the assembled node list empty.
         _returnedRlp = [5, 6, 7];
-        AssertFailedRecoveryReturnsBuffer(_snapRecovery, _peerEth67);
+        IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_snapRecovery, _peerEth67);
+        Assert.That(response, Is.Null);
     }
 
     [Test]
@@ -188,31 +190,6 @@ public class RecoveryTests
             .Returns(_ => Task.FromResult<IByteArrayList>(new ByteArrayListAdapter(new ArrayPoolList<byte[]>(1) { new byte[] { 5, 6, 7 } })));
         IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_nodeDataDataRecovery, _peerEth67);
         Assert.That(response, Is.Null);
-    }
-
-    private void AssertFailedRecoveryReturnsBuffer(IPathRecovery recovery, PeerInfo peer)
-    {
-        (TreePath, byte[])[] expected = SafeArrayPool<(TreePath, byte[])>.Shared.Rent(1);
-        SafeArrayPool<(TreePath, byte[])>.Shared.Return(expected);
-
-        Task<IOwnedReadOnlyList<(TreePath, byte[])>?> task = Recover(recovery, peer);
-        // Completed mocks keep all rentals on this thread, where the pool reuses its last returned array.
-        Assert.That(task.IsCompletedSuccessfully, Is.True);
-        using IOwnedReadOnlyList<(TreePath, byte[])>? response = task.GetAwaiter().GetResult();
-
-        (TreePath, byte[])[] actual = SafeArrayPool<(TreePath, byte[])>.Shared.Rent(1);
-        try
-        {
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(response, Is.Null);
-                Assert.That(actual, Is.SameAs(expected), "Recovery must return its rented node buffer.");
-            }
-        }
-        finally
-        {
-            SafeArrayPool<(TreePath, byte[])>.Shared.Return(actual);
-        }
     }
 
     private Task<IOwnedReadOnlyList<(TreePath, byte[])>?> Recover(IPathRecovery recovery, params PeerInfo[] peers)

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
@@ -131,6 +131,18 @@ public class RecoveryTests
     }
 
     [Test]
+    public async Task cannot_recover_eth66_partial_path()
+    {
+        // The first node resolves and is collected, then its child is unavailable, so the walk gives up mid-path.
+        TrieNode extension = new(new ExtensionData { Key = [3], Value = TestItem.KeccakB });
+        _returnedRlp = extension.RlpEncode(Substitute.For<ITrieNodeResolver>(), ref _path).ToArray()!;
+        _hash = Keccak.Compute(_returnedRlp);
+
+        IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_nodeDataDataRecovery, _peerEth66);
+        Assert.That(response, Is.Null);
+    }
+
+    [Test]
     public async Task can_recover_eth67()
     {
         IOwnedReadOnlyList<(TreePath, byte[])>? response = await Recover(_snapRecovery, _peerEth67);

--- a/src/Nethermind/Nethermind.Synchronization/Trie/NodeDataRecovery.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/NodeDataRecovery.cs
@@ -58,6 +58,7 @@ public class NodeDataRecovery(ISyncPeerPool peerPool, INodeStorage nodeStorage, 
             if (nodeRlp is null)
             {
                 if (_logger.IsDebug) _logger.Debug($"Failed to fetch complete path when recovering {fullPath}. Fetched nodes: {recoveredNodes.Count}.");
+                recoveredNodes.Dispose();
                 return null;
             }
 

--- a/src/Nethermind/Nethermind.Synchronization/Trie/SnapRangeRecovery.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Trie/SnapRangeRecovery.cs
@@ -237,6 +237,7 @@ public class SnapRangeRecovery(ISyncPeerPool peerPool, ILogManager logManager) :
 
         if (result.Count == 0)
         {
+            result.Dispose();
             return null;
         }
         return result;


### PR DESCRIPTION
## Changes

Pooled-array leaks in trie path recovery, all pre-existing on `master` and found while reviewing #9417.

- **`Wait.AnyWhere` never released the results it didn't forward.** It hands one result to the caller and owns every other one, but dropped them. Two of its three callers pass an `IOwnedReadOnlyList`, so each attempt that lost the race leaked its pooled array — the three concurrent snap attempts in `SnapRangeRecovery.Recover`, and the node-data/snap pair in `PathNodeRecovery.Recover`. The loop now sits in a `try`/`finally` whose `finally` attaches a disposing continuation to every task still in the set, and the resolved task is removed from that set only on the path that forwards it. One shape covers all three exits:
  - a result rejected by the predicate is disposed as soon as it is seen;
  - a result is forwarded and the tasks still in flight are disposed once they complete;
  - the awaited task faults or is cancelled, or the predicate itself throws — the caller sees nothing, so everything left in the set is disposed, the resolved task included.

  Forwarding still doesn't wait on the in-flight tasks, so that disposal is asynchronous — documented in `<remarks>`. `NodeDataRecovery` passes `byte[]` and is unaffected by the disposal, though it now benefits from the exception observation.
- **`NodeDataRecovery.Recover` dropped `recoveredNodes` when the path ran out mid-walk.** Returned to the pool before returning `null`.
- **`SnapRangeRecovery.AssembleResponse` dropped its `ArrayPoolList` on the `Count == 0` path.** Same one-line fix.

On the two rental fixes, [`robustness.md`](../blob/master/.agents/rules/robustness.md) scopes the "abandoned array stays GC-reclaimable" exemption to bare `ArrayPool<T>.Shared` and explicitly excludes `ArrayPoolList<T>`. Both are expected failure paths rather than aborted operations, so the rentals are returned inline — no `try`/`finally` added.

`DiscardRemaining` no longer skips non-disposable `T`. `Discard` tests the runtime value and the static guard tested the type parameter, so the two disagreed for a `T` the signature gives no hint about (`object`, or a non-disposable interface with disposable implementations). Dropping the guard makes them agree by construction, and it means a `byte[]` caller's abandoned failures are observed rather than left to surface as `UnobservedTaskException`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`WaitAnyWhereTests` — 8 cases. Four of them fail on `master` and pass here, which is the point:

| case | on `master` |
|---|---|
| `Rejected_result_is_disposed` | `Expected: True, But was: False` |
| `Result_of_a_task_abandoned_in_flight_is_disposed` | `Expected: True, But was: False` |
| `Result_of_a_task_abandoned_by_a_failure_is_disposed(cancelled)` | `Expected: True, But was: False` |
| `Throwing_predicate_disposes_current_and_abandoned_results` | `Expected: True, But was: False` |

`Disposable_results_typed_as_object_are_disposed(rejected)` pins the `T` = `object` case that the dropped static guard used to leak. The remaining three pin what must *not* change: the forwarded result reaches the caller undisposed, a last rejected result is still forwarded undisposed (the caller owns it), and non-disposable `T` is forwarded untouched.

`cannot_recover_eth66_partial_path` and `cannot_recover_eth67_unassemblable_proofs` cover the two early returns, neither of which an existing test reached. Verified by mutation: throwing at the `NodeDataRecovery` branch when `recoveredNodes.Count > 0` fails the first case and only it, so nothing else walked past the first node; returning the empty list instead of `null` from `AssembleResponse` fails the second and only it.

Both pin the return contract, not the disposal. I did write a version asserting the rentals came back, by renting from `SafeArrayPool` before and after and comparing identity, and dropped it: both recoveries run their attempts concurrently and `AnyWhere` disposes the losers from continuations, so those returns race the assertion — it failed locally on both cases. Making the rentals observable properly needs an injected pool, which is more surface area than these one-line fixes are worth.

Full suites: `Nethermind.Core.Test` (6108) and `Nethermind.Synchronization.Test` (2191) green.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The `DiscardRemaining` continuation also observes a faulted abandoned task's exception, so abandoning one can't surface later as an `UnobservedTaskException`. I did write a test for that and then dropped it — it needed a GC + finalizer round to force the event, which is exactly the kind of timing-dependent test that turns flaky in CI.

`AnyWhere` disposes by runtime type check rather than a `where T : IDisposable` constraint or an opt-in callback, because `NodeDataRecovery` legitimately passes `byte[]`. A constraint would exclude it and a callback is the kind of thing a future caller silently forgets, which is how these leaks got here.
