### PR TITLE
Merge master into eip8141-frame-txs-devnet7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL analysis
 
 on:
   push:
-    tags: ['*', '!zisk-guest-*']
+    tags: ['*', '!zisk-guest-*', '!bootnode-*']
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:

--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -2,7 +2,7 @@ name: Hive tests
 
 on:
   push:
-    tags: ['*', '!zisk-guest-*']
+    tags: ['*', '!zisk-guest-*', '!bootnode-*']
     branches: [master]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -8,7 +8,7 @@ jobs:
   publish-ppa:
     name: Publish on PPA
     runs-on: ubuntu-latest
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ !github.event.release.prerelease && !startsWith(github.event.release.tag_name, 'bootnode-') }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -87,7 +87,7 @@ jobs:
   publish-winget:
     name: Publish on Windows Package Manager
     runs-on: windows-latest
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ !github.event.release.prerelease && !startsWith(github.event.release.tag_name, 'bootnode-') }}
     steps:
       - name: Submit package
         env:
@@ -103,7 +103,7 @@ jobs:
   publish-homebrew:
     name: Publish on Homebrew
     runs-on: ubuntu-latest
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ !github.event.release.prerelease && !startsWith(github.event.release.tag_name, 'bootnode-') }}
     env:
       FORMULA: nethermind.rb
     steps:
@@ -155,7 +155,7 @@ jobs:
   publish-nuget:
     name: Publish NuGet packages
     runs-on: ubuntu-latest
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ !github.event.release.prerelease && !startsWith(github.event.release.tag_name, 'bootnode-') }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/release-bootnode.yml
+++ b/.github/workflows/release-bootnode.yml
@@ -3,27 +3,14 @@ name: Release Bootnode
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: Bootnode release tag, for example bootnode-r1
-        required: true
-        default: bootnode-r1
-      release_name:
-        description: GitHub release title. Leave empty to derive it from the tag.
-        required: false
-        default: ""
-      prerelease:
-        description: Mark the GitHub release as a prerelease.
-        required: true
-        type: boolean
-        default: true
       publish_latest:
-        description: Also publish Docker latest and mark the GitHub release latest. Valid only when prerelease is false.
+        description: Also publish Docker latest.
         required: true
         type: boolean
         default: false
 
 concurrency:
-  group: bootnode-release-${{ inputs.tag }}
+  group: bootnode-release
   cancel-in-progress: false
 
 permissions:
@@ -41,45 +28,62 @@ jobs:
     name: Build Bootnode packages
     runs-on: ubuntu-latest
     outputs:
-      release-tag: ${{ steps.release.outputs.release-tag }}
-      release-name: ${{ steps.release.outputs.release-name }}
-      package-prefix: ${{ steps.release.outputs.package-prefix }}
-      prerelease: ${{ steps.release.outputs.prerelease }}
-      publish-latest: ${{ steps.release.outputs.publish-latest }}
+      release-tag: ${{ steps.version.outputs.release-tag }}
+      release-name: ${{ steps.version.outputs.release-name }}
+      version: ${{ steps.version.outputs.version }}
+      package-prefix: ${{ steps.version.outputs.package-prefix }}
+      publish-latest: ${{ steps.version.outputs.publish-latest }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Resolve release metadata
-        id: release
+      - name: Detect version
+        id: version
+        working-directory: tools/Bootnode/Nethermind.Bootnode
         env:
-          INPUT_TAG: ${{ inputs.tag }}
-          INPUT_RELEASE_NAME: ${{ inputs.release_name }}
-          INPUT_PRERELEASE: ${{ inputs.prerelease }}
+          GH_TOKEN: ${{ github.token }}
           INPUT_PUBLISH_LATEST: ${{ inputs.publish_latest }}
         run: |
-          tag="$INPUT_TAG"
-          if [[ ! "$tag" =~ ^bootnode-[0-9A-Za-z][0-9A-Za-z._-]*$ ]]; then
-            echo "Bootnode release tags must start with 'bootnode-' and contain only letters, digits, dots, underscores, or hyphens."
+          sudo apt-get update && sudo apt-get install xmlstarlet -y --no-install-recommends
+          version_prefix=$(xmlstarlet sel -t -v "//Project/PropertyGroup/VersionPrefix" Nethermind.Bootnode.csproj)
+          version=$version_prefix
+          release_tag=bootnode-$version
+          release_name="Nethermind Bootnode $version"
+          package_prefix=nethermind-bootnode-$version
+
+          if [[ -z "$version_prefix" || ! "$version" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]] || ! git check-ref-format --allow-onelevel "refs/tags/$release_tag"; then
+            echo "Bootnode version '$version' must produce valid Docker and Git tags."
             exit 1
           fi
 
-          if [[ "$INPUT_PRERELEASE" == "true" && "$INPUT_PUBLISH_LATEST" == "true" ]]; then
-            echo "A prerelease cannot also be published as latest."
+          if ! tag_ref=$(git ls-remote --refs origin "refs/tags/$release_tag"); then
+            echo "::error::Could not inspect the Bootnode tag $release_tag."
             exit 1
           fi
 
-          release_name="$INPUT_RELEASE_NAME"
-          if [[ -z "$release_name" ]]; then
-            release_name="Nethermind Bootnode ${tag#bootnode-}"
+          if [[ -n "$tag_ref" ]] || release=$(gh release view "$release_tag" --json isDraft,targetCommitish 2>/dev/null); then
+            if [[ -z "$tag_ref" && "$(jq -r '.isDraft' <<< "$release")" == "true" ]]; then
+              release_ref=$(jq -r '.targetCommitish' <<< "$release")
+            else
+              release_ref=refs/tags/$release_tag
+            fi
+
+            if ! release_target=$(gh api "repos/$GITHUB_REPOSITORY/commits/$release_ref" --jq .sha); then
+              echo "::error::Could not resolve the existing Bootnode release $release_tag."
+              exit 1
+            fi
+
+            if [[ "$release_target" != "$GITHUB_SHA" ]]; then
+              echo "::error::Bootnode release $release_tag already targets $release_target, not $GITHUB_SHA. Bump VersionPrefix in tools/Bootnode/Nethermind.Bootnode/Nethermind.Bootnode.csproj to publish a new version, or delete the stale untagged draft before re-cutting this version."
+              exit 1
+            fi
           fi
 
-          package_prefix=nethermind-$tag
-
-          echo "release-tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Detected version $version"
+          echo "release-tag=$release_tag" >> "$GITHUB_OUTPUT"
           echo "release-name=$release_name" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "package-prefix=$package_prefix" >> "$GITHUB_OUTPUT"
-          echo "prerelease=$INPUT_PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "publish-latest=$INPUT_PUBLISH_LATEST" >> "$GITHUB_OUTPUT"
           echo "PACKAGE_PREFIX=$package_prefix" >> "$GITHUB_ENV"
 
@@ -159,18 +163,17 @@ jobs:
           GITHUB_TOKEN: ${{ steps.gh-app.outputs.token }}
           RELEASE_TAG: ${{ needs.build.outputs.release-tag }}
           RELEASE_NAME: ${{ needs.build.outputs.release-name }}
-          PRERELEASE: ${{ needs.build.outputs.prerelease }}
-          PUBLISH_LATEST: ${{ needs.build.outputs.publish-latest }}
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
         run: |
           relnotes=$(cat <<EOF
           # Release notes
 
-          Standalone Nethermind Bootnode release.
+          Standalone Nethermind Bootnode release, version $RELEASE_VERSION.
 
           ## Docker image
 
           \`\`\`bash
-          docker pull nethermind/nethermind-bootnode:$RELEASE_TAG
+          docker pull nethermind/bootnode:$RELEASE_VERSION
           \`\`\`
 
           ## Build signatures
@@ -179,22 +182,39 @@ jobs:
           EOF
           )
 
-          prerelease_flag=()
-          latest_flag=()
-          if [[ "$PRERELEASE" == "true" ]]; then
-            prerelease_flag=(-p)
-          elif [[ "$PUBLISH_LATEST" == "true" ]]; then
-            latest_flag=(--latest)
-          fi
-
           if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             echo "Drafting release $RELEASE_TAG"
             gh release create "$RELEASE_TAG" \
               --target "$GITHUB_SHA" \
               -t "$RELEASE_NAME" \
               -d \
-              "${prerelease_flag[@]}" \
               -F <(printf '%s' "$relnotes")
+          fi
+
+          if ! release=$(gh release view "$RELEASE_TAG" --json isDraft,targetCommitish); then
+            echo "::error::Could not inspect Bootnode release $RELEASE_TAG."
+            exit 1
+          fi
+
+          if ! tag_ref=$(git ls-remote --refs origin "refs/tags/$RELEASE_TAG"); then
+            echo "::error::Could not inspect the Bootnode tag $RELEASE_TAG."
+            exit 1
+          fi
+
+          if [[ -z "$tag_ref" && "$(jq -r '.isDraft' <<< "$release")" == "true" ]]; then
+            commitish=$(jq -r '.targetCommitish' <<< "$release")
+          else
+            commitish=refs/tags/$RELEASE_TAG
+          fi
+
+          if ! release_target=$(gh api "repos/$GITHUB_REPOSITORY/commits/$commitish" --jq .sha); then
+            echo "::error::Could not resolve the commit for Bootnode release $RELEASE_TAG."
+            exit 1
+          fi
+
+          if [[ "$release_target" != "$GITHUB_SHA" ]]; then
+            echo "::error::Bootnode release $RELEASE_TAG resolves to $release_target, but this build targets $GITHUB_SHA. Bump VersionPrefix in tools/Bootnode/Nethermind.Bootnode/Nethermind.Bootnode.csproj to publish a new version, or delete the stale untagged draft before re-cutting it."
+            exit 1
           fi
 
           echo "Uploading assets"
@@ -202,17 +222,14 @@ jobs:
 
           echo "Publishing release $RELEASE_TAG"
           gh release edit "$RELEASE_TAG" \
-            --verify-tag \
-            --target "$GITHUB_SHA" \
             -t "$RELEASE_NAME" \
             --draft=false \
-            "${prerelease_flag[@]}" \
-            "${latest_flag[@]}"
+            --latest=false
 
   publish-docker:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
-    needs: [approval, build]
+    needs: [build, publish-github]
     steps:
       - name: Check out Nethermind repository
         uses: actions/checkout@v6
@@ -231,14 +248,26 @@ jobs:
 
       - name: Build and push image to Docker Hub
         env:
-          RELEASE_TAG: ${{ needs.build.outputs.release-tag }}
-          PRERELEASE: ${{ needs.build.outputs.prerelease }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
           PUBLISH_LATEST: ${{ needs.build.outputs.publish-latest }}
         run: |
-          image=nethermind/nethermind-bootnode
-          tags=(-t "$image:$RELEASE_TAG")
-          if [[ "$PRERELEASE" == "false" && "$PUBLISH_LATEST" == "true" ]]; then
-            tags+=(-t "$image:latest")
+          image=nethermind/bootnode
+          tags=(-t "$image:$RELEASE_VERSION")
+          if [[ "$PUBLISH_LATEST" == "true" ]]; then
+            if ! release_versions=$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq \
+              '.[] | select(.draft == false and (.tag_name | startswith("bootnode-"))) | .tag_name | sub("^bootnode-"; "")'); then
+              echo "::error::Could not determine the highest published Bootnode version."
+              exit 1
+            fi
+            latest_release_version=$(printf '%s\n' "$release_versions" | sort -V | tail -n 1)
+            if [[ -z "$latest_release_version" ]]; then
+              echo "::warning::Skipping Docker latest: no published Bootnode release was found."
+            elif [[ "$RELEASE_VERSION" != "$latest_release_version" ]]; then
+              echo "::warning::Skipping Docker latest: it tracks the highest published Bootnode version ($latest_release_version), not $RELEASE_VERSION."
+            else
+              tags+=(-t "$image:latest")
+            fi
           fi
 
           docker buildx build . \

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,8 +17,8 @@ jobs:
   update-docs:
     name: Update docs
     runs-on: ubuntu-latest
-    # Component releases (e.g. the ZisK guest) ship no docs
-    if: github.event_name != 'release' || !startsWith(github.event.release.tag_name, 'zisk-guest-')
+    # Component releases (e.g. the ZisK guest and Bootnode) ship no docs
+    if: github.event_name != 'release' || (!startsWith(github.event.release.tag_name, 'zisk-guest-') && !startsWith(github.event.release.tag_name, 'bootnode-'))
     steps:
       - name: Create GitHub app token
         id: gh-app

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="DynamicExpresso.Core" Version="2.19.3" />
     <PackageVersion Include="FastEnum" Version="2.0.7" />
     <PackageVersion Include="Fody" Version="6.9.3" />
+    <PackageVersion Include="FodyHelpers" Version="6.9.3" />
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Google.Protobuf.Tools" Version="3.35.1" />
     <PackageVersion Include="Grpc" Version="2.46.6" />

--- a/nix/nuget-deps.json
+++ b/nix/nuget-deps.json
@@ -105,6 +105,11 @@
     "hash": "sha256-JLom3mbO4NCUXDHoU86l720QXlRx52+ROb5wBwcC5nM="
   },
   {
+    "pname": "FodyHelpers",
+    "version": "6.9.3",
+    "hash": "sha256-2F6jkmn7Ja0cM86avL+FFDHaWTBsV8e+M06vNb26LGU="
+  },
+  {
     "pname": "Fractions",
     "version": "7.3.0",
     "hash": "sha256-wr4I1mj1qrXjD2Z3dca70OBe14zZNGagDLW9/8xQtCU="

--- a/scripts/ci/test_bootnode_release.py
+++ b/scripts/ci/test_bootnode_release.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+# SPDX-License-Identifier: LGPL-3.0-only
+
+"""Exercise both Bootnode release gates without publishing artifacts or using the network."""
+
+import os
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github/workflows/release-bootnode.yml"
+MOCK_COMMANDS = r"""
+sudo() { :; }
+xmlstarlet() { printf '%s\n' "$VERSION_PREFIX"; }
+git() {
+  case "$1" in
+    check-ref-format) command git "$@" ;;
+    ls-remote)
+      echo TAG_LOOKUP >&2
+      [[ "$*" == "ls-remote --refs origin refs/tags/bootnode-$VERSION_PREFIX" ]] || return 99
+      [[ "$TAG_STATE" != error ]] || return 128
+      if [[ "$TAG_STATE" != absent ]]; then
+        printf '%s\t%s\n' "$TAG_STATE" refs/tags/bootnode-1.0.0
+      fi
+      ;;
+    *) return 99 ;;
+  esac
+}
+jq() {
+  python3 -c 'import json, sys
+value = json.load(sys.stdin)[sys.argv[1].removeprefix(".")]
+print(json.dumps(value) if isinstance(value, bool) else value)' "$2"
+}
+gh() {
+  case "$1 $2" in
+    'release view')
+      [[ "$RELEASE_EXISTS" == true ]] || return 1
+      if [[ "${4:-}" == --json ]]; then
+        [[ "$5" == isDraft,targetCommitish ]] || return 99
+        printf '{"isDraft":%s,"targetCommitish":"%s"}\n' "$IS_DRAFT" "$DRAFT_TARGET"
+      fi
+      ;;
+    'release create') RELEASE_EXISTS=true; IS_DRAFT=true; DRAFT_TARGET=$GITHUB_SHA ;;
+    'release upload') echo ASSETS_UPLOADED ;;
+    'release edit') echo RELEASE_PUBLISHED ;;
+    'api repos/NethermindEth/nethermind/commits/'*)
+      case "${2##*/commits/}" in
+        refs/tags/bootnode-1.0.0|bootnode-1.0.0)
+          [[ "$TAG_STATE" != absent ]] || return 1
+          [[ "$TAG_COMMIT" != error ]] || return 1
+          printf '%s\n' "$TAG_COMMIT"
+          ;;
+        A|B) printf '%s\n' "$DRAFT_TARGET" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 99 ;;
+  esac
+}
+"""
+
+
+class BootnodeReleaseTests(unittest.TestCase):
+    def run_step(self, step, **values):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        match = re.search(
+            rf"(?ms)^      - name: {step}\n.*?^        run: \|\n"
+            r"(?P<script>(?:^          [^\n]*\n|^\n)+)", workflow
+        )
+        self.assertIsNotNone(match, step)
+        script = re.sub(r"(?m)^          ", "", match["script"])
+        environment = dict(
+            os.environ, VERSION_PREFIX="1.0.0", TAG_STATE="absent", TAG_COMMIT="A",
+            RELEASE_EXISTS="false", IS_DRAFT="true", DRAFT_TARGET="B",
+            GITHUB_SHA="B", GITHUB_REPOSITORY="NethermindEth/nethermind",
+            RELEASE_TAG="bootnode-1.0.0", RELEASE_NAME="Bootnode 1.0.0",
+            RELEASE_VERSION="1.0.0", PACKAGE_DIR="packages",
+            INPUT_PUBLISH_LATEST="false", GITHUB_OUTPUT="/dev/null", GITHUB_ENV="/dev/null",
+        )
+        environment.update(values)
+        return subprocess.run(
+            ["bash", "-e"], input=MOCK_COMMANDS + script,
+            text=True, capture_output=True, env=environment, timeout=10,
+        )
+
+    def test_version_validation(self):
+        cases = [
+            ("1.0.0", True),
+            ("1.10.0", True),
+            ("1" * 128, True),
+            ("1" * 129, False),
+            ("", False),
+            (".1.0.0", False),
+            ("-1.0.0", False),
+            ("1.0.0+build", False),
+            ("1.0.0/extra", False),
+            ("1.0.0 extra", False),
+            ("1.0.0\nextra", False),
+            ("1..0", False),
+            ("1.0.0.lock", False),
+        ]
+        for version, succeeds in cases:
+            with self.subTest(version=version):
+                result = self.run_step("Detect version", VERSION_PREFIX=version)
+                output = result.stdout + result.stderr
+                self.assertEqual(result.returncode == 0, succeeds, output)
+                self.assertEqual("TAG_LOOKUP" in output, succeeds, output)
+                if not succeeds:
+                    self.assertIn("must produce valid Docker and Git tags", output)
+
+    def test_release_commit_gates(self):
+        # An annotated tag's object ID differs from its peeled commit ID.
+        cases = [
+            ("new release", "absent", "A", "false", "true", "B", True),
+            ("new draft", "absent", "A", "true", "true", "B", True),
+            ("stale draft", "absent", "A", "true", "true", "A", False),
+            ("draft with stale lightweight tag", "A", "A", "true", "true", "B", False),
+            ("draft with stale annotated tag", "tag-object", "A", "true", "true", "B", False),
+            ("tag overrides stale draft target", "B", "B", "true", "true", "A", True),
+            ("matching annotated tag", "tag-object", "B", "true", "true", "A", True),
+            ("published rerun", "B", "B", "true", "false", "A", True),
+            ("published stale tag", "A", "A", "true", "false", "B", False),
+            ("published missing tag", "absent", "A", "true", "false", "B", False),
+            ("retained tag without release", "A", "A", "false", "true", "B", False),
+            ("matching tag without release", "B", "B", "false", "true", "B", True),
+            ("tag lookup failure", "error", "A", "true", "true", "B", False),
+            ("tag resolution failure", "A", "error", "true", "true", "B", False),
+            ("draft resolution failure", "absent", "A", "true", "true", "error", False),
+        ]
+        for step in ("Detect version", "Publish"):
+            for name, tag_state, tag_commit, exists, draft, target, succeeds in cases:
+                with self.subTest(step=step, case=name):
+                    result = self.run_step(
+                        step, TAG_STATE=tag_state, TAG_COMMIT=tag_commit,
+                        RELEASE_EXISTS=exists, IS_DRAFT=draft, DRAFT_TARGET=target,
+                    )
+                    output = result.stdout + result.stderr
+                    self.assertEqual(result.returncode == 0, succeeds, output)
+                    if not succeeds:
+                        self.assertIn("::error::", output)
+                    self.assertEqual("ASSETS_UPLOADED" in output, succeeds and step == "Publish", output)
+                    self.assertEqual("RELEASE_PUBLISHED" in output, succeeds and step == "Publish", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Nethermind/Benchmarks.slnx
+++ b/src/Nethermind/Benchmarks.slnx
@@ -18,9 +18,10 @@
     <Project Path="Nethermind.Era1/Nethermind.Era1.csproj" />
     <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
     <Project Path="Nethermind.EthStats/Nethermind.EthStats.csproj" />
+    <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
+    <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
     <Project Path="Nethermind.Evm.Test/Nethermind.Evm.Test.csproj" />
     <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
-    <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
     <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />
     <Project Path="Nethermind.Grpc/Nethermind.Grpc.csproj" />
     <Project Path="Nethermind.History/Nethermind.History.csproj" />

--- a/src/Nethermind/Directory.Build.props
+++ b/src/Nethermind/Directory.Build.props
@@ -21,11 +21,11 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-  <!-- Exclude the analyzer itself and the source generator (netstandard2.0, can't reference analyzers).
+  <!-- Exclude the analyzer itself, source generator and EVM weaver (netstandard2.0, can't reference analyzers).
        Also skipped on the ZisK guest build (EnableZkEvm), where the analyzers/generators are not wired and
        the generated members are stubbed (e.g. ChainSpecStyle/HardforkLabels.cs). Mainline MUST keep this:
        removing it left HardforkLabels.All empty and broke ChainSpec/BlobSchedule transitions. -->
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Nethermind.Analyzers' AND '$(MSBuildProjectName)' != 'Nethermind.Serialization.SszGenerator' AND '$(EnableZkEvm)' != 'true'">
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'Nethermind.Analyzers' AND '$(MSBuildProjectName)' != 'Nethermind.Serialization.SszGenerator' AND '$(MSBuildProjectName)' != 'Nethermind.Evm.Fody' AND '$(EnableZkEvm)' != 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.Analyzers/Nethermind.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 

--- a/src/Nethermind/EthereumTests.slnx
+++ b/src/Nethermind/EthereumTests.slnx
@@ -16,6 +16,7 @@
     <Project Path="Nethermind.Db/Nethermind.Db.csproj" />
     <Project Path="Nethermind.Era1/Nethermind.Era1.csproj" />
     <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
+    <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
     <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
     <Project Path="Nethermind.Evm.Test/Nethermind.Evm.Test.csproj" />
     <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />

--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -149,6 +149,51 @@ namespace Nethermind.Core.Test
             AssertValueWriterMatchesExpected(writer, buffer, ExpectedValueHash(value));
         }
 
+        [TestCaseSource(nameof(ValueWriterValueHashCases))]
+        public void RlpReader_roundtrips_value_hash(ValueHash256? value)
+        {
+            byte[] buffer = new byte[Rlp.LengthOf(in value)];
+            RlpWriter writer = new(buffer);
+            writer.Encode(in value);
+
+            RlpReader reader = new(buffer);
+
+            Assert.That(reader.DecodeValueKeccak(), Is.EqualTo(value));
+
+            if (value is null)
+            {
+                Assert.Throws<RlpException>(() =>
+                {
+                    RlpReader nonNullReader = new(buffer);
+                    nonNullReader.DecodeValueKeccakNonNull();
+                });
+            }
+            else
+            {
+                RlpReader nonNullReader = new(buffer);
+                Assert.That(nonNullReader.DecodeValueKeccakNonNull(), Is.EqualTo(value.Value));
+            }
+        }
+
+        [TestCaseSource(nameof(ValueWriterHashCases))]
+        public void RlpReader_roundtrips_hash(Hash256? value)
+        {
+            byte[] buffer = new byte[Rlp.LengthOf(value)];
+            RlpWriter writer = new(buffer);
+            writer.Encode(value);
+
+            RlpReader reader = new(buffer);
+            Hash256? decoded = reader.DecodeKeccakOrNull();
+
+            Assert.That(decoded, Is.EqualTo(value));
+            if (value == Keccak.OfAnEmptyString || value == Keccak.EmptyTreeHash)
+            {
+                // The interned instances must come back by reference, which is the only observable
+                // difference between comparing the payload as a span and as a ValueHash256.
+                Assert.That(decoded, Is.SameAs(value));
+            }
+        }
+
         [TestCaseSource(nameof(ValueWriterAddressCases))]
         public void RlpWriter_encodes_address_like_Rlp(Address? value)
         {

--- a/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
+++ b/src/Nethermind/Nethermind.Db.Rocks/Statistics/DbMetricsUpdater.cs
@@ -177,7 +177,7 @@ public partial class DbMetricsUpdater<T>(string dbName, Options<T> dbOptions, Ro
 
     private void LogMemoryProfile()
     {
-        if (!logger.IsInfo) return;
+        if (!logger.IsDebug) return;
 
         long Prop(string name)
         {
@@ -210,7 +210,7 @@ public partial class DbMetricsUpdater<T>(string dbName, Options<T> dbOptions, Ro
             ? $"block_cache={Mb(blockCache)}(shared)"
             : $"block_cache={Mb(blockCache)}(pinned {Mb(blockCachePinned)})";
 
-        logger.Info($"[RocksDbMem] {dbName}: table_readers={Mb(tableReaders)} memtables={Mb(memtables)} " +
+        logger.Debug($"[RocksDbMem] {dbName}: table_readers={Mb(tableReaders)} memtables={Mb(memtables)} " +
                     $"{blockCacheField} " +
                     $"live_sst={Gb(liveSst)} sst_files={liveFiles} keys={(numKeys < 0 ? "n/a" : numKeys.ToString())}");
     }

--- a/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/MethodCloner.cs
@@ -1,0 +1,227 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Fody;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Nethermind.Evm.Fody;
+
+internal sealed class MethodCloner(MethodDefinition source, Action<string> warn)
+{
+    private MethodDefinition _target = null!;
+
+    public MethodDefinition Clone(string name)
+    {
+        if (!source.IsStatic)
+            throw new WeavingException($"Only static methods can be cloned: {source.FullName}.");
+        _target = new MethodDefinition(name, source.Attributes, source.ReturnType)
+        {
+            DeclaringType = source.DeclaringType,
+            ImplAttributes = source.ImplAttributes,
+            CallingConvention = source.CallingConvention
+        };
+        foreach (GenericParameter parameter in source.GenericParameters)
+            _target.GenericParameters.Add(new GenericParameter(parameter.Name, _target) { Attributes = parameter.Attributes });
+        for (int i = 0; i < source.GenericParameters.Count; i++)
+            foreach (GenericParameterConstraint constraint in source.GenericParameters[i].Constraints)
+                _target.GenericParameters[i].Constraints.Add(new GenericParameterConstraint(MapType(constraint.ConstraintType)));
+        _target.ReturnType = MapType(source.ReturnType);
+        foreach (ParameterDefinition parameter in source.Parameters)
+            _target.Parameters.Add(new ParameterDefinition(parameter.Name, parameter.Attributes, MapType(parameter.ParameterType)));
+        foreach (CustomAttribute attribute in source.CustomAttributes)
+            _target.CustomAttributes.Add(CloneAttribute(attribute));
+
+        MethodBody body = _target.Body;
+        body.InitLocals = source.Body.InitLocals;
+        body.MaxStackSize = source.Body.MaxStackSize;
+        foreach (VariableDefinition variable in source.Body.Variables)
+            body.Variables.Add(new VariableDefinition(MapType(variable.VariableType)));
+
+        Dictionary<Instruction, Instruction> instructions = [];
+        foreach (Instruction instruction in source.Body.Instructions)
+        {
+            Instruction copy = Instruction.Create(OpCodes.Nop);
+            copy.OpCode = instruction.OpCode;
+            instructions.Add(instruction, copy);
+            body.Instructions.Add(copy);
+        }
+        foreach (Instruction instruction in source.Body.Instructions)
+        {
+            instructions[instruction].Operand = instruction.Operand switch
+            {
+                Instruction branch => instructions[branch],
+                Instruction[] branches => MapBranches(branches, instructions),
+                VariableDefinition variable => body.Variables[variable.Index],
+                ParameterDefinition parameter => _target.Parameters[parameter.Index],
+                TypeReference type => MapType(type),
+                MethodReference method => MapMethod(method),
+                FieldReference field => new FieldReference(field.Name, MapType(field.FieldType), MapType(field.DeclaringType)),
+                CallSite site => MapCallSite(site),
+                object operand => operand,
+                null => null
+            };
+        }
+        foreach (ExceptionHandler handler in source.Body.ExceptionHandlers)
+            body.ExceptionHandlers.Add(new ExceptionHandler(handler.HandlerType)
+            {
+                CatchType = handler.CatchType is null ? null : MapType(handler.CatchType),
+                TryStart = instructions[handler.TryStart],
+                TryEnd = handler.TryEnd is null ? null : instructions[handler.TryEnd],
+                HandlerStart = instructions[handler.HandlerStart],
+                HandlerEnd = handler.HandlerEnd is null ? null : instructions[handler.HandlerEnd],
+                FilterStart = handler.FilterStart is null ? null : instructions[handler.FilterStart]
+            });
+        // Cecil exposes sequence points and scope bounds by offset only, and instructions an earlier weaver
+        // inserted still carry offset zero. Writing the recomputed offsets back to the source makes them a
+        // truthful join key; the writer recomputes them again anyway.
+        int offset = 0;
+        Dictionary<int, Instruction> byOffset = [];
+        foreach (Instruction instruction in source.Body.Instructions)
+        {
+            instruction.Offset = offset;
+            byOffset.Add(offset, instructions[instruction]);
+            offset += instruction.GetSize();
+        }
+        foreach (SequencePoint point in source.DebugInformation.SequencePoints)
+        {
+            if (!byOffset.TryGetValue(point.Offset, out Instruction? instruction))
+            {
+                // Debug info only: a stale point drifts a line number, so it is not worth failing the build.
+                warn($"Sequence point at IL_{point.Offset:x4} in {source.FullName} is not an instruction.");
+                continue;
+            }
+            _target.DebugInformation.SequencePoints.Add(new SequencePoint(instruction, point.Document)
+            {
+                StartLine = point.StartLine,
+                StartColumn = point.StartColumn,
+                EndLine = point.EndLine,
+                EndColumn = point.EndColumn
+            });
+        }
+        if (source.DebugInformation.Scope is not null)
+            _target.DebugInformation.Scope = CloneScope(source.DebugInformation.Scope, byOffset, body);
+        return _target;
+    }
+
+    private ScopeDebugInformation? CloneScope(ScopeDebugInformation scope, Dictionary<int, Instruction> byOffset, MethodBody body)
+    {
+        if (!TryMapOffset(scope.Start, out Instruction? start) || !TryMapOffset(scope.End, out Instruction? end))
+            return null;
+        ScopeDebugInformation copy = new(start, end) { Import = scope.Import };
+        foreach (VariableDebugInformation variable in scope.Variables)
+        {
+            if ((uint)variable.Index >= (uint)body.Variables.Count)
+            {
+                warn($"Debug variable {variable.Name} at index {variable.Index} in {source.FullName} has no local.");
+                continue;
+            }
+            copy.Variables.Add(new VariableDebugInformation(body.Variables[variable.Index], variable.Name) { Attributes = variable.Attributes });
+        }
+        foreach (ConstantDebugInformation constant in scope.Constants)
+            copy.Constants.Add(new ConstantDebugInformation(constant.Name, MapType(constant.ConstantType), constant.Value));
+        foreach (ScopeDebugInformation nested in scope.Scopes)
+            if (CloneScope(nested, byOffset, body) is { } cloned) copy.Scopes.Add(cloned);
+        return copy;
+
+        // A scope end at the method's end has no instruction; Cecil represents it as an unresolved offset.
+        bool TryMapOffset(InstructionOffset offset, out Instruction? instruction)
+        {
+            instruction = null;
+            if (offset.IsEndOfMethod || byOffset.TryGetValue(offset.Offset, out instruction)) return true;
+            warn($"Scope boundary at IL_{offset.Offset:x4} in {source.FullName} is not an instruction; dropping scope and its nested scopes.");
+            return false;
+        }
+    }
+
+    /// <summary>Copies an attribute read from the image by blob; an attribute another weaver built in memory has no blob, so copy its arguments instead.</summary>
+    private static CustomAttribute CloneAttribute(CustomAttribute attribute)
+    {
+        if (!attribute.IsResolved) return new CustomAttribute(attribute.Constructor, attribute.GetBlob());
+        CustomAttribute copy = new(attribute.Constructor);
+        foreach (CustomAttributeArgument argument in attribute.ConstructorArguments) copy.ConstructorArguments.Add(argument);
+        foreach (CustomAttributeNamedArgument field in attribute.Fields) copy.Fields.Add(field);
+        foreach (CustomAttributeNamedArgument property in attribute.Properties) copy.Properties.Add(property);
+        return copy;
+    }
+
+    private static Instruction[] MapBranches(Instruction[] branches, Dictionary<Instruction, Instruction> instructions)
+    {
+        Instruction[] result = new Instruction[branches.Length];
+        for (int i = 0; i < result.Length; i++) result[i] = instructions[branches[i]];
+        return result;
+    }
+
+    private TypeReference MapType(TypeReference type)
+    {
+        if (type is GenericParameter parameter && parameter.Owner == source)
+            return _target.GenericParameters[parameter.Position];
+        if (type is GenericInstanceType instance)
+        {
+            GenericInstanceType result = new(MapType(instance.ElementType));
+            foreach (TypeReference argument in instance.GenericArguments) result.GenericArguments.Add(MapType(argument));
+            return result;
+        }
+        return type switch
+        {
+            ByReferenceType reference => new ByReferenceType(MapType(reference.ElementType)),
+            PointerType pointer => new PointerType(MapType(pointer.ElementType)),
+            PinnedType pinned => new PinnedType(MapType(pinned.ElementType)),
+            ArrayType array => new ArrayType(MapType(array.ElementType), array.Rank),
+            RequiredModifierType modifier => new RequiredModifierType(MapType(modifier.ModifierType), MapType(modifier.ElementType)),
+            OptionalModifierType modifier => new OptionalModifierType(MapType(modifier.ModifierType), MapType(modifier.ElementType)),
+            FunctionPointerType pointer => MapFunctionPointer(pointer),
+            _ => type
+        };
+    }
+
+    private FunctionPointerType MapFunctionPointer(FunctionPointerType pointer)
+    {
+        FunctionPointerType result = new()
+        {
+            ReturnType = MapType(pointer.ReturnType),
+            CallingConvention = pointer.CallingConvention,
+            HasThis = pointer.HasThis,
+            ExplicitThis = pointer.ExplicitThis
+        };
+        foreach (ParameterDefinition parameter in pointer.Parameters)
+            result.Parameters.Add(new ParameterDefinition(MapType(parameter.ParameterType)));
+        return result;
+    }
+
+    private MethodReference MapMethod(MethodReference method)
+    {
+        if (method is GenericInstanceMethod instance)
+        {
+            GenericInstanceMethod result = new(MapMethod(instance.ElementMethod));
+            foreach (TypeReference argument in instance.GenericArguments) result.GenericArguments.Add(MapType(argument));
+            return result;
+        }
+        MethodReference reference = new(method.Name, MapType(method.ReturnType), MapType(method.DeclaringType))
+        {
+            HasThis = method.HasThis,
+            ExplicitThis = method.ExplicitThis,
+            CallingConvention = method.CallingConvention
+        };
+        foreach (GenericParameter parameter in method.GenericParameters)
+            reference.GenericParameters.Add(new GenericParameter(parameter.Name, reference));
+        foreach (ParameterDefinition parameter in method.Parameters)
+            reference.Parameters.Add(new ParameterDefinition(MapType(parameter.ParameterType)));
+        return reference;
+    }
+
+    private CallSite MapCallSite(CallSite site)
+    {
+        CallSite result = new(MapType(site.ReturnType))
+        {
+            HasThis = site.HasThis,
+            ExplicitThis = site.ExplicitThis,
+            CallingConvention = site.CallingConvention
+        };
+        foreach (ParameterDefinition parameter in site.Parameters)
+            result.Parameters.Add(new ParameterDefinition(MapType(parameter.ParameterType)));
+        return result;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
+++ b/src/Nethermind/Nethermind.Evm.Fody/ModuleWeaver.cs
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Fody;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Nethermind.Evm.Fody;
+
+/// <summary>Gives opcode specializations distinct profiler-visible entry points.</summary>
+public sealed class ModuleWeaver : BaseModuleWeaver
+{
+    private readonly Dictionary<(MethodDefinition Template, string Opcode), MethodDefinition> _factories = [];
+    private readonly Dictionary<string, MethodDefinition> _handlers = [];
+
+    /// <inheritdoc />
+    public override IEnumerable<string> GetAssembliesForScanning() => Array.Empty<string>();
+
+    /// <inheritdoc />
+    public override void Execute()
+    {
+        TypeDefinition vm = ModuleDefinition.GetType("Nethermind.Evm.VirtualMachine`1")
+            ?? throw new WeavingException("VirtualMachine type was not found.");
+        MethodDefinition handler = GetMethod(vm, "ExecuteOpcode");
+        bool hasTailCall = false;
+        foreach (Instruction instruction in handler.Body.Instructions)
+            if (instruction.OpCode == OpCodes.Tail) { hasTailCall = true; break; }
+        if (!hasTailCall)
+            throw new WeavingException("Opcode naming must run after InlineIL and preserve the dispatch tail call.");
+
+        MethodDefinition[] methods = new MethodDefinition[vm.Methods.Count];
+        vm.Methods.CopyTo(methods, 0);
+        foreach (MethodDefinition method in methods)
+        {
+            // CALL/CREATE carry an opcode type through several fork-selection factories.
+            // Clone that chain from its concrete entry point before redirecting its leaf.
+            if (!method.HasBody || IsFactory(method.Name)) continue;
+            foreach (Instruction instruction in method.Body.Instructions)
+            {
+                if (instruction.Operand is not GenericInstanceMethod call || !IsFactory(call.Name)
+                    || call.DeclaringType.Resolve() != vm) continue;
+                string name = call.Name switch
+                {
+                    "JumpIfOpcodeHandler" => "JumpI",
+                    "GetCallHandler" or "GetCreateHandler" => GetOperationName(call.GenericArguments[0]),
+                    _ => GetOpcodeName(call.GenericArguments[0])
+                };
+                instruction.Operand = Retarget(call, CloneFactory(Resolve(call), name));
+            }
+        }
+
+        HashSet<string> names = new(_handlers.Keys, StringComparer.OrdinalIgnoreCase);
+        if (names.Count != _handlers.Count)
+            throw new WeavingException("Named handlers differ only by case.");
+        TypeDefinition instructionType = ModuleDefinition.GetType("Nethermind.Evm.Instruction")
+            ?? throw new WeavingException("Instruction enum was not found.");
+        foreach (FieldDefinition opcode in instructionType.Fields)
+            if (opcode.HasConstant && !names.Remove(opcode.Name))
+                throw new WeavingException($"No named handler for opcode {opcode.Name}.");
+        if (!names.SetEquals(new[] { "BadInstruction" }))
+            throw new WeavingException("Named handlers do not match the instruction enum.");
+        VerifyTableHandlers(vm);
+        RemoveUnusedFactories(vm, methods);
+        WriteInfo($"Named {_handlers.Count} opcode handlers without adding runtime calls.");
+    }
+
+    private static void RemoveUnusedFactories(TypeDefinition vm, MethodDefinition[] originals)
+    {
+        HashSet<MethodDefinition> factories = [];
+        foreach (MethodDefinition method in originals)
+            if (IsFactory(method.Name)) factories.Add(method);
+        foreach (TypeDefinition type in vm.Module.GetTypes())
+            foreach (MethodDefinition method in type.Methods)
+            {
+                if (!method.HasBody || factories.Contains(method)) continue;
+                foreach (Instruction instruction in method.Body.Instructions)
+                    if (instruction.Operand is MethodReference reference && IsFactory(reference.Name)
+                        && reference.DeclaringType.Resolve() == vm
+                        && factories.Contains(Resolve(reference)))
+                        throw new WeavingException($"Method {method.FullName} still references an original opcode factory.");
+            }
+        foreach (MethodDefinition factory in factories) vm.Methods.Remove(factory);
+    }
+
+    private void VerifyTableHandlers(TypeDefinition vm)
+    {
+        Stack<MethodDefinition> pending = [];
+        HashSet<MethodDefinition> visited = [];
+        HashSet<MethodDefinition> expected = [.. _handlers.Values];
+        HashSet<MethodDefinition> actual = [];
+        pending.Push(GetMethod(vm, "GenerateOpcodeHandlers"));
+        while (pending.Count != 0)
+        {
+            MethodDefinition method = pending.Pop();
+            if (!visited.Add(method) || !method.HasBody) continue;
+            foreach (Instruction instruction in method.Body.Instructions)
+            {
+                if (instruction.Operand is not MethodReference reference
+                    || reference.DeclaringType.GetElementType().FullName != vm.FullName
+                    || reference.DeclaringType.Resolve() != vm) continue;
+                MethodDefinition target = Resolve(reference);
+                if (instruction.OpCode == OpCodes.Ldftn)
+                {
+                    if (expected.Contains(target)) actual.Add(target);
+                    else if (target.Name is "ExecuteOpcode" or "ExecuteJumpIfOpcode")
+                        throw new WeavingException($"Opcode table still references unnamed handler {target.Name}.");
+                }
+                else
+                {
+                    pending.Push(target);
+                }
+            }
+        }
+        if (!actual.SetEquals(expected))
+            throw new WeavingException("Named opcode handlers are not all reachable from the opcode table factories.");
+    }
+
+    private static MethodDefinition GetMethod(TypeDefinition type, string name)
+    {
+        MethodDefinition? result = null;
+        foreach (MethodDefinition method in type.Methods)
+        {
+            if (method.Name != name) continue;
+            if (result is not null) throw new WeavingException($"Multiple methods named {name} in {type.FullName}.");
+            result = method;
+        }
+        return result ?? throw new WeavingException($"Method {name} was not found in {type.FullName}.");
+    }
+
+    private static MethodDefinition Resolve(MethodReference reference) =>
+        reference.Resolve() ?? throw new WeavingException($"Could not resolve {reference.FullName}.");
+
+    private static bool IsFactory(string name) => name is
+        "OpcodeHandler" or "TerminatingOpcodeHandler" or "JumpIfOpcodeHandler" or "GetCallHandler" or "GetCreateHandler";
+
+    private MethodDefinition CloneFactory(MethodDefinition source, string opcode)
+    {
+        if (_factories.TryGetValue((source, opcode), out MethodDefinition? existing)) return existing;
+        MethodDefinition factory = new MethodCloner(source, WriteWarning).Clone(source.Name + "_" + opcode);
+        _factories.Add((source, opcode), factory);
+        source.DeclaringType.Methods.Add(factory);
+        bool redirected = false;
+        foreach (Instruction instruction in factory.Body.Instructions)
+        {
+            if (instruction.Operand is not GenericInstanceMethod target || target.DeclaringType.Resolve() != source.DeclaringType)
+                continue;
+            if (IsFactory(target.Name))
+            {
+                instruction.Operand = Retarget(target, CloneFactory(Resolve(target), opcode));
+                redirected = true;
+            }
+            else if (instruction.OpCode == OpCodes.Ldftn && target.Name is "ExecuteOpcode" or "ExecuteJumpIfOpcode")
+            {
+                if (!_handlers.TryGetValue(opcode, out MethodDefinition? handler))
+                {
+                    // Retain the generic parameters: only the metadata name and table target change.
+                    handler = new MethodCloner(Resolve(target), WriteWarning).Clone("Op" + opcode);
+                    source.DeclaringType.Methods.Add(handler);
+                    _handlers.Add(opcode, handler);
+                }
+                instruction.Operand = Retarget(target, handler);
+                redirected = true;
+            }
+        }
+        if (!redirected) throw new WeavingException($"Opcode factory {source.FullName} no longer selects a dispatch handler.");
+        return factory;
+    }
+
+    private static string GetOperationName(TypeReference type)
+    {
+        string name = type.Name.Split('`')[0];
+        if (type is GenericParameter || !name.StartsWith("Op", StringComparison.Ordinal))
+            throw new WeavingException($"Expected a concrete opcode operation, found {type.FullName}.");
+        return name.Substring(2);
+    }
+
+    private static string GetOpcodeName(TypeReference type)
+    {
+        string name = type.Name.Split('`')[0];
+        if (type is GenericParameter || !name.EndsWith("Opcode", StringComparison.Ordinal))
+            throw new WeavingException($"Unknown opcode body {type.FullName}.");
+        name = name.Substring(0, name.Length - "Opcode".Length);
+        if (name is "Math1" or "Math2" or "Math3" or "Bitwise" or "Shift"
+            or "EnvAddress" or "Env32Bytes" or "EnvUInt256" or "EnvUInt32" or "EnvUInt64"
+            or "BlkAddress" or "BlkUInt256" or "BlkUInt64" or "Push" or "Dup" or "Swap" or "Log")
+        {
+            // These bodies are nested in VirtualMachine<TGasPolicy>; argument zero is the enclosing gas policy.
+            string operation = GetOperationName(((GenericInstanceType)type).GenericArguments[1]);
+            if (name is "Push" or "Dup" or "Swap" or "Log") return name + operation;
+            return operation.StartsWith("Bitwise", StringComparison.Ordinal) ? operation.Substring("Bitwise".Length) : operation;
+        }
+        return name switch
+        {
+            "CountLeadingZeros" => "Clz",
+            "ProgramCounter" => "Pc",
+            "Keccak" => "Keccak256",
+            "SStoreMetered" or "SStoreUnmetered" => "SStore",
+            _ => name
+        };
+    }
+
+    internal static GenericInstanceMethod Retarget(GenericInstanceMethod original, MethodDefinition target)
+    {
+        if (target.GenericParameters.Count != original.GenericArguments.Count)
+            throw new WeavingException($"Handler {target.Name} does not match the dispatch arity of {original.ElementMethod.FullName}.");
+        MethodDefinition template = Resolve(original);
+        if (target.HasThis != template.HasThis || target.ExplicitThis != template.ExplicitThis
+            || target.CallingConvention != template.CallingConvention
+            || target.ReturnType.FullName != template.ReturnType.FullName
+            || target.Parameters.Count != template.Parameters.Count)
+            throw new WeavingException($"Handler {target.Name} does not match the dispatch signature of {template.FullName}.");
+        for (int i = 0; i < target.Parameters.Count; i++)
+            if (target.Parameters[i].ParameterType.FullName != template.Parameters[i].ParameterType.FullName)
+                throw new WeavingException($"Handler {target.Name} does not match parameter {i} of {template.FullName}.");
+        MethodReference reference = new(target.Name, original.ElementMethod.ReturnType, original.DeclaringType)
+        {
+            HasThis = original.HasThis,
+            ExplicitThis = original.ExplicitThis,
+            CallingConvention = original.ElementMethod.CallingConvention
+        };
+        foreach (GenericParameter parameter in target.GenericParameters)
+            reference.GenericParameters.Add(new GenericParameter(parameter.Name, reference));
+        foreach (ParameterDefinition parameter in original.ElementMethod.Parameters)
+            reference.Parameters.Add(new ParameterDefinition(parameter.ParameterType));
+        GenericInstanceMethod result = new(reference);
+        foreach (TypeReference argument in original.GenericArguments) result.GenericArguments.Add(argument);
+        return result;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj
+++ b/src/Nethermind/Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Nethermind.Evm.Test" />
+    <PackageReference Include="FodyHelpers" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/src/Nethermind/Nethermind.Evm.Fody/README.md
+++ b/src/Nethermind/Nethermind.Evm.Fody/README.md
@@ -1,0 +1,96 @@
+# Opcode naming
+
+This build-only Fody weaver gives every opcode a distinct `Op…` method
+name in CPU profiles, even when the profiler omits generic arguments.
+The EVM project runs it after InlineIL on ordinary builds.
+
+The generic shape is part of the execution design. Struct type arguments select
+the opcode body, gas policy, tracing, cancellation and fork behavior when the
+dispatch table is constructed. They give the JIT/AOT compiler concrete targets
+for static interface calls and constants for flag checks, allowing it to inline
+instruction work and eliminate disabled paths. One source template can therefore
+serve many specialized handlers without repeating dispatch logic for each opcode.
+Retaining those arguments and constraints preserves these optimization opportunities.
+
+The profiling side effect is that different native specializations still have
+the same metadata method name, `ExecuteOpcode`. Profilers that omit generic
+arguments show many indistinguishable entries under that name. When instruction
+bodies inline, their separate frames disappear too, making it difficult to tell
+which opcode accounts for the samples or to compare an opcode across runs.
+
+The renaming step gives those dispatch entry points stable names such as
+`OpSLoad`, `OpPush2` and `OpStaticCall` while keeping their generic shape. This
+makes opcode attribution visible even without generic arguments in the profile;
+tracing, cancellation and fork variants of the same opcode still share its name.
+Generating the named bodies after compilation keeps the source template shared
+and avoids relying on a forwarding wrapper being inlined to retain the dispatch
+shape.
+
+It clones `ExecuteOpcode` (or the dedicated JUMPI dispatcher) and its pointer factory for each opcode,
+then redirects the table construction calls to the named factories. The cloned
+methods retain all generic arguments, constraints, implementation flags and the
+explicit `tail.calli`. The instruction implementation stays in one source
+template; there is no runtime forwarding wrapper. Table refreshes use the same
+rewritten construction paths.
+
+CALL, CALLCODE, DELEGATECALL and STATICCALL have separate names, as do CREATE
+and CREATE2. Their fork-selection factory chains are cloned with the opcode name
+carried through to the final function pointer. Gas-policy and fork variants keep
+their generic specialization. The build fails if the generated names do not cover
+the instruction enum; unassigned table entries use `OpBadInstruction`.
+
+After checking for remaining references, the weaver removes the original pointer
+factories. The two dispatch templates remain for the reflection tests that compare
+their IL and attributes against every named handler. Invalid debug sequence points,
+scope boundaries and local indices produce warnings and omit the affected debug
+information; invalid executable signatures still fail the build.
+
+Validation:
+
+```sh
+dotnet build src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c Release -nr:false
+dotnet test --project src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj -c Release --no-build -- --filter "FullyQualifiedName~VirtualMachineTests|FullyQualifiedName~OpcodeWeaverTests"
+```
+
+When editing the weaver itself, disable MSBuild node reuse as above so a node
+cannot retain a previously loaded version of the add-in.
+
+For native-code inspection, set `DOTNET_JitDisasm` to
+`*:OpPush1 *:OpPush2 *:OpAdd *:OpSLoad` and
+`DOTNET_JitStdOutFile` to a local output file before running the tests.
+Confirm that the named methods contain the instruction work and tail transfers,
+not calls to `ExecuteOpcode`. Compare unprofiled timings separately before
+assuming unchanged throughput; identical IL semantics do not guarantee identical
+JIT layout or tiering behavior.
+
+## Measured scope
+
+A Windows x64 Release build on SDK 10.0.400 produces a 487,424-byte managed
+`Nethermind.Evm.dll`. Named handler bodies and their specialized factories add IL
+and metadata even after unused factories are removed. Managed assembly size is
+separate from native JIT code size and the guest ELF measurements below.
+
+Windows x64 .NET 10 FullOpts disassembly confirmed that the SLOAD, metered
+SSTORE and STATICCALL instruction bodies inline into their named handlers while
+retaining tail dispatch. This does not establish a block-processing speedup or
+total JIT code size across all generic specializations. `SkipLocalsInit` on
+local-free opcode bodies records the call-chain policy but changes no emitted
+local-initialization flag for those methods.
+
+For the naming and annotation changes relative to `014462bff6`, the pinned
+bflat/ZisK Docker toolchain in the guest Makefile produced these results on
+the existing block 25,532,382 witness:
+
+| Metric | Parent | Naming and annotations |
+|---|---:|---:|
+| Stripped ELF bytes | 4,651,736 | 4,651,528 |
+| `.text` bytes | 3,271,696 | 3,270,464 |
+| Executed steps | 396,212,620 | 396,802,794 |
+| Modeled memory cost | 4,076,629,105 | 4,084,009,643 |
+| Modeled total cost | 45,580,415,805 | 45,635,335,086 |
+
+Both guests validated the block with identical output. Naming alone had identical
+step counts and costs to the parent; the full annotation change increases steps
+by 0.149% and modeled total cost by 0.120% on this witness despite reducing code
+size. These are single-witness guest measurements, not proving time or desktop
+JIT performance measurements.

--- a/src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj
+++ b/src/Nethermind/Nethermind.Evm.Test/Nethermind.Evm.Test.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FodyHelpers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.ClearScript.V8" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" />
@@ -22,6 +23,9 @@
     <ProjectReference Include="..\Nethermind.Core.Test\Nethermind.Core.Test.csproj" />
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Evm\Nethermind.Evm.csproj" />
+    <ProjectReference Include="../Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" PrivateAssets="all"
+                      GlobalPropertiesToRemove="RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;PublishAot"
+                      UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;PublishAot" />
     <ProjectReference Include="..\Nethermind.JsonRpc\Nethermind.JsonRpc.csproj" />
     <ProjectReference Include="..\Nethermind.Synchronization\Nethermind.Synchronization.csproj" />
   </ItemGroup>

--- a/src/Nethermind/Nethermind.Evm.Test/OpcodeWeaverTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/OpcodeWeaverTests.cs
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Fody;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Nethermind.Evm.Fody;
+using NUnit.Framework;
+using CilInstruction = Mono.Cecil.Cil.Instruction;
+
+namespace Nethermind.Evm.Test;
+
+[TestFixture, Parallelizable(ParallelScope.All)]
+public class OpcodeWeaverTests
+{
+    [Test]
+    public void Opcode_cloner_rejects_instance_methods()
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Instance");
+        method.IsStatic = false;
+        method.HasThis = true;
+        method.Body.Instructions.Insert(0, CilInstruction.Create(OpCodes.Ldarg, method.Body.ThisParameter));
+
+        Assert.That(() => new MethodCloner(method, _ => { }).Clone("Clone"),
+            Throws.TypeOf<WeavingException>().With.Message.Contains("Only static methods"));
+    }
+
+    [Test]
+    public void Opcode_cloner_drops_stale_scopes([Values] bool nested, [Values] bool staleStart)
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Template");
+        CilInstruction first = method.Body.Instructions[0];
+        ScopeDebugInformation scope = new(first, null);
+        if (staleStart) scope.Start = new InstructionOffset(99);
+        else scope.End = new InstructionOffset(99);
+        scope.Scopes.Add(new ScopeDebugInformation(first, null));
+        method.DebugInformation.SequencePoints.Add(new SequencePoint(first, new Document("Test.cs")) { StartLine = 1, EndLine = 1 });
+        method.DebugInformation.Scope = nested ? new ScopeDebugInformation(first, null) : scope;
+        if (nested) method.DebugInformation.Scope.Scopes.Add(scope);
+        List<string> warnings = [];
+
+        MethodDefinition clone = new MethodCloner(method, warnings.Add).Clone("Clone");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warnings, Has.Count.EqualTo(1));
+            Assert.That(warnings[0], Does.Contain("dropping scope and its nested scopes"));
+            if (nested) Assert.That(clone.DebugInformation.Scope.Scopes, Is.Empty);
+            else Assert.That(clone.DebugInformation.Scope, Is.Null);
+            Assert.That(clone.Body.Instructions, Has.Count.EqualTo(1));
+            Assert.That(clone.DebugInformation.SequencePoints, Has.Count.EqualTo(1));
+        }
+    }
+
+    [Test]
+    public void Opcode_cloner_skips_stale_debug_locals()
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Template");
+        method.Body.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+        VariableDefinition removed = new(module.TypeSystem.Int32);
+        method.Body.Variables.Add(removed);
+        method.DebugInformation.Scope = new ScopeDebugInformation(method.Body.Instructions[0], null);
+        method.DebugInformation.Scope.Variables.Add(new VariableDebugInformation(method.Body.Variables[0], "kept"));
+        method.DebugInformation.Scope.Variables.Add(new VariableDebugInformation(removed, "removed"));
+        MethodBody updatedBody = new(method);
+        updatedBody.Instructions.Add(method.Body.Instructions[0]);
+        updatedBody.Variables.Add(new VariableDefinition(module.TypeSystem.Int32));
+        method.Body = updatedBody;
+        List<string> warnings = [];
+
+        MethodDefinition clone = new MethodCloner(method, warnings.Add).Clone("Clone");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warnings, Is.EqualTo(new[] { $"Debug variable removed at index 1 in {method.FullName} has no local." }));
+            Assert.That(clone.DebugInformation.Scope.Variables, Has.Count.EqualTo(1));
+            Assert.That(clone.DebugInformation.Scope.Variables[0].Name, Is.EqualTo("kept"));
+        }
+    }
+
+    [Test]
+    public void Opcode_retarget_rejects_incompatible_signatures([Values("count", "type", "return", "instance")] string mismatch)
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        MethodDefinition method = CreateWeaverMethod(module, "Template");
+        method.Parameters.Add(new ParameterDefinition(module.TypeSystem.Int32));
+        MethodDefinition clone = new MethodCloner(method, _ => { }).Clone("Clone");
+        switch (mismatch)
+        {
+            case "count": clone.Parameters.Clear(); break;
+            case "type": clone.Parameters[0].ParameterType = module.TypeSystem.Int64; break;
+            case "return": clone.ReturnType = module.TypeSystem.Int32; break;
+            case "instance": clone.HasThis = true; break;
+        }
+
+        Assert.That(() => ModuleWeaver.Retarget(new GenericInstanceMethod(method), clone),
+            Throws.TypeOf<WeavingException>());
+    }
+
+    [Test]
+    public void Opcode_weaver_rejects_names_differing_only_by_case()
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        SetUpOpcodeTable(module, ["SLoadOpcode", "SloadOpcode"]);
+        ModuleWeaver weaver = new() { ModuleDefinition = module };
+
+        Assert.That(weaver.Execute, Throws.TypeOf<WeavingException>().With.Message.Contains("differ only by case"));
+    }
+
+    [Test]
+    public void Opcode_validation_ignores_unrelated_unresolved_calls_but_rejects_factory_calls([Values] bool factoryCall, [Values] bool inTable)
+    {
+        using ModuleDefinition module = ModuleDefinition.CreateModule("Test", ModuleKind.Dll);
+        (MethodDefinition factory, MethodDefinition table) = SetUpOpcodeTable(module, ["BadInstructionOpcode"]);
+        module.Types.Add(new TypeDefinition("Nethermind.Evm", "Instruction", TypeAttributes.Class, module.TypeSystem.Object));
+        TypeDefinition unrelated = new("Test", "Unrelated", TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(unrelated);
+        MethodDefinition caller = new("Caller", MethodAttributes.Static, module.TypeSystem.Void);
+        unrelated.Methods.Add(caller);
+        AssemblyNameReference missing = new("MissingAssembly", new Version(1, 0));
+        TypeReference external = new("Missing", "External", module, missing);
+        MethodDefinition externalCaller = inTable ? table : caller;
+        externalCaller.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, new MethodReference("UnrelatedCall", module.TypeSystem.Void, external)));
+        TypeDefinition vm = module.GetType("Nethermind.Evm.VirtualMachine`1");
+        if (factoryCall)
+            caller.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, factory));
+        caller.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
+        ModuleWeaver weaver = new() { ModuleDefinition = module };
+
+        if (factoryCall)
+            Assert.That(weaver.Execute, Throws.TypeOf<WeavingException>().With.Message.Contains("still references an original opcode factory"));
+        else
+        {
+            weaver.Execute();
+            foreach (MethodDefinition method in vm.Methods)
+                Assert.That(method.Name, Is.Not.EqualTo("OpcodeHandler"));
+        }
+    }
+
+    private static (MethodDefinition Factory, MethodDefinition Table) SetUpOpcodeTable(ModuleDefinition module, string[] opcodeNames)
+    {
+        MethodDefinition handler = CreateWeaverMethod(module, "ExecuteOpcode");
+        TypeDefinition vm = handler.DeclaringType;
+        handler.Body.Instructions.Insert(0, CilInstruction.Create(OpCodes.Tail));
+        MethodDefinition factory = new("OpcodeHandler", MethodAttributes.Static, module.TypeSystem.Void);
+        vm.Methods.Add(factory);
+        factory.GenericParameters.Add(new GenericParameter("TOpcode", factory));
+        factory.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ldftn, new GenericInstanceMethod(handler)));
+        factory.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
+        MethodDefinition table = new("GenerateOpcodeHandlers", MethodAttributes.Static, module.TypeSystem.Void);
+        vm.Methods.Add(table);
+        foreach (string name in opcodeNames)
+        {
+            TypeDefinition opcode = new("Test", name, TypeAttributes.Class, module.TypeSystem.Object);
+            module.Types.Add(opcode);
+            GenericInstanceMethod call = new(factory);
+            call.GenericArguments.Add(opcode);
+            table.Body.Instructions.Add(CilInstruction.Create(OpCodes.Call, call));
+        }
+        return (factory, table);
+    }
+
+    private static MethodDefinition CreateWeaverMethod(ModuleDefinition module, string name)
+    {
+        TypeDefinition vm = new("Nethermind.Evm", "VirtualMachine`1", TypeAttributes.Class, module.TypeSystem.Object);
+        module.Types.Add(vm);
+        MethodDefinition method = new(name, MethodAttributes.Static, module.TypeSystem.Void);
+        vm.Methods.Add(method);
+        method.Body.Instructions.Add(CilInstruction.Create(OpCodes.Ret));
+        return method;
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/VirtualMachineTests.cs
@@ -103,6 +103,35 @@ public class VirtualMachineTests : VirtualMachineTestsBase
     }
 
     [Test]
+    public void Original_opcode_factories_are_removed()
+    {
+        Type vmType = typeof(VirtualMachine<EthereumGasPolicy>);
+        foreach (MethodInfo method in vmType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
+            Assert.That(method.Name, Is.Not.AnyOf("OpcodeHandler", "TerminatingOpcodeHandler", "JumpIfOpcodeHandler", "GetCallHandler", "GetCreateHandler"));
+    }
+
+    [Test]
+    public void Named_opcode_handlers_are_emitted([Values] Instruction opcode)
+    {
+        Type vmType = typeof(VirtualMachine<EthereumGasPolicy>);
+        MethodInfo template = vmType.GetMethod(opcode == Instruction.JUMPI ? "ExecuteJumpIfOpcode" : "ExecuteOpcode",
+            BindingFlags.Static | BindingFlags.NonPublic)!;
+        MethodInfo handler = Array.Find(vmType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic), method =>
+            method.Name.Equals("Op" + opcode, StringComparison.OrdinalIgnoreCase)
+            && method.GetGenericArguments().Length == template.GetGenericArguments().Length
+            && method.GetParameters().Length == template.GetParameters().Length);
+        Assert.That(handler, Is.Not.Null, "the opcode naming weaver must run after InlineIL");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(handler.GetMethodBody()!.GetILAsByteArray()!.Length, Is.EqualTo(template.GetMethodBody()!.GetILAsByteArray()!.Length),
+                "the named entry point must contain the dispatch body rather than a forwarding wrapper");
+            Assert.That(handler.GetMethodImplementationFlags(), Is.EqualTo(template.GetMethodImplementationFlags()));
+            Assert.That(handler.GetCustomAttributesData().Select(a => a.AttributeType), Is.EquivalentTo(template.GetCustomAttributesData().Select(a => a.AttributeType)));
+        }
+    }
+
+    [Test]
     public void Frame_handlers_are_reused_across_blocks_and_reselected_across_forks()
     {
         Execute((0UL, 0UL), (byte)Instruction.STOP);

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -252,6 +252,7 @@ public struct EvmPooledMemory
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public ReadOnlyMemory<byte> Inspect(in UInt256 location, in UInt256 length)
     {
         if (length.IsZero)
@@ -283,6 +284,7 @@ public struct EvmPooledMemory
         return GetBackingMemory((int)location, (int)length);
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private void ClearForTracing(ulong size)
     {
         ulong capacity = GetBackingCapacity();
@@ -584,6 +586,7 @@ public struct EvmPooledMemory
 
     private static readonly TraceMemory EmptyTraceMemory = new(0, default);
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public TraceMemory GetTrace()
     {
         ulong size = Size;

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -1556,6 +1556,7 @@ public ref partial struct EvmStack
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public EvmExceptionType PushZero<TTracingInst, TCheckDepth>()
         where TTracingInst : struct, IFlag
         where TCheckDepth : struct, IFlag
@@ -1969,6 +1970,7 @@ public ref partial struct EvmStack
     /// <summary>
     /// Pops an address, reusing the cached instance when the popped bytes match the previously popped address.
     /// </summary>
+    [SkipLocalsInit]
     public Address? PopAddress(PoppedAddressCache cache)
     {
         nint head = Head - 1;
@@ -2200,6 +2202,7 @@ public ref partial struct EvmStack
         return true;
     }
 
+    [SkipLocalsInit]
     public bool PopWord256(out Span<byte> word)
     {
         nint head = Head - 1;

--- a/src/Nethermind/Nethermind.Evm/FodyWeavers.xml
+++ b/src/Nethermind/Nethermind.Evm/FodyWeavers.xml
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
   <InlineIL />
+  <Nethermind.Evm />
 </Weavers>

--- a/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.CodeAnalysis;
@@ -46,6 +47,7 @@ public static class CodeInfoRepositoryExtensions
     /// <summary>
     /// Returns the <see cref="CodeInfo"/> at <paramref name="codeSource"/> without resolving any EIP-7702 delegation.
     /// </summary>
+    [SkipLocalsInit]
     public static CodeInfo GetCachedCodeInfoNoDelegation(this ICodeInfoRepository codeInfoRepository, Address codeSource, IReleaseSpec vmSpec)
         => codeInfoRepository.GetCachedCodeInfo(codeSource, false, vmSpec, out _);
 }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Call.cs
@@ -83,6 +83,7 @@ public static partial class EvmInstructions
     /// An <see cref="EvmExceptionType"/> value indicating success or the type of error encountered.
     /// </returns>
     [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static EvmExceptionType InstructionCall<TGasPolicy, TOpCall, TTracingInst, TEip8037, TEip7708, TSpec>(
         ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
@@ -290,6 +291,7 @@ public static partial class EvmInstructions
 #else
     [MethodImpl(MethodImplOptions.NoInlining)]
 #endif
+    [SkipLocalsInit]
     private static EvmExceptionType CreateFullCallFrame<TGasPolicy, TOpCall, TTracingInst>(
         VirtualMachine<TGasPolicy> vm,
         ref EvmStack stack,
@@ -380,6 +382,7 @@ public static partial class EvmInstructions
     /// declines (returns <c>false</c>) so the call flows through its dedicated <c>InlinePrecompileCall</c> path.
     /// </remarks>
     /// <returns><c>true</c> when the call was handled inline (with the outcome in <paramref name="result"/>); otherwise <c>false</c>.</returns>
+    [SkipLocalsInit]
     private static partial bool TryInlineStaticPrecompileCall<TGasPolicy, TTracingInst>(
         VirtualMachine<TGasPolicy> vm,
         ref EvmStack stack,

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.CodeCopy.cs
@@ -75,6 +75,7 @@ public static partial class EvmInstructions
     /// CALLDATACOPY - copies a portion of the transaction's calldata into memory.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public static EvmExceptionType InstructionCallDataCopy<TGasPolicy, TTracingInst>(
         ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -440,6 +440,7 @@ public static partial class EvmInstructions
     /// <see cref="EvmExceptionType.None"/>, or <see cref="EvmExceptionType.BadInstruction"/> if blob base fee not set.
     /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public static EvmExceptionType InstructionBlobBaseFee<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -786,6 +787,7 @@ public static partial class EvmInstructions
     /// <returns>
     /// <see cref="EvmExceptionType.None"/>, or <see cref="EvmExceptionType.BadInstruction"/> if slot number not set.
     /// </returns>
+    [SkipLocalsInit]
     public static EvmExceptionType InstructionSlotNum<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -104,6 +104,7 @@ public static partial class EvmInstructions
     /// Push operation for two bytes.
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public static EvmExceptionType InstructionPush2<TGasPolicy, TTracingInst>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -441,6 +441,7 @@ public static partial class EvmInstructions
     /// <param name="gas">The gas state, updated by the operation's cost.</param>
     /// <returns>An <see cref="EvmExceptionType"/> indicating the outcome.</returns>
     [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static EvmExceptionType InstructionSStoreMetered<TGasPolicy, TTracingInst, TUseNetGasStipendFix, TEip8037, Eip8038, Eip2929>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -626,6 +627,7 @@ public static partial class EvmInstructions
     /// <param name="gas">The gas state, updated by the operation's cost.</param>
     /// <returns>An <see cref="EvmExceptionType"/> indicating the result of the operation.</returns>
     [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static EvmExceptionType InstructionSLoad<TGasPolicy, TTracingInst, Eip8038, Eip2929>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm)
         where TGasPolicy : struct, IGasPolicy<TGasPolicy>
         where TTracingInst : struct, IFlag

--- a/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
+++ b/src/Nethermind/Nethermind.Evm/Nethermind.Evm.csproj
@@ -11,9 +11,18 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" ReferenceOutputAssembly="false" OutputItemType="WeaverFiles" PrivateAssets="all"
+                      GlobalPropertiesToRemove="RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;PublishAot"
+                      UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;PublishReadyToRun;PublishAot" />
     <ProjectReference Include="..\Nethermind.Core\Nethermind.Core.csproj" />
     <ProjectReference Include="..\Nethermind.Crypto\Nethermind.Crypto.csproj" />
     <ProjectReference Include="..\Nethermind.Serialization.Rlp\Nethermind.Serialization.Rlp.csproj" />
     <ProjectReference Include="..\Nethermind.Specs\Nethermind.Specs.csproj" />
   </ItemGroup>
+
+  <Target Name="TrackOpcodeWeaverChanges" BeforeTargets="CoreCompile" DependsOnTargets="ResolveProjectReferences">
+    <ItemGroup>
+      <CustomAdditionalCompileInputs Include="@(WeaverFiles)" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Nethermind/Nethermind.Evm/State/WorldStateExtensions.cs
+++ b/src/Nethermind/Nethermind.Evm/State/WorldStateExtensions.cs
@@ -26,13 +26,16 @@ public static class WorldStateExtensions
     public static void AddToBalance(this IWorldState worldState, Address address, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.AddToBalance(address, balanceChange, spec, out _);
 
+    [SkipLocalsInit]
     public static bool AddToBalanceAndCreateIfNotExists(this IWorldState worldState, Address address, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.AddToBalanceAndCreateIfNotExists(address, balanceChange, spec, out _);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     public static void AddToBalanceAndCreateIfNotExists(this IWorldState worldState, Address address, ExecutionType executionType, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.AddToBalanceAndCreateIfNotExists(address, executionType.GetBalanceCredit(in balanceChange), spec, out _);
 
+    [SkipLocalsInit]
     public static void SubtractFromBalance(this IWorldState worldState, Address address, in UInt256 balanceChange, IReleaseSpec spec)
         => worldState.SubtractFromBalance(address, balanceChange, spec, out _);
 

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
@@ -507,6 +507,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionStop(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Math2Opcode<TOpMath, TTracingInst> : IOpcodeBody
         where TOpMath : struct, EvmInstructions.IOpMath2Param
         where TTracingInst : struct, IFlag
@@ -530,6 +531,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct Math3Opcode<TOpMath, TTracingInst> : IOpcodeBody
         where TOpMath : struct, EvmInstructions.IOpMath3Param
         where TTracingInst : struct, IFlag
@@ -550,6 +552,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionMath3Param<TGasPolicy, TOpMath, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Math1Opcode<TOpMath, TTracingInst> : IOpcodeBody
         where TOpMath : struct, EvmInstructions.IOpMath1Param
         where TTracingInst : struct, IFlag
@@ -573,6 +576,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct BitwiseOpcode<TOpBitwise, TTracingInst> : IOpcodeBody
         where TOpBitwise : struct, EvmInstructions.IOpBitwise
         where TTracingInst : struct, IFlag
@@ -596,6 +600,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct ExpOpcode<TTracingInst, Eip160> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip160 : struct, IFlag
@@ -604,12 +609,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionExp<TGasPolicy, TTracingInst, Eip160>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SignExtendOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionSignExtend(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CountLeadingZerosOpcode : IOpcodeBody
     {
         public static bool HasCheckedBody => true;
@@ -621,6 +628,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.CountLeadingZerosCore<OffFlag>(ref stack);
     }
 
+    [SkipLocalsInit]
     private readonly struct ByteOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -637,6 +645,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionByte<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct ShiftOpcode<TOpShift, TTracingInst> : IOpcodeBody
         where TOpShift : struct, EvmInstructions.IOpShift
         where TTracingInst : struct, IFlag
@@ -657,6 +666,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionShift<TGasPolicy, TOpShift, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct SarOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -673,12 +683,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionSar<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct KeccakOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionKeccak256<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct EnvAddressOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvAddress<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -697,6 +709,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnvAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Env32BytesOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnv32Bytes<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -715,6 +728,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnv32Bytes<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct EnvUInt256Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -733,6 +747,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnvUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct EnvUInt32Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt32<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -751,6 +766,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnvUInt32<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct EnvUInt64Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpEnvUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -769,6 +785,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionEnvUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlkAddressOpcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkAddress<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -787,6 +804,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionBlkAddress<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlkUInt256Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkUInt256<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -805,6 +823,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionBlkUInt256<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlkUInt64Opcode<TOpEnv, TTracingInst> : IOpcodeBody
         where TOpEnv : struct, EvmInstructions.IOpBlkUInt64<TGasPolicy>
         where TTracingInst : struct, IFlag
@@ -823,6 +842,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionBlkUInt64<TGasPolicy, TOpEnv, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BalanceOpcode<TTracingInst, TSpec> : IOpcodeBody where TTracingInst : struct, IFlag
         where TSpec : struct, EvmInstructions.IAccessSpec
     {
@@ -830,6 +850,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionBalance<TGasPolicy, TTracingInst, TSpec>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CallDataLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody => true;
@@ -841,12 +862,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.CallDataLoadCore<TGasPolicy, TTracingInst>(ref stack, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CallDataCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionCallDataCopy<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CodeSizeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -863,12 +886,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionCodeSize<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct CodeCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionCodeCopy<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ExtCodeSizeOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
@@ -882,6 +907,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct ExtCodeCopyOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
@@ -891,6 +917,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionExtCodeCopy<TGasPolicy, TTracingInst, Eip8038, Eip2929>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ReturnDataSizeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -908,12 +935,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionReturnDataSize<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ReturnDataCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionReturnDataCopy<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ExtCodeHashOpcode<TTracingInst, TSpec> : IOpcodeBody where TTracingInst : struct, IFlag
         where TSpec : struct, EvmInstructions.IAccessSpec
     {
@@ -921,12 +950,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionExtCodeHash<TGasPolicy, TTracingInst, TSpec>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlockHashOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionBlockHash<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct PrevRandaoOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -944,6 +975,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionPrevRandao<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SelfBalanceOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -961,24 +993,28 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionSelfBalance<TGasPolicy, TTracingInst, OnFlag>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlobHashOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionBlobHash<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct BlobBaseFeeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionBlobBaseFee<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SlotNumOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionSlotNum<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct PopOpcode : IOpcodeBody
     {
         public static bool HasCheckedBody => true;
@@ -994,24 +1030,28 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct MLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionMLoad<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct MStoreOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionMStore<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct MStore8Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionMStore8<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private static delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>
         SStoreOpcodeHandler<TTracingInst, TCancelable, Eip8038, Eip2929>(IReleaseSpec spec)
         where TTracingInst : struct, IFlag
@@ -1028,6 +1068,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                     : OpcodeHandler<SStoreMeteredOpcode<TTracingInst, OffFlag, OffFlag, Eip8038, Eip2929>, TTracingInst, TCancelable>()
             : OpcodeHandler<SStoreUnmeteredOpcode<TTracingInst, Eip8038, Eip2929>, TTracingInst, TCancelable>();
 
+    [SkipLocalsInit]
     private readonly struct SLoadOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
@@ -1037,6 +1078,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionSLoad<TGasPolicy, TTracingInst, Eip8038, Eip2929>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SStoreMeteredOpcode<TTracingInst, TStipendFix, TEip8037, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where TStipendFix : struct, IFlag
@@ -1048,6 +1090,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionSStoreMetered<TGasPolicy, TTracingInst, TStipendFix, TEip8037, Eip8038, Eip2929>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SStoreUnmeteredOpcode<TTracingInst, Eip8038, Eip2929> : IOpcodeBody
         where TTracingInst : struct, IFlag
         where Eip8038 : struct, IEip8038Flag
@@ -1057,6 +1100,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionSStoreUnmetered<TGasPolicy, TTracingInst, Eip8038, Eip2929>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct JumpOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
@@ -1069,6 +1113,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct ProgramCounterOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -1085,6 +1130,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionProgramCounter<TGasPolicy, TTracingInst>(ref stack, ref gas, vm, programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct GasOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static bool HasCheckedBody
@@ -1101,30 +1147,35 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionGas<TGasPolicy, TTracingInst>(ref stack, ref gas);
     }
 
+    [SkipLocalsInit]
     private readonly struct JumpDestOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionJumpDest(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct TLoadOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionTLoad<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct TStoreOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionTStore(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct MCopyOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionMCopy<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Push0Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static int PushSize => 0;
@@ -1144,12 +1195,14 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionPush0<TGasPolicy, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct Push2Opcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionPush2<TGasPolicy, TTracingInst>(ref stack, ref gas, vm, ref programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct PushOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
@@ -1176,6 +1229,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         }
     }
 
+    [SkipLocalsInit]
     private readonly struct DupOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
@@ -1197,6 +1251,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionDup<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SwapOpcode<TOpCount, TTracingInst> : IOpcodeBody
         where TOpCount : struct, EvmInstructions.IOpCount
         where TTracingInst : struct, IFlag
@@ -1217,30 +1272,35 @@ public unsafe partial class VirtualMachine<TGasPolicy>
                 : EvmInstructions.InstructionSwap<TGasPolicy, TOpCount, TTracingInst>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct LogOpcode<TOpCount> : IOpcodeBody where TOpCount : struct, EvmInstructions.IOpCount
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionLog<TGasPolicy, TOpCount>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct DupNOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionDupN<TGasPolicy, TTracingInst>(ref stack, ref gas, ref programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct SwapNOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionSwapN<TGasPolicy, TTracingInst>(ref stack, ref gas, ref programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct ExchangeOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionExchange<TGasPolicy, TTracingInst>(ref stack, ref gas, ref programCounter);
     }
 
+    [SkipLocalsInit]
     private readonly struct CreateOpcode<TOpCreate, TTracingInst, TEip8037, TSpec> : IOpcodeBody
         where TOpCreate : struct, EvmInstructions.IOpCreate
         where TTracingInst : struct, IFlag
@@ -1251,6 +1311,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionCreate<TGasPolicy, TOpCreate, TTracingInst, TEip8037, TSpec>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct CallOpcode<TOpCall, TTracingInst, TEip8037, TEip7708, TSpec> : IOpcodeBody
         where TOpCall : struct, EvmInstructions.IOpCall
         where TTracingInst : struct, IFlag
@@ -1262,24 +1323,28 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             EvmInstructions.InstructionCall<TGasPolicy, TOpCall, TTracingInst, TEip8037, TEip7708, TSpec>(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct ReturnOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionReturn(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct RevertOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionRevert(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct InvalidOpcode : IOpcodeBody
     {
         public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
             EvmInstructions.InstructionInvalid(ref stack, ref gas, vm);
     }
 
+    [SkipLocalsInit]
     private readonly struct SelfDestructOpcode<TEip8037, TEip7708, TSpec> : IOpcodeBody
         where TEip8037 : struct, IFlag
         where TEip7708 : struct, IFlag

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -734,6 +734,7 @@ public partial class VirtualMachine<TGasPolicy>(
         GetExecutionHandlers().CreditStateGasRefund(this, ref gas, amount, trackSpillRefund);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [SkipLocalsInit]
     internal void CreditStateGasRefund<Eip8037>(ref TGasPolicy gas, long amount, bool trackSpillRefund = true)
         where Eip8037 : struct, IFlag
     {
@@ -994,6 +995,7 @@ public partial class VirtualMachine<TGasPolicy>(
         }
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
     protected void TraceTransactionActionStart(VmState<TGasPolicy> currentState)
     {
         _txTracer.ReportAction(TGasPolicy.GetRemainingGas(currentState.Gas),
@@ -1022,6 +1024,7 @@ public partial class VirtualMachine<TGasPolicy>(
     /// <param name="callResult">
     /// The result of the executed call, including output bytes, exception and revert flags, and additional metadata.
     /// </param>
+    [MethodImpl(MethodImplOptions.NoInlining)]
     protected void TraceTransactionActionEnd(VmState<TGasPolicy> currentState, in CallResult callResult)
     {
         IReleaseSpec spec = BlockExecutionContext.Spec;

--- a/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptFixMigration.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/Migrations/ReceiptFixMigration.cs
@@ -113,7 +113,7 @@ namespace Nethermind.Init.Steps.Migrations
                 }
 
                 FastBlocksAllocationStrategy strategy = new(TransferSpeedType.Receipts, block.Number, true);
-                SyncPeerAllocation peer = await syncPeerPool.Allocate(strategy, AllocationContexts.Receipts);
+                using SyncPeerAllocation peer = await syncPeerPool.Allocate(strategy, AllocationContexts.Receipts);
                 ISyncPeer? currentSyncPeer = peer.Current?.SyncPeer;
                 if (currentSyncPeer is not null)
                 {
@@ -135,10 +135,6 @@ namespace Nethermind.Init.Steps.Migrations
                     catch (Exception e)
                     {
                         if (_logger.IsInfo) _logger.Error($"Fail to download missing receipts for block {block.ToString(Block.Format.FullHashAndNumber)}.", e);
-                    }
-                    finally
-                    {
-                        syncPeerPool.Free(peer);
                     }
                 }
                 else

--- a/src/Nethermind/Nethermind.Kademlia/README.md
+++ b/src/Nethermind/Nethermind.Kademlia/README.md
@@ -61,6 +61,6 @@ Call `AddOrRefresh` when an authenticated node sends a valid protocol message, a
 
 Use `LookupNodesClosest(key, token)` when the caller needs the final closest set. Use `LookupNodes(key, token, maxResults)` or `IKademliaDiscovery<TKey, TNode>.DiscoverNodes(...)` when the caller wants candidates streamed as soon as lookups find them.
 
-`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled or lookups keep admitting nodes, and backs off exponentially up to five minutes once a filled table stops learning anything new.
+`RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>` paces itself: it keeps looking up every second while the routing table is underfilled. Once the table is healthy, it backs off exponentially to a 30-second productive pace while admissions continue. Successive admission-free windows may extend that toward a five-minute worst-case ceiling, although shared inbound and concurrent-job admissions normally return a live node to the productive range sooner.
 
 Dispose `NodeHealthTracker<TKey, TNode, TKadKey>` when the host shuts down, or let the dependency-injection container that owns it dispose it.

--- a/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
+++ b/src/Nethermind/Nethermind.Kademlia/RandomWalkKademliaDiscovery.cs
@@ -12,10 +12,13 @@ namespace Nethermind.Kademlia;
 /// Runs active random Kademlia lookups and streams discovered nodes.
 /// </summary>
 /// <remarks>
-/// Jobs iterate at <see cref="MinimumIterationDuration"/> while the routing table is still underfilled or while
-/// lookups keep admitting nodes into it. Once the table is filled and a lookup admits nothing, the job doubles its
-/// interval up to <see cref="MaximumIterationDuration"/>, so a node with a healthy table stops behaving like a
-/// crawler. Periodic bootstrap and bucket refresh in <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
+/// Jobs iterate at <see cref="MinimumIterationDuration"/> while the routing table is still underfilled. Once the table
+/// is healthy, each job backs off to <see cref="MaximumProductiveIterationDuration"/> while nodes are still being
+/// admitted. Sustained admission-free windows may extend the interval toward <see cref="MaximumIterationDuration"/>,
+/// which bounds worst-case staleness rather than describing the usual steady state. Periodic bootstrap and bucket
+/// refresh in <see cref="IKademlia{TKey,TNode}.Run"/> are unaffected.
+/// Routing-table occupancy deliberately controls this protocol-independent loop because it cannot observe whether
+/// downstream consumers accept emitted nodes or establish peer connections.
 /// </remarks>
 public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     IKademlia<TKey, TNode> kademlia,
@@ -30,16 +33,27 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     where TKadKey : notnull
 {
     private static readonly TimeSpan MinimumIterationDuration = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan OccupancyCacheDuration = TimeSpan.FromSeconds(1);
 
     /// <summary>
-    /// Longest interval an idle job backs off to.
+    /// Longest interval used while a healthy routing table is still admitting nodes.
     /// </summary>
     /// <remarks>
-    /// The lookup rate is inversely proportional to this cap, so almost all of the saving is already banked by the
-    /// first few doublings: a one-minute cap removes 98% of the one-second crawl rate and this one removes 99.7%,
-    /// while a half-hour cap would buy a further 0.3% at six times the worst-case delay. Because a reset only
-    /// applies to the next iteration and never wakes a sleeping job, this cap alone bounds how long a job can go
-    /// without looking up, whatever else happens in the table meanwhile.
+    /// At the default <c>Discovery.ConcurrentDiscoveryJob</c> of ten jobs this keeps one active random walk starting
+    /// about every three seconds, while preventing ordinary routing churn from pinning every job at the one-second
+    /// bootstrap pace.
+    /// </remarks>
+    private static readonly TimeSpan MaximumProductiveIterationDuration = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Longest interval an admission-free job can back off to.
+    /// </summary>
+    /// <remarks>
+    /// Shared admissions normally return a live node to the productive range before this ceiling. The lookup rate is
+    /// inversely proportional to the cap, so almost all of the saving is already banked by the first few doublings:
+    /// a one-minute cap removes 98% of the one-second crawl rate and this one removes 99.7%, while a half-hour cap
+    /// would buy a further 0.3% at six times the worst-case delay. Because a reset only applies to the next iteration
+    /// and never wakes a sleeping job, this cap alone bounds how long a job can go without looking up.
     /// </remarks>
     private static readonly TimeSpan MaximumIterationDuration = TimeSpan.FromMinutes(5);
 
@@ -47,9 +61,11 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// Reciprocal of the bucket-slot fill ratio the table must reach before idle lookups may slow down.
     /// </summary>
     /// <remarks>
+    /// A cold table has one bucket, so it must first collect a full bucket's worth of nodes before this ratio applies.
+    /// Networks with fewer than KSize reachable nodes therefore stay at the minimum interval.
     /// Buckets only split once they overflow, so a table that saturated its reachable neighbourhood settles above
-    /// 90% of its slots. A table holding only a handful of contacts, such as one still bootstrapping or one whose
-    /// peers were just evicted for being unresponsive, stays below this ratio and keeps discovering at full speed.
+    /// 90% of its slots. A table whose peers were evicted for being unresponsive falls below this ratio and resumes
+    /// discovering at full speed.
     /// </remarks>
     private const int HealthyOccupancyDivisor = 3;
 
@@ -65,8 +81,13 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
 
     private readonly ILogger _logger = loggerFactory.CreateLogger<RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>>();
     private readonly TKadKey _currentNodeHash = keyOperator.GetNodeHash(kademliaConfig.CurrentNodeId);
+    private readonly int _kSize = kademliaConfig.KSize;
     private readonly int _maxDistance = distance.MaxDistance;
     private readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+    private readonly Lock _occupancyLock = new();
+    private long _lastOccupancyTimestamp;
+    private bool _hasCachedOccupancy;
+    private bool _cachedUnderfilled;
 
     /// <inheritdoc/>
     public IAsyncEnumerable<TNode> DiscoverNodes(int concurrentDiscoveryJobs, int lookupResultLimit, CancellationToken token)
@@ -126,7 +147,7 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     {
         TimeSpan iterationDuration = MinimumIterationDuration;
         // Carried across iterations so that the window covers the paced wait as well as the lookup; a job at the
-        // maximum interval is asleep for nearly all of its iteration, and admissions made then must still reset it.
+        // maximum interval is asleep for nearly all of its iteration, and admissions made then must restore productive pacing.
         long admissionsSeen = admissions.Count;
         while (!token.IsCancellationRequested)
         {
@@ -175,24 +196,40 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     }
 
     /// <summary>
-    /// Returns the pace for the next iteration, resetting it when the last lookup was worth running.
+    /// Returns the pace for the next iteration, retaining a sustainable crawl rate while the table changes.
     /// </summary>
     /// <param name="current">Pace the finished iteration ran at.</param>
     /// <param name="admittedNodes">Whether the routing table admitted a node since the previous iteration decided its pace.</param>
     private TimeSpan NextIterationDuration(TimeSpan current, bool admittedNodes)
     {
-        if (admittedNodes || IsUnderfilled())
+        if (IsUnderfilled())
         {
             return MinimumIterationDuration;
         }
 
-        return TimeSpan.FromTicks(Math.Min(current.Ticks * 2, MaximumIterationDuration.Ticks));
+        TimeSpan maximum = admittedNodes ? MaximumProductiveIterationDuration : MaximumIterationDuration;
+        return TimeSpan.FromTicks(Math.Min(current.Ticks * 2, maximum.Ticks));
     }
 
     private bool IsUnderfilled()
     {
-        RoutingTableOccupancy occupancy = routingTable.GetOccupancy();
-        return occupancy.NodeCount * HealthyOccupancyDivisor < occupancy.Capacity;
+        lock (_occupancyLock)
+        {
+            long timestamp = _timeProvider.GetTimestamp();
+            // Coalesce discovery jobs because GetOccupancy may walk the full table under its mutation lock.
+            if (_hasCachedOccupancy &&
+                _timeProvider.GetElapsedTime(_lastOccupancyTimestamp, timestamp) < OccupancyCacheDuration)
+            {
+                return _cachedUnderfilled;
+            }
+
+            RoutingTableOccupancy occupancy = routingTable.GetOccupancy();
+            _cachedUnderfilled = occupancy.NodeCount < _kSize ||
+                occupancy.NodeCount * HealthyOccupancyDivisor < occupancy.Capacity;
+            _lastOccupancyTimestamp = timestamp;
+            _hasCachedOccupancy = true;
+            return _cachedUnderfilled;
+        }
     }
 
     /// <summary>
@@ -202,8 +239,8 @@ public sealed class RandomWalkKademliaDiscovery<TKey, TNode, TKadKey>(
     /// <remarks>
     /// Jobs compare this counter across their whole iteration, so admissions made by a concurrent job or by inbound
     /// traffic count too. Attributing an admission to the lookup that caused it would mean threading a lookup
-    /// identity through every protocol adapter, and the imprecision is one-sided: an admission this job did not
-    /// cause still means the table is changing, and reading it as productive only keeps discovery eager.
+    /// identity through every protocol adapter. An admission this job did not cause can therefore keep it at the
+    /// sustainable productive pace, but cannot return it to the one-second bootstrap pace once the table is healthy.
     /// </remarks>
     private sealed class AdmissionCounter
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V3.cs
@@ -836,12 +836,17 @@ public partial class EngineModuleTests
         ExecutionPayloadV3 payloadResultB3 = await AddNewBlockV3(rpcModuleB, chainB, 1);
 
         SyncPeerMock chainAPeer = new(chainA.BlockTree);
-        SyncPeerAllocation alloc = new(new PeerInfo(chainAPeer), AllocationContexts.All);
+        PeerInfo chainAPeerInfo = new(chainAPeer);
         chainC.SyncPeerPool!.Allocate(
             Arg.Any<IPeerAllocationStrategy>(),
             Arg.Any<AllocationContexts>(),
             Arg.Any<int>(),
-            Arg.Any<CancellationToken>())!.Returns(Task.FromResult(alloc));
+            Arg.Any<CancellationToken>())!.Returns(ci =>
+            {
+                SyncPeerAllocation allocation = new(ci.ArgAt<AllocationContexts>(1));
+                allocation.AllocatePeer(chainAPeerInfo);
+                return Task.FromResult(allocation);
+            });
 
 
         await rpcModuleC.engine_forkchoiceUpdatedV3(new(payloadResultA1.BlockHash, chainC.BlockTree.GenesisHash!, chainC.BlockTree.GenesisHash!), null);

--- a/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/Kademlia/RandomWalkKademliaDiscoveryTests.cs
@@ -9,8 +9,10 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging.Abstractions;
+using Autofac;
+using Nethermind.Core;
 using Nethermind.Kademlia;
+using Nethermind.Network.Discovery.Kademlia;
 using NUnit.Framework;
 
 namespace Nethermind.Network.Discovery.Test.Kademlia;
@@ -29,7 +31,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_stream_nodes_from_random_lookup(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(2).ToListAsync(token);
 
@@ -46,7 +49,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_not_run_any_job_when_disabled(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         List<int> nodes = await discovery.DiscoverNodes(0, 2, token).ToListAsync(token);
 
@@ -62,7 +66,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_pace_iterations_to_minimum_iteration_duration(CancellationToken token)
     {
         TestKademlia kademlia = new();
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(4).ToListAsync(token);
@@ -79,7 +84,8 @@ public class RandomWalkKademliaDiscoveryTests
     public async Task DiscoverNodes_should_not_delay_when_lookup_exceeds_minimum_iteration_duration(CancellationToken token)
     {
         TestKademlia kademlia = new() { LookupDelay = TimeSpan.FromMilliseconds(1100) };
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, new RoutingTableStub());
+        using IContainer container = CreateContainer(kademlia, new RoutingTableStub());
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
         Stopwatch stopwatch = Stopwatch.StartNew();
         List<int> nodes = await discovery.DiscoverNodes(1, 2, token).Take(3).ToListAsync(token);
@@ -91,11 +97,12 @@ public class RandomWalkKademliaDiscoveryTests
         }
     }
 
-    [Test]
+    [TestCase(15, 16)]
+    [TestCase(21, 64)]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_keep_minimum_pace_while_table_is_underfilled(CancellationToken token)
+    public async Task DiscoverNodes_should_keep_minimum_pace_while_table_is_underfilled(int nodeCount, int capacity, CancellationToken token)
     {
-        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(5, 16) };
+        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(nodeCount, capacity) };
 
         TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 4, token);
 
@@ -104,9 +111,9 @@ public class RandomWalkKademliaDiscoveryTests
 
     [Test]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_back_off_when_filled_table_admits_nothing(CancellationToken token)
+    public async Task DiscoverNodes_should_back_off_when_filled_table_admits_nothing([Values(16, 48)] int capacity, CancellationToken token)
     {
-        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+        RoutingTableStub routingTable = new() { Occupancy = new RoutingTableOccupancy(16, capacity) };
 
         TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 11, token);
 
@@ -118,49 +125,169 @@ public class RandomWalkKademliaDiscoveryTests
         ]);
     }
 
-    [Test]
+    [TestCaseSource(nameof(ProductivePacingCases))]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_reset_pace_when_lookup_admits_a_node(CancellationToken token)
+    public async Task DiscoverNodes_should_bound_productive_filled_table_pace(
+        int[] admittingLookups,
+        int iterations,
+        int[] expectedDelaySeconds,
+        CancellationToken token)
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
-        TestKademlia kademlia = new() { OnLookup = lookup => { if (lookup == 3) routingTable.RaiseNodeAdded(42); } };
+        TestKademlia kademlia = new()
+        {
+            OnLookup = lookup =>
+            {
+                if (Array.IndexOf(admittingLookups, lookup) >= 0)
+                {
+                    routingTable.RaiseNodeAdded(42);
+                }
+            }
+        };
 
-        TimeSpan[] delays = await RunIterations(kademlia, routingTable, iterations: 5, token);
+        TimeSpan[] delays = await RunIterations(kademlia, routingTable, iterations, token);
 
-        AssertPacedBy(delays, [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), OneSecond, TimeSpan.FromSeconds(2)]);
+        AssertPacedBy(delays, Array.ConvertAll(expectedDelaySeconds, static seconds => TimeSpan.FromSeconds(seconds)));
     }
 
     /// <summary>
     /// A backed-off job spends nearly all of its iteration waiting, so an admission arriving from inbound traffic or
-    /// another job while it waits has to reset it just as one during its own lookup does.
+    /// another job while it waits has to restore productive pacing just as one during its own lookup does.
     /// </summary>
     [Test]
     [CancelAfter(10000)]
-    public async Task DiscoverNodes_should_reset_pace_when_a_node_is_admitted_while_waiting(CancellationToken token)
+    public async Task DiscoverNodes_should_return_to_productive_pace_when_a_node_is_admitted_while_waiting(CancellationToken token)
     {
         RoutingTableStub routingTable = new() { Occupancy = FilledTable };
 
-        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 5, token,
-            onDelayRequested: wait => { if (wait == 2) routingTable.RaiseNodeAdded(42); });
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 8, token,
+            onDelayRequested: wait => { if (wait == 5) routingTable.RaiseNodeAdded(42); });
 
-        AssertPacedBy(delays, [TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), OneSecond, TimeSpan.FromSeconds(2)]);
+        AssertPacedBy(delays, [
+            TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32), TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(60)
+        ]);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_return_to_minimum_pace_when_table_becomes_underfilled(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        TimeSpan[] delays = await RunIterations(new TestKademlia(), routingTable, iterations: 8, token,
+            onDelayRequested: wait =>
+            {
+                if (wait == 5)
+                {
+                    routingTable.Occupancy = new RoutingTableOccupancy(5, 16);
+                }
+            });
+
+        AssertPacedBy(delays, [
+            TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(16),
+            TimeSpan.FromSeconds(32), OneSecond, OneSecond
+        ]);
+    }
+
+    [Test]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_share_cached_routing_table_occupancy_between_jobs(CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        await RunPacingChecks(routingTable, checks: 4, token, concurrentJobs: 4);
+
+        Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(1));
+    }
+
+    [TestCase(999, 1, 4)]
+    [TestCase(1000, 2, 1)]
+    [CancelAfter(10000)]
+    public async Task DiscoverNodes_should_expire_cached_routing_table_occupancy_after_one_second(
+        int elapsedMilliseconds,
+        int expectedOccupancyCalls,
+        int expectedDelaySeconds,
+        CancellationToken token)
+    {
+        RoutingTableStub routingTable = new() { Occupancy = FilledTable };
+
+        TimeSpan[] delays = await RunPacingChecks(routingTable, checks: 2, token,
+            timeAdvance: TimeSpan.FromMilliseconds(elapsedMilliseconds),
+            onDelayRequested: wait => { if (wait == 1) routingTable.Occupancy = new RoutingTableOccupancy(0, 16); });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(routingTable.GetOccupancyCalls, Is.EqualTo(expectedOccupancyCalls));
+            Assert.That(delays, Is.EqualTo(new[] { TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(expectedDelaySeconds) }));
+        }
+    }
+
+    private static async Task<TimeSpan[]> RunPacingChecks(
+        RoutingTableStub routingTable,
+        int checks,
+        CancellationToken token,
+        int concurrentJobs = 1,
+        TimeSpan? timeAdvance = null,
+        Action<int>? onDelayRequested = null)
+    {
+        TaskCompletionSource completed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        NoWaitTimeProvider timeProvider = new()
+        {
+            TimeAdvance = timeAdvance ?? TimeSpan.Zero,
+            CompletedTimers = checks - concurrentJobs,
+            OnDelayRequested = wait =>
+            {
+                onDelayRequested?.Invoke(wait);
+                if (wait == checks) completed.TrySetResult();
+            }
+        };
+        using IContainer container = CreateContainer(new TestKademlia(), routingTable, timeProvider);
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
+
+        // Leave enough channel space for every lookup and park each job only after it has checked occupancy.
+        await using IAsyncEnumerator<int> nodes = discovery.DiscoverNodes(concurrentJobs, checks * NodesPerLookup, token).GetAsyncEnumerator(token);
+        Assert.That(await nodes.MoveNextAsync(), Is.True);
+        await completed.Task.WaitAsync(token);
+        return timeProvider.RequestedDelays;
     }
 
     /// <summary>Asserts that the first iterations waited for exactly the expected paces.</summary>
     private static void AssertPacedBy(TimeSpan[] delays, TimeSpan[] expected) =>
-        Assert.That(delays.Take(expected.Length).ToArray(), Is.EqualTo(expected));
+        Assert.That(delays[..expected.Length], Is.EqualTo(expected));
 
-    private static RandomWalkKademliaDiscovery<int, int, int> CreateDiscovery(
+    private static IEnumerable<TestCaseData> ProductivePacingCases()
+    {
+        yield return new TestCaseData(
+                new[] { 6 },
+                8,
+                new[] { 2, 4, 8, 16, 32, 30, 60 })
+            .SetName("DiscoverNodes_returns_to_productive_pace_when_lookup_admits_a_node");
+        yield return new TestCaseData(
+                new[] { 1, 2, 3, 4, 5, 6, 7 },
+                7,
+                new[] { 2, 4, 8, 16, 30, 30 })
+            .SetName("DiscoverNodes_limits_continuously_productive_filled_table_pace");
+        yield return new TestCaseData(
+                new[] { 10 },
+                12,
+                new[] { 2, 4, 8, 16, 32, 64, 128, 256, 300, 30, 60 })
+            .SetName("DiscoverNodes_returns_from_idle_ceiling_to_productive_pace");
+    }
+
+    private static IContainer CreateContainer(
         TestKademlia kademlia,
         RoutingTableStub routingTable,
         TimeProvider? timeProvider = null) =>
-        new(kademlia,
-            routingTable,
-            IntKeyOperator.Instance,
-            Int32KademliaDistance.Instance,
-            new KademliaConfig<int> { CurrentNodeId = 0 },
-            NullLoggerFactory.Instance,
-            timeProvider);
+        new ContainerBuilder()
+            .AddModule(new KademliaModule<int, int, int>())
+            .AddSingleton<IKademlia<int, int>>(kademlia)
+            .AddSingleton<IRoutingTable<int, int>>(routingTable)
+            .AddSingleton<IKeyOperator<int, int, int>>(IntKeyOperator.Instance)
+            .AddSingleton<IKademliaDistance<int>>(Int32KademliaDistance.Instance)
+            .AddSingleton(new KademliaConfig<int> { CurrentNodeId = 0 })
+            .AddSingleton(timeProvider ?? TimeProvider.System)
+            .Build();
 
     /// <summary>
     /// Runs the requested number of lookup iterations and returns the paced delays each of them asked for.
@@ -176,45 +303,68 @@ public class RandomWalkKademliaDiscoveryTests
         CancellationToken token,
         Action<int>? onDelayRequested = null)
     {
-        NoWaitTimeProvider timeProvider = new() { OnDelayRequested = onDelayRequested };
-        RandomWalkKademliaDiscovery<int, int, int> discovery = CreateDiscovery(kademlia, routingTable, timeProvider);
+        NoWaitTimeProvider timeProvider = new()
+        {
+            OnDelayRequested = onDelayRequested
+        };
+        using IContainer container = CreateContainer(kademlia, routingTable, timeProvider);
+        IKademliaDiscovery<int, int> discovery = container.Resolve<IKademliaDiscovery<int, int>>();
 
-        await discovery.DiscoverNodes(1, NodesPerLookup, token).Take(iterations * NodesPerLookup).ToListAsync(token);
+        await discovery.DiscoverNodes(1, NodesPerLookup, token)
+            .Take(iterations * NodesPerLookup).ToListAsync(token);
 
         return timeProvider.RequestedDelays;
     }
 
     /// <summary>
-    /// Runs timers immediately while recording the delay that was asked for, on a clock that never advances.
+    /// Records paced delays and advances the clock only when a timer is requested.
     /// </summary>
     /// <remarks>
-    /// Freezing <see cref="GetTimestamp"/> makes the measured lookup time zero, so a job asks for exactly the pace it
-    /// chose rather than the pace minus however long the test machine took.
+    /// Lookup time stays zero regardless of the test machine's speed. Timers beyond <see cref="CompletedTimers"/>
+    /// stay pending until discovery is disposed, allowing tests to inspect a fixed number of completed pacing checks.
     /// </remarks>
     private sealed class NoWaitTimeProvider : TimeProvider
     {
         private readonly ConcurrentQueue<TimeSpan> _requestedDelays = new();
+        private long _timestamp;
+        private int _timerCount;
 
         public TimeSpan[] RequestedDelays => _requestedDelays.ToArray();
+
+        public int CompletedTimers { get; init; } = int.MaxValue;
+
+        public TimeSpan? TimeAdvance { get; init; }
 
         /// <summary>Called as a job starts waiting, with the one-based ordinal of that wait.</summary>
         public Action<int>? OnDelayRequested { get; init; }
 
-        public override long GetTimestamp() => 0;
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => Volatile.Read(ref _timestamp);
 
         public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
         {
             _requestedDelays.Enqueue(dueTime);
-            OnDelayRequested?.Invoke(_requestedDelays.Count);
-            return System.CreateTimer(callback, state, TimeSpan.Zero, period);
+            int timer = Interlocked.Increment(ref _timerCount);
+            Interlocked.Add(ref _timestamp, (TimeAdvance ?? dueTime).Ticks);
+            OnDelayRequested?.Invoke(timer);
+            return System.CreateTimer(callback, state, timer <= CompletedTimers ? TimeSpan.Zero : Timeout.InfiniteTimeSpan, period);
         }
     }
 
     private sealed class RoutingTableStub : IRoutingTable<int, int>
     {
-        public RoutingTableOccupancy Occupancy { get; init; } = new(0, 16);
+        private int _getOccupancyCalls;
 
-        public RoutingTableOccupancy GetOccupancy() => Occupancy;
+        public RoutingTableOccupancy Occupancy { get; set; } = new(0, 16);
+
+        public int GetOccupancyCalls => Volatile.Read(ref _getOccupancyCalls);
+
+        public RoutingTableOccupancy GetOccupancy()
+        {
+            Interlocked.Increment(ref _getOccupancyCalls);
+            return Occupancy;
+        }
 
         public void RaiseNodeAdded(int node) => OnNodeAdded?.Invoke(this, node);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/Rlp.cs
@@ -527,10 +527,11 @@ namespace Nethermind.Serialization.Rlp
             return 4;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LengthOfLength(int value)
         {
             int bits = 32 - BitOperations.LeadingZeroCount((uint)value | 1);
-            return (bits + 7) / 8;
+            return (bits + 7) >>> 3;
         }
 
         public static Rlp Encode(Hash256? keccak)
@@ -788,6 +789,7 @@ namespace Nethermind.Serialization.Rlp
 
         public static int LengthOf(Bloom? bloom) => bloom is null ? 1 : 259;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int LengthOfSequence(int contentLength)
         {
             if (contentLength < RlpHelpers.SmallPrefixBarrier)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
@@ -172,6 +172,7 @@ internal static class RlpHelpers
     /// <summary>
     /// Counts the number of top-level RLP items in the given data range.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int CountItems(ReadOnlySpan<byte> data, int position, int end, int maxSearch)
     {
         int numberOfItems = 0;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -48,6 +48,7 @@ public ref struct RlpReader
         _isNotNull = true;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public RlpReader(CappedArray<byte> data)
     {
         Data = data.AsSpan();
@@ -71,9 +72,11 @@ public ref struct RlpReader
 
     public readonly bool IsSequenceNext() => Data[Position] >= 192;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public readonly int PeekNumberOfItemsRemaining(int? beforePosition = null, int maxSearch = int.MaxValue)
         => RlpHelpers.CountItems(Data, Position, beforePosition ?? Data.Length, maxSearch);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SkipLength() => Position += PeekPrefixLength();
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -133,6 +136,7 @@ public ref struct RlpReader
         return result;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public byte ReadByte() => Data[Position++];
 
     public ReadOnlySpan<byte> Read(int length)
@@ -226,43 +230,35 @@ public ref struct RlpReader
 
     private Hash256 DecodeKeccakPayload()
     {
-        ReadOnlySpan<byte> keccakSpan = Read(Hash256.Size);
-        if (keccakSpan.SequenceEqual(Keccak.OfAnEmptyString.Bytes))
+        ValueHash256 keccak = new(Read(Hash256.Size));
+        if (keccak == Keccak.OfAnEmptyString)
         {
             return Keccak.OfAnEmptyString;
         }
 
-        if (keccakSpan.SequenceEqual(Keccak.EmptyTreeHash.Bytes))
+        if (keccak == Keccak.EmptyTreeHash)
         {
             return Keccak.EmptyTreeHash;
         }
 
-        return new Hash256(keccakSpan);
+        return new Hash256(in keccak);
     }
 
     public ValueHash256? DecodeValueKeccak()
     {
-        if (!ReadKeccakPrefix(allowNull: true))
-        {
-            return null;
-        }
-
-        ReadOnlySpan<byte> keccakSpan = Read(Hash256.Size);
-        if (keccakSpan.SequenceEqual(Keccak.OfAnEmptyString.Bytes))
-        {
-            return Keccak.OfAnEmptyString.ValueHash256;
-        }
-
-        if (keccakSpan.SequenceEqual(Keccak.EmptyTreeHash.Bytes))
-        {
-            return Keccak.EmptyTreeHash.ValueHash256;
-        }
-
-        return new ValueHash256(keccakSpan);
+        // Not a conditional expression: the implicit Hash256? -> ValueHash256 conversion would
+        // give `null` the type ValueHash256, silently yielding a non-null zero hash.
+        if (!TryDecodeValueKeccak(out ValueHash256 keccak)) return null;
+        return keccak;
     }
 
-    public ValueHash256 DecodeValueKeccakNonNull() => DecodeValueKeccak() ?? ThrowNullDecodedValue<ValueHash256>();
+    public ValueHash256 DecodeValueKeccakNonNull()
+    {
+        if (!TryDecodeValueKeccak(out ValueHash256 keccak)) ThrowNullDecodedValue<ValueHash256>();
+        return keccak;
+    }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryDecodeValueKeccak(out ValueHash256 keccak)
     {
         Unsafe.SkipInit(out keccak);

--- a/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/BlockDownloaderTests.cs
@@ -974,20 +974,16 @@ public partial class BlockDownloaderTests
         public void ConfigureBestPeer(PeerInfo peerInfo)
         {
             SemaphoreSlim peerSemaphore = new(1, 1);
-            SyncPeerAllocation peerAllocation = new(peerInfo, AllocationContexts.Blocks, null);
-
             PeerPool
                 .Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
                 .Returns(async ci =>
                 {
                     CancellationToken token = ci.ArgAt<CancellationToken>(3);
                     await peerSemaphore.WaitAsync(token);
+                    SyncPeerAllocation peerAllocation = new(ci.ArgAt<AllocationContexts>(1), null, () => peerSemaphore.Release());
+                    peerAllocation.AllocatePeer(peerInfo);
                     return peerAllocation;
                 });
-
-            PeerPool
-                .When((p) => p.Free(peerAllocation))
-                .Do((c) => peerSemaphore.Release());
         }
 
         public async Task SyncUntilNoRequest(SyncFeedComponent<BlocksRequest> component, PeerInfo peerInfo)

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/BalFetcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/BalFetcherTests.cs
@@ -26,12 +26,20 @@ namespace Nethermind.Synchronization.Test.FastSync;
 
 public class BalFetcherTests
 {
+    public enum FetchOutcome
+    {
+        Success,
+        Failure,
+        Cancellation,
+    }
+
     private const int BlockCount = 300;
     private const int AllocateTimeoutMs = 5;
 
     private readonly Dictionary<ValueHash256, byte[]> _balByHash = [];
     private int _largestRequest;
     private int _responseLimit;
+    private int _disposedAllocations;
     private IBlockTree _blockTree = null!;
     private MemDb _balDb = null!;
     private BlockAccessListStore _balStore = null!;
@@ -44,6 +52,7 @@ public class BalFetcherTests
         _balByHash.Clear();
         _largestRequest = 0;
         _responseLimit = int.MaxValue;
+        _disposedAllocations = 0;
         _blockTree = Substitute.For<IBlockTree>();
         _balDb = new MemDb();
         _balStore = new BlockAccessListStore(_balDb);
@@ -92,7 +101,7 @@ public class BalFetcherTests
         BlockHeader from = Block(10, bal: null);
         BlockHeader b11 = Block(11, [0x01, 0x02]);
         _pool.Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(SyncPeerAllocation.FailedAllocation);
+            .Returns(new SyncPeerAllocation(AllocationContexts.State));
 
         bool result = await _fetcher.EnsureRange(from, b11, default);
 
@@ -100,6 +109,32 @@ public class BalFetcherTests
         Assert.That(_balStore.Exists(11, b11.Hash!), Is.False);
 
         await _pool.Received().Allocate(Arg.Any<IPeerAllocationStrategy>(), AllocationContexts.State, AllocateTimeoutMs, Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task Disposes_allocation_after_fetch([Values(FetchOutcome.Success, FetchOutcome.Failure, FetchOutcome.Cancellation)] FetchOutcome outcome)
+    {
+        BlockHeader from = Block(10, bal: null);
+        BlockHeader b11 = Block(11, [0x01, 0x02]);
+        PeerInfo peer = Snap2Peer(outcome);
+        AllocatePeer(peer);
+
+        if (outcome == FetchOutcome.Cancellation)
+        {
+            Assert.ThrowsAsync<OperationCanceledException>(async () => await _fetcher.EnsureRange(from, b11, default));
+        }
+        else
+        {
+            bool result = await _fetcher.EnsureRange(from, b11, default);
+            Assert.That(result, Is.EqualTo(outcome == FetchOutcome.Success));
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            int expectedDisposals = outcome == FetchOutcome.Failure ? 50 : 1;
+            Assert.That(_disposedAllocations, Is.EqualTo(expectedDisposals));
+            Assert.That(peer.IsAllocated(AllocationContexts.State), Is.False);
+        }
     }
 
     [Test]
@@ -229,15 +264,24 @@ public class BalFetcherTests
 
     private void AllocatePeer(PeerInfo peer) =>
         _pool.Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-            .Returns(ci => new SyncPeerAllocation(peer, (AllocationContexts)ci[1]));
+            .Returns(ci =>
+            {
+                AllocationContexts contexts = ci.Arg<AllocationContexts>();
+                SyncPeerAllocation allocation = new(contexts, null, () => _disposedAllocations++);
+                allocation.AllocatePeer(peer);
+                return allocation;
+            });
 
-    private PeerInfo Snap2Peer()
+    private PeerInfo Snap2Peer(FetchOutcome outcome = FetchOutcome.Success)
     {
         ISnapSyncPeer snap = Substitute.For<ISnapSyncPeer>();
         snap.SnapProtocolVersion.Returns(SnapVersions.Snap2);
         snap.GetBlockAccessLists(Arg.Any<IReadOnlyList<ValueHash256>>(), Arg.Any<CancellationToken>())
             .Returns(ci =>
             {
+                if (outcome == FetchOutcome.Failure) throw new InvalidOperationException("fetch failed");
+                if (outcome == FetchOutcome.Cancellation) throw new OperationCanceledException();
+
                 IReadOnlyList<ValueHash256> requested = ci.Arg<IReadOnlyList<ValueHash256>>();
                 _largestRequest = Math.Max(_largestRequest, requested.Count);
                 int served = Math.Min(requested.Count, _responseLimit);

--- a/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTester.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/FastSync/SnapProtocolTests/StateSyncDispatcherTester.cs
@@ -21,15 +21,13 @@ namespace Nethermind.Synchronization.Test.FastSync.SnapProtocolTests
         public async Task ExecuteDispatch(StateSyncBatch batch, int times)
         {
             StateSyncAllocationStrategyFactory strategyFactory = new();
-            SyncPeerAllocation allocation = await syncPeerPool.Allocate(
+            using SyncPeerAllocation allocation = await syncPeerPool.Allocate(
                 strategyFactory.Create(batch), AllocationContexts.State, _syncConfig.SyncDispatcherAllocateTimeoutMs);
 
             for (int i = 0; i < times; i++)
             {
                 await downloader.Dispatch(allocation.Current!, batch, CancellationToken.None);
             }
-
-            syncPeerPool.Free(allocation);
         }
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;

--- a/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ForwardHeaderProviderTests.cs
@@ -277,7 +277,7 @@ public partial class ForwardHeaderProviderTests
         int allocationTimeout = -1;
         ctx.PeerPool
             .Allocate(Arg.Do<IPeerAllocationStrategy>(s => strategy = s), Arg.Any<AllocationContexts>(), Arg.Do<int>(t => allocationTimeout = t), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(SyncPeerAllocation.FailedAllocation));
+            .Returns(Task.FromResult(new SyncPeerAllocation(AllocationContexts.None)));
 
         using IOwnedReadOnlyList<BlockHeader?>? headers = await ctx.ForwardHeaderProvider.GetBlockHeaders(0, 128, CancellationToken.None);
         using (Assert.EnterMultipleScope())
@@ -543,14 +543,15 @@ public partial class ForwardHeaderProviderTests
         public void ConfigureBestPeer(ISyncPeer syncPeer) =>
             ConfigureBestPeer(new PeerInfo(syncPeer));
 
-        public void ConfigureBestPeer(PeerInfo peerInfo)
-        {
-            SyncPeerAllocation peerAllocation = new(peerInfo, AllocationContexts.Blocks, null);
-
+        public void ConfigureBestPeer(PeerInfo peerInfo) =>
             PeerPool
                 .Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
-                .Returns(Task.FromResult(peerAllocation));
-        }
+                .Returns(ci =>
+                {
+                    SyncPeerAllocation peerAllocation = new(ci.ArgAt<AllocationContexts>(1), null);
+                    peerAllocation.AllocatePeer(peerInfo);
+                    return Task.FromResult(peerAllocation);
+                });
     }
 
     private class SyncPeerMock : ISyncPeer

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SyncDispatcherTests.cs
@@ -35,12 +35,13 @@ public class SyncDispatcherTests
             CancellationToken cancellationToken = default)
         {
             // Mirrors SyncPeerPool.Allocate: a cancelled token reports a failed allocation, it does not throw.
-            if (cancellationToken.IsCancellationRequested) return SyncPeerAllocation.FailedAllocation;
+            if (cancellationToken.IsCancellationRequested) return new SyncPeerAllocation(contexts);
 
             await Task.Yield();
             await _peerSemaphore.WaitAsync(cancellationToken);
             ISyncPeer syncPeer = new MockSyncPeer("Nethermind", UInt256.One);
-            SyncPeerAllocation allocation = new(new PeerInfo(syncPeer), contexts, _lock);
+            SyncPeerAllocation allocation = new(contexts, _lock, () => _peerSemaphore.Release());
+            allocation.AllocatePeer(new PeerInfo(syncPeer));
             return allocation;
         }
 
@@ -51,9 +52,6 @@ public class SyncDispatcherTests
         }
 
         public int AvailablePeers => _peerSemaphore.CurrentCount;
-
-        public void Free(SyncPeerAllocation syncPeerAllocation) =>
-            _peerSemaphore.Release();
 
         public void ReportNoSyncProgress(PeerInfo peerInfo, AllocationContexts contexts)
         {
@@ -320,11 +318,11 @@ public class SyncDispatcherTests
     }
 
     [Test, CancelAfter(30_000)]
-    public async Task Cancelled_in_flight_dispatch_skips_its_response_and_frees_its_allocation(CancellationToken cancellationToken)
+    public async Task Cancelled_in_flight_dispatch_skips_its_response_and_disposes_its_allocation(CancellationToken cancellationToken)
     {
         // The dispatch loop cancels its token on every exit, including the routine feed-finish exit
         // on a live node. The cancelled dispatch must not handle its response into a finishing feed,
-        // and it must still free its allocation - a leaked slot retires the peer for the lifetime
+        // and it must still dispose its allocation - a leaked slot retires the peer for the lifetime
         // of the connection.
         TestSyncPeerPool pool = new(peerCount: 2);
         TestSyncFeed syncFeed = new(max: 16);

--- a/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SyncPeerPoolTests.cs
@@ -447,7 +447,7 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 1);
 
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
 
         Assert.That(allocation.Current?.SyncPeer, Is.SameAs(peers[0]));
     }
@@ -458,13 +458,19 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 1);
 
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        ctx.Pool.Free(allocation);
-        allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        ctx.Pool.Free(allocation);
-        allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using (SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true)))
+        {
+            Assert.That(allocation.Current?.SyncPeer, Is.SameAs(peers[0]));
+        }
 
-        Assert.That(allocation.Current?.SyncPeer, Is.SameAs(peers[0]));
+        using (SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true)))
+        {
+            allocation.Dispose();
+            allocation.Dispose();
+        }
+
+        using SyncPeerAllocation reallocated = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        Assert.That(reallocated.Current?.SyncPeer, Is.SameAs(peers[0]));
     }
 
     [Test]
@@ -473,19 +479,16 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         await SetupPeers(ctx, 2);
 
-        SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        Assert.That(allocation2.Current, Is.Not.SameAs(allocation1.Current), "first");
-        Assert.That(allocation1.Current, Is.Not.Null, "first A");
-        Assert.That(allocation2.Current, Is.Not.Null, "first B");
+        using (SyncPeerAllocation firstAllocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true)))
+        using (SyncPeerAllocation secondAllocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true)))
+        {
+            Assert.That(secondAllocation.Current, Is.Not.SameAs(firstAllocation.Current), "first");
+            Assert.That(firstAllocation.Current, Is.Not.Null, "first A");
+            Assert.That(secondAllocation.Current, Is.Not.Null, "first B");
+        }
 
-        ctx.Pool.Free(allocation1);
-        ctx.Pool.Free(allocation2);
-        Assert.That(allocation1.Current, Is.Null, "null A");
-        Assert.That(allocation2.Current, Is.Null, "null B");
-
-        allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
         Assert.That(allocation2.Current, Is.Not.SameAs(allocation1.Current));
         Assert.That(allocation1.Current, Is.Not.Null, "second A");
         Assert.That(allocation2.Current, Is.Not.Null, "second B");
@@ -501,9 +504,9 @@ public class SyncPeerPoolTests
             ctx.Pool.ReportNoSyncProgress(ctx.Pool.InitializedPeers.First(), AllocationContexts.All);
         }
 
-        SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation3 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation3 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
 
         Assert.That(allocation1.HasPeer, Is.True);
         Assert.That(allocation2.HasPeer, Is.True);
@@ -520,9 +523,9 @@ public class SyncPeerPoolTests
 
         ctx.Pool.WakeUpAll();
 
-        SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation3 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation3 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
 
         Assert.That(allocation1.HasPeer, Is.True);
         Assert.That(allocation2.HasPeer, Is.True);
@@ -554,8 +557,8 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         SimpleSyncPeerMock[] peers = await SetupPeers(ctx, 1);
 
-        SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
 
         Assert.That(allocation1.Current?.SyncPeer, Is.SameAs(peers[0]));
         Assert.That(allocation2.Current, Is.Null);
@@ -586,21 +589,11 @@ public class SyncPeerPoolTests
         bool refreshAttempted = await Wait.ForCondition(() => peer.DisconnectRequested, TimeSpan.FromSeconds(30), TimeSpan.FromMilliseconds(50));
         Assert.That(refreshAttempted, Is.True, "refresh loop did not attempt the failing peer in time");
 
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        using SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
         ctx.Pool.RemovePeer(peer);
 
         Assert.That(allocation.Current, Is.EqualTo(null));
         Assert.That(ctx.Pool.PeerCount, Is.EqualTo(0));
-    }
-
-    [Test]
-    public async Task Can_return()
-    {
-        await using Context ctx = new();
-        await SetupPeers(ctx, 1);
-
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        ctx.Pool.Free(allocation);
     }
 
     [Test]
@@ -609,8 +602,8 @@ public class SyncPeerPoolTests
         await using Context ctx = new();
         await SetupPeers(ctx, 1);
 
-        SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
-        allocation.Cancel();
+        using SyncPeerAllocation allocation = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true));
+        allocation.Dispose();
 
         ctx.BlockTree.NewHeadBlock += Raise.EventWith(new object(), new BlockEventArgs(Build.A.Block.WithTotalDifficulty(1L).TestObject));
     }
@@ -637,8 +630,7 @@ public class SyncPeerPoolTests
 
         foreach (SyncPeerAllocation allocation in successfulAllocations)
         {
-            // free allocated peers
-            ctx.Pool.Free(allocation);
+            allocation.Dispose();
         }
 
         foreach (SyncPeerAllocation allocation in allocations)
@@ -685,16 +677,16 @@ public class SyncPeerPoolTests
         await SetupPeers(ctx, 1);
 
         // Allocate the only peer
-        SyncPeerAllocation first = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
+        using SyncPeerAllocation first = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
         Assert.That(first.HasPeer, Is.True);
 
         // Start a second allocation that must wait (only 1 peer, already allocated)
         Task<SyncPeerAllocation> secondTask = ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 2000);
 
-        // Free the first — this signals peers changed and wakes the waiter
-        ctx.Pool.Free(first);
+        // Dispose the first — this signals peers changed and wakes the waiter
+        first.Dispose();
 
-        SyncPeerAllocation second = await secondTask;
+        using SyncPeerAllocation second = await secondTask;
         Assert.That(second.HasPeer, Is.True);
     }
 
@@ -708,7 +700,7 @@ public class SyncPeerPoolTests
         using CancellationTokenSource cts = new();
         cts.CancelAfter(100);
 
-        SyncPeerAllocation result = await ctx.Pool.Allocate(
+        using SyncPeerAllocation result = await ctx.Pool.Allocate(
             new BySpeedStrategy(TransferSpeedType.Headers, true),
             AllocationContexts.All,
             5000,
@@ -733,7 +725,7 @@ public class SyncPeerPoolTests
         await ctx.DisposeAsync();
 
         // Must complete (not hang) and return failed
-        SyncPeerAllocation result = await allocTask.WaitAsync(TimeSpan.FromSeconds(2));
+        using SyncPeerAllocation result = await allocTask.WaitAsync(TimeSpan.FromSeconds(2));
         Assert.That(result.HasPeer, Is.False);
     }
 
@@ -753,15 +745,20 @@ public class SyncPeerPoolTests
                 100);
         }
 
-        await Task.WhenAll(tasks);
+        SyncPeerAllocation[] allocations = await Task.WhenAll(tasks);
 
         int successful = 0;
-        for (int i = 0; i < tasks.Length; i++)
+        foreach (SyncPeerAllocation allocation in allocations)
         {
-            if (tasks[i].Result.HasPeer) successful++;
+            if (allocation.HasPeer) successful++;
         }
 
         Assert.That(successful, Is.EqualTo(3));
+
+        foreach (SyncPeerAllocation allocation in allocations)
+        {
+            allocation.Dispose();
+        }
     }
 
     [Test]
@@ -771,8 +768,8 @@ public class SyncPeerPoolTests
         await SetupPeers(ctx, 2);
 
         // Allocate both peers — pool exhausted
-        SyncPeerAllocation a1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
-        SyncPeerAllocation a2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
+        using SyncPeerAllocation a1 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
+        using SyncPeerAllocation a2 = await ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 1000);
         Assert.That(a1.HasPeer, Is.True);
         Assert.That(a2.HasPeer, Is.True);
 
@@ -780,12 +777,12 @@ public class SyncPeerPoolTests
         Task<SyncPeerAllocation> w1 = ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 3000);
         Task<SyncPeerAllocation> w2 = ctx.Pool.Allocate(new BySpeedStrategy(TransferSpeedType.Headers, true), AllocationContexts.All, 3000);
 
-        // Free both peers — both waiters must wake
-        ctx.Pool.Free(a1);
-        ctx.Pool.Free(a2);
+        // Dispose both peers — both waiters must wake
+        a1.Dispose();
+        a2.Dispose();
 
-        SyncPeerAllocation r1 = await w1;
-        SyncPeerAllocation r2 = await w2;
+        using SyncPeerAllocation r1 = await w1;
+        using SyncPeerAllocation r2 = await w2;
         Assert.That(r1.HasPeer, Is.True);
         Assert.That(r2.HasPeer, Is.True);
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/Trie/RecoveryTests.cs
@@ -177,8 +177,9 @@ public class RecoveryTests
         _syncPeerPool.Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(c =>
         {
             AllocationContexts allocationContexts = (AllocationContexts)c[1];
-            SyncPeerAllocation alloc = new(peers[0], allocationContexts);
-            return alloc;
+            SyncPeerAllocation allocation = new(allocationContexts);
+            allocation.AllocatePeer(peers[0]);
+            return allocation;
         });
         return recovery.Recover(_rootHash, _storageHash, _path, _hash, _fullPath);
     }

--- a/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Blocks/PowForwardHeaderProvider.cs
@@ -62,56 +62,48 @@ public class PowForwardHeaderProvider(
     {
         // PrepareRequest must return to the dispatcher when no better peer exists so a feed-state
         // transition is observed; an unbounded allocation would remain parked inside this method.
-        SyncPeerAllocation allocation = await syncPeerPool.Allocate(
+        using SyncPeerAllocation allocation = await syncPeerPool.Allocate(
             _bestPeerAllocationStrategy,
             AllocationContexts.ForwardHeader,
             timeoutMilliseconds: 0,
             cancellationToken: cancellation);
 
-        // Skip Free for a failed allocation: it holds no peer and would signal peers-changed each poll.
         PeerInfo? peerInfo = allocation.Current;
         if (peerInfo is null) return null;
 
-        try
+        if (peerInfo != _currentBestPeer)
         {
-            if (peerInfo != _currentBestPeer)
-            {
-                OnNewBestPeer(peerInfo);
-            }
+            OnNewBestPeer(peerInfo);
+        }
 
-            syncReport.FullSyncBlocksDownloaded.TargetValue = peerInfo.HeadNumber;
+        syncReport.FullSyncBlocksDownloaded.TargetValue = peerInfo.HeadNumber;
 
-            if (_logger.IsTrace) _logger.Trace($"Allocated {peerInfo} for PoW header info. currentNumber: {_currentNumber} skipLastN: {skipLastN}, maxHeaders: {maxHeaders}");
+        if (_logger.IsTrace) _logger.Trace($"Allocated {peerInfo} for PoW header info. currentNumber: {_currentNumber} skipLastN: {skipLastN}, maxHeaders: {maxHeaders}");
 
-            // Provide a way so that it does not redownload if part of the. I guess it does not care about skiplastn and maxheaders.
-            // TODO: Unit test this mechanism.
-            IOwnedReadOnlyList<BlockHeader?>? headers = AssembleResponseFromLastResponseBatch();
-            if (headers is not null)
-            {
-                ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
-                if (_logger.IsTrace) _logger.Trace($"PoW header info from last response from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
-                return headers;
-            }
-
-            headers = await GetBlockHeaders(peerInfo, skipLastN, maxHeaders, cancellation);
-            if (headers is not null)
-            {
-                ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
-                if (_logger.IsTrace) _logger.Trace($"Assembled batch from {peerInfo} of {headersSpan.Length} header from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
-            }
-            else
-            {
-                if (_logger.IsTrace) _logger.Trace($"No header received");
-                _currentBestPeer = null;
-            }
-
-            if (headers is not null && headers.Count > MinCachedHeaderBatchSize) LastResponseBatch = headers.AsSpan().ToPooledList();
+        // Provide a way so that it does not redownload if part of the. I guess it does not care about skiplastn and maxheaders.
+        // TODO: Unit test this mechanism.
+        IOwnedReadOnlyList<BlockHeader?>? headers = AssembleResponseFromLastResponseBatch();
+        if (headers is not null)
+        {
+            ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
+            if (_logger.IsTrace) _logger.Trace($"PoW header info from last response from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
             return headers;
         }
-        finally
+
+        headers = await GetBlockHeaders(peerInfo, skipLastN, maxHeaders, cancellation);
+        if (headers is not null)
         {
-            syncPeerPool.Free(allocation);
+            ReadOnlySpan<BlockHeader?> headersSpan = headers.AsSpan();
+            if (_logger.IsTrace) _logger.Trace($"Assembled batch from {peerInfo} of {headersSpan.Length} header from {headersSpan[0].ToString(BlockHeader.Format.Short)} to {headersSpan[^1].ToString(BlockHeader.Format.Short)}");
         }
+        else
+        {
+            if (_logger.IsTrace) _logger.Trace($"No header received");
+            _currentBestPeer = null;
+        }
+
+        if (headers is not null && headers.Count > MinCachedHeaderBatchSize) LastResponseBatch = headers.AsSpan().ToPooledList();
+        return headers;
     }
 
     private IOwnedReadOnlyList<BlockHeader>? AssembleResponseFromLastResponseBatch()

--- a/src/Nethermind/Nethermind.Synchronization/FastSync/BalFetcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/FastSync/BalFetcher.cs
@@ -69,15 +69,10 @@ public class BalFetcher(
                     return false;
                 }
 
-                SyncPeerAllocation allocation = await peerPool.Allocate(PeerStrategy, AllocationContexts.State, _allocateTimeoutMs, token);
                 int stored;
-                try
+                using (SyncPeerAllocation allocation = await peerPool.Allocate(PeerStrategy, AllocationContexts.State, _allocateTimeoutMs, token))
                 {
                     stored = allocation.Current is null ? 0 : await FetchFromPeer(allocation.Current, missing, token);
-                }
-                finally
-                {
-                    peerPool.Free(allocation);
                 }
 
                 if (stored == 0)

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
@@ -57,11 +57,21 @@ public class SimpleDispatcher<T>(
 
             if (peer is null)
             {
+                allocation.Dispose();
                 HandleResponse(request, null);
                 continue;
             }
 
-            await semaphore.WaitAsync(token);
+            try
+            {
+                await semaphore.WaitAsync(token);
+            }
+            catch
+            {
+                allocation.Dispose();
+                throw;
+            }
+
             _ = Task.Run(async () =>
             {
                 try
@@ -75,8 +85,7 @@ public class SimpleDispatcher<T>(
             });
         }
 
-        // Wait for in-flight tasks to complete. Drain with CancellationToken.None so that
-        // peer allocations are always freed in DoDispatch even when the caller cancels.
+        // Drain with CancellationToken.None so cancellation does not abandon in-flight tasks.
         for (int i = 0; i < maxThreads; i++)
             await semaphore.WaitAsync(CancellationToken.None);
     }
@@ -88,30 +97,31 @@ public class SimpleDispatcher<T>(
         CancellationToken token)
     {
         long dispatchTime = Stopwatch.GetTimestamp();
-        try
+        using (allocation)
         {
-            await downloader.Dispatch(peer, request, token);
+            try
+            {
+                await downloader.Dispatch(peer, request, token);
+            }
+            catch (ConcurrencyLimitReachedException)
+            {
+                if (_logger.IsDebug) _logger.Debug($"{request} - concurrency limit reached. Peer: {peer}");
+            }
+            catch (TimeoutException)
+            {
+                if (_logger.IsDebug) _logger.Debug($"{request} - timed out. Peer: {peer}");
+            }
+            catch (OperationCanceledException)
+            {
+                if (_logger.IsTrace) _logger.Trace($"{request} - cancelled");
+            }
+            catch (Exception e)
+            {
+                if (_logger.IsWarn) _logger.Warn($"Failure when executing request {e}");
+            }
+            Metrics.SyncDispatcherDispatchTimeMicros.Observe(
+                Stopwatch.GetElapsedTime(dispatchTime).TotalMicroseconds, new StringLabel(_feedName));
         }
-        catch (ConcurrencyLimitReachedException)
-        {
-            if (_logger.IsDebug) _logger.Debug($"{request} - concurrency limit reached. Peer: {peer}");
-        }
-        catch (TimeoutException)
-        {
-            if (_logger.IsDebug) _logger.Debug($"{request} - timed out. Peer: {peer}");
-        }
-        catch (OperationCanceledException)
-        {
-            if (_logger.IsTrace) _logger.Trace($"{request} - cancelled");
-        }
-        catch (Exception e)
-        {
-            if (_logger.IsWarn) _logger.Warn($"Failure when executing request {e}");
-        }
-        Metrics.SyncDispatcherDispatchTimeMicros.Observe(
-            Stopwatch.GetElapsedTime(dispatchTime).TotalMicroseconds, new StringLabel(_feedName));
-
-        peerPool.Free(allocation);
 
         if (token.IsCancellationRequested) return;
 

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SyncDispatcher.cs
@@ -157,10 +157,14 @@ namespace Nethermind.Synchronization.ParallelSync
                             try
                             {
                                 if (!_activeTasks.TryAddCount())
+                                {
+                                    allocation.Dispose();
                                     break;
+                                }
                             }
                             catch (ObjectDisposedException)
                             {
+                                allocation.Dispose();
                                 break;
                             }
 
@@ -191,6 +195,7 @@ namespace Nethermind.Synchronization.ParallelSync
                         }
                         else
                         {
+                            allocation.Dispose();
                             Logger.Debug($"DISPATCHER - {GetType().NameWithGenerics()}: peer NOT allocated");
                             DoHandleResponse(request);
                         }
@@ -214,52 +219,48 @@ namespace Nethermind.Synchronization.ParallelSync
             SyncPeerAllocation allocation)
         {
             long dispatchTimeStart = Stopwatch.GetTimestamp();
-            try
+            using (allocation)
             {
-                await Downloader.Dispatch(allocatedPeer, request, cancellationToken);
-            }
-            catch (ConcurrencyLimitReachedException)
-            {
-                if (Logger.IsDebug) Logger.Debug($"{request} - concurrency limit reached. Peer: {allocatedPeer}");
-            }
-            catch (TimeoutException)
-            {
-                if (Logger.IsDebug) Logger.Debug($"{request} - timed out. Peer: {allocatedPeer}");
-            }
-            catch (OperationCanceledException)
-            {
-                if (Logger.IsTrace) Logger.Debug($"{request} - Operation was canceled");
-            }
-            catch (Exception e)
-            {
-                if (Logger.IsWarn) Logger.Warn($"Failure when executing request {e}");
-            }
-            Metrics.SyncDispatcherDispatchTimeMicros.Observe(Stopwatch.GetElapsedTime(dispatchTimeStart).TotalMicroseconds, new StringLabel(_feedName));
-
-            try
-            {
-                if (Feed.IsMultiFeed)
+                try
                 {
-                    // Limit multithreaded feed concurrency. Note, this also blocks freeing the allocation, which is deliberate.
-                    // otherwise, we will keep spawning requests without processing it fast enough, which consume memory.
-                    await _concurrentProcessingSemaphore.WaitAsync(cancellationToken);
+                    await Downloader.Dispatch(allocatedPeer, request, cancellationToken);
                 }
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (ObjectDisposedException)
-            {
-                // Teardown raced this dispatch; stop rather than fault the un-awaited task.
-                if (Logger.IsDebug) Logger.Debug($"{_feedName} dispatch abandoned during shutdown.");
-                return;
-            }
-            finally
-            {
-                // The allocation must return to the pool on every exit: a cancelled wait would
-                // otherwise retire the peer's slot for the lifetime of the connection.
-                Free(allocation);
+                catch (ConcurrencyLimitReachedException)
+                {
+                    if (Logger.IsDebug) Logger.Debug($"{request} - concurrency limit reached. Peer: {allocatedPeer}");
+                }
+                catch (TimeoutException)
+                {
+                    if (Logger.IsDebug) Logger.Debug($"{request} - timed out. Peer: {allocatedPeer}");
+                }
+                catch (OperationCanceledException)
+                {
+                    if (Logger.IsTrace) Logger.Debug($"{request} - Operation was canceled");
+                }
+                catch (Exception e)
+                {
+                    if (Logger.IsWarn) Logger.Warn($"Failure when executing request {e}");
+                }
+                Metrics.SyncDispatcherDispatchTimeMicros.Observe(Stopwatch.GetElapsedTime(dispatchTimeStart).TotalMicroseconds, new StringLabel(_feedName));
+
+                try
+                {
+                    if (Feed.IsMultiFeed)
+                    {
+                        // Holding the allocation across this wait provides backpressure while responses queue for processing.
+                        await _concurrentProcessingSemaphore.WaitAsync(cancellationToken);
+                    }
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Teardown raced this dispatch; stop rather than fault the un-awaited task.
+                    if (Logger.IsDebug) Logger.Debug($"{_feedName} dispatch abandoned during shutdown.");
+                    return;
+                }
             }
 
             dispatchTimeStart = Stopwatch.GetTimestamp();
@@ -301,8 +302,6 @@ namespace Nethermind.Synchronization.ParallelSync
                 if (Logger.IsError) Logger.Error("Error when handling response", e);
             }
         }
-
-        private void Free(SyncPeerAllocation allocation) => SyncPeerPool.Free(allocation);
 
         protected async Task<SyncPeerAllocation> Allocate(T request, CancellationToken cancellationToken) =>
             await SyncPeerPool.Allocate(PeerAllocationStrategyFactory.Create(request), Feed.Contexts, _allocateTimeoutMs, cancellationToken);

--- a/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/ISyncPeerPool.cs
@@ -23,8 +23,6 @@ namespace Nethermind.Synchronization.Peers
             int timeoutMilliseconds = 0,
             CancellationToken cancellationToken = default);
 
-        void Free(SyncPeerAllocation syncPeerAllocation);
-
         void ReportNoSyncProgress(PeerInfo peerInfo, AllocationContexts allocationContexts);
 
         void ReportBreachOfProtocol(PeerInfo peerInfo, DisconnectReason disconnectReason, string details);
@@ -127,20 +125,13 @@ namespace Nethermind.Synchronization.Peers
             AllocationContexts allocationContexts,
             CancellationToken cancellationToken)
         {
-            SyncPeerAllocation? allocation = await syncPeerPool.Allocate(
+            using SyncPeerAllocation? allocation = await syncPeerPool.Allocate(
                 peerAllocationStrategy,
                 allocationContexts,
                 timeoutMilliseconds: int.MaxValue,
                 cancellationToken: cancellationToken);
-            try
-            {
-                if (allocation?.Current is null) return default;
-                return await func(allocation.Current);
-            }
-            finally
-            {
-                syncPeerPool.Free(allocation);
-            }
+            if (allocation?.Current is null) return default;
+            return await func(allocation.Current);
         }
 
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerAllocation.cs
@@ -1,19 +1,23 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 namespace Nethermind.Synchronization.Peers
 {
-    public class SyncPeerAllocation(AllocationContexts contexts, Lock? allocationLock = null)
+    public class SyncPeerAllocation(AllocationContexts contexts, Lock? allocationLock = null) : IDisposable
     {
-        public static SyncPeerAllocation FailedAllocation = new(AllocationContexts.None, null);
-
         /// <summary>
         /// this should be used whenever we change IsAllocated property on PeerInfo-
         /// </summary>
         private readonly Lock? _allocationLock = allocationLock ?? new Lock();
+        private readonly Action? _onDisposed;
+        private bool _disposed;
+
+        internal SyncPeerAllocation(AllocationContexts contexts, Lock? allocationLock, Action onDisposed)
+            : this(contexts, allocationLock) => _onDisposed = onDisposed;
 
         private AllocationContexts Contexts { get; } = contexts;
 
@@ -22,40 +26,51 @@ namespace Nethermind.Synchronization.Peers
 
         public bool HasPeer => Current is not null;
 
-        public SyncPeerAllocation(PeerInfo peerInfo, AllocationContexts contexts, Lock? allocationLock = null)
-
-            : this(contexts, allocationLock) => Current = peerInfo;
-
         public void AllocatePeer(PeerInfo? selected)
         {
-            PeerInfo? current = Current;
-            if (selected == current)
-            {
-                return;
-            }
-
             lock (_allocationLock)
             {
+                if (_disposed || selected == Current)
+                {
+                    return;
+                }
+
                 if (selected is not null && selected.TryAllocate(Contexts))
                 {
+                    PeerInfo? current = Current;
                     Current = selected;
                     current?.Free(Contexts);
                 }
             }
         }
 
-        public void Cancel()
+        /// <summary>
+        /// Returns the allocated peer slot. Repeated calls have no effect.
+        /// </summary>
+        public void Dispose()
         {
-            PeerInfo? current = Current;
-            if (current is null)
-            {
-                return;
-            }
-
+            bool released = false;
             lock (_allocationLock)
             {
-                current.Free(Contexts);
-                Current = null;
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                PeerInfo? current = Current;
+                if (current is not null)
+                {
+                    current.Free(Contexts);
+                    Current = null;
+                    released = true;
+                }
+            }
+
+            // A peer-less disposal must not wake every allocator on zero-timeout polling paths.
+            if (released)
+            {
+                _onDisposed?.Invoke();
             }
         }
 

--- a/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Peers/SyncPeerPool.cs
@@ -137,13 +137,11 @@ namespace Nethermind.Synchronization.Peers
 
         public async Task<int?> EstimateRequestLimit(RequestType requestType, IPeerAllocationStrategy allocationStrategy, AllocationContexts context, CancellationToken token)
         {
-            // So, to know which peer is next, we just try to allocate it, and then free it back.
-            SyncPeerAllocation syncPeerAllocation = await Allocate(allocationStrategy, context, 1000, token);
+            // So, to know which peer is next, we just try to allocate it, and then dispose it.
+            using SyncPeerAllocation syncPeerAllocation = await Allocate(allocationStrategy, context, 1000, token);
             if (!syncPeerAllocation.HasPeer) return null;
 
-            int requestSize = _stats.GetOrAdd(syncPeerAllocation.Current!.SyncPeer.Node).GetCurrentRequestLimit(requestType);
-            Free(syncPeerAllocation);
-            return requestSize;
+            return _stats.GetOrAdd(syncPeerAllocation.Current!.SyncPeer.Node).GetCurrentRequestLimit(requestType);
         }
 
         public void Start()
@@ -363,9 +361,10 @@ namespace Nethermind.Synchronization.Peers
             int timeoutMilliseconds = 0,
             CancellationToken cancellationToken = default)
         {
+            SyncPeerAllocation allocation = new(allocationContexts, _isAllocatedChecks, SignalPeersChanged);
             if (cancellationToken.IsCancellationRequested)
             {
-                return SyncPeerAllocation.FailedAllocation;
+                return allocation;
             }
 
             int tryCount = 1;
@@ -373,7 +372,6 @@ namespace Nethermind.Synchronization.Peers
 
             using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _refreshLoopCancellation.Token);
 
-            SyncPeerAllocation allocation = new(allocationContexts, _isAllocatedChecks);
             while (true)
             {
                 // Snapshot the signal task before attempting allocation so that any
@@ -389,7 +387,7 @@ namespace Nethermind.Synchronization.Peers
                 bool timeoutReached = timeoutMilliseconds == 0
                                       || elapsedMilliseconds < 0
                                       || elapsedMilliseconds > timeoutMilliseconds;
-                if (timeoutReached) return SyncPeerAllocation.FailedAllocation;
+                if (timeoutReached) return allocation;
 
                 int waitTime = GetAllocationWaitTime(tryCount++);
                 waitTime = Math.Min(waitTime, timeoutMilliseconds - (int)elapsedMilliseconds);
@@ -399,7 +397,7 @@ namespace Nethermind.Synchronization.Peers
                     await Task.WhenAny(signal, Task.Delay(waitTime, cts.Token));
                     if (cts.IsCancellationRequested)
                     {
-                        return SyncPeerAllocation.FailedAllocation;
+                        return allocation;
                     }
                 }
             }
@@ -417,19 +415,6 @@ namespace Nethermind.Synchronization.Peers
                 allocation.AllocatePeer(selected);
                 return allocation.HasPeer;
             }
-        }
-
-        /// <summary>
-        ///     Frees the allocation space borrowed earlier for some sync consumer.
-        /// </summary>
-        /// <param name="syncPeerAllocation">Allocation to free</param>
-        public void Free(SyncPeerAllocation syncPeerAllocation)
-        {
-            if (_logger.IsTrace) _logger.Trace($"Returning {syncPeerAllocation}");
-
-            syncPeerAllocation.Cancel();
-
-            SignalPeersChanged();
         }
 
         private async Task RunRefreshPeerLoop()

--- a/src/Nethermind/Nethermind.slnx
+++ b/src/Nethermind/Nethermind.slnx
@@ -125,6 +125,7 @@
   <Project Path="Nethermind.Era1/Nethermind.Era1.csproj" />
   <Project Path="Nethermind.EraE/Nethermind.EraE.csproj" />
   <Project Path="Nethermind.EthStats/Nethermind.EthStats.csproj" />
+  <Project Path="Nethermind.Evm.Fody/Nethermind.Evm.Fody.csproj" />
   <Project Path="Nethermind.Evm.Precompiles/Nethermind.Evm.Precompiles.csproj" />
   <Project Path="Nethermind.Evm/Nethermind.Evm.csproj" />
   <Project Path="Nethermind.Facade/Nethermind.Facade.csproj" />

--- a/tools/Bootnode/Nethermind.Bootnode.Test/BootnodeMetricsTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/BootnodeMetricsTests.cs
@@ -3,6 +3,7 @@
 
 using Nethermind.Network;
 using NUnit.Framework;
+using Prometheus;
 using System.Text;
 using PrometheusMetrics = Prometheus.Metrics;
 
@@ -102,7 +103,7 @@ public class BootnodeMetricsTests
     }
 
     [Test]
-    public async Task UpdateKademliaBucketStats_unpublishes_removed_buckets()
+    public async Task UpdateKademliaBucketStats_removes_stale_metric_children()
     {
         string id = Guid.NewGuid().ToString("N");
         BootnodeMetrics metrics = new();
@@ -112,18 +113,23 @@ public class BootnodeMetricsTests
             new BootnodeKademliaBucketSnapshot("discv4", 0, 1, $"prefix-old-{id}", 1),
             new BootnodeKademliaBucketSnapshot("discv4", 1, 1, $"prefix-current-{id}", 2)
         ]);
+        Gauge.Child staleChild = BootnodeMetrics.KademliaBucketNodes.WithLabels("discv4", "0", "1", $"prefix-old-{id}");
         metrics.UpdateKademliaBucketStats(
         [
             new BootnodeKademliaBucketSnapshot("discv4", 1, 1, $"prefix-current-{id}", 3)
         ]);
 
         string scrape = await ScrapeMetrics();
+        Gauge.Child recreatedChild = BootnodeMetrics.KademliaBucketNodes.WithLabels("discv4", "0", "1", $"prefix-old-{id}");
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(scrape, Does.Contain($"prefix-current-{id}"));
             Assert.That(scrape, Does.Not.Contain($"prefix-old-{id}"));
+            Assert.That(recreatedChild, Is.Not.SameAs(staleChild));
         }
+
+        recreatedChild.Remove();
     }
 
     [Test]

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveredNodeStoreTests.cs
@@ -1,9 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Buffers.Text;
 using System.Net;
+using System.Runtime.CompilerServices;
 using Nethermind.Config;
+using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
+using Nethermind.Network.Enr;
 using Nethermind.Stats.Model;
 using NUnit.Framework;
 
@@ -22,7 +26,8 @@ public class DiscoveredNodeStoreTests
         DiscoveredNodeStore store = new();
 
         DiscoverySnapshot configuredSnapshot = store.AddConfiguredBootnodes([networkNode]);
-        DiscoverySnapshot activeSnapshot = store.AddOrUpdate(node, "discv4", isActive: true);
+        store.AddOrUpdate(node, "discv4", isActive: true);
+        DiscoverySnapshot activeSnapshot = store.CreateSnapshot();
         NodeDto activeNode = store.GetActiveNodes().Single();
 
         using (Assert.EnterMultipleScope())
@@ -56,6 +61,23 @@ public class DiscoveredNodeStoreTests
         }
     }
 
+    [Test]
+    public void Node_dto_host_matches_node_host([Values("127.0.0.1", "::ffff:127.0.0.1", "2001:db8::1")] string address)
+    {
+        using PrivateKeyGenerator generator = new();
+        using PrivateKey privateKey = generator.Generate();
+        Node node = Node.FromDiscoveryEndpoint(
+            privateKey.PublicKey,
+            new IPEndPoint(IPAddress.Parse(address), 30303));
+        DiscoveredNodeStore store = new();
+
+        store.AddOrUpdate(node, "discv4", isActive: true);
+
+        NodeDto[] activeNodes = store.GetActiveNodes();
+        Assert.That(activeNodes, Has.Length.EqualTo(1));
+        Assert.That(activeNodes[0].Host, Is.EqualTo(node.Host));
+    }
+
     [TestCase(false)]
     [TestCase(true)]
     public void Retention_limit_prunes_inactive_nodes_before_active_nodes(bool deactivateAfterAdd)
@@ -76,11 +98,12 @@ public class DiscoveredNodeStoreTests
             store.Remove(secondNode, "discv5");
         }
 
-        DiscoverySnapshot snapshot = store.AddOrUpdate(thirdNode, "discv4", isActive: true);
+        store.AddOrUpdate(thirdNode, "discv4", isActive: true);
+        DiscoverySnapshot snapshot = store.CreateSnapshot();
         NodeDto[] retainedNodes = store.GetAllNodes();
         NodeDto[] activeRetainedNodes = store.GetActiveNodes();
-        string[] retainedNodeIds = retainedNodes.Select(static node => node.NodeId).ToArray();
-        string[] activeRetainedNodeIds = activeRetainedNodes.Select(static node => node.NodeId).ToArray();
+        string[] retainedNodeIds = Array.ConvertAll(retainedNodes, static node => node.NodeId);
+        string[] activeRetainedNodeIds = Array.ConvertAll(activeRetainedNodes, static node => node.NodeId);
 
         using (Assert.EnterMultipleScope())
         {
@@ -114,7 +137,8 @@ public class DiscoveredNodeStoreTests
 
         store.AddConfiguredBootnodes([configuredNetworkNode]);
         store.AddOrUpdate(firstNode, "discv4", isActive: false);
-        DiscoverySnapshot snapshot = store.AddOrUpdate(secondNode, "discv5", isActive: false);
+        store.AddOrUpdate(secondNode, "discv5", isActive: false);
+        DiscoverySnapshot snapshot = store.CreateSnapshot();
         NodeDto[] retainedNodes = store.GetAllNodes(limit: 2);
         string[] retainedNodeIds = new string[retainedNodes.Length];
         for (int i = 0; i < retainedNodes.Length; i++)
@@ -150,6 +174,86 @@ public class DiscoveredNodeStoreTests
     }
 
     [Test]
+    public void Retained_node_does_not_keep_discovery_graph_alive()
+    {
+        DiscoveredNodeStore store = new();
+        (WeakReference<Node> nodeReference, WeakReference<NodeRecord> enrReference, string enr) = AddNodeWithEnr(store);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        NodeDto retainedNode = store.GetAllNodes().Single();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(nodeReference.TryGetTarget(out _), Is.False);
+            Assert.That(enrReference.TryGetTarget(out _), Is.False);
+            Assert.That(retainedNode.Enr, Is.EqualTo(enr));
+        }
+
+        GC.KeepAlive(store);
+    }
+
+    [TestCase(1ul, false)]
+    [TestCase(2ul, false)]
+    [TestCase(3ul, true)]
+    public void Enr_sequence_controls_retained_enr_replacement(ulong candidateSequence, bool shouldReplace)
+    {
+        using PrivateKeyGenerator generator = new();
+        using PrivateKey privateKey = generator.Generate();
+        Node original = CreateNodeWithEnr(privateKey, sequence: 2, udpPort: 30303);
+        Node candidate = CreateNodeWithEnr(privateKey, candidateSequence, udpPort: 30304);
+        DiscoveredNodeStore store = new();
+
+        store.AddOrUpdate(original, "discv5", isActive: true);
+        store.AddOrUpdate(candidate, "discv5", isActive: true);
+
+        NodeDto[] retainedNodes = store.GetAllNodes();
+        NodeRecord expected = shouldReplace ? candidate.Enr! : original.Enr!;
+        Assert.That(retainedNodes, Has.Length.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(candidate.Enr!.ToString(), Is.Not.EqualTo(original.Enr!.ToString()));
+            Assert.That(retainedNodes[0].Enr, Is.EqualTo(expected.ToString()));
+        }
+    }
+
+    [Test]
+    public void Unsigned_enr_is_not_retained()
+    {
+        using PrivateKeyGenerator generator = new();
+        using PrivateKey privateKey = generator.Generate();
+        Node node = new(privateKey.PublicKey, "127.0.0.1", 30303)
+        {
+            Enr = new NodeRecord()
+        };
+        DiscoveredNodeStore store = new();
+
+        store.AddOrUpdate(node, "discv5", isActive: true);
+
+        NodeDto[] retainedNodes = store.GetAllNodes();
+        Assert.That(retainedNodes, Has.Length.EqualTo(1));
+        Assert.That(retainedNodes[0].Enr, Is.Null);
+    }
+
+    [Test]
+    public void Enr_formatting_does_not_allocate_an_intermediate_encoding()
+    {
+        byte[] rlp = new byte[300];
+        _ = DiscoveredNodeStore.ToEnrString(rlp);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        string enr = DiscoveredNodeStore.ToEnrString(rlp);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(enr, Is.EqualTo($"enr:{Base64Url.EncodeToString(rlp)}"));
+            Assert.That(allocated, Is.LessThanOrEqualTo(enr.Length * sizeof(char) + 128));
+        }
+    }
+
+    [Test]
     public void Removing_one_protocol_keeps_node_active_on_the_other_protocol()
     {
         using PrivateKeyGenerator generator = new();
@@ -159,11 +263,13 @@ public class DiscoveredNodeStoreTests
 
         store.AddOrUpdate(node, "discv4", isActive: true);
         store.AddOrUpdate(node, "discv5", isActive: true);
-        DiscoverySnapshot discv4Removed = store.Remove(node, "discv4");
+        store.Remove(node, "discv4");
+        DiscoverySnapshot discv4Removed = store.CreateSnapshot();
         NodeDto[] activeNodes = store.GetActiveNodes();
         Assert.That(activeNodes, Has.Length.EqualTo(1));
         NodeDto retainedNode = activeNodes[0];
-        DiscoverySnapshot discv5Removed = store.Remove(node, "discv5");
+        store.Remove(node, "discv5");
+        DiscoverySnapshot discv5Removed = store.CreateSnapshot();
 
         using (Assert.EnterMultipleScope())
         {
@@ -182,24 +288,100 @@ public class DiscoveredNodeStoreTests
         using PrivateKey firstKey = generator.Generate();
         using PrivateKey secondKey = generator.Generate();
         using PrivateKey thirdKey = generator.Generate();
+        Node firstNode = CreateNode(firstKey, 30303);
+        Node secondNodeEntry = CreateNode(secondKey, 30304);
+        Node thirdNode = CreateNode(thirdKey, 30305);
         DiscoveredNodeStore store = new();
-        store.AddOrUpdate(CreateNode(firstKey, 30303), "discv4", isActive: true);
-        store.AddOrUpdate(CreateNode(secondKey, 30304), "discv4", isActive: true);
-        store.AddOrUpdate(CreateNode(thirdKey, 30305), "discv5", isActive: false);
+        store.AddOrUpdate(firstNode, "discv4", isActive: true);
+        store.AddOrUpdate(secondNodeEntry, "discv4", isActive: true);
+        store.AddOrUpdate(thirdNode, "discv5", isActive: false);
 
         NodeDto[] allNodes = store.GetAllNodes(limit: 3);
         NodeDto[] secondNode = store.GetAllNodes(offset: 1, limit: 1);
         NodeDto[] secondActiveNode = store.GetActiveNodes(offset: 1, limit: 1);
+        string[] expectedOrder =
+        [
+            firstNode.IdHash.ToString(),
+            secondNodeEntry.IdHash.ToString(),
+            thirdNode.IdHash.ToString()
+        ];
+        Array.Sort(expectedOrder, StringComparer.Ordinal);
 
+        Assert.That(secondNode, Has.Length.EqualTo(1));
+        Assert.That(secondActiveNode, Has.Length.EqualTo(1));
+        Assert.That(allNodes, Has.Length.EqualTo(3));
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(secondNode, Has.Length.EqualTo(1));
+            Assert.That(Array.ConvertAll(allNodes, static node => node.IdHash), Is.EqualTo(expectedOrder));
             Assert.That(secondNode[0].IdHash, Is.EqualTo(allNodes[1].IdHash));
-            Assert.That(secondActiveNode, Has.Length.EqualTo(1));
             Assert.That(secondActiveNode[0].Active, Is.True);
+        }
+    }
+
+    [Test]
+    public void Node_queries_match_global_order_across_bucket_boundaries([Values] bool activeOnly)
+    {
+        DiscoveredNodeStore store = new();
+        Random random = new(42);
+        List<string> expectedHashes = [];
+        byte[] publicKeyBytes = new byte[PublicKey.LengthInBytes];
+        for (int i = 0; i < 8192; i++)
+        {
+            random.NextBytes(publicKeyBytes);
+            Node node = new(new PublicKey(publicKeyBytes), "127.0.0.1", 30303);
+            bool active = i % 3 != 0;
+            store.AddOrUpdate(node, "discv4", isActive: true);
+            if (!active) store.Remove(node, "discv4");
+            if (!activeOnly || active) expectedHashes.Add(node.IdHash.ToString());
+        }
+
+        expectedHashes.Sort(StringComparer.Ordinal);
+        string[] expected = expectedHashes.ToArray();
+        int boundary = expected.Length / 2;
+        while (boundary < expected.Length && expected[boundary][..5] == expected[boundary - 1][..5]) boundary++;
+        Assert.That(boundary, Is.LessThan(expected.Length));
+        int insideBucket = boundary;
+        while (insideBucket < expected.Length && expected[insideBucket][..5] != expected[insideBucket - 1][..5]) insideBucket++;
+        Assert.That(insideBucket, Is.LessThan(expected.Length));
+
+        foreach (int offset in new[] { 0, boundary - 1, boundary, insideBucket, expected.Length - 3, expected.Length, expected.Length + 1 })
+        {
+            foreach (int limit in new[] { 1, 37, 1000 })
+            {
+                NodeDto[] page = activeOnly ? store.GetActiveNodes(offset, limit) : store.GetAllNodes(offset, limit);
+                int start = Math.Min(offset, expected.Length);
+                Assert.That(Array.ConvertAll(page, static node => node.IdHash),
+                    Is.EqualTo(expected.AsSpan(start, Math.Min(limit, expected.Length - start)).ToArray()), $"offset={offset}, limit={limit}");
+            }
         }
     }
 
     private static Node CreateNode(PrivateKey privateKey, int port) =>
         new(privateKey.PublicKey, "127.0.0.1", port);
+
+    private static Node CreateNodeWithEnr(PrivateKey privateKey, ulong sequence, int udpPort)
+    {
+        NodeRecord nodeRecord = new() { EnrSequence = sequence };
+        nodeRecord.SetEntry(new SecP256k1Entry(privateKey.CompressedPublicKey));
+        nodeRecord.SetEntry(new UdpEntry(udpPort));
+        new NodeRecordSigner(new Ecdsa(), privateKey).Sign(nodeRecord);
+        Node node = CreateNode(privateKey, udpPort);
+        node.SetVerifiedEnr(nodeRecord);
+        return node;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static (WeakReference<Node>, WeakReference<NodeRecord>, string) AddNodeWithEnr(DiscoveredNodeStore store)
+    {
+        using PrivateKeyGenerator generator = new();
+        using PrivateKey privateKey = generator.Generate();
+        NodeRecord nodeRecord = new();
+        nodeRecord.SetEntry(new SecP256k1Entry(privateKey.CompressedPublicKey));
+        new NodeRecordSigner(new Ecdsa(), privateKey).Sign(nodeRecord);
+        Node node = new(privateKey.PublicKey, "127.0.0.1", 30303);
+        node.SetVerifiedEnr(nodeRecord);
+        string enr = nodeRecord.ToString();
+        store.AddOrUpdate(node, "discv5", isActive: true);
+        return (new WeakReference<Node>(node), new WeakReference<NodeRecord>(nodeRecord), enr);
+    }
 }

--- a/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveryContainerTests.cs
+++ b/tools/Bootnode/Nethermind.Bootnode.Test/DiscoveryContainerTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Autofac;
+using DotNetty.Buffers;
 using System.Net;
 using Nethermind.Config;
 using Nethermind.Crypto;
@@ -9,6 +10,7 @@ using Nethermind.Logging;
 using Nethermind.Network;
 using Nethermind.Network.Discovery;
 using Nethermind.Network.Enr;
+using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
 
 namespace Nethermind.Bootnode.Test;
@@ -16,6 +18,32 @@ namespace Nethermind.Bootnode.Test;
 [TestFixture]
 public class DiscoveryContainerTests
 {
+    [Test]
+    public void ConfigureNetworkBuffers_uses_single_small_shared_arena()
+    {
+        IByteBufferAllocator originalDefault = NethermindBuffers.Default;
+        IByteBufferAllocator originalDiscovery = NethermindBuffers.DiscoveryAllocator;
+
+        try
+        {
+            DiscoveryContainer.ConfigureNetworkBuffers();
+
+            PooledByteBufferAllocator allocator = (PooledByteBufferAllocator)NethermindBuffers.DiscoveryAllocator;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(NethermindBuffers.Default, Is.SameAs(allocator));
+                Assert.That(allocator.Metric.HeapArenas(), Has.Count.EqualTo(1));
+                Assert.That(allocator.Metric.DirectArenas(), Has.Count.EqualTo(1));
+                Assert.That(allocator.Metric.ChunkSize, Is.EqualTo(2 * 1024 * 1024));
+            }
+        }
+        finally
+        {
+            NethermindBuffers.Default = originalDefault;
+            NethermindBuffers.DiscoveryAllocator = originalDiscovery;
+        }
+    }
+
     [Test]
     public async Task Build_registers_bucket_sources_for_enabled_protocols()
     {

--- a/tools/Bootnode/Nethermind.Bootnode/BootnodeMetrics.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/BootnodeMetrics.cs
@@ -51,7 +51,7 @@ internal sealed class BootnodeMetrics
         "Total discovery UDP traffic handled by the bootnode.",
         new CounterConfiguration { LabelNames = ["direction"] });
 
-    private static readonly Gauge KademliaBucketNodes = PrometheusMetrics.CreateGauge(
+    internal static readonly Gauge KademliaBucketNodes = PrometheusMetrics.CreateGauge(
         "nethermind_bootnode_kademlia_bucket_nodes",
         "Number of nodes in each bootnode Kademlia routing-table bucket.",
         new GaugeConfiguration { LabelNames = ["protocol", "bucket", "depth", "prefix"] });
@@ -61,9 +61,25 @@ internal sealed class BootnodeMetrics
         "Bootnode identity information.",
         new GaugeConfiguration { LabelNames = ["enode", "enr", "seq", "node_id", "address"] });
 
-    public void RecordSeen(string protocol) => DiscoveredNodes.WithLabels(protocol).Inc();
+    // High-frequency fixed-label counters are process-lifetime caches.
+    private static readonly Counter.Child DiscoveredDiscv4Nodes = DiscoveredNodes.WithLabels("discv4");
+    private static readonly Counter.Child DiscoveredDiscv5Nodes = DiscoveredNodes.WithLabels("discv5");
+    private static readonly Counter.Child RemovedDiscv4Nodes = RemovedNodes.WithLabels("discv4");
+    private static readonly Counter.Child RemovedDiscv5Nodes = RemovedNodes.WithLabels("discv5");
 
-    public void RecordRemoved(string protocol) => RemovedNodes.WithLabels(protocol).Inc();
+    public void RecordSeen(string protocol) => (protocol switch
+    {
+        "discv4" => DiscoveredDiscv4Nodes,
+        "discv5" => DiscoveredDiscv5Nodes,
+        _ => DiscoveredNodes.WithLabels(protocol)
+    }).Inc();
+
+    public void RecordRemoved(string protocol) => (protocol switch
+    {
+        "discv4" => RemovedDiscv4Nodes,
+        "discv5" => RemovedDiscv5Nodes,
+        _ => RemovedNodes.WithLabels(protocol)
+    }).Inc();
 
     public void SetIdentity(BootnodeIdentity identity)
     {
@@ -83,7 +99,9 @@ internal sealed class BootnodeMetrics
 
             if (_publishedIdentity is { } previous)
             {
-                IdentityInfo.WithLabels(previous.Enode, previous.Enr, previous.EnrSequence, previous.NodeId, previous.Address).Unpublish();
+                Gauge.Child previousIdentity = IdentityInfo.WithLabels(previous.Enode, previous.Enr, previous.EnrSequence, previous.NodeId, previous.Address);
+                previousIdentity.Unpublish();
+                previousIdentity.Remove();
             }
 
             IdentityInfo.WithLabels(key.Enode, key.Enr, key.EnrSequence, key.NodeId, key.Address).Set(1);
@@ -175,9 +193,10 @@ internal sealed class BootnodeMetrics
             {
                 if (!currentBuckets.Contains(publishedBucket))
                 {
-                    KademliaBucketNodes
-                        .WithLabels(publishedBucket.Protocol, publishedBucket.Bucket, publishedBucket.Depth, publishedBucket.Prefix)
-                        .Unpublish();
+                    Gauge.Child previousBucket = KademliaBucketNodes
+                        .WithLabels(publishedBucket.Protocol, publishedBucket.Bucket, publishedBucket.Depth, publishedBucket.Prefix);
+                    previousBucket.Unpublish();
+                    previousBucket.Remove();
                 }
             }
 

--- a/tools/Bootnode/Nethermind.Bootnode/BootnodeRuntime.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/BootnodeRuntime.cs
@@ -66,7 +66,7 @@ internal sealed class BootnodeRuntime(
             await foreach (Node node in source.NodeSource.DiscoverNodes(cancellationToken))
             {
                 metrics.RecordSeen(source.Protocol);
-                metrics.UpdateSnapshot(nodeStore.AddOrUpdate(node, source.Protocol, isActive: true));
+                nodeStore.AddOrUpdate(node, source.Protocol, isActive: true);
                 if (_logger.IsDebug) _logger.Debug($"Discovered {source.Protocol} node {node:s}");
             }
 
@@ -94,12 +94,14 @@ internal sealed class BootnodeRuntime(
             metrics.UpdateDiscoveryMessageCounters();
             metrics.UpdateDiscoveryTrafficCounters();
             metrics.UpdateKademliaBucketStats(bucketRegistry.CreateSnapshot());
+            metrics.UpdateSnapshot(nodeStore.CreateSnapshot());
 
             while (await timer.WaitForNextTickAsync(cancellationToken))
             {
                 metrics.UpdateDiscoveryMessageCounters();
                 metrics.UpdateDiscoveryTrafficCounters();
                 metrics.UpdateKademliaBucketStats(bucketRegistry.CreateSnapshot());
+                metrics.UpdateSnapshot(nodeStore.CreateSnapshot());
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -114,7 +116,7 @@ internal sealed class BootnodeRuntime(
     private void OnNodeRemoved(string protocol, NodeEventArgs args)
     {
         metrics.RecordRemoved(protocol);
-        metrics.UpdateSnapshot(nodeStore.Remove(args.Node, protocol));
+        nodeStore.Remove(args.Node, protocol);
         if (_logger.IsDebug) _logger.Debug($"Removed discovery node {args.Node:s}");
     }
 

--- a/tools/Bootnode/Nethermind.Bootnode/DiscoveredNodeStore.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/DiscoveredNodeStore.cs
@@ -1,25 +1,29 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System.Collections.Concurrent;
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Net;
 using Nethermind.Config;
 using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Network.Enr;
 using Nethermind.Stats.Model;
 
 namespace Nethermind.Bootnode;
 
 internal sealed class DiscoveredNodeStore
 {
+    private const string EnrPrefix = "enr:";
     private const int DefaultMaxRetainedNodes = 100_000;
     internal const int DefaultNodePageSize = 1_000;
     internal const int MaxNodePageSize = 1_000;
 
-    private readonly ConcurrentDictionary<Hash256, TrackedNode> _nodes = new();
-    private readonly LinkedList<Hash256> _activeRetentionOrder = new();
-    private readonly LinkedList<Hash256> _inactiveRetentionOrder = new();
-    private readonly Dictionary<Hash256, RetentionEntry> _retentionEntries = [];
-    private readonly SortedSet<Hash256> _orderedNodes = [];
-    private readonly SortedSet<Hash256> _orderedActiveNodes = [];
+    private readonly Dictionary<Hash256, TrackedNode> _nodes;
+    private readonly RetentionList _activeRetentionOrder = new(active: true);
+    private readonly RetentionList _inactiveRetentionOrder = new(active: false);
+    private readonly BucketedNodeIndex _orderedNodes = new();
+    private readonly BucketedNodeIndex _orderedActiveNodes = new();
     private readonly Lock _lock = new();
     private readonly int _maxRetainedNodes;
     private int _activeCount;
@@ -37,26 +41,30 @@ internal sealed class DiscoveredNodeStore
     {
         BootnodeOptionValidation.ValidatePositive(nameof(maxRetainedNodes), maxRetainedNodes);
         _maxRetainedNodes = maxRetainedNodes;
+        _nodes = new Dictionary<Hash256, TrackedNode>(maxRetainedNodes);
     }
 
-    public DiscoverySnapshot AddOrUpdate(Node node, string protocol, bool isActive)
+    public void AddOrUpdate(Node node, string protocol, bool isActive)
     {
+        NodeProtocol parsedProtocol = ParseProtocol(protocol);
         DateTimeOffset now = DateTimeOffset.UtcNow;
 
         lock (_lock)
         {
             TrackedNodeSnapshot after;
+            TrackedNode trackedNode;
             if (_nodes.TryGetValue(node.IdHash, out TrackedNode? existing))
             {
+                trackedNode = existing;
                 TrackedNodeSnapshot before = existing.CreateSnapshot();
-                existing.Update(node, protocol, now, isActive);
+                existing.Update(node, parsedProtocol, now, isActive);
                 after = existing.CreateSnapshot();
                 ApplyTransition(before, after);
                 UpdateActiveIndex(node.IdHash, after.Active);
             }
             else
             {
-                TrackedNode trackedNode = TrackedNode.Create(node, protocol, now, isActive);
+                trackedNode = TrackedNode.Create(node, parsedProtocol, now, isActive);
                 _nodes[node.IdHash] = trackedNode;
                 _orderedNodes.Add(node.IdHash);
                 after = trackedNode.CreateSnapshot();
@@ -64,9 +72,8 @@ internal sealed class DiscoveredNodeStore
                 UpdateActiveIndex(node.IdHash, after.Active);
             }
 
-            UpdateRetentionOrder(node.IdHash, after);
+            UpdateRetentionOrder(trackedNode, after);
             PruneRetainedNodes();
-            return CreateSnapshotCore();
         }
     }
 
@@ -84,33 +91,35 @@ internal sealed class DiscoveredNodeStore
         return CreateSnapshot();
     }
 
-    public DiscoverySnapshot Remove(Node node, string protocol)
+    public void Remove(Node node, string protocol)
     {
+        NodeProtocol parsedProtocol = ParseProtocol(protocol);
         lock (_lock)
         {
             if (_nodes.TryGetValue(node.IdHash, out TrackedNode? trackedNode))
             {
                 TrackedNodeSnapshot before = trackedNode.CreateSnapshot();
-                trackedNode.MarkInactive(protocol, DateTimeOffset.UtcNow);
+                trackedNode.MarkInactive(parsedProtocol, DateTimeOffset.UtcNow);
                 TrackedNodeSnapshot after = trackedNode.CreateSnapshot();
                 ApplyTransition(before, after);
                 UpdateActiveIndex(node.IdHash, after.Active);
-                UpdateRetentionOrder(node.IdHash, after);
+                UpdateRetentionOrder(trackedNode, after);
                 PruneRetainedNodes();
             }
-
-            return CreateSnapshotCore();
         }
     }
 
     public string? GetProtocol(Node node)
     {
-        if (_nodes.TryGetValue(node.IdHash, out TrackedNode? trackedNode))
+        lock (_lock)
         {
-            return trackedNode.GetProtocol();
-        }
+            if (_nodes.TryGetValue(node.IdHash, out TrackedNode? trackedNode))
+            {
+                return trackedNode.GetProtocol();
+            }
 
-        return null;
+            return null;
+        }
     }
 
     public NodeDto[] GetActiveNodes(int offset = 0, int limit = DefaultNodePageSize) => GetNodes(activeOnly: true, offset, limit);
@@ -123,7 +132,7 @@ internal sealed class DiscoveredNodeStore
         {
             lock (_lock)
             {
-                return _retentionEntries.Count;
+                return _activeRetentionOrder.Count + _inactiveRetentionOrder.Count;
             }
         }
     }
@@ -153,6 +162,13 @@ internal sealed class DiscoveredNodeStore
         error = string.Empty;
         return true;
     }
+
+    internal static string ToEnrString(byte[] rlp) =>
+        string.Create(EnrPrefix.Length + Base64Url.GetEncodedLength(rlp.Length), rlp, static (chars, state) =>
+        {
+            EnrPrefix.CopyTo(chars);
+            Base64Url.EncodeToChars(state, chars[EnrPrefix.Length..]);
+        });
 
     private DiscoverySnapshot CreateSnapshotCore() =>
         new(
@@ -189,19 +205,19 @@ internal sealed class DiscoveredNodeStore
 
         switch (snapshot.Protocol)
         {
-            case "discv4":
+            case NodeProtocol.Discv4:
                 _allDiscv4Count += delta;
                 if (snapshot.Active) _activeDiscv4Count += delta;
                 break;
-            case "discv5":
+            case NodeProtocol.Discv5:
                 _allDiscv5Count += delta;
                 if (snapshot.Active) _activeDiscv5Count += delta;
                 break;
-            case "both":
+            case NodeProtocol.Both:
                 _allBothCount += delta;
                 if (snapshot.Active) _activeBothCount += delta;
                 break;
-            case "configured":
+            case NodeProtocol.Configured:
                 _allConfiguredCount += delta;
                 if (snapshot.Active) _activeConfiguredCount += delta;
                 break;
@@ -212,58 +228,51 @@ internal sealed class DiscoveredNodeStore
     {
         while (_allCount > _maxRetainedNodes)
         {
-            LinkedListNode<Hash256>? oldestNode = _inactiveRetentionOrder.First ?? _activeRetentionOrder.First;
+            TrackedNode? oldestNode = _inactiveRetentionOrder.First ?? _activeRetentionOrder.First;
             if (oldestNode is null)
             {
                 return;
             }
 
-            RemoveRetentionEntry(oldestNode.Value);
-            _orderedNodes.Remove(oldestNode.Value);
-            _orderedActiveNodes.Remove(oldestNode.Value);
-            if (_nodes.TryRemove(oldestNode.Value, out TrackedNode? trackedNode))
+            RemoveRetentionEntry(oldestNode);
+            _orderedNodes.Remove(oldestNode.IdHash);
+            _orderedActiveNodes.Remove(oldestNode.IdHash);
+            if (_nodes.Remove(oldestNode.IdHash))
             {
-                RemoveFromSnapshot(trackedNode.CreateSnapshot());
+                RemoveFromSnapshot(oldestNode.CreateSnapshot());
             }
         }
     }
 
-    private void TouchRetentionOrder(Hash256 idHash, bool active)
+    private void TouchRetentionOrder(TrackedNode trackedNode, bool active)
     {
-        LinkedListNode<Hash256> node;
-        if (_retentionEntries.TryGetValue(idHash, out RetentionEntry existingEntry))
+        if (trackedNode.IsInRetentionOrder)
         {
-            GetRetentionOrder(existingEntry.Active).Remove(existingEntry.Node);
-            node = existingEntry.Node;
-        }
-        else
-        {
-            node = new LinkedListNode<Hash256>(idHash);
+            GetRetentionOrder(trackedNode.RetainedAsActive).Remove(trackedNode);
         }
 
-        GetRetentionOrder(active).AddLast(node);
-        _retentionEntries[idHash] = new RetentionEntry(node, active);
+        GetRetentionOrder(active).AddLast(trackedNode);
     }
 
-    private void UpdateRetentionOrder(Hash256 idHash, TrackedNodeSnapshot snapshot)
+    private void UpdateRetentionOrder(TrackedNode trackedNode, TrackedNodeSnapshot snapshot)
     {
         if (snapshot.IsBootnode)
         {
-            RemoveRetentionEntry(idHash);
+            RemoveRetentionEntry(trackedNode);
             return;
         }
 
-        TouchRetentionOrder(idHash, snapshot.Active);
+        TouchRetentionOrder(trackedNode, snapshot.Active);
     }
 
-    private LinkedList<Hash256> GetRetentionOrder(bool active) =>
+    private RetentionList GetRetentionOrder(bool active) =>
         active ? _activeRetentionOrder : _inactiveRetentionOrder;
 
-    private void RemoveRetentionEntry(Hash256 idHash)
+    private void RemoveRetentionEntry(TrackedNode trackedNode)
     {
-        if (_retentionEntries.Remove(idHash, out RetentionEntry entry))
+        if (trackedNode.IsInRetentionOrder)
         {
-            GetRetentionOrder(entry.Active).Remove(entry.Node);
+            GetRetentionOrder(trackedNode.RetainedAsActive).Remove(trackedNode);
         }
     }
 
@@ -274,35 +283,39 @@ internal sealed class DiscoveredNodeStore
             throw new ArgumentOutOfRangeException(offset < 0 ? nameof(offset) : nameof(limit), error);
         }
 
-        List<TrackedNodeView> nodeViews;
+        TrackedNodeView[] nodeViews;
         lock (_lock)
         {
             int nodeCount = activeOnly ? _activeCount : _allCount;
-            nodeViews = new List<TrackedNodeView>(Math.Min(limit, nodeCount));
-            int matchedNodes = 0;
-            SortedSet<Hash256> orderedNodes = activeOnly ? _orderedActiveNodes : _orderedNodes;
-            foreach (Hash256 idHash in orderedNodes)
+            int resultCount = Math.Min(limit, Math.Max(0, nodeCount - offset));
+            if (resultCount == 0)
             {
+                return [];
+            }
+
+            nodeViews = new TrackedNodeView[resultCount];
+            int resultIndex = 0;
+            BucketedNodeIndex.Enumerator enumerator =
+                (activeOnly ? _orderedActiveNodes : _orderedNodes).GetEnumerator(offset);
+            while (resultIndex < resultCount && enumerator.MoveNext())
+            {
+                Hash256 idHash = enumerator.Current;
                 if (!_nodes.TryGetValue(idHash, out TrackedNode? trackedNode))
                 {
                     continue;
                 }
 
-                if (matchedNodes++ < offset)
-                {
-                    continue;
-                }
+                nodeViews[resultIndex++] = trackedNode.CreateView();
+            }
 
-                nodeViews.Add(trackedNode.CreateView());
-                if (nodeViews.Count == limit)
-                {
-                    break;
-                }
+            if (resultIndex != resultCount)
+            {
+                Array.Resize(ref nodeViews, resultIndex);
             }
         }
 
-        NodeDto[] nodes = new NodeDto[nodeViews.Count];
-        for (int i = 0; i < nodeViews.Count; i++)
+        NodeDto[] nodes = new NodeDto[nodeViews.Length];
+        for (int i = 0; i < nodeViews.Length; i++)
         {
             nodes[i] = nodeViews[i].ToDto();
         }
@@ -322,160 +335,344 @@ internal sealed class DiscoveredNodeStore
         }
     }
 
+    private sealed class BucketedNodeIndex
+    {
+        // High-bit buckets preserve hash order while making offset seeks independent of the number of skipped nodes.
+        private const int BucketCount = 1 << 12;
+        private readonly List<Hash256>?[] _buckets = new List<Hash256>?[BucketCount];
+
+        public void Add(Hash256 idHash)
+        {
+            int bucketIndex = GetBucketIndex(idHash);
+            List<Hash256> bucket = _buckets[bucketIndex] ??= [];
+            int index = bucket.BinarySearch(idHash);
+            if (index < 0)
+            {
+                bucket.Insert(~index, idHash);
+            }
+        }
+
+        public void Remove(Hash256 idHash)
+        {
+            int bucketIndex = GetBucketIndex(idHash);
+            List<Hash256>? bucket = _buckets[bucketIndex];
+            if (bucket is null)
+            {
+                return;
+            }
+
+            int index = bucket.BinarySearch(idHash);
+            if (index >= 0)
+            {
+                bucket.RemoveAt(index);
+                if (bucket.Count == 0)
+                {
+                    _buckets[bucketIndex] = null;
+                }
+            }
+        }
+
+        public Enumerator GetEnumerator(int offset) => new(_buckets, offset);
+
+        private static int GetBucketIndex(Hash256 idHash)
+        {
+            ReadOnlySpan<byte> bytes = idHash.Bytes;
+            return (bytes[0] << 4) | (bytes[1] >> 4);
+        }
+
+        public struct Enumerator
+        {
+            private readonly List<Hash256>?[] _buckets;
+            private int _bucketIndex;
+            private int _nodeIndex;
+
+            public Hash256 Current { get; private set; }
+
+            public Enumerator(List<Hash256>?[] buckets, int offset)
+            {
+                _buckets = buckets;
+                _bucketIndex = 0;
+                _nodeIndex = -1;
+                Current = null!;
+
+                while (_bucketIndex < buckets.Length)
+                {
+                    int bucketCount = buckets[_bucketIndex]?.Count ?? 0;
+                    if (offset < bucketCount)
+                    {
+                        _nodeIndex = offset - 1;
+                        return;
+                    }
+
+                    offset -= bucketCount;
+                    _bucketIndex++;
+                }
+            }
+
+            public bool MoveNext()
+            {
+                while (_bucketIndex < _buckets.Length)
+                {
+                    List<Hash256>? bucket = _buckets[_bucketIndex];
+                    if (bucket is not null && ++_nodeIndex < bucket.Count)
+                    {
+                        Current = bucket[_nodeIndex];
+                        return true;
+                    }
+
+                    _bucketIndex++;
+                    _nodeIndex = -1;
+                }
+
+                return false;
+            }
+        }
+    }
+
     private sealed class TrackedNode
     {
-        private readonly Lock _lock = new();
-        private Node _node;
-        private string _protocol;
+        private readonly byte[] _nodeId;
+        private IPAddress _host;
+        private int _tcpPort;
+        private int _discoveryPort;
+        private NodeProtocol _protocols;
+        private NodeProtocol _activeProtocols;
         private bool _isBootnode;
         private string? _configuredEnode;
-        private bool _activeDiscv4;
-        private bool _activeDiscv5;
-        private bool _activeConfigured;
-        private DateTimeOffset _lastSeenUtc;
+        private byte[]? _enrRlp;
+        private ulong _enrSequence;
+        private long _lastSeenUtcTicks;
         private int _seenCount;
 
-        private TrackedNode(Node node, string protocol, DateTimeOffset now, bool isActive)
+        private TrackedNode(Node node, NodeProtocol protocol, DateTimeOffset now, bool isActive)
         {
-            _node = node;
-            _protocol = protocol;
+            IdHash = node.IdHash;
+            _nodeId = node.Id.Bytes;
+            _host = node.Address.Address;
+            _tcpPort = node.Port;
+            _discoveryPort = node.DiscoveryPort;
+            _protocols = protocol;
             _isBootnode = node.IsBootnode;
             _configuredEnode = node.IsBootnode ? node.ToString(Node.Format.ENode) : null;
+            UpdateEnr(node);
             SetProtocolActive(protocol, isActive);
-            FirstSeenUtc = now;
-            _lastSeenUtc = now;
+            FirstSeenUtcTicks = now.UtcTicks;
+            _lastSeenUtcTicks = now.UtcTicks;
             _seenCount = 1;
         }
 
-        private DateTimeOffset FirstSeenUtc { get; }
+        public Hash256 IdHash { get; }
+        public bool IsActive => _activeProtocols != NodeProtocol.None;
+        public bool IsInRetentionOrder { get; set; }
+        public bool RetainedAsActive { get; set; }
+        public TrackedNode? PreviousRetentionNode { get; set; }
+        public TrackedNode? NextRetentionNode { get; set; }
+        private long FirstSeenUtcTicks { get; }
 
-        public static TrackedNode Create(Node node, string protocol, DateTimeOffset now, bool isActive) =>
+        public static TrackedNode Create(Node node, NodeProtocol protocol, DateTimeOffset now, bool isActive) =>
             new(node, protocol, now, isActive);
 
-        public void Update(Node node, string protocol, DateTimeOffset now, bool isActive)
+        public void Update(Node node, NodeProtocol protocol, DateTimeOffset now, bool isActive)
         {
-            lock (_lock)
+            if (node.IsBootnode)
             {
-                if (node.IsBootnode)
-                {
-                    _configuredEnode ??= node.ToString(Node.Format.ENode);
-                }
-
-                _node = node;
-                _isBootnode |= node.IsBootnode;
-                _protocol = MergeProtocol(_protocol, protocol);
-                if (isActive)
-                {
-                    SetProtocolActive(protocol, isActive: true);
-                }
-                _lastSeenUtc = now;
-                _seenCount++;
+                _configuredEnode ??= node.ToString(Node.Format.ENode);
             }
+
+            SetEndpoint(node);
+            UpdateEnr(node);
+            _isBootnode |= node.IsBootnode;
+            _protocols |= protocol;
+            if (isActive)
+            {
+                SetProtocolActive(protocol, isActive: true);
+            }
+
+            _lastSeenUtcTicks = now.UtcTicks;
+            _seenCount++;
         }
 
-        public void MarkInactive(string protocol, DateTimeOffset now)
+        public void MarkInactive(NodeProtocol protocol, DateTimeOffset now)
         {
-            lock (_lock)
-            {
-                SetProtocolActive(protocol, isActive: false);
-                _lastSeenUtc = now;
-            }
+            SetProtocolActive(protocol, isActive: false);
+            _lastSeenUtcTicks = now.UtcTicks;
         }
 
-        public string GetProtocol()
+        public string GetProtocol() => ProtocolToString(GetProtocolCore());
+
+        public TrackedNodeSnapshot CreateSnapshot() => new(GetProtocolCore(), IsActive, _isBootnode);
+
+        public TrackedNodeView CreateView() =>
+            new(
+                _nodeId,
+                IdHash,
+                _host,
+                _tcpPort,
+                _discoveryPort,
+                _configuredEnode,
+                _enrRlp,
+                GetProtocolCore(),
+                IsActive,
+                _isBootnode,
+                FirstSeenUtcTicks,
+                _lastSeenUtcTicks,
+                _seenCount);
+
+        private NodeProtocol GetProtocolCore()
         {
-            lock (_lock)
-            {
-                return _protocol;
-            }
+            NodeProtocol discoveryProtocols = _protocols & NodeProtocol.Both;
+            return discoveryProtocols == NodeProtocol.None ? NodeProtocol.Configured : discoveryProtocols;
         }
 
-        public TrackedNodeSnapshot CreateSnapshot()
+        private void SetEndpoint(Node node)
         {
-            lock (_lock)
-            {
-                return new TrackedNodeSnapshot(_protocol, IsActiveCore, _isBootnode);
-            }
+            _host = node.Address.Address;
+            _tcpPort = node.Port;
+            _discoveryPort = node.DiscoveryPort;
         }
 
-        public TrackedNodeView CreateView()
+        private void UpdateEnr(Node node)
         {
-            lock (_lock)
+            NodeRecord? enr = node.Enr;
+            if (enr?.Signature is null || (_enrRlp is not null && enr.EnrSequence <= _enrSequence))
             {
-                return new TrackedNodeView(
-                    _node,
-                    _protocol,
-                    IsActiveCore,
-                    FirstSeenUtc,
-                    _lastSeenUtc,
-                    _seenCount,
-                    _isBootnode,
-                    _configuredEnode);
+                return;
             }
+
+            _enrRlp = enr.ToRlpBytes();
+            _enrSequence = enr.EnrSequence;
         }
 
-        private bool IsActiveCore => _activeDiscv4 || _activeDiscv5 || _activeConfigured;
-
-        private void SetProtocolActive(string protocol, bool isActive)
+        private void SetProtocolActive(NodeProtocol protocol, bool isActive)
         {
-            switch (protocol)
+            if (isActive)
             {
-                case "discv4":
-                    _activeDiscv4 = isActive;
-                    break;
-                case "discv5":
-                    _activeDiscv5 = isActive;
-                    break;
-                case "both":
-                    _activeDiscv4 = isActive;
-                    _activeDiscv5 = isActive;
-                    break;
-                case "configured":
-                    _activeConfigured = isActive;
-                    break;
-                default:
-                    throw new ArgumentException($"Unsupported discovery protocol '{protocol}'.", nameof(protocol));
+                _activeProtocols |= protocol;
             }
-        }
-
-        private static string MergeProtocol(string current, string next)
-        {
-            if (current == next)
+            else
             {
-                return current;
+                _activeProtocols &= ~protocol;
             }
-
-            if (current == "configured")
-            {
-                return next;
-            }
-
-            if (next == "configured")
-            {
-                return current;
-            }
-
-            return "both";
         }
     }
 
     private readonly record struct TrackedNodeView(
-        Node Node,
-        string Protocol,
+        byte[] NodeId,
+        Hash256 IdHash,
+        IPAddress Host,
+        int TcpPort,
+        int DiscoveryPort,
+        string? Enode,
+        byte[]? EnrRlp,
+        NodeProtocol Protocol,
         bool Active,
-        DateTimeOffset FirstSeenUtc,
-        DateTimeOffset LastSeenUtc,
-        int SeenCount,
         bool IsBootnode,
-        string? ConfiguredEnode)
+        long FirstSeenUtcTicks,
+        long LastSeenUtcTicks,
+        int SeenCount)
     {
         public NodeDto ToDto() =>
-            NodeDto.FromNode(Node, Protocol, Active, FirstSeenUtc, LastSeenUtc, SeenCount, IsBootnode, ConfiguredEnode);
+            new(
+                NodeId.AsSpan().ToHexString(withZeroX: false),
+                IdHash.ToString(),
+                // Match Node.Host formatting without retaining the discovery Node graph.
+                Host.IsIPv4MappedToIPv6 ? Host.MapToIPv4().ToString() : Host.ToString(),
+                TcpPort,
+                DiscoveryPort,
+                Enode,
+                EnrRlp is null ? null : ToEnrString(EnrRlp),
+                ProtocolToString(Protocol),
+                Active,
+                IsBootnode,
+                new DateTimeOffset(FirstSeenUtcTicks, TimeSpan.Zero),
+                new DateTimeOffset(LastSeenUtcTicks, TimeSpan.Zero),
+                SeenCount);
     }
 
-    private readonly record struct TrackedNodeSnapshot(string Protocol, bool Active, bool IsBootnode);
+    private sealed class RetentionList(bool active)
+    {
+        public TrackedNode? First { get; private set; }
+        public TrackedNode? Last { get; private set; }
+        public int Count { get; private set; }
 
-    private readonly record struct RetentionEntry(LinkedListNode<Hash256> Node, bool Active);
+        public void AddLast(TrackedNode node)
+        {
+            Debug.Assert(!node.IsInRetentionOrder);
+            node.PreviousRetentionNode = Last;
+            node.NextRetentionNode = null;
+            node.IsInRetentionOrder = true;
+            node.RetainedAsActive = active;
+            if (Last is null)
+            {
+                First = node;
+            }
+            else
+            {
+                Last.NextRetentionNode = node;
+            }
+
+            Last = node;
+            Count++;
+        }
+
+        /// <remarks>The caller must ensure <paramref name="node"/> belongs to this list.</remarks>
+        public void Remove(TrackedNode node)
+        {
+            Debug.Assert(node.IsInRetentionOrder && node.RetainedAsActive == active);
+            if (node.PreviousRetentionNode is null)
+            {
+                First = node.NextRetentionNode;
+            }
+            else
+            {
+                node.PreviousRetentionNode.NextRetentionNode = node.NextRetentionNode;
+            }
+
+            if (node.NextRetentionNode is null)
+            {
+                Last = node.PreviousRetentionNode;
+            }
+            else
+            {
+                node.NextRetentionNode.PreviousRetentionNode = node.PreviousRetentionNode;
+            }
+
+            node.PreviousRetentionNode = null;
+            node.NextRetentionNode = null;
+            node.IsInRetentionOrder = false;
+            Count--;
+        }
+    }
+
+    private static NodeProtocol ParseProtocol(string protocol) => protocol switch
+    {
+        "discv4" => NodeProtocol.Discv4,
+        "discv5" => NodeProtocol.Discv5,
+        "both" => NodeProtocol.Both,
+        "configured" => NodeProtocol.Configured,
+        _ => throw new ArgumentException($"Unsupported discovery protocol '{protocol}'.", nameof(protocol))
+    };
+
+    private static string ProtocolToString(NodeProtocol protocol) => protocol switch
+    {
+        NodeProtocol.Discv4 => "discv4",
+        NodeProtocol.Discv5 => "discv5",
+        NodeProtocol.Both => "both",
+        NodeProtocol.Configured => "configured",
+        _ => throw new ArgumentOutOfRangeException(nameof(protocol), protocol, null)
+    };
+
+    [Flags]
+    private enum NodeProtocol : byte
+    {
+        None = 0,
+        Discv4 = 1,
+        Discv5 = 2,
+        Both = Discv4 | Discv5,
+        Configured = 4
+    }
+
+    private readonly record struct TrackedNodeSnapshot(NodeProtocol Protocol, bool Active, bool IsBootnode);
 }
 
 internal readonly record struct DiscoverySnapshot(

--- a/tools/Bootnode/Nethermind.Bootnode/DiscoveryContainer.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/DiscoveryContainer.cs
@@ -20,6 +20,7 @@ using Nethermind.Network.Discovery.Discv4.Messages;
 using Nethermind.Network.Discovery.Discv4.Serializers;
 using Nethermind.Network.Discovery.Discv5;
 using Nethermind.Network.Discovery.Kademlia;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Stats;
 using Nethermind.Stats.Model;
 
@@ -27,6 +28,19 @@ namespace Nethermind.Bootnode;
 
 internal static class DiscoveryContainer
 {
+    /// <summary>
+    /// Points the general and discovery buffers at one small pooled allocator.
+    /// </summary>
+    /// <remarks>
+    /// A bootnode only serializes discovery traffic, so one arena of 2 MiB chunks replaces the process-wide default's
+    /// per-core 16 MiB arenas. This must run before anything allocates from <see cref="NethermindBuffers.Default"/>, or
+    /// the default allocator's chunks remain reachable.
+    /// </remarks>
+    internal static void ConfigureNetworkBuffers() =>
+        NethermindBuffers.Default = NethermindBuffers.DiscoveryAllocator = NethermindBuffers.CreateAllocator(
+            arenaOrder: 8,
+            arenaCount: 1);
+
     public static async Task<IContainer> BuildAsync(
         BootnodeOptions options,
         ILogManager logManager,
@@ -35,6 +49,8 @@ internal static class DiscoveryContainer
         BootnodeKademliaBucketRegistry bucketRegistry,
         CancellationToken cancellationToken)
     {
+        ConfigureNetworkBuffers();
+
         NetworkConfig networkConfig = new()
         {
             DiscoveryPort = options.DiscoveryPort,

--- a/tools/Bootnode/Nethermind.Bootnode/Nethermind.Bootnode.csproj
+++ b/tools/Bootnode/Nethermind.Bootnode/Nethermind.Bootnode.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Nethermind.Bootnode</AssemblyName>
     <RootNamespace>Nethermind.Bootnode</RootNamespace>
     <Nullable>enable</Nullable>
+    <VersionPrefix>1.0.0</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup Label="PackagesLock">

--- a/tools/Bootnode/Nethermind.Bootnode/NodeDtos.cs
+++ b/tools/Bootnode/Nethermind.Bootnode/NodeDtos.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using Nethermind.Stats.Model;
-
 namespace Nethermind.Bootnode;
 
 internal sealed record NodeDto(
@@ -18,32 +16,7 @@ internal sealed record NodeDto(
     bool IsBootnode,
     DateTimeOffset FirstSeenUtc,
     DateTimeOffset LastSeenUtc,
-    int SeenCount)
-{
-    public static NodeDto FromNode(
-        Node node,
-        string protocol,
-        bool active,
-        DateTimeOffset firstSeenUtc,
-        DateTimeOffset lastSeenUtc,
-        int seenCount,
-        bool isBootnode,
-        string? configuredEnode) =>
-        new(
-            node.Id.ToString(false),
-            node.IdHash.ToString(),
-            node.Host,
-            node.Port,
-            node.DiscoveryPort,
-            configuredEnode ?? (protocol == "configured" ? node.ToString(Node.Format.ENode) : null),
-            node.Enr?.ToString(),
-            protocol,
-            active,
-            isBootnode,
-            firstSeenUtc,
-            lastSeenUtc,
-            seenCount);
-}
+    int SeenCount);
 
 internal sealed record BootnodeIdentity(string Enode, string Enr, ulong EnrSequence, string NodeId, string Address);
 

--- a/tools/Bootnode/README.md
+++ b/tools/Bootnode/README.md
@@ -39,10 +39,14 @@ The tool is a discovery-only bootnode. It advertises TCP port `0` in the enode a
 
 ## Release Assets
 
-Bootnode side releases use `bootnode-*` tags and the `Release Bootnode` GitHub workflow. The workflow builds signed standalone binaries for Linux x64/arm64, macOS x64/arm64, and Windows x64, then publishes a Docker image:
+Bootnode maintains an independent version line starting at `1.0.0`. Its separate GitHub Release tag includes the `bootnode-` prefix, for example `bootnode-1.0.0`; package archive names and Docker tags use the same unprefixed Bootnode version, for example `nethermind-bootnode-1.0.0-linux-x64.tar.gz` and `nethermind/bootnode:1.0.0`. The `Release Bootnode` workflow always marks its GitHub release as not latest, so it does not replace the Nethermind client release in the repository sidebar.
+
+To publish a new version, update `VersionPrefix` in `tools/Bootnode/Nethermind.Bootnode/Nethermind.Bootnode.csproj` and dispatch `Release Bootnode` from a ref containing that change. To re-upload an existing published version, dispatch from its `bootnode-<version>` tag; delete a stale untagged draft before re-cutting that version at another commit. An existing Git tag determines the release commit even when the release is a draft or has been deleted. Each release includes `SHA256SUMS` and detached `.asc` signatures. The `nethermind/bootnode` image name replaces `nethermind/nethermind-bootnode`.
+
+The workflow builds signed standalone binaries for Linux x64/arm64, macOS x64/arm64, and Windows x64, then publishes a Docker image. For the highest published Bootnode version, select `publish_latest` to also refresh the Bootnode `latest` image tag; an older version still publishes its versioned image but leaves `latest` unchanged.
 
 ```powershell
-docker pull nethermind/nethermind-bootnode:bootnode-r1
+docker pull nethermind/bootnode:latest
 ```
 
 The default container command stores state in `/nethermind-bootnode/data` and binds REST and Prometheus to all interfaces:
@@ -53,7 +57,7 @@ docker run --rm -it `
   -p 127.0.0.1:8546:8546 `
   -p 127.0.0.1:6060:6060 `
   -v bootnode-data:/nethermind-bootnode/data `
-  nethermind/nethermind-bootnode:bootnode-r1
+  nethermind/bootnode:latest
 ```
 
 Pass CLI options after the image name to override the defaults, for example:
@@ -64,7 +68,7 @@ docker run --rm -it `
   -p 127.0.0.1:8546:8546 `
   -p 127.0.0.1:6060:6060 `
   -v bootnode-data:/nethermind-bootnode/data `
-  nethermind/nethermind-bootnode:bootnode-r1 `
+  nethermind/bootnode:latest `
   --local-ip :: `
   --external-ip-v4 203.0.113.10 `
   --external-ip-v6 2001:db8::10


### PR DESCRIPTION
Merges `master` (`de52a92e43`, 7 commits ahead) into `eip8141-frame-txs-devnet7` (`abbac6cfe9`).

> [!IMPORTANT]
> **This PR must be merged with a merge commit — do not squash.**
> Squashing destroys the recorded merge base, which makes the *next* master merge replay every conflict resolved here. That is exactly what happened on #13213 and had to be repaired with `df07cfecbd`.

## Conflicts

One conflict, in `src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs`.

Master's #13253 ("name opcode handlers for profiler attribution") annotated all 65 of its opcode body structs with `[SkipLocalsInit]`. The frames branch had inserted its 11 EIP-8141 and EIP-7906 opcode bodies into the same region, between `SlotNumOpcode` and `PopOpcode`, so git could not place master's annotation on `PopOpcode` without choosing a side.

Resolution: kept every frame/7906 body **and** applied master's annotation to each of them, so the whole table carries the new mechanism uniformly rather than half-converted. The dispatch table region itself merged cleanly and was not edited.

Uniformity check — the set of opcode bodies left *without* `[SkipLocalsInit]` after the merge is identical to master's own:

| | annotated | unannotated | unannotated set |
|---|---|---|---|
| master `de52a92e43` | 65 | 22 | 20 `delegate*` factories, `BadInstructionOpcode`, `StopOpcode` |
| devnet7 `abbac6cfe9` | 0 | 98 | (all) |
| **resolved** | **76** | **22** | **20 `delegate*` factories, `BadInstructionOpcode`, `StopOpcode`** |

76 = master's 65 + the 11 frames bodies. No body was left on the old shape.

## Handler-set comparison

Dispatch entries extracted from `lookup[(int)Instruction.X] = <handler>` in all three versions and diffed as sets, rather than read off the hunk:

```
entries: master=154  devnet7=165  resolved=165

resolved vs devnet7
  lost opcodes ................ NONE
  extra opcodes ............... NONE
  handler-expression changes .. NONE

resolved vs master
  opcodes master has that resolved lost .. NONE
  handler-expression changes ............. NONE
```

The 11 opcodes present only on the frames side, all still registered at their original bytes (`Instruction.cs` is untouched by this merge):

`APPROVE 0xaa`, `TXPARAM 0xb0`, `FRAMEDATALOAD 0xb1`, `FRAMEDATACOPY 0xb2`, `FRAMEPARAM 0xb3`, `SIGPARAM 0xb4`, `SIGDATACOPY 0xb5`, `RECENTROOTREFLOAD 0xb6`, `TXTRACE 0xb7`, `TXDIFF 0xb8`, `EVENTDATACOPY 0xb9`.

Independently confirmed against the emitted assembly: master's new Fody opcode weaver hard-fails the build on any `Instruction` enum constant lacking a named handler, or on any named handler unreachable from the table factories. The build passes, and all 11 frame opcode names are present as woven entry points in `Nethermind.Evm.dll`.

## Build and test

Full solution, both configurations, **0 warnings / 0 errors**:

- `dotnet build src/Nethermind/Nethermind.slnx -c release`
- `dotnet build src/Nethermind/Nethermind.slnx -c release -p:DefineConstants=TRACE;DEBUG` (checked — `Debug.Assert` in the VM has broken CI here before while release stayed green)

| suite | release | checked |
|---|---|---|
| Nethermind.Evm.Test | 10862 total, 0 failed | 10860 total, 0 failed |
| Nethermind.Blockchain.Test | 2023 total, 0 failed | 2023 total, 0 failed |
| Nethermind.Consensus.Test | 266 total, 0 failed | 266 total, 0 failed |
| Nethermind.Core.Test | 6403 total, 0 failed | — |
| Nethermind.Network.Discovery.Test | 467 total, 0 failed | — |
| Nethermind.Merge.Plugin.Test | 1884 total, 0 failed | — |

The last three cover the other files master touched (`RlpTests`, Kademlia discovery, `EngineModuleTests.V3`). `dotnet format whitespace --verify-no-changes` is clean on `Nethermind.Evm`.

## Frame fixture lanes

`tests-frames-devnet@v0.3.0`, `--forkAlias Bogota=Eip8141Prototype`, counts read from the runner's JSON output rather than the exit code. These are the load-bearing check given the conflict was in the dispatch table.

| lane | result |
|---|---|
| `blockTest` | **218 / 218** |
| `engineTest` | **218 / 218** |
