### PR TITLE
fix(eip8141): keep the block gas limit on the frame estimate's execution dimension

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GasEstimator.cs
@@ -115,8 +115,8 @@ public class GasEstimator(
             || !FrameTxValidation.TryCalculateBlockGasReservations(tx, spec, out ulong executionReservation, out ulong stateReservation))
             return EstimationResult.Failure(FrameTxGasLimitOverflows);
 
-        // EIP-8037: each dimension gets its own block budget, and only execution carries the per-tx cap.
-        return executionReservation > Eip7825Constants.DefaultTxGasLimitCap || stateReservation > header.GasLimit
+        // EIP-8037: each dimension gets its own block budget, and execution carries the per-tx cap on top.
+        return executionReservation > Math.Min(header.GasLimit, Eip7825Constants.DefaultTxGasLimitCap) || stateReservation > header.GasLimit
             ? EstimationResult.Failure(CannotEstimateGasExceeded)
             : EstimationResult.Success(maxGas);
     }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -16,6 +16,7 @@ using Nethermind.Core.Test;
 using Nethermind.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.Precompiles;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
@@ -1125,6 +1126,37 @@ public class FrameTxProcessorTests
         {
             Assert.That(execution, Is.LessThanOrEqualTo(blockGasLimit), "the execution dimension fits the block");
             Assert.That(state, Is.GreaterThan(blockGasLimit), "only the state dimension exceeds it");
+            Assert.That(error, Is.EqualTo(GasEstimator.CannotEstimateGasExceeded));
+        }
+    }
+
+    /// <remarks>The mirror of the state case: the execution dimension carries the block budget as well as the
+    /// per-transaction cap, so a reservation under that cap but over the block is unestimable, matching what
+    /// <see cref="Eip8037BlockGasInclusionCheck"/> refuses even in an empty block.</remarks>
+    [Test]
+    public void EstimateGas_FrameTxWhoseExecutionBudgetAloneExceedsTheBlock_ReportsTheBudgetAsUnestimable()
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
+
+        const ulong blockGasLimit = 300_000;
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Recipient));
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithGasLimit(blockGasLimit).TestObject;
+
+        Assert.That(FrameTxValidation.TryCalculateBlockGasReservations(tx, Spec, out ulong execution, out ulong state), Is.True);
+
+        GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
+        estimator.Estimate(tx, header, new EstimateGasTracer(), out string? error);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(execution, Is.GreaterThan(blockGasLimit), "only the execution dimension exceeds the block");
+            Assert.That(execution, Is.LessThanOrEqualTo(Eip7825Constants.DefaultTxGasLimitCap), "the per-tx cap cannot be what fires");
+            Assert.That(state, Is.LessThanOrEqualTo(blockGasLimit), "the state dimension fits the block");
+            Assert.That(Eip8037BlockGasInclusionCheck.Validate(blockGasLimit, 0, 0, execution, state),
+                Is.EqualTo(Eip8037BlockGasInclusionCheck.Outcome.ExecutionDimensionExceeded),
+                "an empty block cannot hold this reservation");
             Assert.That(error, Is.EqualTo(GasEstimator.CannotEstimateGasExceeded));
         }
     }


### PR DESCRIPTION
Follow-up to #13191, addressing [flcl42's MEDIUM finding](https://github.com/NethermindEth/nethermind/pull/13191#discussion_r3955355644).

#13191 corrected the *source* of the per-transaction cap `EstimateFrameTx` applies — `FrameTxFieldsTxValidator` enforces the raw `Eip7825Constants.DefaultTxGasLimitCap`, while `spec.GetTxGasLimitCap()` returns `ulong.MaxValue` on every fork that enables EIP-8141. That part is right and is preserved here.

Replacing `Math.Min` in the process dropped the block-limit half of the bound, so the execution dimension is no longer tested against the block at all. Under EIP-8037 execution carries **both** bounds — the per-transaction cap and the block gas limit — while state is bounded by the block gas limit alone.

#### Reproduction

flcl42's case reproduces exactly on `eip8141-frame-txs-devnet7` at `37c8602`. Frames reserving **412,950 execution** / **200,000 state** gas against a **300,000-gas block** estimate successfully, while `Eip8037BlockGasInclusionCheck.Validate` returns `ExecutionDimensionExceeded` for the same reservations in an *empty* block. `eth_estimateGas` therefore reports a budget that cannot fit the block it was estimated against.

His secondary point also holds: `EstimateGas_FrameTxReservingMoreThanTheBlock_ReportsTheBudgetAsUnestimable` passes for the wrong reason. Its own execution reservation is 412,950 against a 100,000-gas block, but its state reservation (200,000) also exceeds the block, so the state clause is what fires. Confirmed by neutralising the state clause alone: that test then fails, so nothing in it exercises the execution dimension against the block.

## Changes

- `GasEstimator.EstimateFrameTx` bounds the execution reservation by `Math.Min(header.GasLimit, Eip7825Constants.DefaultTxGasLimitCap)` again, keeping #13191's corrected cap source. Both bounds now hold.
- Adds `EstimateGas_FrameTxWhoseExecutionBudgetAloneExceedsTheBlock_ReportsTheBudgetAsUnestimable`, the mirror of the state-dimension test #13241 added — execution over the block, state comfortably under it, and the reservation below the per-transaction cap so the cap clause cannot be what fires. It also pins that `Eip8037BlockGasInclusionCheck` refuses the same reservation in an empty block, so the estimate and admission are asserted against each other rather than against a hardcoded expectation.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Red/green pair on the new test:

- **Red** (fix not applied): `Nethermind.Evm.Test --filter FullyQualifiedName~EstimateGas_FrameTx` → 9 total, **1 failed**, 8 passed. The new test is the only failure, and within it only the `error` assertion fails — the assertions that execution exceeds the block, sits under the per-transaction cap, that state fits the block, and that `Eip8037BlockGasInclusionCheck` returns `ExecutionDimensionExceeded` all pass, so the isolation holds and the finding is confirmed as stated.
- **Green** (fix applied): same filter → 9 total, 0 failed.

Full runs with the fix applied:

- `Nethermind.Evm.Test --filter FullyQualifiedName~FrameTx` → 376 total, 0 failed.
- `Nethermind.Blockchain.Test` (whole assembly) → 2023 total, 1872 passed, 151 skipped, 0 failed.

Build is clean, 0 warnings.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This should land with or after #13191. #13191 merged while this was being prepared and its head branch was deleted, so the branch is based on and targets `eip8141-frame-txs-devnet7`, which now contains it — the diff is the follow-up alone.
