### PR TITLE
Build a sparse block bodies response body's transaction trie once

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -76,10 +76,17 @@ public class BodiesSyncFeedTests
 
         _syncPeerPool = Substitute.For<ISyncPeerPool>();
         _historyPruner = Substitute.For<IHistoryPruner>();
-        _feed = new BodiesSyncFeed(
+        _feed = CreateFeed(CreateBlockValidator());
+    }
+
+    private static BlockValidator CreateBlockValidator() =>
+        new(Always.Valid, Always.Valid, Always.Valid, MainnetSpecProvider.Instance, LimboLogs.Instance);
+
+    private BodiesSyncFeed CreateFeed(IBlockValidator blockValidator) =>
+        new(
             MainnetSpecProvider.Instance,
             _syncingToBlockTree,
-            CreateBlockValidator(),
+            blockValidator,
             _syncPointers,
             _syncPeerPool,
             _syncConfig,
@@ -90,10 +97,6 @@ public class BodiesSyncFeedTests
             LimboLogs.Instance,
             flushDbInterval: 10
         );
-    }
-
-    private static BlockValidator CreateBlockValidator() =>
-        new(Always.Valid, Always.Valid, Always.Valid, MainnetSpecProvider.Instance, LimboLogs.Instance);
 
     [TearDown]
     public void TearDown()
@@ -188,20 +191,7 @@ public class BodiesSyncFeedTests
         blockValidator
             .ValidateBodyAgainstHeader(Arg.Any<BlockHeader>(), Arg.Any<BlockBody>(), out Arg.Any<string?>())
             .Returns(false);
-        using BodiesSyncFeed feed = new(
-            MainnetSpecProvider.Instance,
-            _syncingToBlockTree,
-            blockValidator,
-            _syncPointers,
-            _syncPeerPool,
-            _syncConfig,
-            new NullSyncReport(),
-            _historyPruner,
-            _blocksDb,
-            _metadataDb,
-            LimboLogs.Instance,
-            flushDbInterval: 10
-        );
+        using BodiesSyncFeed feed = CreateFeed(blockValidator);
         feed.InitializeFeed();
 
         using BodiesSyncBatch req = (await feed.PrepareRequest())!;
@@ -217,8 +207,8 @@ public class BodiesSyncFeedTests
 
         Assert.That(
             blockValidator.ReceivedCalls().Count(static (call) => call.GetMethodInfo().Name == nameof(IBlockValidator.ValidateBodyAgainstHeader)),
-            Is.LessThanOrEqualTo(1),
-            "an unmatched body must not be revalidated once per requested header");
+            Is.EqualTo(1),
+            "an unmatched body must be validated exactly once, not once per requested header");
         _syncPeerPool.Received(1).ReportBreachOfProtocol(
             Arg.Any<PeerInfo>(),
             DisconnectReason.InvalidTxOrUncle,

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -169,7 +169,12 @@ public class BodiesSyncFeedTests
         Block firstBlock = _syncingFromBlockTree.FindBlock(req.Infos[0]!.BlockNumber, BlockTreeLookupOptions.None)!;
         Block skippedBlock = _syncingFromBlockTree.FindBlock(req.Infos[1]!.BlockNumber, BlockTreeLookupOptions.None)!;
         Block thirdBlock = _syncingFromBlockTree.FindBlock(req.Infos[2]!.BlockNumber, BlockTreeLookupOptions.None)!;
-        req.Response = new OwnedBlockBodies([firstBlock.Body, thirdBlock.Body]);
+        // The third body is rejected against the skipped header before it matches, so it is the body whose
+        // transaction root gets cached. A differing root on the fourth makes the match below depend on that
+        // cache being cleared.
+        Block fourthBlock = _syncingFromBlockTree.FindBlock(req.Infos[3]!.BlockNumber, BlockTreeLookupOptions.None)!;
+        Assert.That(fourthBlock.Header.TxRoot, Is.Not.EqualTo(thirdBlock.Header.TxRoot), "the two bodies must differ for this to assert anything");
+        req.Response = new OwnedBlockBodies([firstBlock.Body, thirdBlock.Body, fourthBlock.Body]);
         req.ResponseSourcePeer = new PeerInfo(Substitute.For<ISyncPeer>());
 
         SyncResponseHandlingResult result = _feed.HandleResponse(req);
@@ -178,6 +183,7 @@ public class BodiesSyncFeedTests
         Assert.That(_syncingToBlockTree.FindBlock(firstBlock.Hash!, BlockTreeLookupOptions.None, firstBlock.Number), Is.Not.Null);
         Assert.That(_syncingToBlockTree.FindBlock(skippedBlock.Hash!, BlockTreeLookupOptions.None, skippedBlock.Number), Is.Null);
         Assert.That(_syncingToBlockTree.FindBlock(thirdBlock.Hash!, BlockTreeLookupOptions.None, thirdBlock.Number), Is.Not.Null);
+        Assert.That(_syncingToBlockTree.FindBlock(fourthBlock.Hash!, BlockTreeLookupOptions.None, fourthBlock.Number), Is.Not.Null);
         _syncPeerPool.DidNotReceive().ReportBreachOfProtocol(
             Arg.Any<PeerInfo>(),
             Arg.Any<DisconnectReason>(),

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastBlocks/BodiesSyncFeedTests.cs
@@ -182,6 +182,50 @@ public class BodiesSyncFeedTests
     }
 
     [Test]
+    public async Task ShouldValidateAnUnmatchedBodyOnceRegardlessOfRequestedHeaderCount()
+    {
+        IBlockValidator blockValidator = Substitute.For<IBlockValidator>();
+        blockValidator
+            .ValidateBodyAgainstHeader(Arg.Any<BlockHeader>(), Arg.Any<BlockBody>(), out Arg.Any<string?>())
+            .Returns(false);
+        using BodiesSyncFeed feed = new(
+            MainnetSpecProvider.Instance,
+            _syncingToBlockTree,
+            blockValidator,
+            _syncPointers,
+            _syncPeerPool,
+            _syncConfig,
+            new NullSyncReport(),
+            _historyPruner,
+            _blocksDb,
+            _metadataDb,
+            LimboLogs.Instance,
+            flushDbInterval: 10
+        );
+        feed.InitializeFeed();
+
+        using BodiesSyncBatch req = (await feed.PrepareRequest())!;
+        int requestedHeaders = req.Infos.Count(static (info) => info is not null);
+        Assert.That(requestedHeaders, Is.GreaterThan(1), "the batch must span several headers for this to assert anything");
+
+        // A body that matches none of the requested headers keeps the response index pinned, so it is
+        // offered to every one of them.
+        req.Response = new OwnedBlockBodies([new BlockBody([Build.A.Transaction.WithNonce(12345).TestObject], [])]);
+        req.ResponseSourcePeer = new PeerInfo(Substitute.For<ISyncPeer>());
+
+        feed.HandleResponse(req);
+
+        Assert.That(
+            blockValidator.ReceivedCalls().Count(static (call) => call.GetMethodInfo().Name == nameof(IBlockValidator.ValidateBodyAgainstHeader)),
+            Is.LessThanOrEqualTo(1),
+            "an unmatched body must not be revalidated once per requested header");
+        _syncPeerPool.Received(1).ReportBreachOfProtocol(
+            Arg.Any<PeerInfo>(),
+            DisconnectReason.InvalidTxOrUncle,
+            Arg.Any<string>());
+    }
+
+    [Test]
     public async Task ShouldRecoverOnInsertFailure()
     {
         _feed.InitializeFeed();

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -9,9 +9,11 @@ using Nethermind.Blockchain;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Db;
 using Nethermind.Logging;
+using Nethermind.State.Proofs;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 using Nethermind.Synchronization.ParallelSync;
@@ -239,10 +241,14 @@ namespace Nethermind.Synchronization.FastBlocks
             }
         }
 
-        private bool TryPrepareBlock(BlockInfo blockInfo, BlockBody blockBody, out Block? block)
+        private bool TryPrepareBlock(BlockInfo blockInfo, BlockBody blockBody, ref Hash256? bodyTxRoot, out Block? block)
         {
             BlockHeader header = _blockTree.FindHeader(blockInfo.BlockHash, blockNumber: blockInfo.BlockNumber);
-            if (_blockValidator.ValidateBodyAgainstHeader(header, blockBody, out _))
+
+            // A sparse response leaves the same body under test against several headers, and building
+            // the transaction trie dominates a comparison, so build it once per body instead.
+            bodyTxRoot ??= TxTrie.CalculateRoot(blockBody.Transactions);
+            if (bodyTxRoot == header.TxRoot && _blockValidator.ValidateBodyAgainstHeader(header, blockBody, out _))
             {
                 block = new Block(header, blockBody);
             }
@@ -259,6 +265,7 @@ namespace Nethermind.Synchronization.FastBlocks
             int validResponsesCount = 0;
             BlockBody[]? responses = batch.Response?.Bodies ?? [];
             int responseIndex = 0;
+            Hash256? bodyTxRoot = null;
 
             for (int i = 0; i < batch.Infos.Length; i++)
             {
@@ -278,15 +285,17 @@ namespace Nethermind.Synchronization.FastBlocks
                     if (responseIndex < responses.Length)
                     {
                         responseIndex++;
+                        bodyTxRoot = null;
                     }
 
                     _syncStatusList.MarkPending(blockInfo);
                     continue;
                 }
 
-                if (TryPrepareBlock(blockInfo, body, out Block? block))
+                if (TryPrepareBlock(blockInfo, body, ref bodyTxRoot, out Block? block))
                 {
                     responseIndex++;
+                    bodyTxRoot = null;
                     validResponsesCount++;
                     InsertOneBlock(block!);
                 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -298,9 +298,10 @@ namespace Nethermind.Synchronization.FastBlocks
                 }
                 else
                 {
-                    // Body responses can be sparse, so an invalid body may belong to a later requested header.
-                    // Building the transaction trie dominates a comparison, so remember the rejected body's
-                    // root and let the remaining headers cost a hash compare instead of another trie build.
+                    // Body responses can be sparse, so a rejected body may belong to a later requested
+                    // header. Remember its transaction root so a header carrying a different one is ruled
+                    // out by a hash compare; a header whose root matches still goes to the validator, which
+                    // rebuilds the trie and may reject the body on uncles or withdrawals.
                     rejectedBodyTxRoot ??= TxTrie.CalculateRoot(body.Transactions);
                     _syncStatusList.MarkPending(blockInfo);
                 }

--- a/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastBlocks/BodiesSyncFeed.cs
@@ -241,14 +241,11 @@ namespace Nethermind.Synchronization.FastBlocks
             }
         }
 
-        private bool TryPrepareBlock(BlockInfo blockInfo, BlockBody blockBody, ref Hash256? bodyTxRoot, out Block? block)
+        private bool TryPrepareBlock(BlockInfo blockInfo, BlockBody blockBody, Hash256? rejectedBodyTxRoot, out Block? block)
         {
             BlockHeader header = _blockTree.FindHeader(blockInfo.BlockHash, blockNumber: blockInfo.BlockNumber);
-
-            // A sparse response leaves the same body under test against several headers, and building
-            // the transaction trie dominates a comparison, so build it once per body instead.
-            bodyTxRoot ??= TxTrie.CalculateRoot(blockBody.Transactions);
-            if (bodyTxRoot == header.TxRoot && _blockValidator.ValidateBodyAgainstHeader(header, blockBody, out _))
+            if ((rejectedBodyTxRoot is null || rejectedBodyTxRoot == header.TxRoot)
+                && _blockValidator.ValidateBodyAgainstHeader(header, blockBody, out _))
             {
                 block = new Block(header, blockBody);
             }
@@ -265,7 +262,7 @@ namespace Nethermind.Synchronization.FastBlocks
             int validResponsesCount = 0;
             BlockBody[]? responses = batch.Response?.Bodies ?? [];
             int responseIndex = 0;
-            Hash256? bodyTxRoot = null;
+            Hash256? rejectedBodyTxRoot = null;
 
             for (int i = 0; i < batch.Infos.Length; i++)
             {
@@ -285,23 +282,26 @@ namespace Nethermind.Synchronization.FastBlocks
                     if (responseIndex < responses.Length)
                     {
                         responseIndex++;
-                        bodyTxRoot = null;
+                        rejectedBodyTxRoot = null;
                     }
 
                     _syncStatusList.MarkPending(blockInfo);
                     continue;
                 }
 
-                if (TryPrepareBlock(blockInfo, body, ref bodyTxRoot, out Block? block))
+                if (TryPrepareBlock(blockInfo, body, rejectedBodyTxRoot, out Block? block))
                 {
                     responseIndex++;
-                    bodyTxRoot = null;
+                    rejectedBodyTxRoot = null;
                     validResponsesCount++;
                     InsertOneBlock(block!);
                 }
                 else
                 {
                     // Body responses can be sparse, so an invalid body may belong to a later requested header.
+                    // Building the transaction trie dominates a comparison, so remember the rejected body's
+                    // root and let the remaining headers cost a hash compare instead of another trie build.
+                    rejectedBodyTxRoot ??= TxTrie.CalculateRoot(body.Transactions);
                     _syncStatusList.MarkPending(blockInfo);
                 }
             }


### PR DESCRIPTION
## Changes

- Cache a block bodies response body's transaction root once the block validator rejects it, and reuse that root to rule out the remaining requested headers by a hash compare rather than rebuilding the transaction trie for each of them.
- Cover the unmatched-body case, and the discarding of the cached root, with regression tests.

### Why

`BlockBodies` responses may omit bodies the peer does not have, so `InsertBodies` keeps the current response body under test until one of the requested headers accepts it — `responseIndex` only advances on a match. Every one of those comparisons went straight into `ValidateBodyAgainstHeader`, whose first check is:

```csharp
(txRoot = TxTrie.CalculateRoot(body.Transactions)) == header.TxRoot;
```

The computed root is discarded, so a body that matches none of the requested headers had its transaction trie rebuilt once per requested header. The batch size for a default mainnet fast sync is up to 128 headers, and `BlockBodyDecoder` accepts up to `MaxBlockGas / GasCostOf.TransactionEip2780 + 1` = 83,334 transactions per body, so the redundant work is substantial: a single ~830 KB body drove ~53 CPU-seconds and multiple GB of transaction-trie churn, of which all but one build was wasted. `TxTrie.CalculateRoot` also parallelises above 64 transactions, so the wasted work spreads across the thread pool.

The validator still runs first, and the root is only computed after it has rejected the body, so the number of trie builds per response body goes from `O(headers)` to:

- 1 on a match — the common dense-response path is unchanged,
- 2 on the first rejection,
- 0 for every subsequent header whose `TxRoot` differs from the cached root.

The cached root only ever rules a header *out*. A subsequent header whose `TxRoot` matches it still goes to the validator, which rebuilds the trie — so a body that is offered to several headers and is then either accepted, or rejected on uncles or withdrawals, incurs that build as well. What this removes is the pathological `O(headers)` case, not every repeat build.

`IBlockValidator` remains the sole authority on whether a body belongs to a header in both directions: a body is only ever skipped after the validator has already rejected it, so chain-specific overrides such as `OptimismBlockValidator`'s withdrawals rules still decide acceptance, and no consensus rule moves into the sync layer.

Sparse-response support is unchanged. For reference, the sibling `BlockAccessListsSyncFeed.InsertBlockAccessLists` and `BlockDownloader` both match positionally and so never had this pattern; `BodiesSyncFeed` was the only feed that re-validated one body against many headers.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`ShouldValidateAnUnmatchedBodyOnceRegardlessOfRequestedHeaderCount` feeds a body matching none of the requested headers and asserts `ValidateBodyAgainstHeader` is invoked exactly once. On `master` it is invoked 99 times for the same batch. The test also asserts the existing breach report and disconnect still happen exactly once, and it self-checks that the batch spans more than one header so it cannot silently become vacuous.

`ShouldHandleSparseBodyResponseWithoutReportingBreach` guards the sparse-matching semantics. It now carries a third body, offered after the response index has advanced past a rejection, whose transaction root differs from the cached one — so it fails if that root is not discarded on a match, and it self-checks that the two roots actually differ. Reverting the reset alone makes it fail. `Nethermind.Synchronization.Test` passes in full (2190 passed, 0 failed).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

