### PR TITLE
fix(cl): credit deposits committed by a successful frame

### DIFF
--- a/src/Nethermind/Nethermind.Optimism.Test/CL/DepositTransactionBuilderTest.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/DepositTransactionBuilderTest.cs
@@ -831,6 +831,29 @@ public class DepositTransactionBuilderTest
         Assert.That(depositTransactions, Is.Empty);
     }
 
+    /// <summary>Each field the attribution compares has to be able to reject a frame log on its own: the
+    /// credited log is the one that is decoded, so a mismatched <c>Data</c> would carry the wrong mint.</summary>
+    [TestCaseSource(nameof(FrameLogMismatchCases))]
+    public void DeriveUserDeposits_FrameTx_MismatchedFrameLogIsUnattributable(LogEntry frameLog)
+    {
+        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, SomeDepositEvent().ToBytes(), 0);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = 0,
+                Logs = [depositLog],
+                FrameReceipts = [new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [frameLog] }],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions, Is.Empty);
+    }
+
     /// <summary>Frames that do not account for exactly the receipt's logs cannot be attributed, so the
     /// aggregate status keeps gating.</summary>
     [TestCase(0L, 0)]
@@ -872,6 +895,21 @@ public class DepositTransactionBuilderTest
         ];
 
         Assert.That(() => _builder.BuildUserDepositTransactions(receipts), Throws.TypeOf<ArgumentException>());
+    }
+
+    /// <summary>A frame log matching the receipt's deposit log in every field but one.</summary>
+    private static TestCaseData[] FrameLogMismatchCases()
+    {
+        LogEntry depositLog = DepositLog(SomeAddressA, SomeAddressB, SomeDepositEvent().ToBytes(), 0).ToLogEntry();
+        DepositLogEventV0 otherEvent = SomeDepositEvent() with { Value = 1 };
+
+        return
+        [
+            new TestCaseData(new LogEntry(SomeAddressC, depositLog.Data, depositLog.Topics)) { TestName = "DeriveUserDeposits_FrameTx_MismatchedFrameLogIsUnattributable(Address)" },
+            new TestCaseData(new LogEntry(depositLog.Address, depositLog.Data, [DepositEvent.ABIHash])) { TestName = "DeriveUserDeposits_FrameTx_MismatchedFrameLogIsUnattributable(TopicCount)" },
+            new TestCaseData(new LogEntry(depositLog.Address, depositLog.Data, [.. depositLog.Topics[..3], SomeHash])) { TestName = "DeriveUserDeposits_FrameTx_MismatchedFrameLogIsUnattributable(Topic)" },
+            new TestCaseData(new LogEntry(depositLog.Address, otherEvent.ToBytes(), depositLog.Topics)) { TestName = "DeriveUserDeposits_FrameTx_MismatchedFrameLogIsUnattributable(Data)" },
+        ];
     }
 
     private static DepositLogEventV0 SomeDepositEvent() => new()

--- a/src/Nethermind/Nethermind.Optimism.Test/CL/DepositTransactionBuilderTest.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/DepositTransactionBuilderTest.cs
@@ -729,4 +729,176 @@ public class DepositTransactionBuilderTest
 
         Assert.That(depositTransactions[1], Is.EqualTo(expectedTransaction_1).UsingTransactionComparer());
     }
+    private static readonly Hash256 SourceHashLogIndex0 = new("0xa39c0336f8bb13bdeb6cb1a969ee335af770f40048fed5064c1f3becf19ca501");
+    private static readonly Hash256 SourceHashLogIndex1 = new("0xe0afd0f8dec64b119c51723546cd6ff231b37aed016d7a2934eb6caf5d40eae2");
+
+    private static DepositLogEventV0 SomeDepositEvent() => new()
+    {
+        Data = Bytes.FromHexString("0x3444f4d68305342838072b3c49df1b64c60a"),
+        Mint = 0,
+        Value = UInt256.Parse("195000000000000000000"),
+        Gas = 8732577,
+        IsCreation = false,
+    };
+
+    private static LogEntryForRpc DepositLog(Address from, Address to, byte[] logData, long logIndex) => new()
+    {
+        Address = DepositAddress,
+        Topics =
+        [
+            DepositEvent.ABIHash,
+            new Hash256(from.Bytes.PadLeft(32)),
+            new Hash256(to.Bytes.PadLeft(32)),
+            DepositEvent.Version0,
+        ],
+        Data = logData,
+        LogIndex = logIndex,
+        BlockHash = SomeHash,
+    };
+
+    private static Transaction ExpectedDeposit(Address from, Address to, in DepositLogEventV0 depositEvent, Hash256 sourceHash) => Build.A.Transaction
+        .WithType(TxType.DepositTx)
+        .WithSenderAddress(from)
+        .WithTo(to)
+        .WithValue(depositEvent.Value)
+        .WithGasLimit(depositEvent.Gas)
+        .WithGasPrice(0)
+        .WithMaxPriorityFeePerGas(0)
+        .WithMaxFeePerGas(0)
+        .WithSourceHash(sourceHash)
+        .WithIsOPSystemTransaction(false)
+        .WithData(depositEvent.Data.ToArray())
+        .TestObject;
+
+    /// <summary>EIP-8141: the receipt status is the aggregate over the frames, so an unrelated frame reverting
+    /// must not discard a deposit a successful frame committed.</summary>
+    [Test]
+    public void DeriveUserDeposits_FrameTx_CommittedDepositSurvivesUnrelatedFrameRevert()
+    {
+        DepositLogEventV0 depositEvent = SomeDepositEvent();
+        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = 0, // Aggregate: the second frame reverted
+                Logs = [depositLog],
+                FrameReceipts =
+                [
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [depositLog.ToLogEntry()] },
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusFailure, Logs = [] },
+                ],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions.Length, Is.EqualTo(1));
+        Assert.That(depositTransactions[0], Is.EqualTo(ExpectedDeposit(SomeAddressA, SomeAddressB, depositEvent, SourceHashLogIndex0)).UsingTransactionComparer());
+    }
+
+    [TestCase(0L, TestName = "DeriveUserDeposits_FrameTx_RevertedFrameDepositIsNotCredited(aggregate failure)")]
+    [TestCase(1L, TestName = "DeriveUserDeposits_FrameTx_RevertedFrameDepositIsNotCredited(status contradicts frames)")]
+    public void DeriveUserDeposits_FrameTx_RevertedFrameDepositIsNotCredited(long receiptStatus)
+    {
+        DepositLogEventV0 depositEvent = SomeDepositEvent();
+        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = receiptStatus,
+                Logs = [depositLog],
+                FrameReceipts =
+                [
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusFailure, Logs = [depositLog.ToLogEntry()] },
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [] },
+                ],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions.Length, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void DeriveUserDeposits_FrameTx_AttributesLogsInFrameOrder()
+    {
+        DepositLogEventV0 revertedEvent = SomeDepositEvent();
+        DepositLogEventV0 committedEvent = SomeDepositEvent();
+        LogEntryForRpc revertedLog = DepositLog(SomeAddressA, SomeAddressB, revertedEvent.ToBytes(), 0);
+        LogEntryForRpc committedLog = DepositLog(SomeAddressC, SomeAddressD, committedEvent.ToBytes(), 1);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = 0,
+                Logs = [revertedLog, committedLog],
+                FrameReceipts =
+                [
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusFailure, Logs = [revertedLog.ToLogEntry()] },
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [committedLog.ToLogEntry()] },
+                ],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions.Length, Is.EqualTo(1));
+        Assert.That(depositTransactions[0], Is.EqualTo(ExpectedDeposit(SomeAddressC, SomeAddressD, committedEvent, SourceHashLogIndex1)).UsingTransactionComparer());
+    }
+
+    [Test]
+    public void DeriveUserDeposits_FrameTx_SkippedFrameDepositIsNotCredited()
+    {
+        DepositLogEventV0 depositEvent = SomeDepositEvent();
+        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = 0,
+                Logs = [depositLog],
+                FrameReceipts = [new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSkipped, Logs = [depositLog.ToLogEntry()] }],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions.Length, Is.EqualTo(0));
+    }
+
+    /// <summary>Frames that do not account for exactly the receipt's logs cannot be attributed, so the
+    /// aggregate status keeps gating.</summary>
+    [TestCase(0L, 0)]
+    [TestCase(1L, 1)]
+    public void DeriveUserDeposits_FrameTx_UnattributableFramesFallBackToAggregateStatus(long receiptStatus, int expectedDeposits)
+    {
+        DepositLogEventV0 depositEvent = SomeDepositEvent();
+        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = receiptStatus,
+                Logs = [depositLog],
+                FrameReceipts = [new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [] }],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions.Length, Is.EqualTo(expectedDeposits));
+    }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/CL/DepositTransactionBuilderTest.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/DepositTransactionBuilderTest.cs
@@ -26,6 +26,8 @@ public class DepositTransactionBuilderTest
     private static readonly Address SomeAddressB = TestItem.AddressC;
     private static readonly Address SomeAddressC = TestItem.AddressD;
     private static readonly Address SomeAddressD = TestItem.AddressE;
+    private static readonly Hash256 SourceHashLogIndex0 = new("0xa39c0336f8bb13bdeb6cb1a969ee335af770f40048fed5064c1f3becf19ca501");
+    private static readonly Hash256 SourceHashLogIndex1 = new("0xe0afd0f8dec64b119c51723546cd6ff231b37aed016d7a2934eb6caf5d40eae2");
 
     private readonly CLChainSpecEngineParameters _engineParameters;
     private readonly DepositTransactionBuilder _builder;
@@ -729,8 +731,148 @@ public class DepositTransactionBuilderTest
 
         Assert.That(depositTransactions[1], Is.EqualTo(expectedTransaction_1).UsingTransactionComparer());
     }
-    private static readonly Hash256 SourceHashLogIndex0 = new("0xa39c0336f8bb13bdeb6cb1a969ee335af770f40048fed5064c1f3becf19ca501");
-    private static readonly Hash256 SourceHashLogIndex1 = new("0xe0afd0f8dec64b119c51723546cd6ff231b37aed016d7a2934eb6caf5d40eae2");
+
+    /// <summary>EIP-8141: the receipt status is the aggregate over the frames, so a deposit is credited exactly
+    /// when the frame that emitted it succeeded, whatever the other frames or the receipt status say.</summary>
+    [TestCase(TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusFailure, 0L, 1, TestName = "DeriveUserDeposits_FrameTx_CommittedDepositSurvivesUnrelatedFrameRevert")]
+    [TestCase(TxFrameReceipt.StatusFailure, TxFrameReceipt.StatusSuccess, 0L, 0, TestName = "DeriveUserDeposits_FrameTx_RevertedFrameDepositIsNotCredited")]
+    [TestCase(TxFrameReceipt.StatusFailure, TxFrameReceipt.StatusSuccess, 1L, 0, TestName = "DeriveUserDeposits_FrameTx_RevertedFrameDepositIsNotCreditedWhenStatusContradictsFrames")]
+    [TestCase(TxFrameReceipt.StatusSkipped, TxFrameReceipt.StatusSuccess, 0L, 0, TestName = "DeriveUserDeposits_FrameTx_SkippedFrameDepositIsNotCredited")]
+    public void DeriveUserDeposits_FrameTx_CreditsByEmittingFrameStatus(byte depositFrameStatus, byte otherFrameStatus, long receiptStatus, int expectedDeposits)
+    {
+        DepositLogEventV0 depositEvent = SomeDepositEvent();
+        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = receiptStatus,
+                Logs = [depositLog],
+                FrameReceipts =
+                [
+                    new FrameReceiptForRpc { Status = depositFrameStatus, Logs = [depositLog.ToLogEntry()] },
+                    new FrameReceiptForRpc { Status = otherFrameStatus, Logs = [] },
+                ],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions.Length, Is.EqualTo(expectedDeposits));
+        if (expectedDeposits == 1)
+        {
+            Assert.That(depositTransactions[0], Is.EqualTo(ExpectedDeposit(SomeAddressA, SomeAddressB, depositEvent, SourceHashLogIndex0)).UsingTransactionComparer());
+        }
+    }
+
+    [Test]
+    public void DeriveUserDeposits_FrameTx_AttributesLogsInFrameOrder()
+    {
+        DepositLogEventV0 depositEvent = SomeDepositEvent();
+        LogEntryForRpc revertedLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
+        LogEntryForRpc committedLog = DepositLog(SomeAddressC, SomeAddressD, depositEvent.ToBytes(), 1);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = 0,
+                Logs = [revertedLog, committedLog],
+                FrameReceipts =
+                [
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusFailure, Logs = [revertedLog.ToLogEntry()] },
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [committedLog.ToLogEntry()] },
+                ],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions.Length, Is.EqualTo(1));
+        Assert.That(depositTransactions[0], Is.EqualTo(ExpectedDeposit(SomeAddressC, SomeAddressD, depositEvent, SourceHashLogIndex1)).UsingTransactionComparer());
+    }
+
+    /// <summary>The frame log counts can add up while a successful frame's run covers a log another frame
+    /// emitted, so the runs are matched against the logs themselves before any of them credits a deposit.</summary>
+    [Test]
+    public void DeriveUserDeposits_FrameTx_MisplacedFrameLogsAreUnattributable()
+    {
+        DepositLogEventV0 depositEvent = SomeDepositEvent();
+        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
+        LogEntryForRpc unrelatedLog = new()
+        {
+            Address = SomeAddressC,
+            Topics = [SomeHash],
+            Data = [],
+            LogIndex = 1,
+            BlockHash = SomeHash,
+        };
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = 0,
+                Logs = [depositLog, unrelatedLog],
+                FrameReceipts =
+                [
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [unrelatedLog.ToLogEntry()] },
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusFailure, Logs = [depositLog.ToLogEntry()] },
+                ],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions, Is.Empty);
+    }
+
+    /// <summary>Frames that do not account for exactly the receipt's logs cannot be attributed, so the
+    /// aggregate status keeps gating.</summary>
+    [TestCase(0L, 0)]
+    [TestCase(1L, 1)]
+    public void DeriveUserDeposits_FrameTx_UnattributableFramesFallBackToAggregateStatus(long receiptStatus, int expectedDeposits)
+    {
+        DepositLogEventV0 depositEvent = SomeDepositEvent();
+        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = receiptStatus,
+                Logs = [depositLog],
+                FrameReceipts = [new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [] }],
+                BlockHash = SomeHash,
+            },
+        ];
+        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
+
+        Assert.That(depositTransactions.Length, Is.EqualTo(expectedDeposits));
+    }
+
+    /// <summary>The element annotation does not bind the deserializer, so an L1 endpoint can send
+    /// <c>"logs": [null]</c>.</summary>
+    [Test]
+    public void DeriveUserDeposits_NullLogEntryIsRejected()
+    {
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Status = 1,
+                Logs = [null!],
+                BlockHash = SomeHash,
+            },
+        ];
+
+        Assert.That(() => _builder.BuildUserDepositTransactions(receipts), Throws.TypeOf<ArgumentException>());
+    }
 
     private static DepositLogEventV0 SomeDepositEvent() => new()
     {
@@ -769,136 +911,4 @@ public class DepositTransactionBuilderTest
         .WithIsOPSystemTransaction(false)
         .WithData(depositEvent.Data.ToArray())
         .TestObject;
-
-    /// <summary>EIP-8141: the receipt status is the aggregate over the frames, so an unrelated frame reverting
-    /// must not discard a deposit a successful frame committed.</summary>
-    [Test]
-    public void DeriveUserDeposits_FrameTx_CommittedDepositSurvivesUnrelatedFrameRevert()
-    {
-        DepositLogEventV0 depositEvent = SomeDepositEvent();
-        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
-
-        ReceiptForRpc[] receipts =
-        [
-            new()
-            {
-                Type = TxType.FrameTx,
-                Status = 0, // Aggregate: the second frame reverted
-                Logs = [depositLog],
-                FrameReceipts =
-                [
-                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [depositLog.ToLogEntry()] },
-                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusFailure, Logs = [] },
-                ],
-                BlockHash = SomeHash,
-            },
-        ];
-        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
-
-        Assert.That(depositTransactions.Length, Is.EqualTo(1));
-        Assert.That(depositTransactions[0], Is.EqualTo(ExpectedDeposit(SomeAddressA, SomeAddressB, depositEvent, SourceHashLogIndex0)).UsingTransactionComparer());
-    }
-
-    [TestCase(0L, TestName = "DeriveUserDeposits_FrameTx_RevertedFrameDepositIsNotCredited(aggregate failure)")]
-    [TestCase(1L, TestName = "DeriveUserDeposits_FrameTx_RevertedFrameDepositIsNotCredited(status contradicts frames)")]
-    public void DeriveUserDeposits_FrameTx_RevertedFrameDepositIsNotCredited(long receiptStatus)
-    {
-        DepositLogEventV0 depositEvent = SomeDepositEvent();
-        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
-
-        ReceiptForRpc[] receipts =
-        [
-            new()
-            {
-                Type = TxType.FrameTx,
-                Status = receiptStatus,
-                Logs = [depositLog],
-                FrameReceipts =
-                [
-                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusFailure, Logs = [depositLog.ToLogEntry()] },
-                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [] },
-                ],
-                BlockHash = SomeHash,
-            },
-        ];
-        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
-
-        Assert.That(depositTransactions.Length, Is.EqualTo(0));
-    }
-
-    [Test]
-    public void DeriveUserDeposits_FrameTx_AttributesLogsInFrameOrder()
-    {
-        DepositLogEventV0 revertedEvent = SomeDepositEvent();
-        DepositLogEventV0 committedEvent = SomeDepositEvent();
-        LogEntryForRpc revertedLog = DepositLog(SomeAddressA, SomeAddressB, revertedEvent.ToBytes(), 0);
-        LogEntryForRpc committedLog = DepositLog(SomeAddressC, SomeAddressD, committedEvent.ToBytes(), 1);
-
-        ReceiptForRpc[] receipts =
-        [
-            new()
-            {
-                Type = TxType.FrameTx,
-                Status = 0,
-                Logs = [revertedLog, committedLog],
-                FrameReceipts =
-                [
-                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusFailure, Logs = [revertedLog.ToLogEntry()] },
-                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [committedLog.ToLogEntry()] },
-                ],
-                BlockHash = SomeHash,
-            },
-        ];
-        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
-
-        Assert.That(depositTransactions.Length, Is.EqualTo(1));
-        Assert.That(depositTransactions[0], Is.EqualTo(ExpectedDeposit(SomeAddressC, SomeAddressD, committedEvent, SourceHashLogIndex1)).UsingTransactionComparer());
-    }
-
-    [Test]
-    public void DeriveUserDeposits_FrameTx_SkippedFrameDepositIsNotCredited()
-    {
-        DepositLogEventV0 depositEvent = SomeDepositEvent();
-        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
-
-        ReceiptForRpc[] receipts =
-        [
-            new()
-            {
-                Type = TxType.FrameTx,
-                Status = 0,
-                Logs = [depositLog],
-                FrameReceipts = [new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSkipped, Logs = [depositLog.ToLogEntry()] }],
-                BlockHash = SomeHash,
-            },
-        ];
-        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
-
-        Assert.That(depositTransactions.Length, Is.EqualTo(0));
-    }
-
-    /// <summary>Frames that do not account for exactly the receipt's logs cannot be attributed, so the
-    /// aggregate status keeps gating.</summary>
-    [TestCase(0L, 0)]
-    [TestCase(1L, 1)]
-    public void DeriveUserDeposits_FrameTx_UnattributableFramesFallBackToAggregateStatus(long receiptStatus, int expectedDeposits)
-    {
-        DepositLogEventV0 depositEvent = SomeDepositEvent();
-        LogEntryForRpc depositLog = DepositLog(SomeAddressA, SomeAddressB, depositEvent.ToBytes(), 0);
-
-        ReceiptForRpc[] receipts =
-        [
-            new()
-            {
-                Type = TxType.FrameTx,
-                Status = receiptStatus,
-                Logs = [depositLog],
-                FrameReceipts = [new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, Logs = [] }],
-                BlockHash = SomeHash,
-            },
-        ];
-        Transaction[] depositTransactions = _builder.BuildUserDepositTransactions(receipts).ToArray();
-
-        Assert.That(depositTransactions.Length, Is.EqualTo(expectedDeposits));
-    }
 }

--- a/src/Nethermind/Nethermind.Optimism.Test/CL/SystemConfigDeriverTests.cs
+++ b/src/Nethermind/Nethermind.Optimism.Test/CL/SystemConfigDeriverTests.cs
@@ -22,20 +22,19 @@ public class SystemConfigDeriverTests
     private static readonly AbiSignature UInt256Signature = new("oneUint256", AbiType.UInt256);
     private static readonly AbiSignature UInt256TupleSignature = new("twoUint256", AbiType.UInt256, AbiType.UInt256);
 
+    private static LogEntryForRpc BuildLog(byte[] data, Hash256 topic) => new()
+    {
+        Address = SystemConfigProxy,
+        Topics = [SystemConfigUpdate.EventABIHash, SystemConfigUpdate.EventVersion0, topic],
+        Data = data,
+    };
+
     private ReceiptForRpc[] BuildReceipts(byte[] data, Hash256 topic) =>
     [
         new()
         {
             Status = StatusCode.Success,
-            Logs =
-            [
-                new()
-                {
-                    Address = SystemConfigProxy,
-                    Topics = [SystemConfigUpdate.EventABIHash, SystemConfigUpdate.EventVersion0, topic],
-                    Data = data,
-                }
-            ]
+            Logs = [BuildLog(data, topic)]
         }
     ];
 
@@ -189,6 +188,40 @@ public class SystemConfigDeriverTests
         };
 
         Assert.That(actualConfig, Is.EqualTo(expectedConfig));
+    }
+
+    /// <summary>EIP-8141: the receipt status is the aggregate over the frames, so an update is applied exactly
+    /// when the frame that emitted it succeeded, not when every frame of the transaction did.</summary>
+    [TestCase(TxFrameReceipt.StatusSuccess, 0xBBul)]
+    [TestCase(TxFrameReceipt.StatusFailure, 0ul)]
+    [TestCase(TxFrameReceipt.StatusSkipped, 0ul)]
+    public void UpdateSystemConfigFromL1BLock_FrameTx_AppliesByEmittingFrameStatus(byte updateFrameStatus, ulong expectedGasLimit)
+    {
+        UInt256 gasLimit = 0xBB;
+
+        byte[] encodedGasLimit = AbiEncoder.Instance.Encode(AbiEncodingStyle.None, UInt256Signature, gasLimit);
+        byte[] encodedData = AbiEncoder.Instance.Encode(AbiEncodingStyle.None, BytesSignature, encodedGasLimit);
+        LogEntryForRpc log = BuildLog(encodedData, SystemConfigUpdate.GasLimit);
+
+        ReceiptForRpc[] receipts =
+        [
+            new()
+            {
+                Type = TxType.FrameTx,
+                Status = StatusCode.Failure, // Aggregate: the second frame reverted
+                Logs = [log],
+                FrameReceipts =
+                [
+                    new FrameReceiptForRpc { Status = updateFrameStatus, Logs = [log.ToLogEntry()] },
+                    new FrameReceiptForRpc { Status = TxFrameReceipt.StatusFailure, Logs = [] },
+                ]
+            }
+        ];
+
+        SystemConfigDeriver deriver = new(SystemConfigProxy);
+        SystemConfig actualConfig = deriver.UpdateSystemConfigFromL1BLockReceipts(new SystemConfig(), receipts);
+
+        Assert.That(actualConfig, Is.EqualTo(new SystemConfig { GasLimit = expectedGasLimit }));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Optimism/CL/Derivation/CommittedLogs.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Derivation/CommittedLogs.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Evm;
 using Nethermind.JsonRpc.Data;
@@ -32,6 +31,13 @@ internal static class CommittedLogs
             if (logs[i] is null) throw new ArgumentException($"Log entry {i} of receipt {receipt.TransactionHash} is null");
         }
 
+        return Committed(receipt, logs);
+    }
+
+    /// <summary>The committed subset of <paramref name="logs"/>, split out so <see cref="Of"/> can reject a
+    /// malformed receipt at the call rather than on the first <c>MoveNext</c>.</summary>
+    private static IEnumerable<LogEntryForRpc> Committed(ReceiptForRpc receipt, LogEntryForRpc[] logs)
+    {
         if (TryGetAttributableFrames(receipt, logs, out FrameReceiptForRpc[]? frames))
         {
             int start = 0;
@@ -77,18 +83,6 @@ internal static class CommittedLogs
     private static bool IsSameLog(LogEntryForRpc log, LogEntry frameLog) =>
         frameLog is not null
         && log.Address == frameLog.Address
-        && HaveSameTopics(log.Topics, frameLog.Topics)
+        && log.Topics.AsSpan().SequenceEqual(frameLog.Topics)
         && Bytes.AreEqual(log.Data, frameLog.Data);
-
-    private static bool HaveSameTopics(ReadOnlySpan<Hash256> left, ReadOnlySpan<Hash256> right)
-    {
-        if (left.Length != right.Length) return false;
-
-        for (int i = 0; i < left.Length; i++)
-        {
-            if (left[i] != right[i]) return false;
-        }
-
-        return true;
-    }
 }

--- a/src/Nethermind/Nethermind.Optimism/CL/Derivation/CommittedLogs.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Derivation/CommittedLogs.cs
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Evm;
+using Nethermind.JsonRpc.Data;
+
+namespace Nethermind.Optimism.CL.Derivation;
+
+/// <summary>The logs of an L1 receipt whose emitting execution committed, the only ones derivation may read.</summary>
+internal static class CommittedLogs
+{
+    /// <summary>Enumerates the receipt's logs, dropping those the L1 execution rolled back.</summary>
+    /// <remarks>
+    /// EIP-8141 carries no transaction-level status: the receipt status is the aggregate over the frames, so
+    /// gating on it discards logs an independent frame committed. The transaction's log set is the frame logs
+    /// concatenated in frame order, so each frame claims the next run of its own length. Frames that do not
+    /// reproduce exactly the logs the receipt carries are unattributable and stay gated on the aggregate.
+    /// </remarks>
+    /// <exception cref="ArgumentException">A log entry is null.</exception>
+    public static IEnumerable<LogEntryForRpc> Of(ReceiptForRpc receipt)
+    {
+        // An L1 node omits "logs" or sends null for a receipt with no logs.
+        LogEntryForRpc[] logs = receipt.Logs ?? [];
+        for (int i = 0; i < logs.Length; i++)
+        {
+            if (logs[i] is null) throw new ArgumentException($"Log entry {i} of receipt {receipt.TransactionHash} is null");
+        }
+
+        if (TryGetAttributableFrames(receipt, logs, out FrameReceiptForRpc[]? frames))
+        {
+            int start = 0;
+            foreach (FrameReceiptForRpc frame in frames)
+            {
+                int count = frame.Logs?.Length ?? 0;
+                if (frame.Status == TxFrameReceipt.StatusSuccess)
+                {
+                    for (int i = start; i < start + count; i++) yield return logs[i];
+                }
+
+                start += count;
+            }
+        }
+        else if (receipt.Status == StatusCode.Success)
+        {
+            foreach (LogEntryForRpc log in logs) yield return log;
+        }
+    }
+
+    private static bool TryGetAttributableFrames(ReceiptForRpc receipt, LogEntryForRpc[] logs, [NotNullWhen(true)] out FrameReceiptForRpc[]? frames)
+    {
+        frames = receipt.FrameReceipts;
+        if (receipt.Type != TxType.FrameTx || frames is not { Length: > 0 }) return false;
+
+        int matched = 0;
+        foreach (FrameReceiptForRpc frame in frames)
+        {
+            if (frame is null) return false;
+
+            foreach (LogEntry frameLog in frame.Logs ?? [])
+            {
+                if (matched == logs.Length || !IsSameLog(logs[matched], frameLog)) return false;
+                matched++;
+            }
+        }
+
+        return matched == logs.Length;
+    }
+
+    /// <summary>Whether the receipt log is the frame log the concatenation puts at its position.</summary>
+    /// <remarks>The counts alone would let a payload place a committed frame's run over a reverted frame's log.</remarks>
+    private static bool IsSameLog(LogEntryForRpc log, LogEntry frameLog) =>
+        frameLog is not null
+        && log.Address == frameLog.Address
+        && HaveSameTopics(log.Topics, frameLog.Topics)
+        && Bytes.AreEqual(log.Data, frameLog.Data);
+
+    private static bool HaveSameTopics(ReadOnlySpan<Hash256> left, ReadOnlySpan<Hash256> right)
+    {
+        if (left.Length != right.Length) return false;
+
+        for (int i = 0; i < left.Length; i++)
+        {
+            if (left[i] != right[i]) return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.Optimism/CL/Derivation/DepositTransactionBuilder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Derivation/DepositTransactionBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Abi;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -77,25 +78,70 @@ public class DepositTransactionBuilder(ulong chainId, CLChainSpecEngineParameter
         List<Transaction> result = [];
         foreach (ReceiptForRpc receipt in receipts)
         {
-            if (receipt.Status != StatusCode.Success) continue;
             // An L1 node omits "logs" or sends null for a receipt with no logs.
-            foreach (LogEntryForRpc log in receipt.Logs ?? [])
+            LogEntryForRpc[] logs = receipt.Logs ?? [];
+            if (TryGetAttributableFrames(receipt, logs.Length, out FrameReceiptForRpc[]? frames))
             {
-                if (log.Address != engineParameters.OptimismPortalProxy) continue;
-                if (log.Topics.Length == 0 || log.Topics[0] != DepositEvent.ABIHash) continue;
+                int start = 0;
+                foreach (FrameReceiptForRpc frame in frames)
+                {
+                    int count = frame.Logs?.Length ?? 0;
+                    if (frame.Status == TxFrameReceipt.StatusSuccess)
+                    {
+                        AddDeposits(result, logs, start, count);
+                    }
 
-                try
-                {
-                    Transaction tx = DecodeDepositTransactionFromLogEvent(log);
-                    result.Add(tx);
+                    start += count;
                 }
-                catch (Exception e)
-                {
-                    throw new ArgumentException($"Failed to decode {nameof(Transaction)} from {nameof(LogEntryForRpc)}", e);
-                }
+            }
+            else if (receipt.Status == StatusCode.Success)
+            {
+                AddDeposits(result, logs, 0, logs.Length);
             }
         }
         return result;
+    }
+
+    /// <summary>Matches a frame transaction's per-frame receipts to the run of receipt logs each frame committed.</summary>
+    /// <remarks>
+    /// EIP-8141 carries no transaction-level status: the receipt status is the aggregate over the frames, so
+    /// gating on it discards a deposit an independent frame committed. The transaction's log set is the frame
+    /// logs concatenated in frame order, so each frame claims the next run of its own length. Frames that do
+    /// not account for exactly the logs the receipt carries are unattributable, leaving the caller the aggregate.
+    /// </remarks>
+    private static bool TryGetAttributableFrames(ReceiptForRpc receipt, int logCount, [NotNullWhen(true)] out FrameReceiptForRpc[]? frames)
+    {
+        frames = receipt.FrameReceipts;
+        if (receipt.Type != TxType.FrameTx || frames is not { Length: > 0 }) return false;
+
+        int total = 0;
+        foreach (FrameReceiptForRpc frame in frames)
+        {
+            if (frame is null) return false;
+            total += frame.Logs?.Length ?? 0;
+        }
+
+        return total == logCount;
+    }
+
+    private void AddDeposits(List<Transaction> result, LogEntryForRpc[] logs, int start, int count)
+    {
+        for (int i = start; i < start + count; i++)
+        {
+            LogEntryForRpc log = logs[i];
+            if (log.Address != engineParameters.OptimismPortalProxy) continue;
+            if (log.Topics.Length == 0 || log.Topics[0] != DepositEvent.ABIHash) continue;
+
+            try
+            {
+                Transaction tx = DecodeDepositTransactionFromLogEvent(log);
+                result.Add(tx);
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException($"Failed to decode {nameof(Transaction)} from {nameof(LogEntryForRpc)}", e);
+            }
+        }
     }
 
     /*

--- a/src/Nethermind/Nethermind.Optimism/CL/Derivation/DepositTransactionBuilder.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Derivation/DepositTransactionBuilder.cs
@@ -5,12 +5,10 @@ using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Nethermind.Abi;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Evm;
 using Nethermind.Int256;
 using Nethermind.JsonRpc.Data;
 
@@ -78,70 +76,23 @@ public class DepositTransactionBuilder(ulong chainId, CLChainSpecEngineParameter
         List<Transaction> result = [];
         foreach (ReceiptForRpc receipt in receipts)
         {
-            // An L1 node omits "logs" or sends null for a receipt with no logs.
-            LogEntryForRpc[] logs = receipt.Logs ?? [];
-            if (TryGetAttributableFrames(receipt, logs.Length, out FrameReceiptForRpc[]? frames))
+            foreach (LogEntryForRpc log in CommittedLogs.Of(receipt))
             {
-                int start = 0;
-                foreach (FrameReceiptForRpc frame in frames)
-                {
-                    int count = frame.Logs?.Length ?? 0;
-                    if (frame.Status == TxFrameReceipt.StatusSuccess)
-                    {
-                        AddDeposits(result, logs, start, count);
-                    }
+                if (log.Address != engineParameters.OptimismPortalProxy) continue;
+                if (log.Topics is not { Length: > 0 } topics || topics[0] != DepositEvent.ABIHash) continue;
 
-                    start += count;
+                try
+                {
+                    Transaction tx = DecodeDepositTransactionFromLogEvent(log);
+                    result.Add(tx);
                 }
-            }
-            else if (receipt.Status == StatusCode.Success)
-            {
-                AddDeposits(result, logs, 0, logs.Length);
+                catch (Exception e)
+                {
+                    throw new ArgumentException($"Failed to decode {nameof(Transaction)} from {nameof(LogEntryForRpc)}", e);
+                }
             }
         }
         return result;
-    }
-
-    /// <summary>Matches a frame transaction's per-frame receipts to the run of receipt logs each frame committed.</summary>
-    /// <remarks>
-    /// EIP-8141 carries no transaction-level status: the receipt status is the aggregate over the frames, so
-    /// gating on it discards a deposit an independent frame committed. The transaction's log set is the frame
-    /// logs concatenated in frame order, so each frame claims the next run of its own length. Frames that do
-    /// not account for exactly the logs the receipt carries are unattributable, leaving the caller the aggregate.
-    /// </remarks>
-    private static bool TryGetAttributableFrames(ReceiptForRpc receipt, int logCount, [NotNullWhen(true)] out FrameReceiptForRpc[]? frames)
-    {
-        frames = receipt.FrameReceipts;
-        if (receipt.Type != TxType.FrameTx || frames is not { Length: > 0 }) return false;
-
-        int total = 0;
-        foreach (FrameReceiptForRpc frame in frames)
-        {
-            if (frame is null) return false;
-            total += frame.Logs?.Length ?? 0;
-        }
-
-        return total == logCount;
-    }
-
-    private void AddDeposits(List<Transaction> result, LogEntryForRpc[] logs, int start, int count)
-    {
-        for (int i = start; i < start + count; i++)
-        {
-            LogEntryForRpc log = logs[i];
-            if (log.Address != engineParameters.OptimismPortalProxy) continue;
-            if (log.Topics.Length == 0 || log.Topics[0] != DepositEvent.ABIHash) continue;
-
-            try
-            {
-                Transaction tx = DecodeDepositTransactionFromLogEvent(log);
-                result.Add(tx);
-            }
-            catch (Exception e)
-            {
-                throw new ArgumentException($"Failed to decode {nameof(Transaction)} from {nameof(LogEntryForRpc)}", e);
-            }
-        }
     }
 
     /*

--- a/src/Nethermind/Nethermind.Optimism/CL/Derivation/SystemConfigDeriver.cs
+++ b/src/Nethermind/Nethermind.Optimism/CL/Derivation/SystemConfigDeriver.cs
@@ -7,7 +7,6 @@ using Nethermind.Abi;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Evm;
 using Nethermind.JsonRpc.Data;
 
 namespace Nethermind.Optimism.CL.Derivation;
@@ -51,11 +50,9 @@ public class SystemConfigDeriver(
 
         foreach (ReceiptForRpc receipt in receipts)
         {
-            if (receipt.Status != StatusCode.Success) continue;
-
-            foreach (LogEntryForRpc log in receipt.Logs ?? [])
+            foreach (LogEntryForRpc log in CommittedLogs.Of(receipt))
             {
-                if (log.Address == systemConfigProxy && log.Topics.Length > 0 && log.Topics[0] == SystemConfigUpdate.EventABIHash)
+                if (log.Address == systemConfigProxy && log.Topics is { Length: > 0 } topics && topics[0] == SystemConfigUpdate.EventABIHash)
                 {
                     config = UpdateSystemConfigFromLogEvent(config, log);
                 }


### PR DESCRIPTION
Addresses a **P1** review thread on #12526 (`DepositTransactionBuilder.cs:82`).

## Problem

An EIP-8141 frame transaction carries no transaction-level status. `TxFrameReceipt.AggregateStatus` derives one by folding the frames: it returns `StatusFailure` as soon as any frame's status is not `StatusSuccess` (so a reverted *or* skipped frame fails the whole receipt), and `StatusSuccess` only when every frame succeeded.

`BuildUserDepositTransactions` gated on that aggregate and skipped the entire receipt. A SENDER frame that deposited into the portal and committed would therefore have its `TransactionDeposited` log discarded because an unrelated later frame in the same transaction reverted — a valid L1 deposit lost during L2 derivation, i.e. user funds not credited.

## Fix

The per-frame receipts do carry enough information to attribute logs. `TxFrameReceipt.ConcatLogs` builds the transaction's log set as the frame logs concatenated in frame order, and every construction path uses it (the processor's `MarkAsSuccess`, `BuildFailedReceipt`, the wire decoder, and `ReceiptForRpc.ToReceipt`). So each frame receipt claims the next run of `Logs.Length` entries in the receipt's log array.

Derivation now walks the frames, and derives deposits only from the runs belonging to frames whose *own* status is `StatusSuccess`. `StatusFailure` and `StatusSkipped` frames are excluded, so the fix does not swing the other way: a deposit log attributed to a frame that reverted is not credited even if the receipt's reported status says success — consistent with `ReceiptForRpc.ToReceipt`, which already treats the frames as authoritative over the status field.

The aggregate gate is kept as the conservative fallback for receipts whose frames cannot be attributed (not a frame transaction, no `frameReceipts`, a null entry, or frame log counts that do not sum to the receipt's log count). Losing a deposit is bad; crediting one L1 reverted is worse, so an unattributable payload keeps the old behaviour.

Note that honest execution never produces a reverted frame with logs — `TransactionProcessorBase.FrameTx` writes `frameLogs = []` unless the frame succeeded. The negative case is reachable only from a malformed L1 RPC payload, which is exactly the untrusted input this component consumes.

## Tests

`DepositTransactionBuilderTest` gains frame-transaction coverage:

- `DeriveUserDeposits_FrameTx_CommittedDepositSurvivesUnrelatedFrameRevert` — the requested regression: success frame with the deposit log, later independent frame reverts, aggregate status 0. Red before (0 deposits), green after (1).
- `DeriveUserDeposits_FrameTx_AttributesLogsInFrameOrder` — reverted frame's deposit log at index 0, committed frame's at index 1; only the second is credited, which also exercises the run offset. Red before, green after.
- `DeriveUserDeposits_FrameTx_RevertedFrameDepositIsNotCredited` — negative case, parameterised over a receipt status of 0 and of 1. The status-1 variant (payload contradicting its frames) was red before and is green after; the status-0 variant guards against over-correcting.
- `DeriveUserDeposits_FrameTx_SkippedFrameDepositIsNotCredited` — `StatusSkipped` is not success.
- `DeriveUserDeposits_FrameTx_UnattributableFramesFallBackToAggregateStatus` — frame log counts disagreeing with the receipt's logs fall back to the aggregate gate.

Full runs: `Nethermind.Optimism.Test` 735/735, `Nethermind.Evm.Test` 10843 passed / 19 skipped, `Nethermind.Blockchain.Test` 1872 passed / 151 skipped. Build clean, 0 warnings.
