### PR TITLE
fix(flat): prevent warmer misses escaping through shared trie children

### DIFF
--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Threading;
 using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -506,7 +507,8 @@ public class SnapshotBundleWarmerTests
         TrieNode sharedParent = new(NodeType.Unknown, branch.Keccak!, branch.FullRlp);
         sharedParent.ResolveNode(NullTrieNodeResolver.Instance, rootPath);
 
-        (byte[] oldRlp, _) = EncodedLeaf();
+        (byte[] oldRlp, Hash256 oldHash) = EncodedLeaf();
+        Assert.That(oldHash, Is.Not.EqualTo(child.Keccak));
         IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
         reader.TryLoadStateRlp(Arg.Any<TreePath>(), Arg.Any<ReadFlags>()).Returns(oldRlp);
         reader.TryLoadStorageRlp(Arg.Any<Hash256>(), Arg.Any<TreePath>(), Arg.Any<ReadFlags>()).Returns(oldRlp);
@@ -522,13 +524,12 @@ public class SnapshotBundleWarmerTests
 
         ITrieNodeResolver warmer = WarmerResolver(bundle, storage ? address : null);
         TrieNode warmedParent = warmer.FindCachedOrUnknown(rootPath, branch.Keccak!);
-        TrieNode.ChildIterator children = warmedParent.CreateChildIterator();
         TrieNode warmedChild = (iterator
-            ? children.GetChildWithChildPath(warmer, ref childPath, 0)
+            ? warmedParent.CreateChildIterator().GetChildWithChildPath(warmer, ref childPath, 0)
             : warmedParent.GetChildWithChildPath(warmer, ref childPath, 0))!;
         Assert.That(warmedChild.TryResolveNode(warmer, ref childPath), Is.False);
 
-        StateTrieStoreAdapter state = new(bundle, new Nethermind.Core.Threading.ConcurrencyController(1));
+        StateTrieStoreAdapter state = new(bundle, new ConcurrencyController(1));
         ITrieNodeResolver live = storage ? state.GetStorageTrieNodeResolver(address) : state;
         Assert.That(live.FindCachedOrUnknown(childPath, child.Keccak!), Is.SameAs(child));
         TrieNode liveParent = live.FindCachedOrUnknown(rootPath, branch.Keccak!);

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
@@ -490,6 +490,53 @@ public class SnapshotBundleWarmerTests
         }
     }
 
+    [Test]
+    public void Live_read_of_shared_parent_uses_snapshot_child_after_warmer_miss(
+        [Values] bool storage, [Values] bool iterator)
+    {
+        Hash256 address = TestItem.KeccakC;
+        TreePath rootPath = TreePath.Empty;
+        TreePath childPath = TreePath.FromHexString("0");
+        TrieNode child = TrieNodeFactory.CreateLeaf([0x3, 0x4], new byte[33]);
+        child.ResolveKey(NullTrieNodeResolver.Instance, ref childPath);
+        child.Seal();
+        TrieNode branch = new(NodeType.Branch);
+        branch.SetChild(0, child);
+        branch.ResolveKey(NullTrieNodeResolver.Instance, ref rootPath);
+        TrieNode sharedParent = new(NodeType.Unknown, branch.Keccak!, branch.FullRlp);
+        sharedParent.ResolveNode(NullTrieNodeResolver.Instance, rootPath);
+
+        (byte[] oldRlp, _) = EncodedLeaf();
+        IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
+        reader.TryLoadStateRlp(Arg.Any<TreePath>(), Arg.Any<ReadFlags>()).Returns(oldRlp);
+        reader.TryLoadStorageRlp(Arg.Any<Hash256>(), Arg.Any<TreePath>(), Arg.Any<ReadFlags>()).Returns(oldRlp);
+        using SnapshotBundle bundle = new(
+            FlatTestHelpers.MakeBundle(_pool, reader, content =>
+            {
+                if (storage) content.StorageNodes[(address, rootPath)] = sharedParent;
+                else content.StateNodes[rootPath] = sharedParent;
+            }), new NullTrieNodeCache(), _pool, ResourcePool.Usage.MainBlockProcessing);
+        if (storage) bundle.SetStorageNode(address, childPath, child);
+        else bundle.SetStateNode(childPath, child);
+        bundle.CollectAndApplySnapshot(StateId.PreGenesis, new StateId(1, TestItem.KeccakA), returnSnapshot: false);
+
+        ITrieNodeResolver warmer = WarmerResolver(bundle, storage ? address : null);
+        TrieNode warmedParent = warmer.FindCachedOrUnknown(rootPath, branch.Keccak!);
+        TrieNode.ChildIterator children = warmedParent.CreateChildIterator();
+        TrieNode warmedChild = (iterator
+            ? children.GetChildWithChildPath(warmer, ref childPath, 0)
+            : warmedParent.GetChildWithChildPath(warmer, ref childPath, 0))!;
+        Assert.That(warmedChild.TryResolveNode(warmer, ref childPath), Is.False);
+
+        StateTrieStoreAdapter state = new(bundle, new Nethermind.Core.Threading.ConcurrencyController(1));
+        ITrieNodeResolver live = storage ? state.GetStorageTrieNodeResolver(address) : state;
+        Assert.That(live.FindCachedOrUnknown(childPath, child.Keccak!), Is.SameAs(child));
+        TrieNode liveParent = live.FindCachedOrUnknown(rootPath, branch.Keccak!);
+        TrieNode liveChild = liveParent.GetChildWithChildPath(live, ref childPath, 0)!;
+        Assert.That(() => liveChild.ResolveNode(live, childPath), Throws.Nothing);
+        Assert.That(liveChild.FullRlp.ToArray(), Is.EqualTo(child.FullRlp.ToArray()));
+    }
+
     private static ITrieNodeResolver WarmerResolver(SnapshotBundle bundle, Hash256? address)
     {
         StateTrieStoreWarmerAdapter state = new(bundle);

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotBundleWarmerTests.cs
@@ -493,7 +493,7 @@ public class SnapshotBundleWarmerTests
 
     [Test]
     public void Live_read_of_shared_parent_uses_snapshot_child_after_warmer_miss(
-        [Values] bool storage, [Values] bool iterator)
+        [Values] bool storage, [Values] bool iterator, [Values] bool staleSnapshot)
     {
         Hash256 address = TestItem.KeccakC;
         TreePath rootPath = TreePath.Empty;
@@ -517,6 +517,12 @@ public class SnapshotBundleWarmerTests
             {
                 if (storage) content.StorageNodes[(address, rootPath)] = sharedParent;
                 else content.StateNodes[rootPath] = sharedParent;
+                if (staleSnapshot)
+                {
+                    TrieNode staleChild = new(NodeType.Unknown, oldHash, oldRlp);
+                    if (storage) content.StorageNodes[(address, childPath)] = staleChild;
+                    else content.StateNodes[childPath] = staleChild;
+                }
             }), new NullTrieNodeCache(), _pool, ResourcePool.Usage.MainBlockProcessing);
         if (storage) bundle.SetStorageNode(address, childPath, child);
         else bundle.SetStateNode(childPath, child);
@@ -524,10 +530,17 @@ public class SnapshotBundleWarmerTests
 
         ITrieNodeResolver warmer = WarmerResolver(bundle, storage ? address : null);
         TrieNode warmedParent = warmer.FindCachedOrUnknown(rootPath, branch.Keccak!);
-        TrieNode warmedChild = (iterator
+        TrieNode ReadWarmedChild() => (iterator
             ? warmedParent.CreateChildIterator().GetChildWithChildPath(warmer, ref childPath, 0)
             : warmedParent.GetChildWithChildPath(warmer, ref childPath, 0))!;
-        Assert.That(warmedChild.TryResolveNode(warmer, ref childPath), Is.False);
+        if (staleSnapshot)
+        {
+            Assert.Throws<NodeHashMismatchException>(() => ReadWarmedChild());
+        }
+        else
+        {
+            Assert.That(ReadWarmedChild().TryResolveNode(warmer, ref childPath), Is.False);
+        }
 
         StateTrieStoreAdapter state = new(bundle, new ConcurrencyController(1));
         ITrieNodeResolver live = storage ? state.GetStorageTrieNodeResolver(address) : state;

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -148,6 +148,40 @@ public class TrieNodeTests
     }
 
     [Test]
+    public void Child_slot_reuses_nodes_except_unresolved_warmer_nodes(
+        [Values] bool warmerOwned, [Values] bool resolved, [Values] bool iterator)
+    {
+        (byte[] rlp, Hash256 hash) = EncodedLeaf();
+        TrieNode child = new(NodeType.Unknown, hash, rlp);
+        if (warmerOwned) child.MarkWarmerOwned();
+        TreePath path = TreePath.Empty;
+        if (resolved) child.ResolveNode(NullTrieNodeResolver.Instance, path);
+
+        TrieNode branch = new(NodeType.Branch);
+        branch.SetChild(0, child);
+        branch.ResolveKey(NullTrieNodeResolver.Instance, ref path);
+        TrieNode parent = new(NodeType.Unknown, branch.Keccak!, branch.FullRlp);
+        parent.ResolveNode(NullTrieNodeResolver.Instance, path);
+        parent.AppendChildPath(ref path, 0);
+
+        ITrieNodeResolver firstResolver = Substitute.For<ITrieNodeResolver>();
+        firstResolver.FindCachedOrUnknown(path, hash).Returns(child);
+        TrieNode? first = iterator
+            ? parent.CreateChildIterator().GetChildWithChildPath(firstResolver, ref path, 0)
+            : parent.GetChildWithChildPath(firstResolver, ref path, 0);
+        Assert.That(first, Is.SameAs(child));
+
+        TrieNode replacement = new(NodeType.Unknown, hash, rlp);
+        ITrieNodeResolver secondResolver = Substitute.For<ITrieNodeResolver>();
+        secondResolver.FindCachedOrUnknown(path, hash).Returns(replacement);
+        TrieNode? second = iterator
+            ? parent.CreateChildIterator().GetChildWithChildPath(secondResolver, ref path, 0)
+            : parent.GetChildWithChildPath(secondResolver, ref path, 0);
+
+        Assert.That(second, Is.SameAs(warmerOwned && !resolved ? replacement : child));
+    }
+
+    [Test]
     public void Concurrent_warmer_owned_try_resolve_loads_once()
     {
         (byte[] rlp, Hash256 hash) = EncodedLeaf();

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -1454,7 +1454,9 @@ namespace Nethermind.Trie
                                 Hash256 keccak = rlpReader.DecodeKeccak();
 
                                 TrieNode child = tree.FindCachedOrUnknown(childPath, keccak);
-                                data = childOrRef = child;
+                                // A warmer miss must not bypass a later live reader's snapshot lookup.
+                                data = child.IsWarmerOwned ? keccak : child;
+                                childOrRef = child;
 
                                 break;
                             }
@@ -1634,7 +1636,9 @@ namespace Nethermind.Trie
                                     _currentStreamIndex++;
 
                                     TrieNode child = tree.FindCachedOrUnknown(childPath, keccak);
-                                    data = childOrRef = child;
+                                    // A warmer miss must not bypass a later live reader's snapshot lookup.
+                                    data = child.IsWarmerOwned ? keccak : child;
+                                    childOrRef = child;
 
                                     break;
                                 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -105,8 +105,9 @@ namespace Nethermind.Trie
 
         internal bool IsWarmerResolved => (ReadBlockAndFlags() & _warmerResolvedMask) != 0;
 
-        /// <summary>Whether this warmer-owned node still requires verified resolution.</summary>
-        /// <remarks>Shared parent slots retain its hash so live readers use their own snapshot lookup.</remarks>
+        /// <summary>Whether this node is owned by the trie warmer and has not yet been resolved with verified RLP.</summary>
+        /// <remarks>Shared parent slots retain the hash of an unresolved warmer-owned child so live readers
+        /// use their own snapshot lookup.</remarks>
         internal bool IsUnresolvedWarmerOwned =>
             (ReadBlockAndFlags() & (_warmerOwnedMask | _warmerResolvedMask)) == _warmerOwnedMask;
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -1455,7 +1455,7 @@ namespace Nethermind.Trie
 
                                 TrieNode child = tree.FindCachedOrUnknown(childPath, keccak);
                                 // A warmer miss must not bypass a later live reader's snapshot lookup.
-                                data = child.IsWarmerOwned ? keccak : child;
+                                data = child.IsWarmerOwned && !child.IsWarmerResolved ? keccak : child;
                                 childOrRef = child;
 
                                 break;
@@ -1637,7 +1637,7 @@ namespace Nethermind.Trie
 
                                     TrieNode child = tree.FindCachedOrUnknown(childPath, keccak);
                                     // A warmer miss must not bypass a later live reader's snapshot lookup.
-                                    data = child.IsWarmerOwned ? keccak : child;
+                                    data = child.IsWarmerOwned && !child.IsWarmerResolved ? keccak : child;
                                     childOrRef = child;
 
                                     break;

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -105,6 +105,11 @@ namespace Nethermind.Trie
 
         internal bool IsWarmerResolved => (ReadBlockAndFlags() & _warmerResolvedMask) != 0;
 
+        /// <summary>Whether this warmer-owned node still requires verified resolution.</summary>
+        /// <remarks>Shared parent slots retain its hash so live readers use their own snapshot lookup.</remarks>
+        internal bool IsUnresolvedWarmerOwned =>
+            (ReadBlockAndFlags() & (_warmerOwnedMask | _warmerResolvedMask)) == _warmerOwnedMask;
+
         internal void MarkWarmerOwned()
         {
             byte previousValue = ReadBlockAndFlags();
@@ -1454,8 +1459,7 @@ namespace Nethermind.Trie
                                 Hash256 keccak = rlpReader.DecodeKeccak();
 
                                 TrieNode child = tree.FindCachedOrUnknown(childPath, keccak);
-                                // A warmer miss must not bypass a later live reader's snapshot lookup.
-                                data = child.IsWarmerOwned && !child.IsWarmerResolved ? keccak : child;
+                                data = child.IsUnresolvedWarmerOwned ? keccak : child;
                                 childOrRef = child;
 
                                 break;
@@ -1636,8 +1640,7 @@ namespace Nethermind.Trie
                                     _currentStreamIndex++;
 
                                     TrieNode child = tree.FindCachedOrUnknown(childPath, keccak);
-                                    // A warmer miss must not bypass a later live reader's snapshot lookup.
-                                    data = child.IsWarmerOwned && !child.IsWarmerResolved ? keccak : child;
+                                    data = child.IsUnresolvedWarmerOwned ? keccak : child;
                                     childOrRef = child;
 
                                     break;


### PR DESCRIPTION
## Changes

- Keep hash references in shared parent child slots when a lookup returns an unresolved warmer-owned node, in both direct traversal and `ChildIterator`. A subsequent live read can then find the correct node in its snapshot instead of resolving the warmer's miss against older path-keyed persistence. Already-resolved warmer nodes retain the parent slot cache.
- Preserve RLP hash verification and reuse of resolved warmer nodes through the transient cache.
- Add eight regression cases covering state/storage tries, both child traversal paths, and stale RLP/node-object snapshot responses. Each case verifies that the subsequent live read gets the correct snapshot child; stale snapshot objects are rejected by the existing warmer adapter before parent-slot publication.
- Add eight Trie-level cases covering parent-slot reuse for ordinary and warmer-owned nodes, resolved and unresolved, through both traversal paths.

This reproduces the exception reported during [Gnosis Flat sync](https://github.com/NethermindEth/nethermind/actions/runs/34166477350/job/101878828235), first seen while processing block 48,136,002. It establishes a matching failure mechanism; the original database/RLP was unavailable for an exact replay.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- The four Flat cases with `staleSnapshot: false` fail before the original fix with `TrieNodeException: Trie returned RLP with an unexpected Keccak`. The four `staleSnapshot: true` cases cover the existing adapter rejection and pass without the fix.
- Release `SnapshotBundleWarmerTests`: 29 passed, including all eight regression cases.
- Release `TrieNodeTests` after the resolved-node cache refinement: 93 passed. The two resolved-warmer cases fail before that refinement.
- Full Release `Nethermind.Trie.Test` on the initial fix: 542 passed, 7 skipped.
- Full Release `Nethermind.State.Flat.Test` on the initial fix: 1,041 passed, 10 skipped, 14 failures in Windows file teardown (`IOException` deleting locked arena/blob files). All 14 failures also reproduce with the production change reverted (22 affected baseline cases: 8 passed, 14 failed).
- Whitespace formatting and `git diff --check` passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Fix a Flat state trie warmer cache interaction that could interrupt block processing with an unexpected-Keccak exception.
