### PR TITLE
test(eip8141): core-normalized F projection + 322,800 sweep point

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
@@ -108,9 +108,13 @@ public class FrameTxFloodMeasurement
         }
     }
 
+    /// <summary>Swept verification ceilings; 322,800 is soispoke's real declared budget (320,000 + 2,800
+    /// signature), distinct from the 236,285 single-public-input point.</summary>
+    private static readonly ulong[] SweptCeilings = [100_000ul, 236_285ul, 300_000ul, 322_800ul, 500_000ul];
+
     private static IEnumerable<TestCaseData> ProductionDelayCases()
     {
-        foreach (ulong ceiling in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 322_800ul, 500_000ul })
+        foreach (ulong ceiling in SweptCeilings)
         {
             yield return new TestCaseData(ceiling, 0);
             yield return new TestCaseData(ceiling, 100);
@@ -119,7 +123,7 @@ public class FrameTxFloodMeasurement
 
     private static IEnumerable<TestCaseData> CeilingRateCases()
     {
-        foreach (ulong ceiling in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 322_800ul, 500_000ul })
+        foreach (ulong ceiling in SweptCeilings)
         {
             foreach (int rate in new int[] { 50, 100, 150, 200 })
             {
@@ -141,7 +145,7 @@ public class FrameTxFloodMeasurement
 
     private static IEnumerable<TestCaseData> CeilingCases()
     {
-        foreach (ulong ceiling in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 322_800ul, 500_000ul })
+        foreach (ulong ceiling in SweptCeilings)
         {
             yield return new TestCaseData(ceiling);
         }
@@ -203,40 +207,6 @@ public class FrameTxFloodMeasurement
             TestContext.Out.WriteLine($"DEBUG CPU affinity could not be read: {e.GetType().Name}: {e.Message}");
             return "unknown";
         }
-    }
-
-    /// <summary>Parses <see cref="ObservedCpuSet"/>'s Linux list/range syntax or Windows mask into a count.
-    /// Falls back to 1 when the set can't be read, so a projection against it is a safe no-op rather than
-    /// a crash.</summary>
-    private static int CpuCount()
-    {
-        string set = ObservedCpuSet();
-
-        if (set.StartsWith("mask:", StringComparison.Ordinal))
-        {
-            return ulong.TryParse(set["mask:".Length..], NumberStyles.HexNumber, CultureInfo.InvariantCulture,
-                       out ulong mask) && mask != 0
-                ? BitOperations.PopCount(mask)
-                : 1;
-        }
-
-        if (set.Length == 0 || set == "unknown") return 1;
-
-        int count = 0;
-        foreach (string part in set.Split(','))
-        {
-            int dash = part.IndexOf('-');
-            if (dash < 0)
-            {
-                count += 1;
-            }
-            else if (int.TryParse(part[..dash], out int first) && int.TryParse(part[(dash + 1)..], out int last))
-            {
-                count += Math.Max(1, last - first + 1);
-            }
-        }
-
-        return Math.Max(count, 1);
     }
 
     private static bool IsSingleCore()
@@ -566,13 +536,20 @@ public class FrameTxFloodMeasurement
         bool saturated = flooded.AchievedRate < offeredRate * RateHeldFloor || !lagBounded;
         double shedPct = ShedPct(flooded);
 
-        // sig-secp256k1 clears the signature filter before the simulator's lock, so unlike execution
-        // shapes it scales with cores rather than self-limiting near 1/t_reject; the projection below
-        // assumes that scaling is linear, which only a real multi-core run can confirm or falsify.
-        string coreNormalizedField = shape == "signature-stuffed"
-            ? $"delta_p50_us_core_normalized={(w - w0) * CpuCount():F1} "
-              + "delta_p50_us_core_normalized_basis=analytic_projection "
-            : "";
+        // sig-secp256k1 (the "signature-stuffed" shape here) scales with cores rather than self-limiting
+        // near 1/t_reject, since it clears the signature filter before the simulator's lock. Projecting
+        // onto FRAME_FLOOD_PROJECT_CORES assumes linear scaling, which only a real multi-core run can
+        // confirm; a delta measured on more than one core is already uncontended, so it isn't a valid
+        // multiplicand.
+        string coreNormalizedField = "";
+        if (shape == "signature-stuffed" && IsSingleCore()
+            && int.TryParse(Environment.GetEnvironmentVariable("FRAME_FLOOD_PROJECT_CORES"), out int targetCores)
+            && targetCores > 0)
+        {
+            coreNormalizedField = $"delta_p50_us_core_normalized={(w - w0) * targetCores:F1} "
+                                  + $"delta_p50_us_core_normalized_cores={targetCores} "
+                                  + "delta_p50_us_core_normalized_basis=analytic_projection ";
+        }
 
         Emit($"case=flood_delay shape={shape} ceiling={ceiling} shedding={(_shedding ? "on" : "off")} "
              + $"cpus={ObservedCpuSet()} single_core={(IsSingleCore() ? "yes" : "no")} "

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
@@ -109,7 +109,7 @@ public class FrameTxFloodMeasurement
     }
 
     /// <summary>322,800 is soispoke's real declared budget (320,000 + 2,800 signature).</summary>
-    private static readonly ulong[] SweptCeilings = [100_000ul, 236_285ul, 300_000ul, 322_800ul, 500_000ul];
+    private static readonly ulong[] SweptCeilings = [100_000ul, 300_000ul, 322_800ul, 500_000ul];
 
     private static IEnumerable<TestCaseData> ProductionDelayCases()
     {
@@ -535,10 +535,8 @@ public class FrameTxFloodMeasurement
         bool saturated = flooded.AchievedRate < offeredRate * RateHeldFloor || !lagBounded;
         double shedPct = ShedPct(flooded);
 
-        // signature-stuffed clears the signature filter before the simulator's lock, so unlike execution
-        // shapes it scales with cores instead of self-limiting near 1/t_reject - hence the projection,
-        // gated on a genuinely single-core row (an already-multi-core delta is uncontended, not a valid
-        // multiplicand) and an explicit target, since only a real multi-core run confirms linear scaling.
+        // signature-stuffed scales with cores, unlike execution shapes, so only its single-core rows get
+        // an explicit-target core projection.
         string coreNormalizedField = "";
         if (shape == "signature-stuffed" && IsSingleCore()
             && int.TryParse(Environment.GetEnvironmentVariable("FRAME_FLOOD_PROJECT_CORES"), out int targetCores)

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
@@ -110,7 +110,7 @@ public class FrameTxFloodMeasurement
 
     private static IEnumerable<TestCaseData> ProductionDelayCases()
     {
-        foreach (ulong ceiling in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 500_000ul })
+        foreach (ulong ceiling in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 322_800ul, 500_000ul })
         {
             yield return new TestCaseData(ceiling, 0);
             yield return new TestCaseData(ceiling, 100);
@@ -119,7 +119,7 @@ public class FrameTxFloodMeasurement
 
     private static IEnumerable<TestCaseData> CeilingRateCases()
     {
-        foreach (ulong ceiling in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 500_000ul })
+        foreach (ulong ceiling in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 322_800ul, 500_000ul })
         {
             foreach (int rate in new int[] { 50, 100, 150, 200 })
             {
@@ -141,7 +141,7 @@ public class FrameTxFloodMeasurement
 
     private static IEnumerable<TestCaseData> CeilingCases()
     {
-        foreach (ulong ceiling in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 500_000ul })
+        foreach (ulong ceiling in new ulong[] { 100_000ul, 236_285ul, 300_000ul, 322_800ul, 500_000ul })
         {
             yield return new TestCaseData(ceiling);
         }
@@ -203,6 +203,40 @@ public class FrameTxFloodMeasurement
             TestContext.Out.WriteLine($"DEBUG CPU affinity could not be read: {e.GetType().Name}: {e.Message}");
             return "unknown";
         }
+    }
+
+    /// <summary>Parses <see cref="ObservedCpuSet"/>'s Linux list/range syntax or Windows mask into a count.
+    /// Falls back to 1 when the set can't be read, so a projection against it is a safe no-op rather than
+    /// a crash.</summary>
+    private static int CpuCount()
+    {
+        string set = ObservedCpuSet();
+
+        if (set.StartsWith("mask:", StringComparison.Ordinal))
+        {
+            return ulong.TryParse(set["mask:".Length..], NumberStyles.HexNumber, CultureInfo.InvariantCulture,
+                       out ulong mask) && mask != 0
+                ? BitOperations.PopCount(mask)
+                : 1;
+        }
+
+        if (set.Length == 0 || set == "unknown") return 1;
+
+        int count = 0;
+        foreach (string part in set.Split(','))
+        {
+            int dash = part.IndexOf('-');
+            if (dash < 0)
+            {
+                count += 1;
+            }
+            else if (int.TryParse(part[..dash], out int first) && int.TryParse(part[(dash + 1)..], out int last))
+            {
+                count += Math.Max(1, last - first + 1);
+            }
+        }
+
+        return Math.Max(count, 1);
     }
 
     private static bool IsSingleCore()
@@ -532,8 +566,17 @@ public class FrameTxFloodMeasurement
         bool saturated = flooded.AchievedRate < offeredRate * RateHeldFloor || !lagBounded;
         double shedPct = ShedPct(flooded);
 
+        // sig-secp256k1 clears the signature filter before the simulator's lock, so unlike execution
+        // shapes it scales with cores rather than self-limiting near 1/t_reject; the projection below
+        // assumes that scaling is linear, which only a real multi-core run can confirm or falsify.
+        string coreNormalizedField = shape == "signature-stuffed"
+            ? $"delta_p50_us_core_normalized={(w - w0) * CpuCount():F1} "
+              + "delta_p50_us_core_normalized_basis=analytic_projection "
+            : "";
+
         Emit($"case=flood_delay shape={shape} ceiling={ceiling} shedding={(_shedding ? "on" : "off")} "
              + $"cpus={ObservedCpuSet()} single_core={(IsSingleCore() ? "yes" : "no")} "
+             + coreNormalizedField
              + $"W0_after_p50_us={w0After:F1} W0_after_p99_us={w0p99After:F1} "
              + $"baseline_drift_pct={baselineDriftPct:F1} baseline_tail_drift_pct={baselineTailDriftPct:F1} "
              + $"valid={(worstDriftPct < MaxBaselineDriftPercent ? "yes" : "no")} "

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
@@ -108,8 +108,7 @@ public class FrameTxFloodMeasurement
         }
     }
 
-    /// <summary>Swept verification ceilings; 322,800 is soispoke's real declared budget (320,000 + 2,800
-    /// signature), distinct from the 236,285 single-public-input point.</summary>
+    /// <summary>322,800 is soispoke's real declared budget (320,000 + 2,800 signature).</summary>
     private static readonly ulong[] SweptCeilings = [100_000ul, 236_285ul, 300_000ul, 322_800ul, 500_000ul];
 
     private static IEnumerable<TestCaseData> ProductionDelayCases()
@@ -536,11 +535,10 @@ public class FrameTxFloodMeasurement
         bool saturated = flooded.AchievedRate < offeredRate * RateHeldFloor || !lagBounded;
         double shedPct = ShedPct(flooded);
 
-        // sig-secp256k1 (the "signature-stuffed" shape here) scales with cores rather than self-limiting
-        // near 1/t_reject, since it clears the signature filter before the simulator's lock. Projecting
-        // onto FRAME_FLOOD_PROJECT_CORES assumes linear scaling, which only a real multi-core run can
-        // confirm; a delta measured on more than one core is already uncontended, so it isn't a valid
-        // multiplicand.
+        // signature-stuffed clears the signature filter before the simulator's lock, so unlike execution
+        // shapes it scales with cores instead of self-limiting near 1/t_reject - hence the projection,
+        // gated on a genuinely single-core row (an already-multi-core delta is uncontended, not a valid
+        // multiplicand) and an explicit target, since only a real multi-core run confirms linear scaling.
         string coreNormalizedField = "";
         if (shape == "signature-stuffed" && IsSingleCore()
             && int.TryParse(Environment.GetEnvironmentVariable("FRAME_FLOOD_PROJECT_CORES"), out int targetCores)

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
@@ -69,11 +69,10 @@ public class FrameTxMempoolDosMeasurement
     private const ulong Ceiling300k = 300_000;
     private const ulong Ceiling500k = 500_000;
 
-    /// <summary>soispoke's real declared frame budget (320,000 + 2,800 signature) - the shielded
-    /// pool's actual floor, distinct from the 236,285 point derived from a single-public-input
-    /// circuit. The <c>groth16-soispoke</c> sweep stays at 300,000 because its artifact burns
-    /// 248,437 and a higher declared ceiling would exceed <see cref="Eip8141Constants.MaxVerifyGas"/>
-    /// and skip the arm.</summary>
+    /// <summary>soispoke's real declared frame budget (320,000 + 2,800 signature), distinct from the
+    /// 236,285 single-public-input point. <c>groth16-soispoke</c> stays at 300,000 below because its
+    /// artifact burns 248,437; declaring 322,800 there would exceed
+    /// <see cref="Eip8141Constants.MaxVerifyGas"/> and skip the arm.</summary>
     private const ulong Ceiling322800 = 322_800;
 
     /// <summary>Small frame budget reserved by the signature-stuffing shape.</summary>

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
@@ -71,7 +71,9 @@ public class FrameTxMempoolDosMeasurement
 
     /// <summary>soispoke's real declared frame budget (320,000 + 2,800 signature) - the shielded
     /// pool's actual floor, distinct from the 236,285 point derived from a single-public-input
-    /// circuit.</summary>
+    /// circuit. The <c>groth16-soispoke</c> sweep stays at 300,000 because its artifact burns
+    /// 248,437 and a higher declared ceiling would exceed <see cref="Eip8141Constants.MaxVerifyGas"/>
+    /// and skip the arm.</summary>
     private const ulong Ceiling322800 = 322_800;
 
     /// <summary>Small frame budget reserved by the signature-stuffing shape.</summary>

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
@@ -65,14 +65,9 @@ public class FrameTxMempoolDosMeasurement
     private const ulong VerifyGas = Eip8141Constants.MaxVerifyGas;
 
     private const ulong Ceiling100k = 100_000;
-    private const ulong Ceiling236k = 236_285;
     private const ulong Ceiling300k = 300_000;
     private const ulong Ceiling500k = 500_000;
 
-    /// <summary>soispoke's real declared frame budget (320,000 + 2,800 signature), distinct from the
-    /// 236,285 single-public-input point. <c>groth16-soispoke</c> stays at 300,000 below because its
-    /// artifact burns 248,437; declaring 322,800 there would exceed
-    /// <see cref="Eip8141Constants.MaxVerifyGas"/> and skip the arm.</summary>
     private const ulong Ceiling322800 = 322_800;
 
     /// <summary>Small frame budget reserved by the signature-stuffing shape.</summary>
@@ -139,7 +134,7 @@ public class FrameTxMempoolDosMeasurement
             }
         }
 
-        foreach (ulong ceiling in new ulong[] { Ceiling100k, Ceiling236k, Ceiling300k, Ceiling322800, Ceiling500k })
+        foreach (ulong ceiling in new ulong[] { Ceiling100k, Ceiling300k, Ceiling322800, Ceiling500k })
         {
             yield return new TestCaseData("keccak-wide", ceiling);
         }
@@ -155,7 +150,7 @@ public class FrameTxMempoolDosMeasurement
 
     private static IEnumerable<TestCaseData> CeilingCases()
     {
-        foreach (ulong ceiling in new ulong[] { Ceiling100k, Ceiling236k, Ceiling300k, Ceiling322800, Ceiling500k })
+        foreach (ulong ceiling in new ulong[] { Ceiling100k, Ceiling300k, Ceiling322800, Ceiling500k })
         {
             yield return new TestCaseData(ceiling);
         }

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
@@ -69,6 +69,11 @@ public class FrameTxMempoolDosMeasurement
     private const ulong Ceiling300k = 300_000;
     private const ulong Ceiling500k = 500_000;
 
+    /// <summary>soispoke's real declared frame budget (320,000 + 2,800 signature) - the shielded
+    /// pool's actual floor, distinct from the 236,285 point derived from a single-public-input
+    /// circuit.</summary>
+    private const ulong Ceiling322800 = 322_800;
+
     /// <summary>Small frame budget reserved by the signature-stuffing shape.</summary>
     private const ulong MinimalFrameGas = 400;
 
@@ -133,7 +138,7 @@ public class FrameTxMempoolDosMeasurement
             }
         }
 
-        foreach (ulong ceiling in new ulong[] { Ceiling100k, Ceiling236k, Ceiling300k, Ceiling500k })
+        foreach (ulong ceiling in new ulong[] { Ceiling100k, Ceiling236k, Ceiling300k, Ceiling322800, Ceiling500k })
         {
             yield return new TestCaseData("keccak-wide", ceiling);
         }
@@ -149,7 +154,7 @@ public class FrameTxMempoolDosMeasurement
 
     private static IEnumerable<TestCaseData> CeilingCases()
     {
-        foreach (ulong ceiling in new ulong[] { Ceiling100k, Ceiling236k, Ceiling300k, Ceiling500k })
+        foreach (ulong ceiling in new ulong[] { Ceiling100k, Ceiling236k, Ceiling300k, Ceiling322800, Ceiling500k })
         {
             yield return new TestCaseData(ceiling);
         }


### PR DESCRIPTION
## Changes

- Add a 322,800 verification-ceiling sweep point (soispoke's real declared frame budget: 320,000 + 2,800 signature) to the existing 100k/236,285/300k/500k sweep, in `FrameTxMempoolDosMeasurement` (`t_reject`) and `FrameTxFloodMeasurement` (flood delay/capacity). Neither existing ceiling measures behavior at the real floor - 300k rejects it, 500k over-admits it.
- Add `delta_p50_us_core_normalized` to `signature-stuffed` flood-delay rows: projects the measured single-core delta onto an explicit `FRAME_FLOOD_PROJECT_CORES` target, gated on the row actually being single-core, labelled `..._basis=analytic_projection` with its own `..._cores=N` so the projection is self-describing and invertible. Scoped to this shape only - execution shapes stay lock-bound regardless of core count.
- Collapse the ceiling sweep (three separate hardcoded arrays in `FrameTxFloodMeasurement`) into one `SweptCeilings` constant.

## Why

`signature-stuffed` clears the signature filter before the prefix simulator's lock, so unlike execution shapes it scales with cores rather than self-limiting near `1/t_reject` - the existing single-core curve alone doesn't answer what a core-normalized safety floor needs.

## Not included

A real multi-core measurement mode to check whether the linear-scaling assumption above actually holds under contention, and curve-role labelling on rows generally - both are follow-ups, not started here.

Test-only, no production code.
