### PR TITLE
fix(trie): record inlined nodes as ambiguous when tracking past keys

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/Pruning/TreeStoreTests.cs
@@ -1789,6 +1789,80 @@ namespace Nethermind.Trie.Test.Pruning
         }
 
         [Test]
+        public void Persisted_hash_recorder_marks_hashless_node_as_ambiguous([Values] bool deleteOldNodes, [Values] bool hashlessFirst)
+        {
+            ConcurrentDictionary<HashAndTinyPath, Hash256?> persistedHashes = new();
+            HashAndTinyPath key = new(TestItem.KeccakA, new TinyTreePath(TreePath.Empty));
+
+            if (hashlessFirst)
+            {
+                TrieStore.RecordPersistedHash(persistedHashes, key, null, deleteOldNodes);
+                TrieStore.RecordPersistedHash(persistedHashes, key, TestItem.KeccakB, deleteOldNodes);
+                Assert.That(persistedHashes[key], Is.Null);
+            }
+            else
+            {
+                TrieStore.RecordPersistedHash(persistedHashes, key, TestItem.KeccakB, deleteOldNodes);
+                TrieStore.RecordPersistedHash(persistedHashes, key, null, deleteOldNodes);
+                Assert.That(persistedHashes[key], deleteOldNodes ? Is.Null : Is.EqualTo(TestItem.KeccakB));
+            }
+
+            Assert.That(persistedHashes.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Persisting_inlined_storage_leaves_with_past_key_tracking_succeeds()
+        {
+            TestLogger testLogger = new();
+            TestMemDb memDb = new();
+            TestFinalizedStateProvider finalizedStateProvider = new(1);
+            using TrieStore trieStore = new(
+                new NodeStorage(memDb, INodeStorage.KeyScheme.HalfPath, requirePath: true),
+                new TestPruningStrategy(shouldPrune: true, deleteObsoleteKeys: true),
+                No.Persistence,
+                finalizedStateProvider,
+                new PruningConfig { TrackPastKeys = true, PruningBoundary = 1 },
+                new OneLoggerLogManager(new ILogger(testLogger)));
+            finalizedStateProvider.TrieStore = trieStore;
+
+            // The two keys share 10 leading nibbles, so the leaves under the shared branch keep 53 key nibbles and a
+            // one-byte value: 30-byte RLP, inlined in the branch and therefore without a Keccak of their own.
+            byte[] firstKey = Bytes.FromHexString("71bca44bf12bab744620327c7dea0fc036220606f8decd882140039eb0cd0402");
+            byte[] secondKey = Bytes.FromHexString("71bca44bf16df1e59d7ded5466f98ad11f75c35f75f909981efa9add30142bcd");
+            Hash256 storageAddress = TestItem.KeccakA;
+            PatriciaTree storageTree = new(trieStore.GetTrieStore(storageAddress), LimboLogs.Instance);
+            PatriciaTree stateTree = new(trieStore.GetTrieStore(null), LimboLogs.Instance);
+
+            BlockHeader? baseBlock = null;
+            for (ulong blockNumber = 1; blockNumber <= 3; blockNumber++)
+            {
+                using (trieStore.BeginScope(baseBlock))
+                {
+                    using (trieStore.BeginBlockCommit(blockNumber))
+                    {
+                        if (blockNumber == 1)
+                        {
+                            storageTree.Set(firstKey, [1]);
+                            storageTree.Set(secondKey, [1]);
+                            storageTree.Commit();
+                            Account account = new(1, 1, storageTree.RootHash, Keccak.OfAnEmptyString);
+                            stateTree.Set(storageAddress.BytesToArray(), Rlp.Encode(account).Bytes);
+                        }
+
+                        stateTree.Commit();
+                    }
+
+                    baseBlock = Build.A.BlockHeader.WithParentOptional(baseBlock).WithStateRoot(stateTree.RootHash).TestObject;
+                }
+
+                trieStore.WaitForPruning();
+            }
+
+            Assert.That(testLogger.LogList.Where(m => m.Contains("Pruning failed")), Is.Empty);
+            Assert.That(trieStore.LastPersistedBlockNumber, Is.GreaterThanOrEqualTo(1UL));
+        }
+
+        [Test]
         public void Incomplete_persisted_prune_warning_is_rate_limited()
         {
             TestLogger testLogger = new() { IsWarn = true };

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -253,16 +253,12 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         static void ThrowUnknownHash(TrieNode node) => throw new TrieStoreException($"The hash of {node} should be known at the time of committing.");
     }
 
-    private int GetNodeShardIdx(in TreePath path, Hash256 hash)
-    {
+    private int GetNodeShardIdx(in TreePath path, Hash256 hash) =>
         // When enabled, the shard have dictionaries for tracking past path hash also.
         // So the same path need to be in the same shard for the remove logic to work.
-        uint hashCode = (uint)(_pastKeyTrackingEnabled
-            ? path.GetHashCode()
-            : hash.GetHashCode());
+        _pastKeyTrackingEnabled ? GetPathShardIdx(path) : (int)((uint)hash.GetHashCode() & _shardMask);
 
-        return (int)(hashCode & _shardMask);
-    }
+    private int GetPathShardIdx(in TreePath path) => (int)((uint)path.GetHashCode() & _shardMask);
 
     private TrieStoreDirtyNodesCache GetDirtyNodeShard(in TrieStoreDirtyNodesCache.Key key) => _dirtyNodes[GetNodeShardIdx(key.Path, key.Keccak)];
 
@@ -869,21 +865,26 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
     {
         if (treePath.Length <= TinyTreePath.MaxNibbleLength)
         {
-            Hash256 keccak = tn.Keccak ?? ThrowUnknownHash(tn);
-            int shardIdx = GetNodeShardIdx(treePath, keccak);
+            // Only wired when past keys are tracked, so shards are keyed by path and a hash is not required here.
+            int shardIdx = GetPathShardIdx(treePath);
 
             HashAndTinyPath key = new(address, new TinyTreePath(treePath));
-            RecordPersistedHash(_persistedHashes[shardIdx], key, keccak, _deleteOldNodes);
+            RecordPersistedHash(_persistedHashes[shardIdx], key, tn.Keccak, _deleteOldNodes);
         }
-
-        [DoesNotReturn, StackTraceHidden]
-        static Hash256 ThrowUnknownHash(TrieNode node) => throw new TrieStoreException($"The hash of {node} should be known when recording persisted nodes.");
     }
 
+    /// <summary>
+    /// Records the hash persisted at <paramref name="key"/> so <see cref="PruneCache"/> can drop cached nodes that the
+    /// path no longer points to.
+    /// </summary>
+    /// <remarks>
+    /// A null <paramref name="hash"/> marks the path ambiguous, which keeps every cached node under it. Nodes inlined in
+    /// their parent (RLP shorter than 32 bytes) have no hash of their own and are recorded this way.
+    /// </remarks>
     internal static void RecordPersistedHash(
         ConcurrentDictionary<HashAndTinyPath, Hash256?> persistedHashes,
         in HashAndTinyPath key,
-        Hash256 hash,
+        Hash256? hash,
         bool deleteOldNodes)
     {
         if (persistedHashes.TryAdd(key, hash) || !deleteOldNodes)


### PR DESCRIPTION
## Changes

- `TrieStore.PersistedNodeRecorder` no longer throws for nodes without a `Keccak`. Nodes inlined in their parent (RLP shorter than 32 bytes) have no hash, and storage leaves under a shared prefix of 9+ nibbles routinely are such nodes at storage-trie paths short enough to be recorded. Since #13099 turned the previously tolerated null into `ThrowUnknownHash`, every memory prune on a hybrid-pruning node failed as soon as one was reachable: `Pruning failed with exception ... should be known when recording persisted nodes`, nothing was persisted, and the dirty cache grew without bound (observed +1.45 GB/h dirty cache, +2.2 GB/h RSS on two freshly snap-synced mainnet nodes; `nethermind_pruned_persisted_nodes_count` stayed 0).
- `RecordPersistedHash` takes a nullable hash again. A null hash marks the path ambiguous, so `PruneCache` keeps every cached node under it, which is exactly what the pre-#13099 code did.
- The recorder shards by path (it is only wired when past-key tracking is on), so the shard lookup no longer needs a hash: `GetNodeShardIdx` delegates to a new private `GetPathShardIdx`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `Persisting_inlined_storage_leaves_with_past_key_tracking_succeeds` builds a HalfPath `TrieStore` with `TrackPastKeys` and `DeleteObsoleteKeys`, commits a storage trie whose two keys share 10 leading nibbles (30-byte inlined leaves) and drives it past the pruning boundary. On master it logs `Pruning failed with exception` and never persists; with this change it persists block 1.
- `Persisted_hash_recorder_marks_hashless_node_as_ambiguous` covers the null-hash path of `RecordPersistedHash` in both orders and both `deleteOldNodes` modes.
- Reproduced on mainnet DevNodes `k3851` (master d66cfd50) and `k7986` (branch on the same master), both hybrid pruning after snap sync; both showed the failure on every block from the first post-sync prune.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Memory pruning failed on every block for hybrid-pruning nodes running master since #13099, leaving state unpersisted and memory growing until restart or OOM.
