### PR TITLE
fix(rpc): bound frame signature verification by the gas cap and map a signature-free envelope

### DIFF
--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -290,9 +290,15 @@ public static class FrameTxValidation
     /// an ARBITRARY entry contributes only its cheap structural-check cost, its witness being verified by frame code.
     /// </summary>
     public static ulong SignatureVerificationWorkGas(Transaction transaction)
+        => SignatureVerificationWorkGas(transaction.FrameSignatures);
+
+    /// <inheritdoc cref="SignatureVerificationWorkGas(Transaction)"/>
+    /// <remarks>Takes the entries directly, for a caller that holds them before a transaction exists —
+    /// the shape <see cref="TotalGasLimit"/> already has for frames.</remarks>
+    public static ulong SignatureVerificationWorkGas(TxFrameSignature[]? signatures)
     {
         ulong total = 0;
-        foreach (TxFrameSignature signature in transaction.FrameSignatures ?? [])
+        foreach (TxFrameSignature signature in signatures ?? [])
         {
             total = Saturating(total, SignatureVerificationGas(signature.Scheme));
         }

--- a/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/ICodeInfoRepository.cs
@@ -10,6 +10,12 @@ using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.Precompiles;
 namespace Nethermind.Evm;
 
+/// <remarks>
+/// Extension contract: there is no base class to derive from, so an added member is a compile error for every
+/// implementation, deliberately. A wrapping repository has to answer for the one it wraps, and a default body
+/// would let a missing forward return the terminal answer silently — the reason <see cref="IsCodeOverridable"/>
+/// had its <c>=> false</c> default stripped again in #12282.
+/// </remarks>
 public interface ICodeInfoRepository
 {
     /// <summary>Whether account code may be overridden (e.g. <c>eth_call</c> state overrides), disabling the simple-transfer fast path.</summary>

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
@@ -68,8 +68,12 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
         // Transaction.GasLimit leaves the work a frame transaction asks for unbounded.
         ulong effectiveCap = gasCap.EffectiveGasCap();
         ulong totalFrameGas = FrameTxValidation.TotalGasLimit(frames);
-        if (totalFrameGas > effectiveCap)
-            return RpcTransactionErrors.FrameGasAboveCap(totalFrameGas, effectiveCap);
+        // The processor verifies every entry before it derives any gas budget, so an unpriced signature list
+        // would buy elliptic-curve work no frame ever pays for. Saturates rather than wrapping past the cap.
+        ulong signatureGas = FrameTxValidation.SignatureVerificationWorkGas(signatures);
+        ulong reservedGas = totalFrameGas > ulong.MaxValue - signatureGas ? ulong.MaxValue : totalFrameGas + signatureGas;
+        if (reservedGas > effectiveCap)
+            return RpcTransactionErrors.FrameGasAboveCap(reservedGas, effectiveCap);
 
         Transaction tx = baseResult.Data;
         // The invariant FrameTxDecoder establishes for a decoded frame tx, so GasLimit readers see the same

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
@@ -68,12 +68,12 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
         // Transaction.GasLimit leaves the work a frame transaction asks for unbounded.
         ulong effectiveCap = gasCap.EffectiveGasCap();
         ulong totalFrameGas = FrameTxValidation.TotalGasLimit(frames);
-        // The processor verifies every entry before it derives any gas budget, so an unpriced signature list
-        // would buy elliptic-curve work no frame ever pays for. Saturates rather than wrapping past the cap.
+        // A bound on work, not the on-chain price TryCalculateGasBudget derives: the processor verifies every
+        // entry before any budget exists, so an unpriced signature list buys recoveries no frame pays for.
         ulong signatureGas = FrameTxValidation.SignatureVerificationWorkGas(signatures);
         ulong reservedGas = totalFrameGas > ulong.MaxValue - signatureGas ? ulong.MaxValue : totalFrameGas + signatureGas;
         if (reservedGas > effectiveCap)
-            return RpcTransactionErrors.FrameGasAboveCap(reservedGas, effectiveCap);
+            return RpcTransactionErrors.FrameGasAboveCap(totalFrameGas, signatureGas, effectiveCap);
 
         Transaction tx = baseResult.Data;
         // The invariant FrameTxDecoder establishes for a decoded frame tx, so GasLimit readers see the same

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RpcTransactionErrors.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RpcTransactionErrors.cs
@@ -20,8 +20,12 @@ public static class RpcTransactionErrors
 
     public static string NullEntryIn(string field) => $"{field} must not contain a null entry";
 
-    /// <summary>Reports the gas an EIP-8141 frame transaction reserves against the RPC cap: its frame gas
-    /// limits plus the signature verification the processor runs before deriving any budget.</summary>
-    public static string FrameGasAboveCap(ulong reservedGas, ulong gasCap)
-        => $"frame gas limits and signature verification ({reservedGas}) exceed the gas cap ({gasCap})";
+    /// <summary>Reports the gas an EIP-8141 frame transaction reserves against the RPC cap.</summary>
+    /// <remarks>The two terms are reported apart so the caller can see which one it has to shrink; either
+    /// may be zero, and a signature-free transaction is the common case.</remarks>
+    /// <param name="frameGas">The sum of the frame gas limits.</param>
+    /// <param name="signatureGas">The signature verification the processor runs before deriving any budget.</param>
+    /// <param name="gasCap">The cap the reservation exceeded.</param>
+    public static string FrameGasAboveCap(ulong frameGas, ulong signatureGas, ulong gasCap)
+        => $"frame gas limits ({frameGas}) and signature verification ({signatureGas}) exceed the gas cap ({gasCap})";
 }

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RpcTransactionErrors.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/RpcTransactionErrors.cs
@@ -20,6 +20,8 @@ public static class RpcTransactionErrors
 
     public static string NullEntryIn(string field) => $"{field} must not contain a null entry";
 
-    public static string FrameGasAboveCap(ulong totalGasLimit, ulong gasCap)
-        => $"frame gas limits ({totalGasLimit}) exceed the gas cap ({gasCap})";
+    /// <summary>Reports the gas an EIP-8141 frame transaction reserves against the RPC cap: its frame gas
+    /// limits plus the signature verification the processor runs before deriving any budget.</summary>
+    public static string FrameGasAboveCap(ulong reservedGas, ulong gasCap)
+        => $"frame gas limits and signature verification ({reservedGas}) exceed the gas cap ({gasCap})";
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/ParityRpcModuleTests.cs
@@ -32,6 +32,7 @@ using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
 using System;
+using System.Text.Json;
 using Nethermind.Serialization.Json;
 
 namespace Nethermind.JsonRpc.Test.Modules
@@ -257,8 +258,8 @@ namespace Nethermind.JsonRpc.Test.Modules
             return peer;
         }
 
-        private IParityRpcModule CreateParityRpcModule(IPeerManager? peerManager = null) => new ParityRpcModule(_ethereumEcdsa,
-                _txPool,
+        private IParityRpcModule CreateParityRpcModule(IPeerManager? peerManager = null, ITxPool? txPool = null) => new ParityRpcModule(_ethereumEcdsa,
+                txPool ?? _txPool,
                 _blockTree,
                 _receiptStorage,
                 new Enode(TestItem.PublicKeyA, IPAddress.Loopback, 8545),
@@ -292,6 +293,42 @@ namespace Nethermind.JsonRpc.Test.Modules
             string serialized = await RpcTest.TestSerializedRequest(_parityRpcModule, "parity_pendingTransactions", "0x0000000000000000000000000000000000000005");
             string expectedResult = "{\"jsonrpc\":\"2.0\",\"result\":[],\"id\":67}";
             Assert.That(serialized, Is.EqualTo(expectedResult));
+        }
+
+        /// <remarks>
+        /// An EIP-8141 frame transaction is accepted with no envelope signature, and every pending transaction
+        /// is mapped through the same constructor, so one of them in the pool used to throw the whole request.
+        /// </remarks>
+        [Test]
+        public async Task parity_pendingTransactions_maps_a_pool_holding_a_frame_transaction()
+        {
+            Transaction ordinary = Build.A.Transaction.Signed(_ethereumEcdsa, TestItem.PrivateKeyD, false)
+                .WithSenderAddress(TestItem.AddressD).TestObject;
+            ordinary.Signature!.V = 37;
+
+            Transaction frameTx = FrameTxTestFrames.FrameTx(TestItem.AddressA, [], FrameTxTestFrames.SelfVerify());
+            frameTx.ChainId = MainnetSpecProvider.Instance.ChainId;
+            frameTx.To = null;
+
+            ITxPool txPool = Substitute.For<ITxPool>();
+            txPool.GetPendingTransactions().Returns([ordinary, frameTx]);
+
+            string serialized = await RpcTest.TestSerializedRequest(CreateParityRpcModule(txPool: txPool), "parity_pendingTransactions");
+
+            using JsonDocument document = JsonDocument.Parse(serialized);
+            JsonElement frame = document.RootElement.GetProperty("result")[1];
+            Assert.Multiple(() =>
+            {
+                // The explicit chain id of the signed payload, which is the only place it survives.
+                Assert.That(frame.GetProperty("chainId").GetString(), Is.EqualTo("0x1"));
+                // Absent rather than a fabricated zero-value signature.
+                Assert.That(frame.GetProperty("r").ValueKind, Is.EqualTo(JsonValueKind.Null));
+                Assert.That(frame.GetProperty("s").ValueKind, Is.EqualTo(JsonValueKind.Null));
+                Assert.That(frame.GetProperty("v").GetString(), Is.EqualTo("0x0"));
+                Assert.That(frame.GetProperty("standardV").GetString(), Is.EqualTo("0x0"));
+                Assert.That(frame.TryGetProperty("publicKey", out _), Is.False, "no envelope key to recover");
+                Assert.That(frame.GetProperty("creates").ValueKind, Is.EqualTo(JsonValueKind.Null));
+            });
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -288,6 +288,25 @@ public class FrameTransactionForRpcTests
 
     private const int Secp256k1EntriesAtTheCap = (int)(GasCap / Eip8141Constants.Secp256k1VerificationGasCost);
 
+    /// <summary><paramref name="count"/> verifying SECP256K1 entries, each costing a full recovery.</summary>
+    /// <remarks>An explicit non-zero digest and a named signer, so every entry is structurally acceptable.</remarks>
+    private static FrameSignatureForRpc[] Secp256k1Signatures(int count)
+    {
+        FrameSignatureForRpc[] signatures = new FrameSignatureForRpc[count];
+        for (int i = 0; i < count; i++)
+        {
+            signatures[i] = new FrameSignatureForRpc
+            {
+                Scheme = TxFrameSignature.SchemeSecp256k1,
+                Signer = TestItem.AddressA,
+                Msg = TestItem.KeccakA.BytesToArray(),
+                Signature = new byte[TxFrameSignature.Secp256k1SignatureLength],
+            };
+        }
+
+        return signatures;
+    }
+
     /// <summary>The RPC gas cap also bounds the signature verification a frame transaction asks for.</summary>
     /// <remarks>
     /// The processor runs <c>validate_signature</c> over every entry before it derives any gas budget, so
@@ -298,49 +317,17 @@ public class FrameTransactionForRpcTests
     [TestCase(Secp256k1EntriesAtTheCap + 1, true, TestName = "ToTransaction_SignatureWorkAboveTheCap_IsRejected")]
     public void FrameTransactionForRpc_ToTransaction_CountsSignatureVerificationAgainstTheCap(int entries, bool expectedError)
     {
-        FrameSignatureForRpc[] signatures = new FrameSignatureForRpc[entries];
-        for (int i = 0; i < entries; i++)
-        {
-            // An explicit non-zero digest and a named signer, so the entry is structurally
-            // acceptable and each repeat costs a full recovery.
-            signatures[i] = new FrameSignatureForRpc
-            {
-                Scheme = TxFrameSignature.SchemeSecp256k1,
-                Signer = TestItem.AddressA,
-                Msg = TestItem.KeccakA.BytesToArray(),
-                Signature = new byte[TxFrameSignature.Secp256k1SignatureLength],
-            };
-        }
-
         FrameTransactionForRpc rpc = new()
         {
             To = TestItem.AddressB,
             // Deliberately free of frame gas, so only the signature list can breach the cap.
             Frames = [new FrameForRpc { Mode = TxFrame.ModeVerify, Flags = TxFrame.ApproveExecutionAndPayment }],
-            Signatures = signatures,
+            Signatures = Secp256k1Signatures(entries),
         };
 
         Result<Transaction> result = rpc.ToTransaction(validateUserInput: true, gasCap: GasCap);
 
         Assert.That(result.IsError, Is.EqualTo(expectedError), result.Error);
-    }
-
-    // Signature work is charged on top of the frame limits, so neither alone hides the other.
-    [Test]
-    public void FrameTransactionForRpc_ToTransaction_AddsSignatureWorkToTheFrameGas()
-    {
-        FrameTransactionForRpc rpc = new()
-        {
-            To = TestItem.AddressB,
-            Frames = [new FrameForRpc { Mode = TxFrame.ModeVerify, ExecutionGasLimit = GasCap }],
-            Signatures = [new FrameSignatureForRpc { Scheme = TxFrameSignature.SchemeSecp256k1, Signer = TestItem.AddressA }],
-        };
-
-        Result<Transaction> result = rpc.ToTransaction(validateUserInput: true, gasCap: GasCap);
-
-        Assert.That(result.IsError, Is.True);
-        // GasLimit still reports the frame sum alone, matching FrameTxDecoder.
-        Assert.That(rpc.ToTransaction(validateUserInput: true).Data!.GasLimit, Is.EqualTo(GasCap));
     }
 
     /// <remarks>
@@ -351,17 +338,11 @@ public class FrameTransactionForRpcTests
     [TestCase(2, 2 * Eip8141Constants.Secp256k1VerificationGasCost, TestName = "ToTransaction_AboveTheCapWithSignatures_ReportsBothTerms")]
     public void FrameTransactionForRpc_ToTransaction_ReportsTheFrameAndSignatureTermsApart(int entries, ulong expectedSignatureGas)
     {
-        FrameSignatureForRpc[] signatures = new FrameSignatureForRpc[entries];
-        for (int i = 0; i < entries; i++)
-        {
-            signatures[i] = new FrameSignatureForRpc { Scheme = TxFrameSignature.SchemeSecp256k1, Signer = TestItem.AddressA };
-        }
-
         FrameTransactionForRpc rpc = new()
         {
             To = TestItem.AddressB,
             Frames = [new FrameForRpc { Mode = TxFrame.ModeVerify, Flags = TxFrame.ApproveExecutionAndPayment, ExecutionGasLimit = GasCap + 1 }],
-            Signatures = signatures,
+            Signatures = Secp256k1Signatures(entries),
         };
 
         Result<Transaction> result = rpc.ToTransaction(validateUserInput: true, gasCap: GasCap);
@@ -370,18 +351,22 @@ public class FrameTransactionForRpcTests
             $"frame gas limits ({GasCap + 1}) and signature verification ({expectedSignatureGas}) exceed the gas cap ({GasCap})"));
     }
 
-    // The combined reservation saturates rather than wrapping to a value under the cap.
-    [Test]
-    public void FrameTransactionForRpc_ToTransaction_SaturatesTheReservationInsteadOfWrapping()
+    /// <summary>Signature work is charged on top of the frame limits, so neither alone hides the other.</summary>
+    /// <remarks>The saturating case also pins that the combined reservation does not wrap to a value under the cap.</remarks>
+    [TestCase(GasCap, TestName = "ToTransaction_SignatureWorkOnTopOfFrameGasAtTheCap_IsRejected")]
+    [TestCase(ulong.MaxValue, TestName = "ToTransaction_SignatureWorkSaturatingTheReservation_IsRejected")]
+    public void FrameTransactionForRpc_ToTransaction_AddsSignatureWorkToTheFrameGas(ulong frameGas)
     {
         FrameTransactionForRpc rpc = new()
         {
             To = TestItem.AddressB,
-            Frames = [new FrameForRpc { Mode = TxFrame.ModeVerify, ExecutionGasLimit = ulong.MaxValue }],
-            Signatures = [new FrameSignatureForRpc { Scheme = TxFrameSignature.SchemeSecp256k1, Signer = TestItem.AddressA }],
+            Frames = [new FrameForRpc { Mode = TxFrame.ModeVerify, ExecutionGasLimit = frameGas }],
+            Signatures = Secp256k1Signatures(1),
         };
 
         Assert.That(rpc.ToTransaction(validateUserInput: true, gasCap: GasCap).IsError, Is.True);
+        // GasLimit still reports the frame sum alone, matching FrameTxDecoder.
+        Assert.That(rpc.ToTransaction(validateUserInput: true).Data!.GasLimit, Is.EqualTo(frameGas));
     }
 
     private static Transaction BuildKeyedFrameTx(UInt256[]? nonceKeys, ulong nonceSeq = 3)

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -301,8 +301,8 @@ public class FrameTransactionForRpcTests
         FrameSignatureForRpc[] signatures = new FrameSignatureForRpc[entries];
         for (int i = 0; i < entries; i++)
         {
-            // The reviewer's shape: an explicit non-zero digest and a named signer, so the entry is
-            // structurally acceptable and each repeat costs a full recovery.
+            // An explicit non-zero digest and a named signer, so the entry is structurally
+            // acceptable and each repeat costs a full recovery.
             signatures[i] = new FrameSignatureForRpc
             {
                 Scheme = TxFrameSignature.SchemeSecp256k1,
@@ -341,6 +341,33 @@ public class FrameTransactionForRpcTests
         Assert.That(result.IsError, Is.True);
         // GasLimit still reports the frame sum alone, matching FrameTxDecoder.
         Assert.That(rpc.ToTransaction(validateUserInput: true).Data!.GasLimit, Is.EqualTo(GasCap));
+    }
+
+    /// <remarks>
+    /// The rejection reports the two terms apart, because the common one is a frame transaction carrying no
+    /// signatures at all: a single combined figure blames a verification cost that contributed nothing to it.
+    /// </remarks>
+    [TestCase(0, 0UL, TestName = "ToTransaction_AboveTheCapWithoutSignatures_ReportsAZeroVerificationTerm")]
+    [TestCase(2, 2 * Eip8141Constants.Secp256k1VerificationGasCost, TestName = "ToTransaction_AboveTheCapWithSignatures_ReportsBothTerms")]
+    public void FrameTransactionForRpc_ToTransaction_ReportsTheFrameAndSignatureTermsApart(int entries, ulong expectedSignatureGas)
+    {
+        FrameSignatureForRpc[] signatures = new FrameSignatureForRpc[entries];
+        for (int i = 0; i < entries; i++)
+        {
+            signatures[i] = new FrameSignatureForRpc { Scheme = TxFrameSignature.SchemeSecp256k1, Signer = TestItem.AddressA };
+        }
+
+        FrameTransactionForRpc rpc = new()
+        {
+            To = TestItem.AddressB,
+            Frames = [new FrameForRpc { Mode = TxFrame.ModeVerify, Flags = TxFrame.ApproveExecutionAndPayment, ExecutionGasLimit = GasCap + 1 }],
+            Signatures = signatures,
+        };
+
+        Result<Transaction> result = rpc.ToTransaction(validateUserInput: true, gasCap: GasCap);
+
+        Assert.That(result.Error, Is.EqualTo(
+            $"frame gas limits ({GasCap + 1}) and signature verification ({expectedSignatureGas}) exceed the gas cap ({GasCap})"));
     }
 
     // The combined reservation saturates rather than wrapping to a value under the cap.

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -286,6 +286,77 @@ public class FrameTransactionForRpcTests
         Assert.That(rpc.ToTransaction(validateUserInput: true).IsError, Is.False);
     }
 
+    private const int Secp256k1EntriesAtTheCap = (int)(GasCap / Eip8141Constants.Secp256k1VerificationGasCost);
+
+    /// <summary>The RPC gas cap also bounds the signature verification a frame transaction asks for.</summary>
+    /// <remarks>
+    /// The processor runs <c>validate_signature</c> over every entry before it derives any gas budget, so
+    /// capping the frame limits alone leaves the elliptic-curve work unpriced: a request can keep its frames
+    /// tiny and repeat a verifying SECP256K1 entry to buy arbitrarily many recoveries off one call.
+    /// </remarks>
+    [TestCase(Secp256k1EntriesAtTheCap, false, TestName = "ToTransaction_SignatureWorkAtTheCap_IsAccepted")]
+    [TestCase(Secp256k1EntriesAtTheCap + 1, true, TestName = "ToTransaction_SignatureWorkAboveTheCap_IsRejected")]
+    public void FrameTransactionForRpc_ToTransaction_CountsSignatureVerificationAgainstTheCap(int entries, bool expectedError)
+    {
+        FrameSignatureForRpc[] signatures = new FrameSignatureForRpc[entries];
+        for (int i = 0; i < entries; i++)
+        {
+            // The reviewer's shape: an explicit non-zero digest and a named signer, so the entry is
+            // structurally acceptable and each repeat costs a full recovery.
+            signatures[i] = new FrameSignatureForRpc
+            {
+                Scheme = TxFrameSignature.SchemeSecp256k1,
+                Signer = TestItem.AddressA,
+                Msg = TestItem.KeccakA.BytesToArray(),
+                Signature = new byte[TxFrameSignature.Secp256k1SignatureLength],
+            };
+        }
+
+        FrameTransactionForRpc rpc = new()
+        {
+            To = TestItem.AddressB,
+            // Deliberately free of frame gas, so only the signature list can breach the cap.
+            Frames = [new FrameForRpc { Mode = TxFrame.ModeVerify, Flags = TxFrame.ApproveExecutionAndPayment }],
+            Signatures = signatures,
+        };
+
+        Result<Transaction> result = rpc.ToTransaction(validateUserInput: true, gasCap: GasCap);
+
+        Assert.That(result.IsError, Is.EqualTo(expectedError), result.Error);
+    }
+
+    // Signature work is charged on top of the frame limits, so neither alone hides the other.
+    [Test]
+    public void FrameTransactionForRpc_ToTransaction_AddsSignatureWorkToTheFrameGas()
+    {
+        FrameTransactionForRpc rpc = new()
+        {
+            To = TestItem.AddressB,
+            Frames = [new FrameForRpc { Mode = TxFrame.ModeVerify, ExecutionGasLimit = GasCap }],
+            Signatures = [new FrameSignatureForRpc { Scheme = TxFrameSignature.SchemeSecp256k1, Signer = TestItem.AddressA }],
+        };
+
+        Result<Transaction> result = rpc.ToTransaction(validateUserInput: true, gasCap: GasCap);
+
+        Assert.That(result.IsError, Is.True);
+        // GasLimit still reports the frame sum alone, matching FrameTxDecoder.
+        Assert.That(rpc.ToTransaction(validateUserInput: true).Data!.GasLimit, Is.EqualTo(GasCap));
+    }
+
+    // The combined reservation saturates rather than wrapping to a value under the cap.
+    [Test]
+    public void FrameTransactionForRpc_ToTransaction_SaturatesTheReservationInsteadOfWrapping()
+    {
+        FrameTransactionForRpc rpc = new()
+        {
+            To = TestItem.AddressB,
+            Frames = [new FrameForRpc { Mode = TxFrame.ModeVerify, ExecutionGasLimit = ulong.MaxValue }],
+            Signatures = [new FrameSignatureForRpc { Scheme = TxFrameSignature.SchemeSecp256k1, Signer = TestItem.AddressA }],
+        };
+
+        Assert.That(rpc.ToTransaction(validateUserInput: true, gasCap: GasCap).IsError, Is.True);
+    }
+
     private static Transaction BuildKeyedFrameTx(UInt256[]? nonceKeys, ulong nonceSeq = 3)
     {
         Transaction tx = BuildMinimalFrameTx();

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityTransaction.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/Parity/ParityTransaction.cs
@@ -46,6 +46,12 @@ namespace Nethermind.JsonRpc.Modules.Parity
         {
         }
 
+        /// <summary>Maps a transaction to the Parity representation.</summary>
+        /// <remarks>
+        /// An EIP-8141 frame transaction has no envelope signature, so <see cref="R"/>/<see cref="S"/> are
+        /// reported absent and <see cref="V"/>/<see cref="StandardV"/> zero rather than fabricated; its
+        /// <see cref="ChainId"/> comes from the explicit field the signed payload carries.
+        /// </remarks>
         public ParityTransaction(Transaction transaction, byte[] raw, PublicKey publicKey,
             Hash256 blockHash = null, UInt256? blockNumber = null, UInt256? txIndex = null)
         {
@@ -62,11 +68,19 @@ namespace Nethermind.JsonRpc.Modules.Parity
             Raw = raw;
             Input = transaction.Data.AsArray();
             PublicKey = publicKey;
-            ChainId = transaction.Signature.ChainId;
-            R = transaction.Signature.R;
-            S = transaction.Signature.S;
-            V = (UInt256)transaction.Signature.V;
-            StandardV = transaction.Signature.RecoveryId;
+            if (transaction.Signature is { } signature)
+            {
+                ChainId = signature.ChainId;
+                R = signature.R;
+                S = signature.S;
+                V = (UInt256)signature.V;
+                StandardV = signature.RecoveryId;
+            }
+            else
+            {
+                ChainId = transaction.ChainId;
+            }
+
             // TKS: it does not seem to work with CREATE2
             Creates = transaction.CreatesTopLevelContract ? ContractAddress.From(transaction.SenderAddress, transaction.Nonce) : null;
         }

--- a/src/Nethermind/Nethermind.TxPool/IChainHeadInfoProvider.cs
+++ b/src/Nethermind/Nethermind.TxPool/IChainHeadInfoProvider.cs
@@ -9,6 +9,11 @@ using Nethermind.Int256;
 
 namespace Nethermind.TxPool
 {
+    /// <remarks>
+    /// Extension contract: derive from <c>ChainHeadInfoProvider</c>, which is public and non-sealed, and added
+    /// head facts arrive tracked. Implementing this interface directly opts into a compile error per addition —
+    /// no member here carries a default body, because a stale or zero head fact is a silent wrong answer.
+    /// </remarks>
     public interface IChainHeadInfoProvider
     {
         IChainHeadSpecProvider SpecProvider { get; }


### PR DESCRIPTION
## Changes

Addresses three P2 review threads on #12526, all on the externally-visible API surface.

**1. The RPC gas cap did not cover signature verification.** `FrameTransactionForRpc.ToTransaction` capped the sum of the frame gas limits. `ExecuteFrameTx` runs `validate_signature` over every entry *before* `TryCalculateGasBudget`, and nothing bounds the entry count — `MaxFrames` is 64, but the signature list has no equivalent limit. So a request could keep its frames at zero gas and repeat a structurally valid SECP256K1 entry (explicit non-zero 32-byte digest, named signer) to buy arbitrarily many `ecrecover` calls per `eth_call`, at 2,800 gas of work each, entirely outside the cap. The reservation now adds the scheme-weighted verification work, saturating instead of wrapping past the cap. `Transaction.GasLimit` still reports the frame sum alone, so the `FrameTxDecoder` invariant is unchanged.

**2. `parity_pendingTransactions` threw on any frame transaction in the pool.** `ParityTransaction`'s constructor dereferenced `transaction.Signature` for ChainId/R/S/V/RecoveryId. A frame transaction is accepted with no envelope signature, and the module maps *every* pending transaction through that constructor inside one `.Select(...).ToArray()`, so one frame transaction took out the whole method with an `Internal error`. Verified as a real `NullReferenceException` at `ParityTransaction.cs:65` before fixing.

The signature-free envelope now reports:

| field | frame transaction | rationale |
|---|---|---|
| `chainId` | the transaction's explicit chain id | the only place it survives; it is a signed field of the payload |
| `r`, `s` | `null` (absent) | there is no envelope signature; a zero-value one would be a fabrication |
| `v`, `standardV` | `0x0` | non-nullable on the wire; making them nullable would change the shape for every transaction |
| `publicKey` | omitted | no envelope key to recover, as the module already passes `null` |

The signed path is byte-for-byte untouched — the existing `parity_pendingTransactions` serialization assertions still pass unchanged.

**3. Extension-API breaks: documented, not shimmed.** No compatibility shims. See the thread reply for the evidence; the short version is that this repo has never used a staged deprecation for a public API removal in these projects, and the one time a compat default *was* added to `ICodeInfoRepository` it was deliberately removed again six weeks later (#11804 → #12282) for exactly the reason a default would be wrong here. What was missing is that the contract was practice and never written down, so this adds a `<remarks>` to `ICodeInfoRepository` and `IChainHeadInfoProvider` stating the extension path and why no member carries a default body — the same remedy that settled the sibling `IReleaseSpec` thread in #13240.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: <!-- description -->

## Testing

Red/green pairs for both fixes, produced by reverting the two production files and rebuilding.

**Red** (production fix reverted, tests present) — 3 failures:

```
failed ToTransaction_SignatureWorkAboveTheCap_IsRejected
    Assert.That(result.IsError, Is.EqualTo(expectedError))
failed FrameTransactionForRpc_ToTransaction_AddsSignatureWorkToTheFrameGas
    Assert.That(result.IsError, Is.True)
failed parity_pendingTransactions_maps_a_pool_holding_a_frame_transaction
    System.NullReferenceException
      at Nethermind.JsonRpc.Modules.Parity.ParityTransaction..ctor(...) ParityTransaction.cs:line 65
      at Nethermind.JsonRpc.Modules.Parity.ParityRpcModule.parity_pendingTransactions(...)
```

**Green** — same tests, fix restored: 56/56 in the two fixtures.

### Requires testing

- [ ] Yes
- [x] No

Full suites, release, on the merge commit:

| suite | total | failed | passed | skipped |
|---|---|---|---|---|
| `Nethermind.JsonRpc.Test` | 2058 | 0 | 2036 | 22 |
| `Nethermind.Facade.Test` | 139 | 0 | 139 | 0 |
| `Nethermind.TxPool.Test` | 1117 | 0 | 1093 | 24 |

`Nethermind.slnx` builds with 0 warnings, 0 errors; `dotnet format whitespace --verify-no-changes` is clean.

## Documentation

### Requires documentation update

- [ ] Yes
- [x] No

The reserved-gas semantics, the Parity field mapping and both interface extension contracts are documented in XML docs on the members themselves.
