### PR TITLE
test(eip8141): repoint the measured-pool-prefix case to 322,800

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
@@ -182,9 +182,13 @@ public class FrameTxVerifyDosMeasurement
     }
 
     /// <summary>The unpaid gas one block-production attempt burns on a prefix that never approves — the
-    /// per-attempt multiplicand for the pool-retention count measured in the TxPool tests.</summary>
+    /// per-attempt multiplicand for the pool-retention count measured in the TxPool tests. The largest
+    /// prefix the pool can retain is <see cref="Eip8141Constants.MaxVerifyGas"/>; the soispoke case sits
+    /// above it and only sizes what raising MAX_VERIFY_GAS to that budget would cost, since block
+    /// execution applies no cap.</summary>
     [TestCase(100_000L, TestName = "burn at the spec default budget")]
-    [TestCase(322_800L, TestName = "burn at the measured pool prefix")]
+    [TestCase((long)Eip8141Constants.MaxVerifyGas, TestName = "burn at the retainable ceiling")]
+    [TestCase(322_800L, TestName = "burn at soispoke's declared privacy-pool budget")]
     public void UnpaidBurnPerAttempt(long verifyGas)
     {
         _stateProvider.CreateAccount(Sender, 1.Ether);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxVerifyDosMeasurement.cs
@@ -184,7 +184,7 @@ public class FrameTxVerifyDosMeasurement
     /// <summary>The unpaid gas one block-production attempt burns on a prefix that never approves — the
     /// per-attempt multiplicand for the pool-retention count measured in the TxPool tests.</summary>
     [TestCase(100_000L, TestName = "burn at the spec default budget")]
-    [TestCase(236_285L, TestName = "burn at the measured pool prefix")]
+    [TestCase(322_800L, TestName = "burn at the measured pool prefix")]
     public void UnpaidBurnPerAttempt(long verifyGas)
     {
         _stateProvider.CreateAccount(Sender, 1.Ether);


### PR DESCRIPTION
236,285 was never soundly derived (a flawed single-public-input microbenchmark, not a real workload); 322,800 is soispoke's real declared privacy-pool budget - the correct number for a case claiming to represent "the measured pool prefix."

Third of three parallel fixes for the same stale value: the other two are #13271 (drops 236,285 from the plain ceiling sweeps, adds 322,800) and a same-day fix on #13265's branch.

Test-only. Verified locally: `budget=322800 consumed=322696` (99.97% of budget, clears the >99% assertion).