### PR TITLE
Reserve one receipt slot per parallel worker tracer

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -1216,12 +1216,8 @@ public class BlockProcessorTests
             .TestObject;
 
         ConcurrentBag<(int TxIndex, uint BalIndex)> balIndexes = [];
-        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor = new(
-            Substitute.For<IBlockProcessor.IBlockTransactionsExecutor>(),
-            stateProvider,
-            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
-            new ParallelTestBlockAccessListManager(balIndex => new BalIndexRecordingTransactionProcessorAdapter(balIndex.GetValueOrDefault(), balIndexes)),
-            LimboLogs.Instance);
+        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor =
+            CreateBalRecordingParallelExecutor(stateProvider, balIndexes);
 
         TxReceipt[] receipts = executor.ProcessTransactions(
             block,
@@ -1390,7 +1386,7 @@ public class BlockProcessorTests
     }
 
     [Test]
-    public void Parallel_validation_resets_the_pooled_slots_a_shorter_block_leaves_unused()
+    public void Parallel_validation_releases_the_pooled_slots_a_shorter_block_leaves_unused()
     {
         const int wideTxCount = 8;
         const int narrowTxCount = 2;
@@ -1399,16 +1395,14 @@ public class BlockProcessorTests
         using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
 
         ConcurrentBag<(int TxIndex, uint BalIndex)> balIndexes = [];
-        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor = new(
-            Substitute.For<IBlockProcessor.IBlockTransactionsExecutor>(),
-            stateProvider,
-            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
-            new ParallelTestBlockAccessListManager(balIndex => new BalIndexRecordingTransactionProcessorAdapter(balIndex.GetValueOrDefault(), balIndexes)),
-            LimboLogs.Instance);
+        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor =
+            CreateBalRecordingParallelExecutor(stateProvider, balIndexes);
 
-        Block wide = BuildParallelValidationBlock(wideTxCount);
-        executor.ProcessTransactions(wide, ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
-        executor.ProcessTransactions(BuildParallelValidationBlock(narrowTxCount), ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
+        // The third block is what makes this bite: releasing only on the step down would leave the
+        // second block in the slots it did not use, and the third block's reset no longer reaches them.
+        ProcessParallelValidationBlock(executor, wideTxCount);
+        ProcessParallelValidationBlock(executor, narrowTxCount);
+        ProcessParallelValidationBlock(executor, narrowTxCount);
 
         BlockReceiptsTracer[] pool = (BlockReceiptsTracer[])typeof(BlockProcessor.ParallelBlockValidationTransactionsExecutor)
             .GetField("_receiptsTracerPool", BindingFlags.Instance | BindingFlags.NonPublic)!
@@ -1421,11 +1415,26 @@ public class BlockProcessorTests
         {
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(pool[i].TxReceipts.Length, Is.Zero, $"slot {i} still holds the wide block's receipt");
-                Assert.That(tracedBlock.GetValue(pool[i]), Is.Not.SameAs(wide), $"slot {i} still references the wide block");
+                Assert.That(pool[i].TxReceipts.Length, Is.Zero, $"slot {i} still holds receipts");
+                Assert.That(tracedBlock.GetValue(pool[i]), Is.Null, $"slot {i} still references a block");
             }
         }
     }
+
+    private static BlockProcessor.ParallelBlockValidationTransactionsExecutor CreateBalRecordingParallelExecutor(
+        IWorldState stateProvider,
+        ConcurrentBag<(int TxIndex, uint BalIndex)> balIndexes) =>
+        new(Substitute.For<IBlockProcessor.IBlockTransactionsExecutor>(),
+            stateProvider,
+            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
+            new ParallelTestBlockAccessListManager(balIndex => new BalIndexRecordingTransactionProcessorAdapter(balIndex.GetValueOrDefault(), balIndexes)),
+            LimboLogs.Instance);
+
+    private static void ProcessParallelValidationBlock(
+        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor,
+        int txCount) =>
+        executor.ProcessTransactions(
+            BuildParallelValidationBlock(txCount), ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
 
     private static Block BuildParallelValidationBlock(int txCount) =>
         Build.A.Block

--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -34,6 +34,7 @@ using NSubstitute;
 using NUnit.Framework;
 using System;
 using System.Collections.Concurrent;
+using System.Reflection;
 using System.Collections.Generic;
 using System.Security;
 using System.Threading;
@@ -1387,6 +1388,52 @@ public class BlockProcessorTests
         }
         return slots;
     }
+
+    [Test]
+    public void Parallel_validation_resets_the_pooled_slots_a_shorter_block_leaves_unused()
+    {
+        const int wideTxCount = 8;
+        const int narrowTxCount = 2;
+
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+
+        ConcurrentBag<(int TxIndex, uint BalIndex)> balIndexes = [];
+        BlockProcessor.ParallelBlockValidationTransactionsExecutor executor = new(
+            Substitute.For<IBlockProcessor.IBlockTransactionsExecutor>(),
+            stateProvider,
+            new TestSingleReleaseSpecProvider(Amsterdam.Instance),
+            new ParallelTestBlockAccessListManager(balIndex => new BalIndexRecordingTransactionProcessorAdapter(balIndex.GetValueOrDefault(), balIndexes)),
+            LimboLogs.Instance);
+
+        Block wide = BuildParallelValidationBlock(wideTxCount);
+        executor.ProcessTransactions(wide, ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
+        executor.ProcessTransactions(BuildParallelValidationBlock(narrowTxCount), ProcessingOptions.None, new BlockReceiptsTracer(), CancellationToken.None);
+
+        BlockReceiptsTracer[] pool = (BlockReceiptsTracer[])typeof(BlockProcessor.ParallelBlockValidationTransactionsExecutor)
+            .GetField("_receiptsTracerPool", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(executor)!;
+        FieldInfo tracedBlock = typeof(BlockReceiptsTracer)
+            .GetField("Block", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        Assert.That(pool, Has.Length.AtLeast(wideTxCount), "the pool must still hold the wide block's slots");
+        for (int i = narrowTxCount; i < wideTxCount; i++)
+        {
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(pool[i].TxReceipts.Length, Is.Zero, $"slot {i} still holds the wide block's receipt");
+                Assert.That(tracedBlock.GetValue(pool[i]), Is.Not.SameAs(wide), $"slot {i} still references the wide block");
+            }
+        }
+    }
+
+    private static Block BuildParallelValidationBlock(int txCount) =>
+        Build.A.Block
+            .WithNumber(1)
+            .WithGasLimit((ulong)txCount * 1_000_000ul)
+            .WithTransactions(CreateParallelValidationTransactions(txCount))
+            .WithBlockAccessList(new ReadOnlyBlockAccessList())
+            .TestObject;
 
     private static Transaction[] CreateParallelValidationTransactions(int txCount, ulong gasLimit = 21_000ul)
     {

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -346,6 +346,28 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         }
     }
 
+    /// <summary>
+    /// Drops everything this tracer holds from its last use, leaving it ready for a later
+    /// <see cref="ResetForParallelTx"/>.
+    /// </summary>
+    /// <remarks>
+    /// For a pooled parallel tracer whose slot this block does not use. <see cref="ResetForParallelTx"/>
+    /// would swap the current block and tracer in rather than let go, so a slot left idle across
+    /// successive blocks would keep the last block that did use it — and its transactions and access
+    /// list — alive for as long as the pool lives. List capacity is kept; only the references go.
+    /// </remarks>
+    public void ReleaseForPooling()
+    {
+        _otherTracer = NullBlockTracer.Instance;
+        _currentTxTracer = NullTxTracer.Instance;
+        Block = null!;
+        CurrentTx = null;
+        _currentIndex = 0;
+        _txReceipts.Clear();
+        _cumulativeBlockGasPerTx.Clear();
+        _cumulativeReceiptGas = 0;
+    }
+
     public ITxTracer StartNewTxTrace(Transaction? tx)
     {
         CurrentTx = tx;

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -321,7 +321,9 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         _currentIndex = 0;
         CurrentTx = null;
         _currentTxTracer = NullTxTracer.Instance;
-        int txCount = block.Transactions.Length;
+        // A parallel worker tracer records exactly one transaction, so presizing it to the block's
+        // transaction count would make a pool of one tracer per transaction reserve O(txCount^2).
+        int txCount = parallel ? 1 : block.Transactions.Length;
         _txReceipts.Clear();
         _txReceipts.EnsureCapacity(txCount);
         _cumulativeBlockGasPerTx.Clear();

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -321,8 +321,6 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         _currentIndex = 0;
         CurrentTx = null;
         _currentTxTracer = NullTxTracer.Instance;
-        // A parallel worker tracer records exactly one transaction, so presizing it to the block's
-        // transaction count would make a pool of one tracer per transaction reserve O(txCount^2).
         int txCount = parallel ? 1 : block.Transactions.Length;
         _txReceipts.Clear();
         _txReceipts.EnsureCapacity(txCount);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -37,6 +37,7 @@ public partial class BlockProcessor
         private GasValidationResultSlot[] _gasResultPool = [];
         private int[] _txExecutionOrder = [];
         private TxExecutionSortKey[] _txExecutionSortKeys = [];
+        private int _pooledSlotsInUse;
 
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
         {
@@ -122,11 +123,17 @@ public partial class BlockProcessor
             EnsureParallelBuffers(len);
             BlockReceiptsTracer[] receiptsTracers = _receiptsTracerPool;
             GasValidationResultSlot[] gasResults = _gasResultPool;
-            for (int i = 0; i < len; i++)
+            // Also reset the slots the previous block used but this one does not: an unreset
+            // tracer keeps that block's receipts and the Block itself, and an unreset gas slot
+            // keeps its InvalidBlockException, so a shrinking tx count would pin the larger
+            // block indefinitely. The pool never shrinks, so this runs once per shrink.
+            int slotsToReset = Math.Max(len, _pooledSlotsInUse);
+            for (int i = 0; i < slotsToReset; i++)
             {
                 receiptsTracers[i].ResetForParallelTx(block, parallelSafeTracer);
                 gasResults[i].Reset();
             }
+            _pooledSlotsInUse = len;
 
             IncrementalValidationWorkItem incrementalValidation = _incrementalValidationWorkItem ??= new();
             incrementalValidation.Schedule(balManager, block, gasResults, receiptsTracers, transactionProcessedEventHandler, token);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -123,16 +123,22 @@ public partial class BlockProcessor
             EnsureParallelBuffers(len);
             BlockReceiptsTracer[] receiptsTracers = _receiptsTracerPool;
             GasValidationResultSlot[] gasResults = _gasResultPool;
-            // Also reset the slots the previous block used but this one does not: an unreset
-            // tracer keeps that block's receipts and the Block itself, and an unreset gas slot
-            // keeps its InvalidBlockException, so a shrinking tx count would pin the larger
-            // block indefinitely. The pool never shrinks, so this runs once per shrink.
-            int slotsToReset = Math.Max(len, _pooledSlotsInUse);
-            for (int i = 0; i < slotsToReset; i++)
+            for (int i = 0; i < len; i++)
             {
                 receiptsTracers[i].ResetForParallelTx(block, parallelSafeTracer);
                 gasResults[i].Reset();
             }
+
+            // Release the slots the previous block used but this one does not. Left alone they keep
+            // that block's receipts, the block itself and any InvalidBlockException in the gas slot;
+            // resetting them like the active ones would only swap the current block in. The pool
+            // never shrinks, so this runs once per shrink rather than every block.
+            for (int i = len; i < _pooledSlotsInUse; i++)
+            {
+                receiptsTracers[i].ReleaseForPooling();
+                gasResults[i].Reset();
+            }
+
             _pooledSlotsInUse = len;
 
             IncrementalValidationWorkItem incrementalValidation = _incrementalValidationWorkItem ??= new();

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -280,9 +280,6 @@ public partial class BlockProcessor
                 gasResultPool[i] = new GasValidationResultSlot();
             }
 
-            // Grow into locals and publish only once every buffer is sized and every new slot is
-            // populated; the guard above reads _receiptsTracerPool.Length, so a pool left half built
-            // by a failure part way through would be reused as if it were complete.
             _receiptsTracerPool = receiptsTracerPool;
             _gasResultPool = gasResultPool;
             _txExecutionOrder = txExecutionOrder;

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -266,15 +266,27 @@ public partial class BlockProcessor
             // GasValidationResultSlot instances already pooled in slots [0, currentLength);
             // freshly allocated arrays would force re-instantiation of every slot every block.
             int newLength = Math.Max(length, currentLength == 0 ? 4 : currentLength * 2);
-            Array.Resize(ref _receiptsTracerPool, newLength);
-            Array.Resize(ref _gasResultPool, newLength);
-            Array.Resize(ref _txExecutionOrder, newLength);
-            Array.Resize(ref _txExecutionSortKeys, newLength);
+            BlockReceiptsTracer[] receiptsTracerPool = _receiptsTracerPool;
+            GasValidationResultSlot[] gasResultPool = _gasResultPool;
+            int[] txExecutionOrder = _txExecutionOrder;
+            TxExecutionSortKey[] txExecutionSortKeys = _txExecutionSortKeys;
+            Array.Resize(ref receiptsTracerPool, newLength);
+            Array.Resize(ref gasResultPool, newLength);
+            Array.Resize(ref txExecutionOrder, newLength);
+            Array.Resize(ref txExecutionSortKeys, newLength);
             for (int i = currentLength; i < newLength; i++)
             {
-                _receiptsTracerPool[i] = new BlockReceiptsTracer(true);
-                _gasResultPool[i] = new GasValidationResultSlot();
+                receiptsTracerPool[i] = new BlockReceiptsTracer(true);
+                gasResultPool[i] = new GasValidationResultSlot();
             }
+
+            // Grow into locals and publish only once every buffer is sized and every new slot is
+            // populated; the guard above reads _receiptsTracerPool.Length, so a pool left half built
+            // by a failure part way through would be reused as if it were complete.
+            _receiptsTracerPool = receiptsTracerPool;
+            _gasResultPool = gasResultPool;
+            _txExecutionOrder = txExecutionOrder;
+            _txExecutionSortKeys = txExecutionSortKeys;
         }
 
         /// <summary>Canonical tx-execution lead: the prefix of the schedule that always runs in

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/BlockReceiptsTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/BlockReceiptsTracerTests.cs
@@ -155,8 +155,6 @@ namespace Nethermind.Evm.Test.Tracing
         [TestCase(100_000)]
         public void ResetForParallelTx_does_not_reserve_capacity_for_the_whole_block(int txCount)
         {
-            // Parallel execution pools one tracer per transaction, so a per-tracer reservation that
-            // scales with the block's transaction count costs O(txCount^2) across the pool.
             Transaction tx = Build.A.Transaction.TestObject;
             Transaction[] txs = new Transaction[txCount];
             Array.Fill(txs, tx);

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/BlockReceiptsTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/BlockReceiptsTracerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
@@ -148,6 +149,26 @@ namespace Nethermind.Evm.Test.Tracing
             tracer.StartNewTxTrace(nextBlock.Transactions[0]);
 
             nextOtherTracer.Received(1).StartNewTxTrace(nextBlock.Transactions[0]);
+        }
+
+        [TestCase(1_000)]
+        [TestCase(100_000)]
+        public void ResetForParallelTx_does_not_reserve_capacity_for_the_whole_block(int txCount)
+        {
+            // Parallel execution pools one tracer per transaction, so a per-tracer reservation that
+            // scales with the block's transaction count costs O(txCount^2) across the pool.
+            Transaction tx = Build.A.Transaction.TestObject;
+            Transaction[] txs = new Transaction[txCount];
+            Array.Fill(txs, tx);
+            Block block = Build.A.Block.WithTransactions(txs).TestObject;
+            BlockReceiptsTracer tracer = new(true);
+
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            tracer.ResetForParallelTx(block, NullBlockTracer.Instance);
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+            Assert.That(allocated, Is.LessThan(1024),
+                "a parallel tracer must reserve receipt capacity for its single transaction, not for the block");
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/BlockReceiptsTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/BlockReceiptsTracerTests.cs
@@ -152,7 +152,7 @@ namespace Nethermind.Evm.Test.Tracing
         }
 
         [Test]
-        public void ResetForParallelTx_does_not_reserve_capacity_for_the_whole_block(int txCount)
+        public void ResetForParallelTx_does_not_reserve_capacity_for_the_whole_block([Values(1_000, 100_000)] int txCount)
         {
             Transaction tx = Build.A.Transaction.TestObject;
             Transaction[] txs = new Transaction[txCount];

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/BlockReceiptsTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/BlockReceiptsTracerTests.cs
@@ -151,8 +151,7 @@ namespace Nethermind.Evm.Test.Tracing
             nextOtherTracer.Received(1).StartNewTxTrace(nextBlock.Transactions[0]);
         }
 
-        [TestCase(1_000)]
-        [TestCase(100_000)]
+        [Test]
         public void ResetForParallelTx_does_not_reserve_capacity_for_the_whole_block(int txCount)
         {
             Transaction tx = Build.A.Transaction.TestObject;


### PR DESCRIPTION
## Changes

- Reserve a single receipt/cumulative-gas slot for a parallel worker `BlockReceiptsTracer` instead of presizing it to the block's transaction count.
- Grow the parallel executor's four pooled buffers into locals and publish them only after every buffer is sized and every new slot is populated.
- Release the pooled slots a block does not use, so a narrower block cannot leave an earlier one reachable through them.
- Cover the per-tracer reservation and the slot release with regression tests.

### Why

`ParallelBlockValidationTransactionsExecutor` pools one `BlockReceiptsTracer` per block transaction and resets each one with the whole block. `StartNewBlockTrace` then presized both of that tracer's lists to `block.Transactions.Length`, so the pool's total reservation grew with the *square* of the transaction count — 8 bytes for the receipt reference plus 16 for the `(ulong, ulong)` gas tuple, per transaction, per tracer:

| transactions | reserved before | reserved after |
| ---: | ---: | ---: |
| 5,000 | 600 MB | 480 KB |
| 12,500 | 3.75 GB | 1.2 MB |
| 16,665 | 6.67 GB | 1.6 MB |

Both columns are element storage only; array headers and other per-object overhead are on top. The *after* column is allocated capacity, not logical use: a worker tracer records exactly one receipt, but `List<T>.EnsureCapacity(1)` on an empty list rounds up to `List<T>`'s default capacity of four, so the floor is `4 x 8 + 4 x 16` = 96 bytes per initialized tracer rather than 24 (measured, not derived). The saving stays linear in the transaction count instead of quadratic, which is the point.

The reservation is also retained rather than transient: `_receiptsTracerPool` only ever grows, and `List<T>.Clear()` keeps its backing array, so the high-water mark stays reachable for the lifetime of the processing scope. Each array is large enough to land on the LOH, which is not compacted by default.

A worker tracer only ever records its own transaction — the executor itself reads only `TxReceipts[0]` — so one slot is sufficient. The outer block tracer keeps the block-wide presizing added in #12498.

### Retention of unused slots

`_receiptsTracerPool` never shrinks, and only the slots a block actually uses were reset. A slot above the current transaction count therefore kept its last `TxReceipt`s, the `Block` it was reset with — reachable through `BlockReceiptsTracer.Block`, so its transactions and access list with it — and any `InvalidBlockException` parked in the matching `GasValidationResultSlot`, which holds a `Block` of its own.

Resetting the previous block's unused slots alongside the active ones is not enough, because it only swaps the current block in and moves the retention on by one: after blocks of 8, 2 and 2 transactions, the third block resets slots 0-1 while slots 2-7 still hold the *second* block, and no later narrow block reaches them again. Those slots now get `BlockReceiptsTracer.ReleaseForPooling`, which drops the references and keeps the list capacity, so a slot returning to use still avoids the regrowth the presizing exists for. The extra work happens once per shrink rather than every block.

The buffer-publishing change addresses a third problem in `EnsureParallelBuffers`: the reuse guard tests `_receiptsTracerPool.Length`, but the old code resized the fields in place before populating the new slots. A failure part way through therefore left a pool whose length said "ready" while its new slots were still `null`, and every later block reusing it would fault. Growing into locals and publishing at the end makes the operation all-or-nothing.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`ResetForParallelTx_does_not_reserve_capacity_for_the_whole_block` measures `GC.GetAllocatedBytesForCurrentThread()` across a single reset of a fresh parallel tracer. On `master` it allocates 2,400,072 bytes for a 100,000-transaction block; with this change the allocation is below the 1 KB bound. Verified the test fails without the production change.

`Parallel_validation_releases_the_pooled_slots_a_shorter_block_leaves_unused` processes blocks of 8, 2 and 2 transactions through one executor and asserts the slots the last block did not use hold no receipts and reference no block. The third block is what makes it bite: with the slots merely reset rather than released it fails at slot 2 with `Expected: null, But was: <1 (0x53f009...)>`.

`Nethermind.Blockchain.Test` (52 `BlockProcessorTests`) and `BlockReceiptsTracerTests` (10) pass.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

