### PR TITLE
fix(flatdb): bound sibling snapshots under a pinned head and re-execute pruned blocks

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/State/ReadOnlySnapshotBundleBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/ReadOnlySnapshotBundleBenchmark.cs
@@ -67,7 +67,7 @@ public class ReadOnlySnapshotBundleBenchmark
         // repository itself does not use the arena managers, so the persisted tier can stay unwired.
         SnapshotCompactor compactor = new(
             config, new CompactionSchedule(new MemDb(), config, NullLogManager.Instance),
-            resourcePool, new SnapshotRepository(null!, null!, NullSnapshotCatalog.Instance, config, NullLogManager.Instance),
+            resourcePool, new SnapshotRepository(null!, null!, NullSnapshotCatalog.Instance, config, NullLogManager.Instance, new SnapshotRetention()),
             NullLogManager.Instance);
         List<FlatSnapshot> allSnapshots = new(SnapshotCount);
         StateId currentStateId = new(0, Keccak.EmptyTreeHash);

--- a/src/Nethermind/Nethermind.Benchmark/State/SnapshotCompactionBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/State/SnapshotCompactionBenchmark.cs
@@ -65,7 +65,7 @@ public class SnapshotCompactionBenchmark
         CompactionSchedule schedule = new(new MemDb(), config, LimboLogs.Instance);
         // The repository only satisfies the compactor ctor; CompactSnapshotBundle never touches it, and the
         // repository itself does not use the arena managers, so the persisted tier can stay unwired.
-        SnapshotRepository repository = new(null!, null!, NullSnapshotCatalog.Instance, config, LimboLogs.Instance);
+        SnapshotRepository repository = new(null!, null!, NullSnapshotCatalog.Instance, config, LimboLogs.Instance, new SnapshotRetention());
         _compactor = new SnapshotCompactor(config, schedule, resourcePool, repository, LimboLogs.Instance);
 
         // Contract addresses and their account-path hashes are shared across every snapshot (the same hot

--- a/src/Nethermind/Nethermind.Blockchain/ReorgDepthFinalizedStateProvider.cs
+++ b/src/Nethermind/Nethermind.Blockchain/ReorgDepthFinalizedStateProvider.cs
@@ -12,6 +12,8 @@ public class ReorgDepthFinalizedStateProvider(IBlockTree blockTree) : IFinalized
 {
     public ulong FinalizedBlockNumber => blockTree.BestKnownNumber.SaturatingSub(Reorganization.MaxDepth);
 
+    public BlockHeader? Head => blockTree.Head?.Header;
+
     public Hash256? GetFinalizedStateRootAt(ulong blockNumber)
     {
         if (FinalizedBlockNumber < blockNumber) return null;

--- a/src/Nethermind/Nethermind.Core.Test/TestFinalizedStateProvider.cs
+++ b/src/Nethermind/Nethermind.Core.Test/TestFinalizedStateProvider.cs
@@ -19,6 +19,8 @@ public class TestFinalizedStateProvider(ulong depth) : IFinalizedStateProvider
     public TrieStore TrieStore { get; set; } = null!;
     private BlockHeader? _manualFinalizedPoint = null;
 
+    public BlockHeader? Head { get; set; }
+
     public ulong FinalizedBlockNumber
     {
         get

--- a/src/Nethermind/Nethermind.Core/Utils/SmallRefCountingDisposable.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/SmallRefCountingDisposable.cs
@@ -36,9 +36,6 @@ public abstract class SmallRefCountingDisposable(int initialCount = RefCountingL
 
     protected bool TryAcquireLease() => RefCountingLease.TryAcquire(ref _leases);
 
-    /// <summary>The current lease count, for holders that must know whether anyone else is reading.</summary>
-    protected long CurrentLeases => Volatile.Read(ref _leases);
-
     /// <summary>
     /// Disposes it once, decreasing the lease count by 1.
     /// </summary>

--- a/src/Nethermind/Nethermind.Core/Utils/SmallRefCountingDisposable.cs
+++ b/src/Nethermind/Nethermind.Core/Utils/SmallRefCountingDisposable.cs
@@ -36,6 +36,9 @@ public abstract class SmallRefCountingDisposable(int initialCount = RefCountingL
 
     protected bool TryAcquireLease() => RefCountingLease.TryAcquire(ref _leases);
 
+    /// <summary>The current lease count, for holders that must know whether anyone else is reading.</summary>
+    protected long CurrentLeases => Volatile.Read(ref _leases);
+
     /// <summary>
     /// Disposes it once, decreasing the lease count by 1.
     /// </summary>

--- a/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/FlatWorldStateModule.cs
@@ -55,7 +55,9 @@ public class FlatWorldStateModule(IFlatDbConfig flatDbConfig) : Module
                 ctx.Resolve<IFlatDbConfig>(),
                 ctx.Resolve<IBlocksConfig>(),
                 ctx.Resolve<ILogManager>(),
-                ctx.Resolve<IMetricsConfig>().EnableDetailedMetric))
+                ctx.Resolve<IMetricsConfig>().EnableDetailedMetric,
+                ctx.Resolve<SnapshotRetention>()))
+            .AddSingleton<SnapshotRetention>()
             .AddSingleton<IResourcePool, ResourcePool>()
             .AddSingleton<ITrieNodeCache, TrieNodeCache>()
             .AddSingleton<ICompactionSchedule, CompactionSchedule>()

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -207,6 +207,8 @@ public class MainPruningTrieStoreFactory
     {
         private ulong? _lastFinalizedBlockNumber = null;
 
+        public BlockHeader? Head => finalizedStateProvider.Head;
+
         public ulong FinalizedBlockNumber
         {
             get

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -14,6 +14,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Events;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Container;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.JsonRpc;
@@ -21,6 +22,7 @@ using Nethermind.Logging;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.State;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
@@ -34,6 +36,43 @@ namespace Nethermind.Merge.Plugin.Test;
 
 public partial class EngineModuleTests
 {
+    [Test]
+    public async Task forkChoiceUpdatedV1_pruned_state_preserves_canonical_replays_and_starts_sync_for_missing_forks([Values] bool canonical)
+    {
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(true);
+        using MergeTestBlockchain chain = await CreateBlockchain(configurer: builder => builder
+            .UpdateSingleton<IForkchoiceUpdatedHandler>(innerBuilder => innerBuilder.AddSingleton(stateReader)));
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+        IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 2, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
+        if (canonical)
+        {
+            ResultWrapper<ForkchoiceUpdatedV1Result> selected = await rpc.engine_forkchoiceUpdatedV1(new(branch[1].BlockHash, Keccak.Zero, Keccak.Zero));
+            Assert.That(selected.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
+        }
+
+        Hash256 previousHead = chain.BlockTree.HeadHash!;
+        Hash256 target = branch[0].BlockHash;
+        stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(false);
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(new(target, target, target));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(canonical ? PayloadStatus.Valid : PayloadStatus.Syncing));
+            Assert.That(chain.BlockTree.FinalizedHash, Is.EqualTo(target));
+            Assert.That(chain.BlockTree.SafeHash, Is.EqualTo(target));
+            Assert.That(chain.BlockTree.HeadHash, Is.EqualTo(canonical ? target : previousHead));
+            if (!canonical)
+            {
+                IBlockCacheService cache = chain.Container.Resolve<IBlockCacheService>();
+                Assert.That(cache.HeadBlockHash, Is.EqualTo(target));
+                Assert.That(cache.FinalizedHash, Is.EqualTo(target));
+                Assert.That(chain.BeaconPivot!.ProcessDestination?.Hash, Is.EqualTo(target));
+                Assert.That(chain.BeaconPivot.BeaconPivotExists(), Is.True);
+            }
+        }
+    }
+
     [Test]
     public async Task forkChoiceUpdatedV1_unknown_block_initiates_syncing()
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Blocks;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
@@ -39,8 +40,12 @@ namespace Nethermind.Merge.Plugin.Test;
 
 public partial class EngineModuleTests
 {
-    [Test]
-    public async Task forkChoiceUpdatedV1_pruned_state_recovery_only_changes_flat_forks([Values] bool canonical, [Values] bool useFlat)
+    [TestCase(false, false, false)]
+    [TestCase(true, false, false)]
+    [TestCase(false, true, false)]
+    [TestCase(true, true, false)]
+    [TestCase(false, true, true)]
+    public async Task forkChoiceUpdatedV1_pruned_state_recovery_only_changes_flat_forks(bool canonical, bool useFlat, bool missingBody)
     {
         IStateReader stateReader = Substitute.For<IStateReader>();
         ManualTimestamper recoveryClock = new(DateTime.UnixEpoch);
@@ -68,6 +73,15 @@ public partial class EngineModuleTests
         Hash256 target = branch[0].BlockHash;
         bool syncing = useFlat && !canonical;
         stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(false);
+        Block? removedBody = null;
+        IBlockStore blockStore = chain.Container.Resolve<IBlockStore>();
+        if (missingBody)
+        {
+            stateReader.HasStateForBlock(chain.BlockTree.Genesis).Returns(true);
+            removedBody = chain.BlockTree.FindBlock(target, BlockTreeLookupOptions.None)!;
+            blockStore.Delete(removedBody.Number, target);
+            Assert.That(chain.BlockTree.FindBlock(target, BlockTreeLookupOptions.None), Is.Null);
+        }
         ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(new(target, target, target));
 
         using (Assert.EnterMultipleScope())
@@ -111,6 +125,7 @@ public partial class EngineModuleTests
             ResultWrapper<ForkchoiceUpdatedV1Result> moved = await rpc.engine_forkchoiceUpdatedV1(new(alternative[0].BlockHash, Keccak.Zero, Keccak.Zero));
             Assert.That(moved.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
             stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(false);
+            if (missingBody) stateReader.HasStateForBlock(chain.BlockTree.Genesis).Returns(true);
             stateReader.ClearReceivedCalls();
             ResultWrapper<ForkchoiceUpdatedV1Result> changedHead = await rpc.engine_forkchoiceUpdatedV1(new(target, target, target));
             using (Assert.EnterMultipleScope())
@@ -119,6 +134,7 @@ public partial class EngineModuleTests
                 Assert.That(stateReader.ReceivedCalls().Count(), Is.GreaterThan(1), "a changed head must invalidate failed searches");
             }
 
+            if (removedBody is not null) blockStore.Insert(removedBody);
             stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(true);
             ResultWrapper<ForkchoiceUpdatedV1Result> available = await rpc.engine_forkchoiceUpdatedV1(new(target, target, target));
             using (Assert.EnterMultipleScope())

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.Synchronization.cs
@@ -13,6 +13,7 @@ using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Events;
+using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Container;
 using Nethermind.Crypto;
@@ -23,6 +24,8 @@ using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.Synchronization;
 using Nethermind.State;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
 using Nethermind.Synchronization;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.ParallelSync;
@@ -37,12 +40,18 @@ namespace Nethermind.Merge.Plugin.Test;
 public partial class EngineModuleTests
 {
     [Test]
-    public async Task forkChoiceUpdatedV1_pruned_state_preserves_canonical_replays_and_starts_sync_for_missing_forks([Values] bool canonical)
+    public async Task forkChoiceUpdatedV1_pruned_state_recovery_only_changes_flat_forks([Values] bool canonical, [Values] bool useFlat)
     {
         IStateReader stateReader = Substitute.For<IStateReader>();
+        ManualTimestamper recoveryClock = new(DateTime.UnixEpoch);
         stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(true);
-        using MergeTestBlockchain chain = await CreateBlockchain(configurer: builder => builder
-            .UpdateSingleton<IForkchoiceUpdatedHandler>(innerBuilder => innerBuilder.AddSingleton(stateReader)));
+        MergeTestBlockchain chainBuilder = CreateBaseBlockchain();
+        chainBuilder.UseFlatDb = useFlat;
+        using MergeTestBlockchain chain = await chainBuilder.BuildMergeTestBlockchain(builder => builder
+            .AddSingleton<ISpecProvider>(new TestSingleReleaseSpecProvider(London.Instance))
+            .UpdateSingleton<IForkchoiceUpdatedHandler>(innerBuilder => innerBuilder
+                .AddSingleton(stateReader)
+                .AddSingleton<ITimestamper>(recoveryClock)));
         IEngineRpcModule rpc = chain.EngineRpcModule;
         IReadOnlyList<ExecutionPayload> branch = await ProduceBranchV1(rpc, chain, 2, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false);
         if (canonical)
@@ -52,23 +61,72 @@ public partial class EngineModuleTests
         }
 
         Hash256 previousHead = chain.BlockTree.HeadHash!;
+        Hash256? previousFinalized = chain.BlockTree.FinalizedHash;
+        Hash256? previousSafe = chain.BlockTree.SafeHash;
+        int forkchoiceEvents = 0;
+        chain.BlockTree.OnForkChoiceUpdated += (_, _) => forkchoiceEvents++;
         Hash256 target = branch[0].BlockHash;
+        bool syncing = useFlat && !canonical;
         stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(false);
         ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV1(new(target, target, target));
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(canonical ? PayloadStatus.Valid : PayloadStatus.Syncing));
-            Assert.That(chain.BlockTree.FinalizedHash, Is.EqualTo(target));
-            Assert.That(chain.BlockTree.SafeHash, Is.EqualTo(target));
-            Assert.That(chain.BlockTree.HeadHash, Is.EqualTo(canonical ? target : previousHead));
-            if (!canonical)
+            Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(syncing ? PayloadStatus.Syncing : PayloadStatus.Valid));
+            Assert.That(chain.BlockTree.FinalizedHash, Is.EqualTo(syncing ? previousFinalized : target));
+            Assert.That(chain.BlockTree.SafeHash, Is.EqualTo(syncing ? previousSafe : target));
+            Assert.That(chain.BlockTree.HeadHash, Is.EqualTo(syncing ? previousHead : target));
+            if (syncing)
             {
+                Assert.That(forkchoiceEvents, Is.Zero);
                 IBlockCacheService cache = chain.Container.Resolve<IBlockCacheService>();
                 Assert.That(cache.HeadBlockHash, Is.EqualTo(target));
                 Assert.That(cache.FinalizedHash, Is.EqualTo(target));
                 Assert.That(chain.BeaconPivot!.ProcessDestination?.Hash, Is.EqualTo(target));
                 Assert.That(chain.BeaconPivot.BeaconPivotExists(), Is.True);
+            }
+        }
+
+        if (syncing)
+        {
+            stateReader.ClearReceivedCalls();
+            ResultWrapper<ForkchoiceUpdatedV1Result> repeated = await rpc.engine_forkchoiceUpdatedV1(new(target, target, target));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(repeated.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Syncing));
+                stateReader.Received(1).HasStateForBlock(Arg.Any<BlockHeader?>());
+            }
+
+            recoveryClock.Add(TimeSpan.FromSeconds(1));
+            stateReader.ClearReceivedCalls();
+            ResultWrapper<ForkchoiceUpdatedV1Result> expired = await rpc.engine_forkchoiceUpdatedV1(new(target, target, target));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(expired.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Syncing));
+                Assert.That(stateReader.ReceivedCalls().Count(), Is.GreaterThan(1), "expired failures must probe ancestors again");
+            }
+
+            IReadOnlyList<ExecutionPayload> alternative = await ProduceBranchV1(rpc, chain, 1, CreateParentBlockRequestOnHead(chain.BlockTree), setHead: false, TestItem.KeccakC);
+            stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(true);
+            ResultWrapper<ForkchoiceUpdatedV1Result> moved = await rpc.engine_forkchoiceUpdatedV1(new(alternative[0].BlockHash, Keccak.Zero, Keccak.Zero));
+            Assert.That(moved.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
+            stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(false);
+            stateReader.ClearReceivedCalls();
+            ResultWrapper<ForkchoiceUpdatedV1Result> changedHead = await rpc.engine_forkchoiceUpdatedV1(new(target, target, target));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(changedHead.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Syncing));
+                Assert.That(stateReader.ReceivedCalls().Count(), Is.GreaterThan(1), "a changed head must invalidate failed searches");
+            }
+
+            stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(true);
+            ResultWrapper<ForkchoiceUpdatedV1Result> available = await rpc.engine_forkchoiceUpdatedV1(new(target, target, target));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(available.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid));
+                Assert.That(chain.BlockTree.HeadHash, Is.EqualTo(target));
+                Assert.That(chain.BlockTree.FinalizedHash, Is.EqualTo(target));
+                Assert.That(chain.BlockTree.SafeHash, Is.EqualTo(target));
             }
         }
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Autofac;
+using Nethermind.Blockchain;
+using Nethermind.Consensus.Producers;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Db;
+using Nethermind.Int256;
+using Nethermind.JsonRpc;
+using Nethermind.Merge.Plugin.Data;
+using Nethermind.Specs.Forks;
+using Nethermind.State.Flat;
+using Nethermind.TxPool;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+/// <summary>
+/// A consensus client replaying payloads against one parent keeps the head pinned: every payload pair is a
+/// fresh sibling of the last, finalization never moves, and nothing in the flat state can persist or convert.
+/// The in-memory snapshot tier has to stay bounded regardless.
+/// </summary>
+public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
+{
+    private const int Iterations = 100;
+    private const int TxsPerBlock = 20;
+    // Amsterdam prices a new account at 120 state bytes x 1530 gas on top of the intrinsic cost, so funding is batched
+    // to fit the 4M test block; the benchmark transfers themselves move value between existing accounts.
+    private const long FundingGasLimit = 210_000;
+    private const int FundingPerBlock = 18;
+    private const long TransferGasLimit = 30_000;
+
+    protected override MergeTestBlockchain CreateBaseBlockchain(IMergeConfig? mergeConfig = null) =>
+        new(mergeConfig) { UseFlatDb = true };
+
+    [Test]
+    public async Task Sibling_payloads_under_a_pinned_head_keep_in_memory_snapshots_bounded()
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain(Amsterdam.Instance);
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+        ISnapshotRepository snapshots = chain.Container.Resolve<ISnapshotRepository>();
+        int budget = chain.Container.Resolve<IFlatDbConfig>().MaxInMemoryBaseSnapshotCount;
+
+        // Every transfer has its own funded sender and recipient, so each sibling snapshot carries the account
+        // fan-out that makes the retained state expensive rather than two accounts.
+        PrivateKey[] firstSenders = CreateAccounts("first");
+        PrivateKey[] secondSenders = CreateAccounts("second");
+
+        BlockHeader parent = chain.BlockTree.Head!.Header;
+        Hash256 finalized = parent.Hash!;
+        PrivateKey[] all = [.. firstSenders, .. secondSenders];
+        for (int offset = 0; offset < all.Length; offset += FundingPerBlock)
+        {
+            PrivateKey[] batch = all[offset..Math.Min(all.Length, offset + FundingPerBlock)];
+            SubmitFunding(chain, TestItem.PrivateKeyB, parent, batch);
+            (ExecutionPayload payload, BlockHeader header) = await ProduceAndSubmit(chain, rpc, parent, Keccak.Compute("prefix" + parent.Number), batch.Length);
+            await ForkchoiceUpdated(chain, rpc, payload.BlockHash, finalized);
+            AssertAllSucceeded(chain, header);
+            finalized = parent.Hash!;
+            parent = header;
+        }
+
+        BlockHeader pinned = parent;
+        Assert.That(budget, Is.LessThan(2 * Iterations), "the run must exceed the in-memory budget to prove the bound");
+
+        int maxBases = 0;
+        for (int iteration = 0; iteration < Iterations; iteration++)
+        {
+            await ForkchoiceUpdated(chain, rpc, pinned.Hash!, finalized);
+
+            SubmitTransfers(chain, firstSenders, secondSenders, pinned, iteration);
+            (ExecutionPayload first, BlockHeader firstHeader) = await ProduceAndSubmit(chain, rpc, pinned, Keccak.Compute(iteration.ToString()), TxsPerBlock);
+            await ForkchoiceUpdated(chain, rpc, first.BlockHash, finalized);
+
+            SubmitTransfers(chain, secondSenders, firstSenders, firstHeader, iteration);
+            (ExecutionPayload second, BlockHeader secondHeader) = await ProduceAndSubmit(chain, rpc, firstHeader, Keccak.Compute("second" + iteration), TxsPerBlock);
+            await ForkchoiceUpdated(chain, rpc, second.BlockHash, finalized);
+
+            if (iteration == 0)
+            {
+                AssertAllSucceeded(chain, firstHeader);
+                AssertAllSucceeded(chain, secondHeader);
+            }
+            maxBases = Math.Max(maxBases, snapshots.SnapshotCount);
+        }
+
+        // Persistence runs on a background task; give the last jobs a moment to drain before sampling.
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshots.SnapshotCount, Is.LessThan(budget), "orphaned sibling snapshots must be pruned");
+            Assert.That(maxBases, Is.LessThan(2 * budget), "the in-memory tier must never run far past the budget");
+            Assert.That(snapshots.HasState(new StateId(pinned.Number, pinned.StateRoot!)), Is.True, "the pinned parent stays readable");
+        }
+    }
+
+    private static PrivateKey[] CreateAccounts(string group)
+    {
+        PrivateKey[] accounts = new PrivateKey[TxsPerBlock];
+        for (int i = 0; i < accounts.Length; i++) accounts[i] = new PrivateKey(Keccak.Compute($"{group}-account-{i}").BytesToArray());
+        return accounts;
+    }
+
+    private static void SubmitFunding(MergeTestBlockchain chain, PrivateKey funder, BlockHeader stateAt, PrivateKey[] recipients)
+    {
+        chain.StateReader.TryGetAccount(stateAt, funder.Address, out AccountStruct account);
+        for (int i = 0; i < recipients.Length; i++)
+        {
+            Submit(chain, funder, (ulong)account.Nonce + (ulong)i, recipients[i].Address, 1.Ether, FundingGasLimit, $"funding {recipients[i].Address}");
+        }
+    }
+
+    private static void SubmitTransfers(MergeTestBlockchain chain, PrivateKey[] senders, PrivateKey[] recipients, BlockHeader stateAt, int iteration)
+    {
+        // Siblings re-spend the same nonces, so the value keeps every iteration's transactions distinct.
+        UInt256 value = (UInt256)(iteration + 1);
+        for (int i = 0; i < senders.Length; i++)
+        {
+            chain.StateReader.TryGetAccount(stateAt, senders[i].Address, out AccountStruct account);
+            Submit(chain, senders[i], (ulong)account.Nonce, recipients[i].Address, value, TransferGasLimit, $"transfer {i} at {stateAt.Number} iteration {iteration}");
+        }
+    }
+
+    private static void Submit(MergeTestBlockchain chain, PrivateKey from, ulong nonce, Address to, UInt256 value, long gasLimit, string what)
+    {
+        Transaction tx = Build.A.Transaction
+            .WithNonce(nonce)
+            .WithGasLimit((ulong)gasLimit)
+            .WithTo(to)
+            .WithValue(value)
+            .WithGasPrice(1.GWei)
+            .WithChainId(chain.SpecProvider.ChainId)
+            .WithType(TxType.EIP1559)
+            .WithMaxFeePerGasIfSupports1559(1.GWei)
+            .SignedAndResolved(from).TestObject;
+        AcceptTxResult result = chain.TxPool.SubmitTx(tx, TxHandlingOptions.None);
+        Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted), what);
+    }
+
+    private static void AssertAllSucceeded(MergeTestBlockchain chain, BlockHeader header)
+    {
+        Block block = chain.BlockTree.FindBlock(header.Hash!, BlockTreeLookupOptions.None)!;
+        TxReceipt[] receipts = chain.ReceiptStorage.Get(block);
+        Assert.That(receipts, Has.Length.EqualTo(block.Transactions.Length), $"receipts of block {header.Number}");
+        Assert.That(receipts.Select(r => r.StatusCode), Is.All.EqualTo((byte)1), $"tx status in block {header.Number}");
+    }
+
+    private static async Task ForkchoiceUpdated(MergeTestBlockchain chain, IEngineRpcModule rpc, Hash256 head, Hash256 finalized)
+    {
+        bool headChanges = chain.BlockTree.Head!.Hash != head;
+        Task txPoolHead = headChanges ? chain.WaitForTxPoolHead(head) : Task.CompletedTask;
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV4(new ForkchoiceStateV1(head, finalized, finalized));
+        Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid), result.Data.PayloadStatus.ValidationError);
+        await txPoolHead;
+    }
+
+    private static async Task<(ExecutionPayload Payload, BlockHeader Header)> ProduceAndSubmit(MergeTestBlockchain chain, IEngineRpcModule rpc, BlockHeader parent, Hash256 random, int expectedTxs)
+    {
+        Task improved = chain.WaitForImprovedBlock(parent.Hash, expectedTxs);
+        PayloadAttributes attributes = new()
+        {
+            Timestamp = parent.Timestamp + 12,
+            PrevRandao = random,
+            SuggestedFeeRecipient = Address.Zero,
+            ParentBeaconBlockRoot = Keccak.Zero,
+            Withdrawals = [],
+            SlotNumber = parent.Number + 1,
+            TargetGasLimit = parent.GasLimit,
+        };
+        string payloadId = chain.PayloadPreparationService.StartPreparingPayload(parent, attributes)!;
+        await improved;
+
+        GetPayloadV6Result result = (await rpc.engine_getPayloadV6(Bytes.FromHexString(payloadId))).Data!;
+        ExecutionPayload payload = result.ExecutionPayload;
+        Assert.That(payload.Transactions.Length, Is.EqualTo(expectedTxs), "payload tx count");
+        PayloadStatusV1 status = (await rpc.engine_newPayloadV5(result.ExecutionPayload, [], Keccak.Zero, result.ExecutionRequests)).Data;
+        Assert.That(status.Status, Is.EqualTo(PayloadStatus.Valid), status.ValidationError);
+
+        BlockHeader header = chain.BlockTree.FindHeader(payload.BlockHash, BlockTreeLookupOptions.None)!;
+        return (payload, header);
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Blockchain;
+using Nethermind.Config;
 using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -32,12 +33,6 @@ namespace Nethermind.Merge.Plugin.Test;
 public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
 {
     private const int Iterations = 100;
-    private const int TxsPerBlock = 20;
-    // Amsterdam prices a new account at 120 state bytes x 1530 gas on top of the intrinsic cost, so funding is batched
-    // to fit the 4M test block; the benchmark transfers themselves move value between existing accounts.
-    private const long FundingGasLimit = 210_000;
-    private const int FundingPerBlock = 18;
-    private const long TransferGasLimit = 30_000;
 
     protected override MergeTestBlockchain CreateBaseBlockchain(IMergeConfig? mergeConfig = null) =>
         new(mergeConfig) { UseFlatDb = true };
@@ -52,43 +47,28 @@ public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
 
         // Every transfer has its own funded sender and recipient, so each sibling snapshot carries the account
         // fan-out that makes the retained state expensive rather than two accounts.
-        PrivateKey[] firstSenders = CreateAccounts("first");
-        PrivateKey[] secondSenders = CreateAccounts("second");
-
-        BlockHeader parent = chain.BlockTree.Head!.Header;
-        Hash256 finalized = parent.Hash!;
-        PrivateKey[] all = [.. firstSenders, .. secondSenders];
-        for (int offset = 0; offset < all.Length; offset += FundingPerBlock)
-        {
-            PrivateKey[] batch = all[offset..Math.Min(all.Length, offset + FundingPerBlock)];
-            SubmitFunding(chain, TestItem.PrivateKeyB, parent, batch);
-            (ExecutionPayload payload, BlockHeader header) = await ProduceAndSubmit(chain, rpc, parent, Keccak.Compute("prefix" + parent.Number), batch.Length);
-            await ForkchoiceUpdated(chain, rpc, payload.BlockHash, finalized);
-            AssertAllSucceeded(chain, header);
-            finalized = parent.Hash!;
-            parent = header;
-        }
-
-        BlockHeader pinned = parent;
+        PrivateKey[] firstSenders = SiblingPayloads.CreateAccounts("first");
+        PrivateKey[] secondSenders = SiblingPayloads.CreateAccounts("second");
+        (BlockHeader pinned, Hash256 finalized) = await SiblingPayloads.Fund(chain, rpc, [.. firstSenders, .. secondSenders]);
         Assert.That(budget, Is.LessThan(2 * Iterations), "the run must exceed the in-memory budget to prove the bound");
 
         int maxBases = 0;
         for (int iteration = 0; iteration < Iterations; iteration++)
         {
-            await ForkchoiceUpdated(chain, rpc, pinned.Hash!, finalized);
+            await SiblingPayloads.ForkchoiceUpdated(chain, rpc, pinned.Hash!, finalized);
 
-            SubmitTransfers(chain, firstSenders, secondSenders, pinned, iteration);
-            (ExecutionPayload first, BlockHeader firstHeader) = await ProduceAndSubmit(chain, rpc, pinned, Keccak.Compute(iteration.ToString()), TxsPerBlock);
-            await ForkchoiceUpdated(chain, rpc, first.BlockHash, finalized);
+            SiblingPayloads.SubmitTransfers(chain, firstSenders, secondSenders, pinned, iteration);
+            (ExecutionPayload first, BlockHeader firstHeader) = await SiblingPayloads.ProduceAndSubmit(chain, rpc, pinned, Keccak.Compute(iteration.ToString()), SiblingPayloads.TxsPerBlock);
+            await SiblingPayloads.ForkchoiceUpdated(chain, rpc, first.BlockHash, finalized);
 
-            SubmitTransfers(chain, secondSenders, firstSenders, firstHeader, iteration);
-            (ExecutionPayload second, BlockHeader secondHeader) = await ProduceAndSubmit(chain, rpc, firstHeader, Keccak.Compute("second" + iteration), TxsPerBlock);
-            await ForkchoiceUpdated(chain, rpc, second.BlockHash, finalized);
+            SiblingPayloads.SubmitTransfers(chain, secondSenders, firstSenders, firstHeader, iteration);
+            (ExecutionPayload second, BlockHeader secondHeader) = await SiblingPayloads.ProduceAndSubmit(chain, rpc, firstHeader, Keccak.Compute("second" + iteration), SiblingPayloads.TxsPerBlock);
+            await SiblingPayloads.ForkchoiceUpdated(chain, rpc, second.BlockHash, finalized);
 
             if (iteration == 0)
             {
-                AssertAllSucceeded(chain, firstHeader);
-                AssertAllSucceeded(chain, secondHeader);
+                SiblingPayloads.AssertAllSucceeded(chain, firstHeader);
+                SiblingPayloads.AssertAllSucceeded(chain, secondHeader);
             }
             maxBases = Math.Max(maxBases, snapshots.SnapshotCount);
         }
@@ -99,27 +79,115 @@ public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
         {
             Assert.That(snapshots.SnapshotCount, Is.LessThan(budget), "orphaned sibling snapshots must be pruned");
             Assert.That(maxBases, Is.LessThan(2 * budget), "the in-memory tier must never run far past the budget");
-            Assert.That(snapshots.HasState(new StateId(pinned.Number, pinned.StateRoot!)), Is.True, "the pinned parent stays readable");
+            Assert.That(snapshots.HasState(new StateId(pinned)), Is.True, "the pinned parent stays readable");
         }
     }
+}
 
-    private static PrivateKey[] CreateAccounts(string group)
+/// <summary>
+/// The other side of orphan pruning: a payload built on a sibling whose state was pruned must re-execute that
+/// sibling instead of answering SYNCING, so a consensus client that switches to an old fork still gets served.
+/// </summary>
+public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
+{
+    private const int InMemoryBudget = 8;
+    // Orphans survive the last 16 commits; this many unselected siblings push the first one out with margin.
+    private const int UnselectedSiblings = 40;
+
+    private sealed class SmallBudgetBlockchain(IMergeConfig? mergeConfig) : MergeTestBlockchain(mergeConfig)
+    {
+        protected override IEnumerable<IConfig> CreateConfigs() =>
+            base.CreateConfigs().Concat([new FlatDbConfig { MaxInMemoryBaseSnapshotCount = InMemoryBudget }]);
+    }
+
+    protected override MergeTestBlockchain CreateBaseBlockchain(IMergeConfig? mergeConfig = null) =>
+        new SmallBudgetBlockchain(mergeConfig) { UseFlatDb = true };
+
+    [Test]
+    public async Task Payload_on_a_pruned_sibling_re_executes_it_instead_of_syncing()
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain(Amsterdam.Instance);
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+        ISnapshotRepository snapshots = chain.Container.Resolve<ISnapshotRepository>();
+
+        PrivateKey[] forkSenders = SiblingPayloads.CreateAccounts("fork");
+        PrivateKey[] siblingSenders = SiblingPayloads.CreateAccounts("sibling");
+        PrivateKey[] childSenders = SiblingPayloads.CreateAccounts("child");
+        (BlockHeader pinned, Hash256 finalized) = await SiblingPayloads.Fund(chain, rpc, [.. forkSenders, .. siblingSenders, .. childSenders]);
+
+        // The fork block is executed but never selected by fork choice. Its child is built now, while the fork
+        // state still exists, the way a consensus client would hand over a payload built by another node.
+        SiblingPayloads.SubmitTransfers(chain, forkSenders, childSenders, pinned, 0);
+        (_, BlockHeader forkHeader) = await SiblingPayloads.ProduceAndSubmit(chain, rpc, pinned, Keccak.Compute("fork"), SiblingPayloads.TxsPerBlock);
+        StateId forkState = new(forkHeader);
+        Assert.That(snapshots.HasState(forkState), Is.True, "precondition: the fork block has state right after execution");
+        SiblingPayloads.SubmitTransfers(chain, childSenders, siblingSenders, pinned, 0);
+        GetPayloadV6Result child = await SiblingPayloads.Produce(chain, rpc, forkHeader, Keccak.Compute("child"), SiblingPayloads.TxsPerBlock);
+
+        for (int i = 1; i <= UnselectedSiblings; i++)
+        {
+            await SiblingPayloads.ForkchoiceUpdated(chain, rpc, pinned.Hash!, finalized);
+            SiblingPayloads.SubmitTransfers(chain, siblingSenders, forkSenders, pinned, i);
+            (ExecutionPayload sibling, _) = await SiblingPayloads.ProduceAndSubmit(chain, rpc, pinned, Keccak.Compute("sibling" + i), SiblingPayloads.TxsPerBlock);
+            await SiblingPayloads.ForkchoiceUpdated(chain, rpc, sibling.BlockHash, finalized);
+        }
+
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        Assert.That(snapshots.HasState(forkState), Is.False, "precondition: the unselected fork block was pruned");
+
+        BlockHeader childHeader = await SiblingPayloads.Submit(chain, rpc, child);
+        await SiblingPayloads.ForkchoiceUpdated(chain, rpc, childHeader.Hash!, finalized);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshots.HasState(new StateId(childHeader)), Is.True, "the child was executed on the rebuilt fork state");
+            Assert.That(snapshots.HasState(forkState), Is.True, "re-execution restored the fork block's state");
+        }
+    }
+}
+
+/// <summary>Builds and submits sibling payloads with distinct funded senders through the Amsterdam engine API.</summary>
+internal static class SiblingPayloads
+{
+    public const int TxsPerBlock = 20;
+    // Amsterdam prices a new account at 120 state bytes x 1530 gas on top of the intrinsic cost, so funding is batched
+    // to fit the 4M test block; the benchmark transfers themselves move value between existing accounts.
+    private const long FundingGasLimit = 210_000;
+    private const int FundingPerBlock = 18;
+    private const long TransferGasLimit = 30_000;
+
+    public static PrivateKey[] CreateAccounts(string group)
     {
         PrivateKey[] accounts = new PrivateKey[TxsPerBlock];
         for (int i = 0; i < accounts.Length; i++) accounts[i] = new PrivateKey(Keccak.Compute($"{group}-account-{i}").BytesToArray());
         return accounts;
     }
 
-    private static void SubmitFunding(MergeTestBlockchain chain, PrivateKey funder, BlockHeader stateAt, PrivateKey[] recipients)
+    /// <summary>Funds <paramref name="accounts"/> from the genesis account B and returns the resulting head and its parent.</summary>
+    public static async Task<(BlockHeader Pinned, Hash256 Finalized)> Fund(BaseEngineModuleTests.MergeTestBlockchain chain, IEngineRpcModule rpc, PrivateKey[] accounts)
     {
-        chain.StateReader.TryGetAccount(stateAt, funder.Address, out AccountStruct account);
-        for (int i = 0; i < recipients.Length; i++)
+        BlockHeader parent = chain.BlockTree.Head!.Header;
+        Hash256 finalized = parent.Hash!;
+        for (int offset = 0; offset < accounts.Length; offset += FundingPerBlock)
         {
-            Submit(chain, funder, (ulong)account.Nonce + (ulong)i, recipients[i].Address, 1.Ether, FundingGasLimit, $"funding {recipients[i].Address}");
+            PrivateKey[] batch = accounts[offset..Math.Min(accounts.Length, offset + FundingPerBlock)];
+            chain.StateReader.TryGetAccount(parent, TestItem.AddressB, out AccountStruct funder);
+            for (int i = 0; i < batch.Length; i++)
+            {
+                Submit(chain, TestItem.PrivateKeyB, (ulong)funder.Nonce + (ulong)i, batch[i].Address, 1.Ether, FundingGasLimit, $"funding {batch[i].Address}");
+            }
+
+            (ExecutionPayload payload, BlockHeader header) = await ProduceAndSubmit(chain, rpc, parent, Keccak.Compute("prefix" + parent.Number), batch.Length);
+            await ForkchoiceUpdated(chain, rpc, payload.BlockHash, finalized);
+            AssertAllSucceeded(chain, header);
+            finalized = parent.Hash!;
+            parent = header;
         }
+
+        return (parent, finalized);
     }
 
-    private static void SubmitTransfers(MergeTestBlockchain chain, PrivateKey[] senders, PrivateKey[] recipients, BlockHeader stateAt, int iteration)
+    public static void SubmitTransfers(BaseEngineModuleTests.MergeTestBlockchain chain, PrivateKey[] senders, PrivateKey[] recipients, BlockHeader stateAt, int iteration)
     {
         // Siblings re-spend the same nonces, so the value keeps every iteration's transactions distinct.
         UInt256 value = (UInt256)(iteration + 1);
@@ -130,7 +198,7 @@ public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
         }
     }
 
-    private static void Submit(MergeTestBlockchain chain, PrivateKey from, ulong nonce, Address to, UInt256 value, long gasLimit, string what)
+    private static void Submit(BaseEngineModuleTests.MergeTestBlockchain chain, PrivateKey from, ulong nonce, Address to, UInt256 value, long gasLimit, string what)
     {
         Transaction tx = Build.A.Transaction
             .WithNonce(nonce)
@@ -146,7 +214,7 @@ public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
         Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted), what);
     }
 
-    private static void AssertAllSucceeded(MergeTestBlockchain chain, BlockHeader header)
+    public static void AssertAllSucceeded(BaseEngineModuleTests.MergeTestBlockchain chain, BlockHeader header)
     {
         Block block = chain.BlockTree.FindBlock(header.Hash!, BlockTreeLookupOptions.None)!;
         TxReceipt[] receipts = chain.ReceiptStorage.Get(block);
@@ -154,7 +222,7 @@ public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
         Assert.That(receipts.Select(r => r.StatusCode), Is.All.EqualTo((byte)1), $"tx status in block {header.Number}");
     }
 
-    private static async Task ForkchoiceUpdated(MergeTestBlockchain chain, IEngineRpcModule rpc, Hash256 head, Hash256 finalized)
+    public static async Task ForkchoiceUpdated(BaseEngineModuleTests.MergeTestBlockchain chain, IEngineRpcModule rpc, Hash256 head, Hash256 finalized)
     {
         bool headChanges = chain.BlockTree.Head!.Hash != head;
         Task txPoolHead = headChanges ? chain.WaitForTxPoolHead(head) : Task.CompletedTask;
@@ -163,7 +231,16 @@ public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
         await txPoolHead;
     }
 
-    private static async Task<(ExecutionPayload Payload, BlockHeader Header)> ProduceAndSubmit(MergeTestBlockchain chain, IEngineRpcModule rpc, BlockHeader parent, Hash256 random, int expectedTxs)
+    /// <summary>Builds a payload on <paramref name="parent"/> carrying at least <paramref name="expectedTxs"/> pool transactions and submits it.</summary>
+    public static async Task<(ExecutionPayload Payload, BlockHeader Header)> ProduceAndSubmit(BaseEngineModuleTests.MergeTestBlockchain chain, IEngineRpcModule rpc, BlockHeader parent, Hash256 random, int expectedTxs)
+    {
+        GetPayloadV6Result result = await Produce(chain, rpc, parent, random, expectedTxs);
+        BlockHeader header = await Submit(chain, rpc, result);
+        return (result.ExecutionPayload, header);
+    }
+
+    /// <summary>Builds a payload on <paramref name="parent"/> carrying at least <paramref name="expectedTxs"/> pool transactions without submitting it.</summary>
+    public static async Task<GetPayloadV6Result> Produce(BaseEngineModuleTests.MergeTestBlockchain chain, IEngineRpcModule rpc, BlockHeader parent, Hash256 random, int expectedTxs)
     {
         Task improved = chain.WaitForImprovedBlock(parent.Hash, expectedTxs);
         PayloadAttributes attributes = new()
@@ -180,12 +257,14 @@ public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
         await improved;
 
         GetPayloadV6Result result = (await rpc.engine_getPayloadV6(Bytes.FromHexString(payloadId))).Data!;
-        ExecutionPayload payload = result.ExecutionPayload;
-        Assert.That(payload.Transactions.Length, Is.EqualTo(expectedTxs), "payload tx count");
-        PayloadStatusV1 status = (await rpc.engine_newPayloadV5(result.ExecutionPayload, [], Keccak.Zero, result.ExecutionRequests)).Data;
-        Assert.That(status.Status, Is.EqualTo(PayloadStatus.Valid), status.ValidationError);
+        Assert.That(result.ExecutionPayload.Transactions.Length, Is.GreaterThanOrEqualTo(expectedTxs), "payload tx count");
+        return result;
+    }
 
-        BlockHeader header = chain.BlockTree.FindHeader(payload.BlockHash, BlockTreeLookupOptions.None)!;
-        return (payload, header);
+    public static async Task<BlockHeader> Submit(BaseEngineModuleTests.MergeTestBlockchain chain, IEngineRpcModule rpc, GetPayloadV6Result payload)
+    {
+        PayloadStatusV1 status = (await rpc.engine_newPayloadV5(payload.ExecutionPayload, [], Keccak.Zero, payload.ExecutionRequests)).Data;
+        Assert.That(status.Status, Is.EqualTo(PayloadStatus.Valid), status.ValidationError);
+        return chain.BlockTree.FindHeader(payload.ExecutionPayload.BlockHash, BlockTreeLookupOptions.None)!;
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
@@ -109,14 +109,49 @@ public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
         using MergeTestBlockchain chain = await CreateBlockchain(Amsterdam.Instance);
         IEngineRpcModule rpc = chain.EngineRpcModule;
         ISnapshotRepository snapshots = chain.Container.Resolve<ISnapshotRepository>();
+        (BlockHeader forkHeader, GetPayloadV6Result child, Hash256 finalized) = await ExecuteForkThenPruneIt(chain, rpc, snapshots);
 
+        BlockHeader childHeader = await SiblingPayloads.Submit(chain, rpc, child);
+        await SiblingPayloads.ForkchoiceUpdated(chain, rpc, childHeader.Hash!, finalized);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(snapshots.HasState(new StateId(childHeader)), Is.True, "the child was executed on the rebuilt fork state");
+            Assert.That(snapshots.HasState(new StateId(forkHeader)), Is.True, "re-execution restored the fork block's state");
+        }
+    }
+
+    [Test]
+    public async Task Fork_choice_selecting_a_pruned_sibling_re_executes_it_instead_of_syncing()
+    {
+        using MergeTestBlockchain chain = await CreateBlockchain(Amsterdam.Instance);
+        IEngineRpcModule rpc = chain.EngineRpcModule;
+        ISnapshotRepository snapshots = chain.Container.Resolve<ISnapshotRepository>();
+        (BlockHeader forkHeader, _, Hash256 finalized) = await ExecuteForkThenPruneIt(chain, rpc, snapshots);
+
+        await SiblingPayloads.ForkchoiceUpdated(chain, rpc, forkHeader.Hash!, finalized);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(chain.BlockTree.Head!.Hash, Is.EqualTo(forkHeader.Hash), "the fork block is the head");
+            Assert.That(snapshots.HasState(new StateId(forkHeader)), Is.True, "the head serves state again");
+            chain.StateReader.TryGetAccount(forkHeader, TestItem.AddressB, out AccountStruct funder);
+            Assert.That(funder.Nonce, Is.GreaterThan(0UL), "state at the head is readable");
+        }
+    }
+
+    /// <summary>
+    /// Executes a fork block on the pinned parent without selecting it, builds its child while the fork state still
+    /// exists, then runs enough unselected siblings for orphan pruning to drop the fork's state.
+    /// </summary>
+    private static async Task<(BlockHeader Fork, GetPayloadV6Result Child, Hash256 Finalized)> ExecuteForkThenPruneIt(
+        MergeTestBlockchain chain, IEngineRpcModule rpc, ISnapshotRepository snapshots)
+    {
         PrivateKey[] forkSenders = SiblingPayloads.CreateAccounts("fork");
         PrivateKey[] siblingSenders = SiblingPayloads.CreateAccounts("sibling");
         PrivateKey[] childSenders = SiblingPayloads.CreateAccounts("child");
         (BlockHeader pinned, Hash256 finalized) = await SiblingPayloads.Fund(chain, rpc, [.. forkSenders, .. siblingSenders, .. childSenders]);
 
-        // The fork block is executed but never selected by fork choice. Its child is built now, while the fork
-        // state still exists, the way a consensus client would hand over a payload built by another node.
         SiblingPayloads.SubmitTransfers(chain, forkSenders, childSenders, pinned, 0);
         (_, BlockHeader forkHeader) = await SiblingPayloads.ProduceAndSubmit(chain, rpc, pinned, Keccak.Compute("fork"), SiblingPayloads.TxsPerBlock);
         StateId forkState = new(forkHeader);
@@ -134,15 +169,7 @@ public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
 
         await Task.Delay(TimeSpan.FromSeconds(1));
         Assert.That(snapshots.HasState(forkState), Is.False, "precondition: the unselected fork block was pruned");
-
-        BlockHeader childHeader = await SiblingPayloads.Submit(chain, rpc, child);
-        await SiblingPayloads.ForkchoiceUpdated(chain, rpc, childHeader.Hash!, finalized);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(snapshots.HasState(new StateId(childHeader)), Is.True, "the child was executed on the rebuilt fork state");
-            Assert.That(snapshots.HasState(forkState), Is.True, "re-execution restored the fork block's state");
-        }
+        return (forkHeader, child, finalized);
     }
 }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Blockchain;
@@ -74,7 +75,8 @@ public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
             maxBases = Math.Max(maxBases, snapshots.SnapshotCount);
         }
 
-        Assert.That(() => snapshots.SnapshotCount, Is.LessThan(budget).After(10000, 10), "orphaned sibling snapshots must be pruned");
+        await chain.Container.Resolve<IPersistenceManager>().AddToPersistence(snapshots.GetLastCommittedStateId()!.Value);
+        Assert.That(snapshots.SnapshotCount, Is.LessThan(budget), "orphaned sibling snapshots must be pruned");
         using (Assert.EnterMultipleScope())
         {
             Assert.That(maxBases, Is.LessThan(2 * budget), "the in-memory tier must never run far past the budget");
@@ -195,7 +197,8 @@ public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
             await SiblingPayloads.ForkchoiceUpdated(chain, rpc, sibling.BlockHash, finalized);
         }
 
-        Assert.That(() => snapshots.HasState(forkState), Is.False.After(10000, 10), "precondition: the unselected fork block was pruned");
+        await chain.Container.Resolve<IPersistenceManager>().AddToPersistence(snapshots.GetLastCommittedStateId()!.Value);
+        Assert.That(snapshots.HasState(forkState), Is.False, "precondition: the unselected fork block was pruned");
         return (forkHeader, child, finalized);
     }
 }
@@ -280,7 +283,11 @@ internal static class SiblingPayloads
     {
         bool headChanges = chain.BlockTree.Head!.Hash != head;
         Task txPoolHead = headChanges ? chain.WaitForTxPoolHead(head) : Task.CompletedTask;
-        ResultWrapper<ForkchoiceUpdatedV1Result> result = await rpc.engine_forkchoiceUpdatedV4(new ForkchoiceStateV1(head, finalized, finalized));
+        Thread caller = Thread.CurrentThread;
+        ThreadPriority priority = caller.Priority;
+        Task<ResultWrapper<ForkchoiceUpdatedV1Result>> update = rpc.engine_forkchoiceUpdatedV4(new ForkchoiceStateV1(head, finalized, finalized));
+        Assert.That(caller.Priority, Is.EqualTo(priority), "fork choice must restore caller priority before yielding");
+        ResultWrapper<ForkchoiceUpdatedV1Result> result = await update;
         Assert.That(result.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Valid), result.Data.PayloadStatus.ValidationError);
         await txPoolHead;
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
@@ -73,11 +73,9 @@ public class PinnedHeadSiblingRetentionTests : BaseEngineModuleTests
             maxBases = Math.Max(maxBases, snapshots.SnapshotCount);
         }
 
-        // Persistence runs on a background task; give the last jobs a moment to drain before sampling.
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        Assert.That(() => snapshots.SnapshotCount, Is.LessThan(budget).After(10000, 10), "orphaned sibling snapshots must be pruned");
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(snapshots.SnapshotCount, Is.LessThan(budget), "orphaned sibling snapshots must be pruned");
             Assert.That(maxBases, Is.LessThan(2 * budget), "the in-memory tier must never run far past the budget");
             Assert.That(snapshots.HasState(new StateId(pinned)), Is.True, "the pinned parent stays readable");
         }
@@ -122,12 +120,24 @@ public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
     }
 
     [Test]
-    public async Task Fork_choice_selecting_a_pruned_sibling_re_executes_it_instead_of_syncing()
+    public async Task Fork_choice_selecting_a_pruned_sibling_re_executes_it_instead_of_syncing([Values(1, 9)] int forkLength)
     {
         using MergeTestBlockchain chain = await CreateBlockchain(Amsterdam.Instance);
         IEngineRpcModule rpc = chain.EngineRpcModule;
         ISnapshotRepository snapshots = chain.Container.Resolve<ISnapshotRepository>();
-        (BlockHeader forkHeader, _, Hash256 finalized) = await ExecuteForkThenPruneIt(chain, rpc, snapshots);
+        (BlockHeader forkHeader, _, Hash256 finalized) = await ExecuteForkThenPruneIt(chain, rpc, snapshots, forkLength);
+
+        if (forkLength > 8)
+        {
+            ResultWrapper<ForkchoiceUpdatedV1Result> partial = await rpc.engine_forkchoiceUpdatedV4(new(forkHeader.Hash!, finalized, finalized));
+            BlockHeader parent = chain.BlockTree.FindHeader(forkHeader.ParentHash!, BlockTreeLookupOptions.None)!;
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(partial.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Syncing));
+                Assert.That(snapshots.HasState(new StateId(parent)), Is.True, "the first replay segment restored eight blocks");
+                Assert.That(snapshots.HasState(new StateId(forkHeader)), Is.False, "the last block remains for the next request");
+            }
+        }
 
         await SiblingPayloads.ForkchoiceUpdated(chain, rpc, forkHeader.Hash!, finalized);
 
@@ -145,7 +155,7 @@ public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
     /// exists, then runs enough unselected siblings for orphan pruning to drop the fork's state.
     /// </summary>
     private static async Task<(BlockHeader Fork, GetPayloadV6Result Child, Hash256 Finalized)> ExecuteForkThenPruneIt(
-        MergeTestBlockchain chain, IEngineRpcModule rpc, ISnapshotRepository snapshots)
+        MergeTestBlockchain chain, IEngineRpcModule rpc, ISnapshotRepository snapshots, int forkLength = 1)
     {
         PrivateKey[] forkSenders = SiblingPayloads.CreateAccounts("fork");
         PrivateKey[] siblingSenders = SiblingPayloads.CreateAccounts("sibling");
@@ -154,6 +164,10 @@ public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
 
         SiblingPayloads.SubmitTransfers(chain, forkSenders, childSenders, pinned, 0);
         (_, BlockHeader forkHeader) = await SiblingPayloads.ProduceAndSubmit(chain, rpc, pinned, Keccak.Compute("fork"), SiblingPayloads.TxsPerBlock);
+        for (int i = 1; i < forkLength; i++)
+        {
+            (_, forkHeader) = await SiblingPayloads.ProduceAndSubmit(chain, rpc, forkHeader, Keccak.Compute("fork" + i), 0);
+        }
         StateId forkState = new(forkHeader);
         Assert.That(snapshots.HasState(forkState), Is.True, "precondition: the fork block has state right after execution");
         SiblingPayloads.SubmitTransfers(chain, childSenders, siblingSenders, pinned, 0);
@@ -167,8 +181,7 @@ public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
             await SiblingPayloads.ForkchoiceUpdated(chain, rpc, sibling.BlockHash, finalized);
         }
 
-        await Task.Delay(TimeSpan.FromSeconds(1));
-        Assert.That(snapshots.HasState(forkState), Is.False, "precondition: the unselected fork block was pruned");
+        Assert.That(() => snapshots.HasState(forkState), Is.False.After(10000, 10), "precondition: the unselected fork block was pruned");
         return (forkHeader, child, finalized);
     }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/PinnedHeadSiblingRetentionTests.cs
@@ -18,6 +18,7 @@ using Nethermind.Db;
 using Nethermind.Int256;
 using Nethermind.JsonRpc;
 using Nethermind.Merge.Plugin.Data;
+using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Specs.Forks;
 using Nethermind.State.Flat;
 using Nethermind.TxPool;
@@ -129,13 +130,24 @@ public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
 
         if (forkLength > 8)
         {
+            Hash256? previousFinalized = chain.BlockTree.FinalizedHash;
+            Hash256? previousSafe = chain.BlockTree.SafeHash;
+            int forkchoiceEvents = 0;
+            chain.BlockTree.OnForkChoiceUpdated += (_, _) => forkchoiceEvents++;
+            finalized = forkHeader.ParentHash!;
             ResultWrapper<ForkchoiceUpdatedV1Result> partial = await rpc.engine_forkchoiceUpdatedV4(new(forkHeader.Hash!, finalized, finalized));
             BlockHeader parent = chain.BlockTree.FindHeader(forkHeader.ParentHash!, BlockTreeLookupOptions.None)!;
+            IBlockCacheService cache = chain.Container.Resolve<IBlockCacheService>();
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(partial.Data.PayloadStatus.Status, Is.EqualTo(PayloadStatus.Syncing));
                 Assert.That(snapshots.HasState(new StateId(parent)), Is.True, "the first replay segment restored eight blocks");
                 Assert.That(snapshots.HasState(new StateId(forkHeader)), Is.False, "the last block remains for the next request");
+                Assert.That(chain.BlockTree.FinalizedHash, Is.EqualTo(previousFinalized));
+                Assert.That(chain.BlockTree.SafeHash, Is.EqualTo(previousSafe));
+                Assert.That(forkchoiceEvents, Is.Zero);
+                Assert.That(cache.HeadBlockHash, Is.EqualTo(forkHeader.Hash));
+                Assert.That(cache.FinalizedHash, Is.EqualTo(finalized));
             }
         }
 
@@ -144,6 +156,8 @@ public class EvictedSiblingRecoveryTests : BaseEngineModuleTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(chain.BlockTree.Head!.Hash, Is.EqualTo(forkHeader.Hash), "the fork block is the head");
+            Assert.That(chain.BlockTree.FinalizedHash, Is.EqualTo(finalized));
+            Assert.That(chain.BlockTree.SafeHash, Is.EqualTo(finalized));
             Assert.That(snapshots.HasState(new StateId(forkHeader)), Is.True, "the head serves state again");
             chain.StateReader.TryGetAccount(forkHeader, TestItem.AddressB, out AccountStruct funder);
             Assert.That(funder.Nonce, Is.GreaterThan(0UL), "state at the head is readable");

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -51,8 +51,8 @@ public class ForkchoiceUpdatedHandler(
     ISyncPeerPool syncPeerPool,
     IMergeConfig mergeConfig,
     ILogManager logManager,
-    IReceiptConfig? receiptConfig = null,
-    IStateReader? stateReader = null,
+    IReceiptConfig receiptConfig,
+    IStateReader stateReader,
     FlatStateActivationPolicy? flatStateActivationPolicy = null,
     ITimestamper? timestamper = null) : IForkchoiceUpdatedHandler
 {
@@ -60,11 +60,11 @@ public class ForkchoiceUpdatedHandler(
     private readonly IPoSSwitcher _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
     private readonly ILogger _logger = logManager.GetClassLogger<ForkchoiceUpdatedHandler>();
     private readonly bool _simulateBlockProduction = mergeConfig.SimulateBlockProduction;
-    private readonly bool _recoverPrunedState = flatStateActivationPolicy?.ShouldTurnOnFlatDb() is true && stateReader is not null;
+    private readonly bool _recoverPrunedState = flatStateActivationPolicy?.ShouldTurnOnFlatDb() is true;
     private readonly ITimestamper _timestamper = timestamper ?? Timestamper.Default;
     // Re-executing a pruned head walks the branch down to the nearest state, so the parent-on-main-chain shortcut is off.
     private readonly ProcessingOptions _reExecutionOptions =
-        (receiptConfig?.StoreReceipts is true ? ProcessingOptions.EthereumMerge | ProcessingOptions.StoreReceipts : ProcessingOptions.EthereumMerge)
+        (receiptConfig.StoreReceipts ? ProcessingOptions.EthereumMerge | ProcessingOptions.StoreReceipts : ProcessingOptions.EthereumMerge)
         & ~ProcessingOptions.IgnoreParentNotOnMainChain;
     private readonly TimeSpan _reExecutionTimeout = TimeSpan.FromMilliseconds(mergeConfig.NewPayloadBlockProcessingTimeout);
     private RecoveryFailure? _lastRecoveryFailure;
@@ -123,9 +123,6 @@ public class ForkchoiceUpdatedHandler(
     {
         // if a head is unknown we are syncing
         bool isDefinitelySyncing = newHeadHeader is null;
-        using ThreadExtensions.Disposable handle = isDefinitelySyncing ?
-            default : // Don't boost priority if we are definitely syncing
-            Thread.CurrentThread.BoostPriority();
 
         if (invalidChainTracker.IsOnKnownInvalidChain(forkchoiceState.HeadBlockHash, out Hash256? lastValidHash))
         {
@@ -282,7 +279,7 @@ public class ForkchoiceUpdatedHandler(
         }
 
         // Canonical historical FCUs remain valid without state; orphan eviction only removes side branches.
-        if (_recoverPrunedState && !_blockTree.IsMainChain(newHeadHeader) && !stateReader!.HasStateForBlock(newHeadHeader))
+        if (_recoverPrunedState && !_blockTree.IsMainChain(newHeadHeader) && !stateReader.HasStateForBlock(newHeadHeader))
         {
             bool? restored = await TryRestoreState(newHeadHeader);
             if (restored is not true)
@@ -298,6 +295,8 @@ public class ForkchoiceUpdatedHandler(
             }
         }
 
+        // Thread priority must only span synchronous work; an await can resume on a different thread.
+        using ThreadExtensions.Disposable handle = Thread.CurrentThread.BoostPriority();
         bool newHeadTheSameAsCurrentHead = _blockTree.Head!.Hash == newHeadHeader.Hash;
         bool shouldUpdateHead = !newHeadTheSameAsCurrentHead;
         // TryUpdateMainChain walks back to the current main chain itself, loading blocks one at a time, and

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -273,10 +273,20 @@ public class ForkchoiceUpdatedHandler(
             return result;
         }
 
-        if (!stateReader.HasStateForBlock(newHeadHeader) && !await TryRestoreState(newHeadHeader))
+        // Canonical historical FCUs remain valid without state; orphan eviction only removes side branches.
+        if (!_blockTree.IsMainChain(newHeadHeader) && !stateReader.HasStateForBlock(newHeadHeader))
         {
-            if (_logger.IsInfo) _logger.Info($"Syncing, state of the processed head {newHeadHeader.ToString(BlockHeader.Format.Short)} is gone and could not be rebuilt. Request: {requestStr}.");
-            return ForkchoiceUpdatedV1Result.Syncing;
+            bool? restored = await TryRestoreState(newHeadHeader);
+            if (restored is not true)
+            {
+                _blockTree.ForkChoiceUpdated(forkchoiceState.FinalizedBlockHash, forkchoiceState.SafeBlockHash);
+                if (restored is false)
+                {
+                    if (_logger.IsWarn) _logger.Warn($"Syncing, state of the processed head {newHeadHeader.ToString(BlockHeader.Format.Short)} is gone and could not be rebuilt. Request: {requestStr}.");
+                    StartNewBeaconHeaderSync(forkchoiceState, newHeadHeader, requestStr);
+                }
+                return ForkchoiceUpdatedV1Result.Syncing;
+            }
         }
 
         bool newHeadTheSameAsCurrentHead = _blockTree.Head!.Hash == newHeadHeader.Hash;
@@ -301,22 +311,24 @@ public class ForkchoiceUpdatedHandler(
     }
 
     /// <summary>
-    /// Re-executes a processed head whose state was pruned, from the nearest ancestor with state, so the fork
-    /// choice can be served instead of answered with SYNCING. Waits for the processing queue as newPayload does.
+    /// Restores a processed head's pruned state, returning null while more processing is needed.
     /// </summary>
-    private async Task<bool> TryRestoreState(BlockHeader newHeadHeader)
+    /// <remarks>A selected fork can exceed the newPayload lookback window. Rebuild at most eight blocks per call,
+    /// so retries make progress without monopolizing the processing queue with the entire fork.</remarks>
+    private async Task<bool?> TryRestoreState(BlockHeader newHeadHeader)
     {
-        if (!PrunedStateRecovery.HasAncestorWithState(_blockTree, stateReader, newHeadHeader)) return false;
+        BlockHeader? recoveryHead = PrunedStateRecovery.FindRecoveryHead(_blockTree, stateReader, newHeadHeader);
+        if (recoveryHead is null) return false;
 
-        Block? block = _blockTree.FindBlock(newHeadHeader.Hash!, BlockTreeLookupOptions.None);
+        Block? block = _blockTree.FindBlock(recoveryHead.Hash!, BlockTreeLookupOptions.None);
         if (block is null) return false;
 
-        if (_logger.IsInfo) _logger.Info($"Re-executing {newHeadHeader.ToString(BlockHeader.Format.Short)}: it was processed but its state has been pruned.");
+        if (_logger.IsInfo) _logger.Info($"Re-executing through {recoveryHead.ToString(BlockHeader.Format.Short)} toward {newHeadHeader.ToString(BlockHeader.Format.Short)}: its state has been pruned.");
 
         TaskCompletionSource<ProcessingResult> processed = new(TaskCreationOptions.RunContinuationsAsynchronously);
         void OnBlockRemoved(object? sender, BlockRemovedEventArgs e)
         {
-            if (e.BlockHash == newHeadHeader.Hash) processed.TrySetResult(e.ProcessingResult);
+            if (e.BlockHash == recoveryHead.Hash) processed.TrySetResult(e.ProcessingResult);
         }
 
         processingQueue.BlockRemoved += OnBlockRemoved;
@@ -324,11 +336,12 @@ public class ForkchoiceUpdatedHandler(
         {
             await processingQueue.Enqueue(block, _reExecutionOptions);
             using CancellationTokenSource timeout = new(_reExecutionTimeout);
-            return await processed.Task.WaitAsync(timeout.Token) == ProcessingResult.Success;
+            if (await processed.Task.WaitAsync(timeout.Token) != ProcessingResult.Success) return false;
+            return stateReader.HasStateForBlock(newHeadHeader) ? true : null;
         }
         catch (OperationCanceledException)
         {
-            return false;
+            return null;
         }
         finally
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -334,15 +334,14 @@ public class ForkchoiceUpdatedHandler(
         }
 
         BlockHeader? recoveryHead = PrunedStateRecovery.FindRecoveryHead(_blockTree, stateReader!, newHeadHeader);
-        if (recoveryHead is null)
+        Block? block = recoveryHead is null ? null : _blockTree.FindBlock(recoveryHead.Hash!, BlockTreeLookupOptions.None);
+        if (block is null)
         {
-            // State can arrive without a head change, so a failed search is cached only briefly.
+            // State or a missing body can arrive without a head change, so failures are cached only briefly.
             Volatile.Write(ref _lastRecoveryFailure, new(newHeadHeader.Hash!, _blockTree.HeadHash, _timestamper.UtcNow));
             return false;
         }
-
-        Block? block = _blockTree.FindBlock(recoveryHead.Hash!, BlockTreeLookupOptions.None);
-        if (block is null) return false;
+        recoveryHead = block.Header;
 
         if (_logger.IsInfo) _logger.Info($"Re-executing through {recoveryHead.ToString(BlockHeader.Format.Short)} toward {newHeadHeader.ToString(BlockHeader.Format.Short)}: its state has been pruned.");
 

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Find;
+using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
@@ -22,6 +23,7 @@ using Nethermind.Merge.Plugin.BlockProduction;
 using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.State;
 using Nethermind.Synchronization.Peers;
 
 namespace Nethermind.Merge.Plugin.Handlers;
@@ -47,12 +49,19 @@ public class ForkchoiceUpdatedHandler(
     ISpecProvider specProvider,
     ISyncPeerPool syncPeerPool,
     IMergeConfig mergeConfig,
+    IReceiptConfig receiptConfig,
+    IStateReader stateReader,
     ILogManager logManager) : IForkchoiceUpdatedHandler
 {
     protected readonly IBlockTree _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
     private readonly IPoSSwitcher _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
     private readonly ILogger _logger = logManager.GetClassLogger<ForkchoiceUpdatedHandler>();
     private readonly bool _simulateBlockProduction = mergeConfig.SimulateBlockProduction;
+    // Re-executing a pruned head walks the branch down to the nearest state, so the parent-on-main-chain shortcut is off.
+    private readonly ProcessingOptions _reExecutionOptions =
+        (receiptConfig.StoreReceipts ? ProcessingOptions.EthereumMerge | ProcessingOptions.StoreReceipts : ProcessingOptions.EthereumMerge)
+        & ~ProcessingOptions.IgnoreParentNotOnMainChain;
+    private readonly TimeSpan _reExecutionTimeout = TimeSpan.FromMilliseconds(mergeConfig.NewPayloadBlockProcessingTimeout);
 
     public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> Handle(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, int version)
     {
@@ -264,6 +273,12 @@ public class ForkchoiceUpdatedHandler(
             return result;
         }
 
+        if (!stateReader.HasStateForBlock(newHeadHeader) && !await TryRestoreState(newHeadHeader))
+        {
+            if (_logger.IsInfo) _logger.Info($"Syncing, state of the processed head {newHeadHeader.ToString(BlockHeader.Format.Short)} is gone and could not be rebuilt. Request: {requestStr}.");
+            return ForkchoiceUpdatedV1Result.Syncing;
+        }
+
         bool newHeadTheSameAsCurrentHead = _blockTree.Head!.Hash == newHeadHeader.Hash;
         bool shouldUpdateHead = !newHeadTheSameAsCurrentHead;
         // TryUpdateMainChain walks back to the current main chain itself, loading blocks one at a time, and
@@ -283,6 +298,42 @@ public class ForkchoiceUpdatedHandler(
 
         _blockTree.ForkChoiceUpdated(forkchoiceState.FinalizedBlockHash, forkchoiceState.SafeBlockHash);
         return null;
+    }
+
+    /// <summary>
+    /// Re-executes a processed head whose state was pruned, from the nearest ancestor with state, so the fork
+    /// choice can be served instead of answered with SYNCING. Waits for the processing queue as newPayload does.
+    /// </summary>
+    private async Task<bool> TryRestoreState(BlockHeader newHeadHeader)
+    {
+        if (!PrunedStateRecovery.HasAncestorWithState(_blockTree, stateReader, newHeadHeader)) return false;
+
+        Block? block = _blockTree.FindBlock(newHeadHeader.Hash!, BlockTreeLookupOptions.None);
+        if (block is null) return false;
+
+        if (_logger.IsInfo) _logger.Info($"Re-executing {newHeadHeader.ToString(BlockHeader.Format.Short)}: it was processed but its state has been pruned.");
+
+        TaskCompletionSource<ProcessingResult> processed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnBlockRemoved(object? sender, BlockRemovedEventArgs e)
+        {
+            if (e.BlockHash == newHeadHeader.Hash) processed.TrySetResult(e.ProcessingResult);
+        }
+
+        processingQueue.BlockRemoved += OnBlockRemoved;
+        try
+        {
+            await processingQueue.Enqueue(block, _reExecutionOptions);
+            using CancellationTokenSource timeout = new(_reExecutionTimeout);
+            return await processed.Task.WaitAsync(timeout.Token) == ProcessingResult.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+        finally
+        {
+            processingQueue.BlockRemoved -= OnBlockRemoved;
+        }
     }
 
     protected virtual bool IsPayloadTimestampValid(BlockHeader newHeadHeader, PayloadAttributes payloadAttributes)

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -332,7 +332,7 @@ public class ForkchoiceUpdatedHandler(
             if (elapsed >= TimeSpan.Zero && elapsed < TimeSpan.FromSeconds(1)) return false;
         }
 
-        BlockHeader? recoveryHead = PrunedStateRecovery.FindRecoveryHead(_blockTree, stateReader!, newHeadHeader);
+        BlockHeader? recoveryHead = PrunedStateRecovery.FindRecoveryHead(_blockTree, stateReader, newHeadHeader);
         Block? block = recoveryHead is null ? null : _blockTree.FindBlock(recoveryHead.Hash!, BlockTreeLookupOptions.None);
         if (block is null)
         {
@@ -356,7 +356,7 @@ public class ForkchoiceUpdatedHandler(
             await processingQueue.Enqueue(block, _reExecutionOptions);
             using CancellationTokenSource timeout = new(_reExecutionTimeout);
             if (await processed.Task.WaitAsync(timeout.Token) != ProcessingResult.Success) return false;
-            return stateReader!.HasStateForBlock(newHeadHeader) ? true : null;
+            return stateReader.HasStateForBlock(newHeadHeader) ? true : null;
         }
         catch (OperationCanceledException)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/ForkchoiceUpdatedHandler.cs
@@ -17,6 +17,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Threading;
 using Nethermind.Crypto;
+using Nethermind.Init;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
@@ -49,19 +50,26 @@ public class ForkchoiceUpdatedHandler(
     ISpecProvider specProvider,
     ISyncPeerPool syncPeerPool,
     IMergeConfig mergeConfig,
-    IReceiptConfig receiptConfig,
-    IStateReader stateReader,
-    ILogManager logManager) : IForkchoiceUpdatedHandler
+    ILogManager logManager,
+    IReceiptConfig? receiptConfig = null,
+    IStateReader? stateReader = null,
+    FlatStateActivationPolicy? flatStateActivationPolicy = null,
+    ITimestamper? timestamper = null) : IForkchoiceUpdatedHandler
 {
     protected readonly IBlockTree _blockTree = blockTree ?? throw new ArgumentNullException(nameof(blockTree));
     private readonly IPoSSwitcher _poSSwitcher = poSSwitcher ?? throw new ArgumentNullException(nameof(poSSwitcher));
     private readonly ILogger _logger = logManager.GetClassLogger<ForkchoiceUpdatedHandler>();
     private readonly bool _simulateBlockProduction = mergeConfig.SimulateBlockProduction;
+    private readonly bool _recoverPrunedState = flatStateActivationPolicy?.ShouldTurnOnFlatDb() is true && stateReader is not null;
+    private readonly ITimestamper _timestamper = timestamper ?? Timestamper.Default;
     // Re-executing a pruned head walks the branch down to the nearest state, so the parent-on-main-chain shortcut is off.
     private readonly ProcessingOptions _reExecutionOptions =
-        (receiptConfig.StoreReceipts ? ProcessingOptions.EthereumMerge | ProcessingOptions.StoreReceipts : ProcessingOptions.EthereumMerge)
+        (receiptConfig?.StoreReceipts is true ? ProcessingOptions.EthereumMerge | ProcessingOptions.StoreReceipts : ProcessingOptions.EthereumMerge)
         & ~ProcessingOptions.IgnoreParentNotOnMainChain;
     private readonly TimeSpan _reExecutionTimeout = TimeSpan.FromMilliseconds(mergeConfig.NewPayloadBlockProcessingTimeout);
+    private RecoveryFailure? _lastRecoveryFailure;
+
+    private sealed record RecoveryFailure(Hash256 Target, Hash256? Head, DateTime Timestamp);
 
     public async Task<ResultWrapper<ForkchoiceUpdatedV1Result>> Handle(ForkchoiceStateV1 forkchoiceState, PayloadAttributes? payloadAttributes, int version)
     {
@@ -274,12 +282,13 @@ public class ForkchoiceUpdatedHandler(
         }
 
         // Canonical historical FCUs remain valid without state; orphan eviction only removes side branches.
-        if (!_blockTree.IsMainChain(newHeadHeader) && !stateReader.HasStateForBlock(newHeadHeader))
+        if (_recoverPrunedState && !_blockTree.IsMainChain(newHeadHeader) && !stateReader!.HasStateForBlock(newHeadHeader))
         {
             bool? restored = await TryRestoreState(newHeadHeader);
             if (restored is not true)
             {
-                _blockTree.ForkChoiceUpdated(forkchoiceState.FinalizedBlockHash, forkchoiceState.SafeBlockHash);
+                blockCacheService.FinalizedHash = forkchoiceState.FinalizedBlockHash;
+                blockCacheService.HeadBlockHash = forkchoiceState.HeadBlockHash;
                 if (restored is false)
                 {
                     if (_logger.IsWarn) _logger.Warn($"Syncing, state of the processed head {newHeadHeader.ToString(BlockHeader.Format.Short)} is gone and could not be rebuilt. Request: {requestStr}.");
@@ -317,8 +326,20 @@ public class ForkchoiceUpdatedHandler(
     /// so retries make progress without monopolizing the processing queue with the entire fork.</remarks>
     private async Task<bool?> TryRestoreState(BlockHeader newHeadHeader)
     {
-        BlockHeader? recoveryHead = PrunedStateRecovery.FindRecoveryHead(_blockTree, stateReader, newHeadHeader);
-        if (recoveryHead is null) return false;
+        RecoveryFailure? lastFailure = Volatile.Read(ref _lastRecoveryFailure);
+        if (lastFailure is not null && lastFailure.Target == newHeadHeader.Hash && lastFailure.Head == _blockTree.HeadHash)
+        {
+            TimeSpan elapsed = _timestamper.UtcNow - lastFailure.Timestamp;
+            if (elapsed >= TimeSpan.Zero && elapsed < TimeSpan.FromSeconds(1)) return false;
+        }
+
+        BlockHeader? recoveryHead = PrunedStateRecovery.FindRecoveryHead(_blockTree, stateReader!, newHeadHeader);
+        if (recoveryHead is null)
+        {
+            // State can arrive without a head change, so a failed search is cached only briefly.
+            Volatile.Write(ref _lastRecoveryFailure, new(newHeadHeader.Hash!, _blockTree.HeadHash, _timestamper.UtcNow));
+            return false;
+        }
 
         Block? block = _blockTree.FindBlock(recoveryHead.Hash!, BlockTreeLookupOptions.None);
         if (block is null) return false;
@@ -337,7 +358,7 @@ public class ForkchoiceUpdatedHandler(
             await processingQueue.Enqueue(block, _reExecutionOptions);
             using CancellationTokenSource timeout = new(_reExecutionTimeout);
             if (await processed.Task.WaitAsync(timeout.Token) != ProcessingResult.Success) return false;
-            return stateReader.HasStateForBlock(newHeadHeader) ? true : null;
+            return stateReader!.HasStateForBlock(newHeadHeader) ? true : null;
         }
         catch (OperationCanceledException)
         {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -440,7 +440,15 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
                                     && parentBlockInfo is { IsBeaconInfo: false } // we are not in beacon sync
                                     && parentIsPoWBlock; // parent was PoW block -> so it was a transition block
 
-        if (!parentProcessed && processTerminalBlock) // so if parent wasn't processed
+        // A processed parent whose state was since pruned (flat state bounding drops orphaned siblings under a head
+        // that never advances) is recovered the same way, re-executing the branch from the nearest ancestor that
+        // still has state. Without such an ancestor the node is behind, and syncing stays the answer.
+        bool parentStateEvicted = !parentProcessed
+                                  && parentBlockInfo is { WasProcessed: true }
+                                  && weHaveOnlyFewBlocksToProcess
+                                  && HasAncestorWithState(parent);
+
+        if (!parentProcessed && (processTerminalBlock || parentStateEvicted)) // so if parent wasn't processed
         {
             if (_logger.IsInfo) _logger.Info($"Forced processing block {block}, block TD: {block.TotalDifficulty}, parent: {parent}, parent TD: {parent.TotalDifficulty}");
 
@@ -450,8 +458,25 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
             processingOptions &= ~ProcessingOptions.IgnoreParentNotOnMainChain;
         }
 
-        return parentProcessed || processTerminalBlock;
+        return parentProcessed || processTerminalBlock || parentStateEvicted;
     }
+
+    /// <summary>Whether an ancestor within the forced-processing window still has state for a branch re-execution to start from.</summary>
+    private bool HasAncestorWithState(BlockHeader parent)
+    {
+        BlockHeader? ancestor = parent;
+        for (int depth = 0; depth < MaxReExecutionDepth; depth++)
+        {
+            ancestor = _blockTree.FindHeader(ancestor.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+            if (ancestor is null) return false;
+            if (_stateReader.HasStateForBlock(ancestor)) return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Mirrors the few-blocks-to-process window: a pruned parent is re-executed only from this close an ancestor.</summary>
+    private const int MaxReExecutionDepth = 8;
 
     /// <summary>Slack above head within which early recovery is worthwhile, mirroring the
     /// few-blocks-to-process window in <see cref="ShouldProcessBlock"/>.</summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -446,7 +446,7 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
         bool parentStateEvicted = !parentProcessed
                                   && parentBlockInfo is { WasProcessed: true }
                                   && weHaveOnlyFewBlocksToProcess
-                                  && HasAncestorWithState(parent);
+                                  && PrunedStateRecovery.HasAncestorWithState(_blockTree, _stateReader, parent);
 
         if (!parentProcessed && (processTerminalBlock || parentStateEvicted)) // so if parent wasn't processed
         {
@@ -460,23 +460,6 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
 
         return parentProcessed || processTerminalBlock || parentStateEvicted;
     }
-
-    /// <summary>Whether an ancestor within the forced-processing window still has state for a branch re-execution to start from.</summary>
-    private bool HasAncestorWithState(BlockHeader parent)
-    {
-        BlockHeader? ancestor = parent;
-        for (int depth = 0; depth < MaxReExecutionDepth; depth++)
-        {
-            ancestor = _blockTree.FindHeader(ancestor.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
-            if (ancestor is null) return false;
-            if (_stateReader.HasStateForBlock(ancestor)) return true;
-        }
-
-        return false;
-    }
-
-    /// <summary>Mirrors the few-blocks-to-process window: a pruned parent is re-executed only from this close an ancestor.</summary>
-    private const int MaxReExecutionDepth = 8;
 
     /// <summary>Slack above head within which early recovery is worthwhile, mirroring the
     /// few-blocks-to-process window in <see cref="ShouldProcessBlock"/>.</summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/NewPayloadHandler.cs
@@ -22,6 +22,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Threading;
 using Nethermind.Crypto;
 using Nethermind.Int256;
+using Nethermind.Init;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin.BlockProduction;
@@ -61,6 +62,7 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
     private readonly LruCache<Hash256AsKey, CachedPayloadResult>? _latestBlocks;
     private readonly ProcessingOptions _defaultProcessingOptions;
     private readonly TimeSpan _timeout;
+    private readonly bool _recoverPrunedState;
 
     private readonly ConcurrentDictionary<Hash256, ValidationCompletion> _blockValidationTasks = new();
 
@@ -85,7 +87,8 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
         IEthereumEcdsa ecdsa,
         ISpecProvider specProvider,
         ITxValidator txValidator,
-        ILogManager logManager)
+        ILogManager logManager,
+        FlatStateActivationPolicy? flatStateActivationPolicy = null)
     {
         _payloadPreparationService = payloadPreparationService;
         _blockValidator = blockValidator ?? throw new ArgumentNullException(nameof(blockValidator));
@@ -98,6 +101,7 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
         _invalidChainTracker = invalidChainTracker;
         _mergeSyncController = mergeSyncController;
         _stateReader = stateReader;
+        _recoverPrunedState = flatStateActivationPolicy?.ShouldTurnOnFlatDb() is true;
         _specProvider = specProvider;
         _txValidator = txValidator;
         _senderRecovery = new RecoverSignatures(ecdsa, specProvider, logManager);
@@ -443,7 +447,7 @@ public sealed class NewPayloadHandler : IAsyncHandler<ExecutionPayload, PayloadS
         // A processed parent whose state was since pruned (flat state bounding drops orphaned siblings under a head
         // that never advances) is recovered the same way, re-executing the branch from the nearest ancestor that
         // still has state. Without such an ancestor the node is behind, and syncing stays the answer.
-        bool parentStateEvicted = !parentProcessed
+        bool parentStateEvicted = _recoverPrunedState && !parentProcessed
                                   && parentBlockInfo is { WasProcessed: true }
                                   && weHaveOnlyFewBlocksToProcess
                                   && PrunedStateRecovery.HasAncestorWithState(_blockTree, _stateReader, parent);

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/PrunedStateRecovery.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/PrunedStateRecovery.cs
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Blockchain;
+using Nethermind.Core;
+using Nethermind.State;
+
+namespace Nethermind.Merge.Plugin.Handlers;
+
+/// <summary>
+/// A processed block can lose its state again: flat state bounding drops orphaned siblings under a head that
+/// never advances. Such a block is recovered by re-executing the branch from the nearest ancestor that still has
+/// state, which the engine handlers only attempt within a short window so a node that is really behind syncs.
+/// </summary>
+internal static class PrunedStateRecovery
+{
+    /// <summary>Mirrors the few-blocks-to-process window of newPayload: re-execution starts at most this many blocks down.</summary>
+    public const int MaxReExecutionDepth = 8;
+
+    /// <summary>Whether an ancestor of <paramref name="header"/> within <see cref="MaxReExecutionDepth"/> still has state.</summary>
+    public static bool HasAncestorWithState(IBlockTree blockTree, IStateReader stateReader, BlockHeader header)
+    {
+        BlockHeader? ancestor = header;
+        for (int depth = 0; depth < MaxReExecutionDepth; depth++)
+        {
+            ancestor = blockTree.FindHeader(ancestor.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+            if (ancestor is null) return false;
+            if (stateReader.HasStateForBlock(ancestor)) return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/PrunedStateRecovery.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/PrunedStateRecovery.cs
@@ -10,18 +10,38 @@ namespace Nethermind.Merge.Plugin.Handlers;
 /// <summary>
 /// A processed block can lose its state again: flat state bounding drops orphaned siblings under a head that
 /// never advances. Such a block is recovered by re-executing the branch from the nearest ancestor that still has
-/// state, which the engine handlers only attempt within a short window so a node that is really behind syncs.
+/// state.
 /// </summary>
 internal static class PrunedStateRecovery
 {
     /// <summary>Mirrors the few-blocks-to-process window of newPayload: re-execution starts at most this many blocks down.</summary>
     public const int MaxReExecutionDepth = 8;
 
+    // Match the processing branch's search bound without scheduling that many blocks at once.
+    private const int MaxAncestorSearchDepth = 8192;
+
+    /// <summary>Finds the first bounded replay segment of a stored fork with an available state ancestor.</summary>
+    public static BlockHeader? FindRecoveryHead(IBlockTree blockTree, IStateReader stateReader, BlockHeader header)
+    {
+        BlockHeader[] recent = new BlockHeader[MaxReExecutionDepth];
+        recent[0] = header;
+        BlockHeader? ancestor = header;
+        for (int depth = 1; depth <= MaxAncestorSearchDepth && !ancestor.IsGenesis; depth++)
+        {
+            ancestor = blockTree.FindHeader(ancestor.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
+            if (ancestor is null) return null;
+            if (stateReader.HasStateForBlock(ancestor)) return recent[depth <= MaxReExecutionDepth ? 0 : depth % MaxReExecutionDepth];
+            recent[depth % MaxReExecutionDepth] = ancestor;
+        }
+
+        return null;
+    }
+
     /// <summary>Whether an ancestor of <paramref name="header"/> within <see cref="MaxReExecutionDepth"/> still has state.</summary>
     public static bool HasAncestorWithState(IBlockTree blockTree, IStateReader stateReader, BlockHeader header)
     {
         BlockHeader? ancestor = header;
-        for (int depth = 0; depth < MaxReExecutionDepth; depth++)
+        for (int depth = 0; depth < MaxReExecutionDepth && !ancestor.IsGenesis; depth++)
         {
             ancestor = blockTree.FindHeader(ancestor.ParentHash!, BlockTreeLookupOptions.TotalDifficultyNotNeeded);
             if (ancestor is null) return false;

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeFinalizedStateProvider.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeFinalizedStateProvider.cs
@@ -12,6 +12,8 @@ namespace Nethermind.Merge.Plugin;
 
 public class MergeFinalizedStateProvider(IPoSSwitcher poSSwitcher, IBlockCacheService blockCacheService, IBlockTree blockTree, IFinalizedStateProvider baseFinalizedStateProvider) : IFinalizedStateProvider
 {
+    public BlockHeader? Head => blockTree.Head?.Header;
+
     public ulong FinalizedBlockNumber
     {
         get

--- a/src/Nethermind/Nethermind.State.Flat.History.Test/HistoricalTraceReExecutionTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.History.Test/HistoricalTraceReExecutionTests.cs
@@ -152,7 +152,8 @@ public class HistoricalTraceReExecutionTests
         new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 4, InlineCompaction = true, HistoryEnabled = true },
         _blocksConfig,
         LimboLogs.Instance,
-        enableDetailedMetrics: false);
+        enableDetailedMetrics: false,
+        new SnapshotRetention());
 
     private static FlatScopeProvider CreateScopeProvider(IFlatDbManager manager) => new(
         new MemDb(),

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
@@ -132,6 +132,8 @@ public class FlatDbManagerPersistedTests
     public async Task RemoveOrphanedStates_ActiveCompactedBundle_PreservesUnleasedBaseAncestry()
     {
         StateId s0 = new(0, Keccak.EmptyTreeHash);
+        StateId canonicalFirst = new(1, Keccak.Compute("canonical1"));
+        StateId canonicalSecond = new(2, Keccak.Compute("canonical2"));
         StateId canonical = new(3, Keccak.Compute("canonical"));
         StateId first = new(1, Keccak.Compute("orphan1"));
         StateId second = new(2, Keccak.Compute("orphan2"));
@@ -140,7 +142,9 @@ public class FlatDbManagerPersistedTests
         using FlatTestContainer tier = CreateRetentionContainer(s0);
         await using FlatDbManager manager = (FlatDbManager)tier.Resolve<IFlatDbManager>();
         SnapshotRepository repository = tier.Repository;
-        AddEmptySnapshot(tier, s0, canonical);
+        AddEmptySnapshot(tier, s0, canonicalFirst);
+        AddEmptySnapshot(tier, canonicalFirst, canonicalSecond);
+        AddEmptySnapshot(tier, canonicalSecond, canonical);
         AddEmptySnapshot(tier, s0, first);
         AddEmptySnapshot(tier, first, second);
         AddEmptySnapshot(tier, second, head);

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerPersistedTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
 using Nethermind.Logging;
+using Nethermind.Monitoring.Config;
 using Nethermind.State.Flat.Persistence;
 using Nethermind.State.Flat.PersistedSnapshots;
 using Nethermind.Trie;
@@ -85,7 +86,8 @@ public class FlatDbManagerPersistedTests
             _config,
             new BlocksConfig(),
             LimboLogs.Instance,
-            enableDetailedMetrics: false);
+            enableDetailedMetrics: false,
+            tier.Resolve<SnapshotRetention>());
 
         ReadOnlySnapshotBundle bundle = manager.GatherReadOnlySnapshotBundle(s1);
 
@@ -93,6 +95,125 @@ public class FlatDbManagerPersistedTests
         Assert.That(result, Is.EqualTo(nodeRlp));
 
         bundle.Dispose();
+    }
+
+    [Test]
+    public async Task GatherReadOnlySnapshotBundle_RetainsHeadUntilCacheAndReadersRelease([Values] bool persisted)
+    {
+        StateId s0 = new(0, Keccak.EmptyTreeHash);
+        StateId s1 = new(1, Keccak.Compute("retained"));
+        using FlatTestContainer tier = CreateRetentionContainer(s0);
+        await using FlatDbManager manager = (FlatDbManager)tier.Resolve<IFlatDbManager>();
+        SnapshotRetention retention = tier.Resolve<SnapshotRetention>();
+        Snapshot snapshot = tier.ResourcePool.CreateSnapshot(s0, s1, ResourcePool.Usage.MainBlockProcessing);
+        if (persisted)
+        {
+            using (snapshot) tier.ConvertToPersistedBase(snapshot).Dispose();
+        }
+        else
+        {
+            Assert.That(tier.Repository.TryAdd(snapshot, SnapshotTier.InMemoryBase), Is.True);
+            tier.Repository.AddStateId(s1);
+        }
+
+        using (ReadOnlySnapshotBundle first = manager.GatherReadOnlySnapshotBundle(s1))
+        {
+            using (ReadOnlySnapshotBundle second = manager.GatherReadOnlySnapshotBundle(s1))
+                Assert.That(second, Is.SameAs(first));
+            AssertRetained(retention, s1, true);
+
+            manager.FlushCache(CancellationToken.None);
+            AssertRetained(retention, s1, true);
+        }
+        AssertRetained(retention, s1, false);
+    }
+
+    [Test]
+    public async Task RemoveOrphanedStates_ActiveCompactedBundle_PreservesUnleasedBaseAncestry()
+    {
+        StateId s0 = new(0, Keccak.EmptyTreeHash);
+        StateId canonical = new(3, Keccak.Compute("canonical"));
+        StateId first = new(1, Keccak.Compute("orphan1"));
+        StateId second = new(2, Keccak.Compute("orphan2"));
+        StateId head = new(3, Keccak.Compute("orphan3"));
+        StateId unused = new(2, Keccak.Compute("unused"));
+        using FlatTestContainer tier = CreateRetentionContainer(s0);
+        await using FlatDbManager manager = (FlatDbManager)tier.Resolve<IFlatDbManager>();
+        SnapshotRepository repository = tier.Repository;
+        AddEmptySnapshot(tier, s0, canonical);
+        AddEmptySnapshot(tier, s0, first);
+        AddEmptySnapshot(tier, first, second);
+        AddEmptySnapshot(tier, second, head);
+        AddEmptySnapshot(tier, s0, head, compacted: true);
+        AddEmptySnapshot(tier, s0, unused);
+        repository.SetLastCommittedStateId(canonical);
+
+        using (ReadOnlySnapshotBundle bundle = manager.GatherReadOnlySnapshotBundle(head))
+        {
+            Assert.That(bundle.SnapshotCount, Is.EqualTo(1), "The compacted edge bypasses the base snapshots.");
+            manager.FlushCache(CancellationToken.None);
+
+            Assert.That(repository.RemoveOrphanedStates(canonical, canonical), Is.EqualTo(1));
+            using AssembledSnapshotResult ancestry = repository.AssembleSnapshots(second, s0, 2);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(repository.HasState(unused), Is.False);
+                Assert.That(repository.HasState(first), Is.True);
+                Assert.That(repository.HasState(second), Is.True);
+                Assert.That(ancestry.SnapshotCount, Is.EqualTo(2));
+            }
+        }
+
+        Assert.That(repository.RemoveOrphanedStates(canonical, canonical), Is.EqualTo(4));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(repository.HasState(first), Is.False);
+            Assert.That(repository.HasState(second), Is.False);
+            Assert.That(repository.HasState(head), Is.False);
+            Assert.That(repository.HasState(canonical), Is.True);
+        }
+    }
+
+    private static void AddEmptySnapshot(FlatTestContainer tier, StateId from, StateId to, bool compacted = false)
+    {
+        Snapshot snapshot = tier.ResourcePool.CreateSnapshot(from, to, ResourcePool.Usage.MainBlockProcessing);
+        Assert.That(tier.Repository.TryAdd(snapshot, compacted ? SnapshotTier.InMemoryCompacted : SnapshotTier.InMemoryBase), Is.True);
+        if (!compacted) tier.Repository.AddStateId(to);
+    }
+
+    [Test]
+    public async Task GatherReadOnlySnapshotBundle_UnavailableState_ReleasesRetention()
+    {
+        StateId s0 = new(0, Keccak.EmptyTreeHash);
+        StateId missing = new(1, Keccak.Compute("missing"));
+        using FlatTestContainer tier = CreateRetentionContainer(s0);
+        await using FlatDbManager manager = (FlatDbManager)tier.Resolve<IFlatDbManager>();
+
+        Assert.That(() => manager.GatherReadOnlySnapshotBundle(missing), Throws.TypeOf<StateUnavailableException>());
+        AssertRetained(tier.Resolve<SnapshotRetention>(), missing, false);
+    }
+
+    private static FlatTestContainer CreateRetentionContainer(StateId persistedState)
+    {
+        IPersistenceManager persistenceManager = Substitute.For<IPersistenceManager>();
+        IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
+        reader.CurrentState.Returns(persistedState);
+        persistenceManager.LeaseReader().Returns(reader);
+        persistenceManager.GetCurrentPersistedStateId().Returns(persistedState);
+        persistenceManager.FlushToPersistence(Arg.Any<CancellationToken>()).Returns(persistedState);
+        return new FlatTestContainer(
+            new FlatDbConfig { TrieCacheMemoryBudget = 0 },
+            arenaFileSizeBytes: 4096,
+            configure: builder => builder
+                .AddSingleton<IPersistenceManager>(persistenceManager)
+                .AddSingleton<IBlocksConfig>(new BlocksConfig())
+                .AddSingleton<IMetricsConfig>(new MetricsConfig()));
+    }
+
+    private static void AssertRetained(SnapshotRetention retention, StateId head, bool expected)
+    {
+        using Lock.Scope scope = retention.Sync.EnterScope();
+        Assert.That(retention.ActiveHeads.Contains(head), Is.EqualTo(expected));
     }
 
     [Test]
@@ -118,7 +239,8 @@ public class FlatDbManagerPersistedTests
             _config,
             new BlocksConfig(),
             LimboLogs.Instance,
-            enableDetailedMetrics: false);
+            enableDetailedMetrics: false,
+            tier.Resolve<SnapshotRetention>());
 
         // WaitAsync bounds only the wait, not the drain. A wedged worker-channel drain
         // causes a fast TimeoutException here instead of a stalled test host.

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -202,14 +202,14 @@ public class FlatDbManagerTests
     }
 
     [Test]
-    public async Task AddSnapshot_RemovedBeforeQueuedCompaction_DoesNotReindexOrCompact()
+    public async Task AddSnapshot_RemovedBeforeQueuedCompaction_StillTriggersPersistenceWithoutReindexing()
     {
         (FlatDbManager manager, StateId snapshotTo) = CreateManagerWithQueuedSnapshot(snapshotAvailable: false);
         await manager.DisposeAsync();
 
         _snapshotRepository.DidNotReceive().AddStateId(snapshotTo);
         _snapshotCompactor.DidNotReceive().DoCompactSnapshot(snapshotTo);
-        await _persistenceManager.DidNotReceive().AddToPersistence(snapshotTo);
+        await _persistenceManager.Received(1).AddToPersistence(snapshotTo);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/FlatDbManagerTests.cs
@@ -34,6 +34,7 @@ public class FlatDbManagerTests
     private IFlatDbConfig _config = null!;
     private IBlocksConfig _blocksConfig = null!;
     private CancellationTokenSource _cts = null!;
+    private SnapshotRetention _retention = null!;
 
     private const long HistoryBarrier = 100;
     private static readonly Address HistoryAddr = new("0x0000000000000000000000000000000000000abc");
@@ -50,6 +51,7 @@ public class FlatDbManagerTests
     {
         _resourcePool = Substitute.For<IResourcePool>();
         _cts = new CancellationTokenSource();
+        _retention = new SnapshotRetention();
         _processExitSource = Substitute.For<IProcessExitSource>();
         _processExitSource.Token.Returns(_cts.Token);
         _trieNodeCache = Substitute.For<ITrieNodeCache>();
@@ -91,7 +93,8 @@ public class FlatDbManagerTests
         _config,
         _blocksConfig,
         LimboLogs.Instance,
-        enableDetailedMetrics: false);
+        enableDetailedMetrics: false,
+        _retention);
 
     private static StateId CreateStateId(ulong blockNumber, byte rootByte = 0)
     {
@@ -101,7 +104,7 @@ public class FlatDbManagerTests
     }
 
     private (FlatDbManager Manager, StateId SnapshotTo) CreateManagerWithQueuedSnapshot(
-        bool processExitAlreadyCancelled = false)
+        bool processExitAlreadyCancelled = false, bool snapshotAvailable = true)
     {
         _config = new FlatDbConfig { CompactSize = 16, MaxInFlightCompactJob = 4, InlineCompaction = false };
         StateId snapshotFrom = CreateStateId(10);
@@ -115,6 +118,11 @@ public class FlatDbManagerTests
         ResourcePool realResourcePool = new(_config);
         Snapshot snapshot = realResourcePool.CreateSnapshot(
             snapshotFrom, snapshotTo, ResourcePool.Usage.MainBlockProcessing);
+        _snapshotRepository.TryLeaseInMemoryState(snapshotTo, SnapshotTier.InMemoryBase, out Arg.Any<Snapshot?>()).Returns(call =>
+        {
+            call[2] = snapshotAvailable ? snapshot : null;
+            return snapshotAvailable && snapshot.TryAcquire();
+        });
         TransientResource transientResource = realResourcePool.GetCachedResource(ResourcePool.Usage.MainBlockProcessing);
 
         FlatDbManager manager = CreateManager();
@@ -191,6 +199,46 @@ public class FlatDbManagerTests
             _ = _persistenceManager.AddToPersistence(snapshotTo);
             _persistenceManager.FlushToPersistence(CancellationToken.None);
         });
+    }
+
+    [Test]
+    public async Task AddSnapshot_RemovedBeforeQueuedCompaction_DoesNotReindexOrCompact()
+    {
+        (FlatDbManager manager, StateId snapshotTo) = CreateManagerWithQueuedSnapshot(snapshotAvailable: false);
+        await manager.DisposeAsync();
+
+        _snapshotRepository.DidNotReceive().AddStateId(snapshotTo);
+        _snapshotCompactor.DidNotReceive().DoCompactSnapshot(snapshotTo);
+        await _persistenceManager.DidNotReceive().AddToPersistence(snapshotTo);
+    }
+
+    [Test]
+    public async Task AddSnapshot_QueuedCompaction_RetainsHeadUntilOutputPublication()
+    {
+        TaskCompletionSource compactStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseCompact = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        _snapshotCompactor.DoCompactSnapshot(Arg.Any<StateId>()).Returns(_ =>
+        {
+            compactStarted.TrySetResult();
+            releaseCompact.Task.GetAwaiter().GetResult();
+            return false;
+        });
+
+        (FlatDbManager manager, StateId snapshotTo) = CreateManagerWithQueuedSnapshot();
+        try
+        {
+            await compactStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            using Lock.Scope scope = _retention.Sync.EnterScope();
+            Assert.That(_retention.ActiveHeads.Contains(snapshotTo), Is.True);
+        }
+        finally
+        {
+            releaseCompact.TrySetResult();
+            await manager.DisposeAsync();
+        }
+
+        using (_retention.Sync.EnterScope())
+            Assert.That(_retention.ActiveHeads, Is.Empty);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/LongFinalityIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/LongFinalityIntegrationTests.cs
@@ -388,6 +388,7 @@ public class LongFinalityIntegrationTests
     {
         private readonly System.Collections.Generic.Dictionary<ulong, Hash256> _roots = [];
         public ulong FinalizedBlockNumber { get; set; }
+        public BlockHeader? Head { get; set; }
         public void SetRoot(ulong block, Hash256 root) => _roots[block] = root;
         public Hash256? GetFinalizedStateRootAt(ulong blockNumber) => _roots.TryGetValue(blockNumber, out Hash256? root) ? root : null;
     }

--- a/src/Nethermind/Nethermind.State.Flat.Test/LongFinalityIntegrationTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/LongFinalityIntegrationTests.cs
@@ -233,14 +233,14 @@ public class LongFinalityIntegrationTests
         Hash256 storageAddr = Keccak.Compute("addr");
         TreePath storagePath = new(Keccak.Compute("stor_path"), 6);
 
-        Snapshot snap1 = CreateSnapshot(s0, s1, c =>
+        using Snapshot snap1 = CreateSnapshot(s0, s1, c =>
         {
             c.Accounts[TestItem.AddressA] = Build.An.Account.WithBalance(100).TestObject;
             c.StateNodes[statePath] = new TrieNode(NodeType.Leaf, [0xC0]);
             c.StorageNodes[(storageAddr, storagePath)] = new TrieNode(NodeType.Branch, [0xC1, 0x80]);
         });
 
-        Snapshot snap2 = CreateSnapshot(s1, s2, c =>
+        using Snapshot snap2 = CreateSnapshot(s1, s2, c =>
         {
             c.Accounts[TestItem.AddressB] = Build.An.Account.WithBalance(200).TestObject;
             c.StateNodes[statePath] = new TrieNode(NodeType.Leaf, [0xC2, 0x80, 0x80]); // Override
@@ -250,10 +250,10 @@ public class LongFinalityIntegrationTests
         byte[] data2 = PersistedSnapshotBuilderTestExtensions.Build(snap2, _helperBlobs);
         PersistedSnapshot baseSnap1 = CreatePersistedSnapshot(s0, s1, data1);
         PersistedSnapshot baseSnap2 = CreatePersistedSnapshot(s1, s2, data2);
-        PersistedSnapshotList toMerge = new(2) { baseSnap1, baseSnap2 };
+        using PersistedSnapshotList toMerge = new(2) { baseSnap1, baseSnap2 };
         byte[] merged = PersistedSnapshotBuilderTestExtensions.NWayMergeSnapshots(toMerge);
 
-        PersistedSnapshot mergedSnap = CreatePersistedSnapshot(s0, s2, merged);
+        using PersistedSnapshot mergedSnap = CreatePersistedSnapshot(s0, s2, merged);
 
         // State node should have newer value
         Assert.That(mergedSnap.TryLoadStateNodeRlp(statePath, out byte[]? stateRlpResult), Is.True);
@@ -319,7 +319,8 @@ public class LongFinalityIntegrationTests
             _config,
             new BlocksConfig(),
             LimboLogs.Instance,
-            enableDetailedMetrics: false);
+            enableDetailedMetrics: false,
+            tier.Resolve<SnapshotRetention>());
 
         ReadOnlySnapshotBundle bundle = manager.GatherReadOnlySnapshotBundle(s1);
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistedSnapshotTests.cs
@@ -664,10 +664,7 @@ public class PersistedSnapshotTests
         long afterBuild = Metrics.BlobAllocatedBytes;
         Assert.That(afterBuild, Is.GreaterThan(baselineBytes), "Building a snapshot with trie nodes should grow blob-allocated bytes");
 
-        // Skip LeaseBlobIds: it acquires an extra lease per blob id that other
-        // tests rely on but that this test must not leave dangling, otherwise the
-        // orphan-reset would correctly refuse to fire.
-        TestFixtureHelpers.CreatePersistedSnapshot(_memArena, _blobs, from, to, data, leaseBlobIds: false)
+        TestFixtureHelpers.CreatePersistedSnapshot(_memArena, _blobs, from, to, data)
             .Dispose();
 
         // After the last external lease drops, the manager's TryResetOrphanedFrontier

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -1444,6 +1444,34 @@ public class PersistenceManagerTests
         }
     }
     [Test]
+    public async Task AddToPersistence_ForkChoiceHead_OffTheCommittedAncestry_IsRetained()
+    {
+        // The chain keeps following the first sibling while every later payload is another sibling that gets
+        // executed but never selected, so the head leaves the recently-committed ring without being an ancestor.
+        StateId pinned = CreateStateId(1);
+        CreateSnapshot(Block0, pinned);
+        Hash256 forkChoiceRoot = Keccak.Compute("fork-choice");
+        StateId forkChoiceHead = new(2, forkChoiceRoot);
+        CreateSnapshot(pinned, forkChoiceHead);
+        _snapshotRepository.SetLastCommittedStateId(forkChoiceHead);
+        _finalizedStateProvider.Head = Build.A.BlockHeader.WithNumber(2).WithStateRoot(forkChoiceRoot).TestObject;
+
+        for (int i = 2; i <= 2 * _config.MaxInMemoryBaseSnapshotCount; i++)
+        {
+            StateId sibling = CreateStateId(2, (byte)i);
+            CreateSnapshot(pinned, sibling);
+            _snapshotRepository.SetLastCommittedStateId(sibling);
+            await _persistenceManager.AddToPersistence(sibling);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_snapshotRepository.HasState(forkChoiceHead), Is.True, "the state the chain follows must survive");
+            Assert.That(_snapshotRepository.HasState(CreateStateId(2, 2)), Is.False, "an unselected sibling that aged out is pruned");
+        }
+    }
+
+    [Test]
     public async Task AddToPersistence_SiblingsWithinInMemoryBudget_AreKept()
     {
         StateId pinned = CreateStateId(1);
@@ -1489,6 +1517,8 @@ public class PersistenceManagerTests
 
         public Hash256? GetFinalizedStateRootAt(ulong blockNumber) =>
             _finalizedStateRoots.TryGetValue(blockNumber, out Hash256? root) ? root : null;
+
+        public BlockHeader? Head { get; set; }
     }
 
     private sealed class RecordingCaptureHook : IFlatPersistenceCaptureHook

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -1369,6 +1369,8 @@ public class PersistenceManagerTests
         repository.SnapshotCount.Returns(3);
         repository.GetLastCommittedStateId().Returns(latest);
         repository.GetStatesUpToBlock(long.MaxValue).Returns(_ => new ArrayPoolList<StateId>(3) { first, second, latest });
+        repository.When(r => r.CollectCommittedAncestry(latest, Arg.Any<ISet<StateId>>()))
+            .Do(call => call.Arg<ISet<StateId>>().UnionWith([first, second, latest]));
         IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
         reader.CurrentState.Returns(persisted);
         IPersistence persistence = Substitute.For<IPersistence>();
@@ -1382,7 +1384,7 @@ public class PersistenceManagerTests
         await container.Resolve<IPersistenceManager>().AddToPersistence(latest);
 
         repository.Received(siblings ? 1 : 0).RemoveOrphanedStates(latest, latest, preGenesis ? 0UL : 1UL);
-        repository.DidNotReceiveWithAnyArgs().CollectCommittedAncestry(default, default!);
+        repository.ReceivedWithAnyArgs(siblings ? 0 : 1).CollectCommittedAncestry(default, default!);
     }
 
     [Test]
@@ -1502,6 +1504,30 @@ public class PersistenceManagerTests
             Assert.That(_snapshotRepository.PersistedSnapshotCount, Is.InRange(40, 40 + 2 * Iterations / 4), "the canonical chain converts; siblings do not accumulate on disk");
         }
     }
+
+    [Test]
+    public async Task AddToPersistence_OrphanWithPersistedRival_IsPruned()
+    {
+        _config.MaxInMemoryBaseSnapshotCount = 1;
+        ResetPersistenceManager(useRealCompactor: true);
+        StateId canonical = CreateStateId(1);
+        PersistBase(Block0, canonical);
+        StateId orphan = CreateStateId(1, 1);
+        CreateSnapshot(Block0, orphan);
+        StateId head = CreateStateId(2);
+        CreateSnapshot(canonical, head);
+        _snapshotRepository.SetLastCommittedStateId(head);
+
+        await _persistenceManager.AddToPersistence(head);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_snapshotRepository.HasState(orphan), Is.False);
+            Assert.That(_snapshotRepository.HasState(canonical), Is.True);
+            Assert.That(_snapshotRepository.HasState(head), Is.True);
+        }
+    }
+
     [Test]
     public async Task AddToPersistence_ForkChoiceHead_OffTheCommittedAncestry_IsRetained()
     {

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -33,11 +33,13 @@ public class PersistenceManagerTests
     private IPersistence _persistence = null!;
     private IPersistedSnapshotCompactor _persistedSnapshotCompactor = null!;
     private ResourcePool _resourcePool = null!;
+    private bool _containerOwnsPersistenceManager;
     private StateId Block0 = new(0, Keccak.EmptyTreeHash);
 
     [SetUp]
     public void SetUp()
     {
+        _containerOwnsPersistenceManager = false;
         _config = new FlatDbConfig
         {
             CompactSize = 16,
@@ -80,7 +82,7 @@ public class PersistenceManagerTests
     [TearDown]
     public async Task TearDown()
     {
-        _persistenceManager.Dispose();
+        if (!_containerOwnsPersistenceManager) _persistenceManager.Dispose();
         await _persistedSnapshotCompactor.DisposeAsync();
         _tier.Dispose();
     }
@@ -1341,23 +1343,76 @@ public class PersistenceManagerTests
     }
 
     [Test]
+    public async Task AddToPersistence_OverBudget_PrunesOnlyCompetingStatesAbovePersistence([Values] bool siblings, [Values] bool preGenesis)
+    {
+        FlatDbConfig config = new() { EnableLongFinality = false, MaxInMemoryBaseSnapshotCount = 2 };
+        StateId persisted = preGenesis ? StateId.PreGenesis : Block0;
+        StateId first = CreateStateId(1);
+        StateId second = CreateStateId(siblings ? 1UL : 2UL, 1);
+        StateId latest = CreateStateId(3);
+        ISnapshotRepository repository = Substitute.For<ISnapshotRepository>();
+        repository.SnapshotCount.Returns(3);
+        repository.GetLastCommittedStateId().Returns(latest);
+        repository.GetStatesUpToBlock(long.MaxValue).Returns(_ => new ArrayPoolList<StateId>(3) { first, second, latest });
+        IPersistence.IPersistenceReader reader = Substitute.For<IPersistence.IPersistenceReader>();
+        reader.CurrentState.Returns(persisted);
+        IPersistence persistence = Substitute.For<IPersistence>();
+        persistence.CreateReader().Returns(reader);
+        using FlatTestContainer container = new(config, configure: builder => builder
+            .AddSingleton<ISnapshotRepository>(repository)
+            .AddSingleton<IPersistence>(persistence)
+            .AddSingleton<IFinalizedStateProvider>(_finalizedStateProvider)
+            .AddSingleton<IStatePersistenceBarrier>(NullStatePersistenceBarrier.Instance));
+
+        await container.Resolve<IPersistenceManager>().AddToPersistence(latest);
+
+        repository.Received(siblings ? 1 : 0).RemoveOrphanedStates(latest, latest, preGenesis ? 0UL : 1UL);
+        repository.DidNotReceiveWithAnyArgs().CollectCommittedAncestry(default, default!);
+    }
+
+    [Test]
+    public void DetermineSnapshotAction_Conversion_CollectsAncestryOnceForAllCandidates()
+    {
+        FlatDbConfig config = new() { EnableLongFinality = true, MaxInMemoryBaseSnapshotCount = 1 };
+        StateId first = CreateStateId(1);
+        StateId second = CreateStateId(1, 1);
+        using Snapshot orphan = _resourcePool.CreateSnapshot(Block0, first, ResourcePool.Usage.ReadOnlyProcessingEnv);
+        using Snapshot retained = _resourcePool.CreateSnapshot(Block0, second, ResourcePool.Usage.ReadOnlyProcessingEnv);
+        ISnapshotRepository repository = Substitute.For<ISnapshotRepository>();
+        repository.SnapshotCount.Returns(2);
+        repository.GetLastCommittedStateId().Returns(second);
+        repository.GetStatesUpToBlock(long.MaxValue).Returns(_ => new ArrayPoolList<StateId>(2) { first, second });
+        repository.When(repo => repo.CollectCommittedAncestry(second, Arg.Any<ISet<StateId>>()))
+            .Do(call => call.Arg<ISet<StateId>>().Add(second));
+        repository.TryLeaseInMemoryState(Arg.Any<StateId>(), SnapshotTier.InMemoryBase, out Arg.Any<Snapshot?>())
+            .Returns(call =>
+            {
+                Snapshot snapshot = call.Arg<StateId>() == first ? orphan : retained;
+                snapshot.TryAcquire();
+                call[2] = snapshot;
+                return true;
+            });
+        using FlatTestContainer container = new(config, configure: builder => builder
+            .AddSingleton<ISnapshotRepository>(repository)
+            .AddSingleton<IPersistence>(_persistence)
+            .AddSingleton<IFinalizedStateProvider>(_finalizedStateProvider)
+            .AddSingleton<IStatePersistenceBarrier>(NullStatePersistenceBarrier.Instance));
+
+        (_, _, PersistenceManager.ConversionCandidate? candidate) =
+            ((PersistenceManager)container.Resolve<IPersistenceManager>()).DetermineSnapshotAction(second);
+        using Snapshot? converted = candidate?.Base;
+
+        Assert.That(converted, Is.SameAs(retained));
+        repository.Received(1).CollectCommittedAncestry(second, Arg.Any<ISet<StateId>>());
+    }
+
+    [Test]
     public async Task AddToPersistence_PinnedHeadSiblings_PrunesOrphansAboveInMemoryBudget()
     {
         // Finality stays at genesis and every new block is a sibling of the last, so neither the finalized
         // trigger nor the backstop ever fires; with long finality off nothing converts to the persisted tier either.
         _config.EnableLongFinality = false;
-        _persistenceManager.Dispose();
-        _persistenceManager = new PersistenceManager(
-            _config,
-            _tier.Resolve<ICompactionSchedule>(),
-            _finalizedStateProvider,
-            _persistence,
-            _snapshotRepository,
-            NullStatePersistenceBarrier.Instance,
-            LimboLogs.Instance,
-            _persistedSnapshotCompactor,
-            _tier.Loader,
-            Substitute.For<IProcessExitSource>());
+        ResetPersistenceManager();
 
         StateId pinned = CreateStateId(1);
         CreateSnapshot(Block0, pinned);
@@ -1391,23 +1446,12 @@ public class PersistenceManagerTests
     }
 
     [Test]
-    public async Task AddToPersistence_PinnedHeadSiblings_WithLongFinality_BoundsInMemorySnapshots()
+    public async Task AddToPersistence_PinnedHeadSiblings_WithLongFinality_BoundsInMemorySnapshots([Values(0, 8)] int budget)
     {
         // Production shape: long finality and the real persisted tier are on, the canonical chain alone exceeds the
         // in-memory budget, and no sibling has a parent on disk until conversion has climbed that chain.
-        _config.MaxInMemoryBaseSnapshotCount = 8;
-        _persistenceManager.Dispose();
-        _persistenceManager = new PersistenceManager(
-            _config,
-            _tier.Resolve<ICompactionSchedule>(),
-            _finalizedStateProvider,
-            _persistence,
-            _snapshotRepository,
-            NullStatePersistenceBarrier.Instance,
-            LimboLogs.Instance,
-            _tier.Compactor,
-            _tier.Loader,
-            Substitute.For<IProcessExitSource>());
+        _config.MaxInMemoryBaseSnapshotCount = budget;
+        ResetPersistenceManager(useRealCompactor: true);
 
         StateId parent = Block0;
         for (ulong block = 1; block <= 40; block++)
@@ -1492,6 +1536,23 @@ public class PersistenceManagerTests
         }
 
         Assert.That(_snapshotRepository.SnapshotCount, Is.EqualTo(1 + 2 * pairs), "below the budget no sibling is pruned");
+    }
+
+    private void ResetPersistenceManager(bool useRealCompactor = false)
+    {
+        if (!_containerOwnsPersistenceManager) _persistenceManager.Dispose();
+        _tier.Dispose();
+        _tier = new FlatTestContainer(_config, configure: builder =>
+        {
+            builder
+                .AddSingleton<IPersistence>(_persistence)
+                .AddSingleton<IFinalizedStateProvider>(_finalizedStateProvider)
+                .AddSingleton<IStatePersistenceBarrier>(NullStatePersistenceBarrier.Instance);
+            if (!useRealCompactor) builder.AddSingleton<IPersistedSnapshotCompactor>(_persistedSnapshotCompactor);
+        });
+        _snapshotRepository = _tier.Repository;
+        _persistenceManager = (PersistenceManager)_tier.Resolve<IPersistenceManager>();
+        _containerOwnsPersistenceManager = true;
     }
 
     private void InvokeConvertCompactedRange(Snapshot compacted)

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -1340,6 +1340,132 @@ public class PersistenceManagerTests
         return (PersistenceManager.ConversionCandidate?)method.Invoke(_persistenceManager, [currentPersistedState]);
     }
 
+    [Test]
+    public async Task AddToPersistence_PinnedHeadSiblings_PrunesOrphansAboveInMemoryBudget()
+    {
+        // Finality stays at genesis and every new block is a sibling of the last, so neither the finalized
+        // trigger nor the backstop ever fires; with long finality off nothing converts to the persisted tier either.
+        _config.EnableLongFinality = false;
+        _persistenceManager.Dispose();
+        _persistenceManager = new PersistenceManager(
+            _config,
+            _tier.Resolve<ICompactionSchedule>(),
+            _finalizedStateProvider,
+            _persistence,
+            _snapshotRepository,
+            NullStatePersistenceBarrier.Instance,
+            LimboLogs.Instance,
+            _persistedSnapshotCompactor,
+            _tier.Loader,
+            Substitute.For<IProcessExitSource>());
+
+        StateId pinned = CreateStateId(1);
+        CreateSnapshot(Block0, pinned);
+        _snapshotRepository.SetLastCommittedStateId(pinned);
+
+        StateId firstOrphan = default;
+        StateId latest = default;
+        for (int i = 1; i <= _config.MaxInMemoryBaseSnapshotCount; i++)
+        {
+            StateId first = CreateStateId(2, (byte)i);
+            StateId second = CreateStateId(3, (byte)i);
+            if (i == 1) firstOrphan = first;
+            latest = second;
+
+            CreateSnapshot(pinned, first);
+            _snapshotRepository.SetLastCommittedStateId(first);
+            await _persistenceManager.AddToPersistence(first);
+
+            CreateSnapshot(first, second);
+            _snapshotRepository.SetLastCommittedStateId(second);
+            await _persistenceManager.AddToPersistence(second);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_snapshotRepository.SnapshotCount, Is.LessThan(_config.MaxInMemoryBaseSnapshotCount), "orphaned siblings must be pruned");
+            Assert.That(_snapshotRepository.HasState(pinned), Is.True, "the pinned parent stays");
+            Assert.That(_snapshotRepository.HasState(latest), Is.True, "the committed head stays");
+            Assert.That(_snapshotRepository.HasState(firstOrphan), Is.False, "the oldest sibling is gone");
+        }
+    }
+
+    [Test]
+    public async Task AddToPersistence_PinnedHeadSiblings_WithLongFinality_BoundsInMemorySnapshots()
+    {
+        // Production shape: long finality and the real persisted tier are on, the canonical chain alone exceeds the
+        // in-memory budget, and no sibling has a parent on disk until conversion has climbed that chain.
+        _config.MaxInMemoryBaseSnapshotCount = 8;
+        _persistenceManager.Dispose();
+        _persistenceManager = new PersistenceManager(
+            _config,
+            _tier.Resolve<ICompactionSchedule>(),
+            _finalizedStateProvider,
+            _persistence,
+            _snapshotRepository,
+            NullStatePersistenceBarrier.Instance,
+            LimboLogs.Instance,
+            _tier.Compactor,
+            _tier.Loader,
+            Substitute.For<IProcessExitSource>());
+
+        StateId parent = Block0;
+        for (ulong block = 1; block <= 40; block++)
+        {
+            StateId next = CreateStateId(block);
+            CreateSnapshot(parent, next);
+            parent = next;
+        }
+        StateId pinned = parent;
+        _snapshotRepository.SetLastCommittedStateId(pinned);
+
+        const int Iterations = 120;
+        StateId firstOrphan = CreateStateId(41, 1);
+        int maxBases = 0;
+        for (int i = 1; i <= Iterations; i++)
+        {
+            StateId first = CreateStateId(41, (byte)i);
+            StateId second = CreateStateId(42, (byte)i);
+            CreateSnapshot(pinned, first);
+            _snapshotRepository.SetLastCommittedStateId(first);
+            await _persistenceManager.AddToPersistence(first);
+            CreateSnapshot(first, second);
+            _snapshotRepository.SetLastCommittedStateId(second);
+            await _persistenceManager.AddToPersistence(second);
+            maxBases = Math.Max(maxBases, _snapshotRepository.SnapshotCount);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(maxBases, Is.LessThan(2 * Iterations / 4), "in-memory bases must stay far below the number of siblings seen");
+            Assert.That(_snapshotRepository.HasState(pinned), Is.True, "the pinned parent stays readable");
+            Assert.That(_snapshotRepository.HasState(firstOrphan), Is.False, "an old sibling is gone from both tiers");
+            Assert.That(_snapshotRepository.PersistedSnapshotCount, Is.InRange(40, 40 + 2 * Iterations / 4), "the canonical chain converts; siblings do not accumulate on disk");
+        }
+    }
+    [Test]
+    public async Task AddToPersistence_SiblingsWithinInMemoryBudget_AreKept()
+    {
+        StateId pinned = CreateStateId(1);
+        CreateSnapshot(Block0, pinned);
+        _snapshotRepository.SetLastCommittedStateId(pinned);
+
+        int pairs = _config.MaxInMemoryBaseSnapshotCount / 4;
+        for (int i = 1; i <= pairs; i++)
+        {
+            StateId first = CreateStateId(2, (byte)i);
+            StateId second = CreateStateId(3, (byte)i);
+            CreateSnapshot(pinned, first);
+            _snapshotRepository.SetLastCommittedStateId(first);
+            await _persistenceManager.AddToPersistence(first);
+            CreateSnapshot(first, second);
+            _snapshotRepository.SetLastCommittedStateId(second);
+            await _persistenceManager.AddToPersistence(second);
+        }
+
+        Assert.That(_snapshotRepository.SnapshotCount, Is.EqualTo(1 + 2 * pairs), "below the budget no sibling is pruned");
+    }
+
     private void InvokeConvertCompactedRange(Snapshot compacted)
     {
         // ConvertCompactedRange is private; reach it via reflection to unit-test the in-memory

--- a/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/PersistenceManagerTests.cs
@@ -755,7 +755,8 @@ public class PersistenceManagerTests
         toPersist.Dispose();
     }
 
-    public void DetermineSnapshotAction_LatestSnapshotBelowPersistedBlock_ReturnsNullWithoutUnderflow()
+    [Test]
+    public void DetermineSnapshotAction_LatestSnapshotBelowPersistedBlock_ReturnsNullWithoutUnderflow([Values] bool triggerAvailable)
     {
         // A deep reorg below a force-persisted unfinalized block can leave the latest snapshot behind the
         // last persisted block. The in-memory depth must saturate to 0 (not underflow to ~2^64) so the
@@ -768,17 +769,18 @@ public class PersistenceManagerTests
         IPersistence persistence = Substitute.For<IPersistence>();
         persistence.CreateReader().Returns(reader);
 
-        using PersistenceManager pm = new(
-            _config,
-            ScheduleHelper.CreateWithOffset(_config, 0),
-            _finalizedStateProvider,
-            persistence,
-            _snapshotRepository,
-            NullStatePersistenceBarrier.Instance,
-            LimboLogs.Instance,
-            _persistedSnapshotCompactor,
-            _tier.Loader,
-            Substitute.For<IProcessExitSource>());
+        InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+        logger.IsWarn.Returns(true);
+        logger.IsDebug.Returns(true);
+        ILogManager logs = Substitute.For<ILogManager>();
+        ILogger wrappedLogger = new(logger);
+        logs.GetClassLogger<PersistenceManager>().Returns(wrappedLogger);
+        using FlatTestContainer container = new(_config, configure: builder => builder
+            .AddSingleton<IPersistence>(persistence)
+            .AddSingleton<IFinalizedStateProvider>(_finalizedStateProvider)
+            .AddSingleton<IStatePersistenceBarrier>(NullStatePersistenceBarrier.Instance)
+            .AddSingleton<ILogManager>(logs));
+        PersistenceManager pm = container.Resolve<PersistenceManager>();
 
         // Latest snapshot (50) is below the persisted block (100); finalized far behind so the buggy
         // underflow path would take the backstop branch. Stage a head-ancestor snapshot it would return.
@@ -786,14 +788,27 @@ public class PersistenceManagerTests
         StateId headAncestor = CreateStateId(101);
         _finalizedStateProvider.SetFinalizedBlockNumber(10);
 
-        using Snapshot staged = CreateSnapshot(persisted, headAncestor, compacted: false);
-        _snapshotRepository.SetLastCommittedStateId(headAncestor);
+        if (triggerAvailable)
+        {
+            Snapshot trigger = container.ResourcePool.CreateSnapshot(CreateStateId(49), latest, ResourcePool.Usage.ReadOnlyProcessingEnv);
+            Assert.That(container.Repository.TryAdd(trigger, SnapshotTier.InMemoryBase), Is.True);
+            container.Repository.AddStateId(latest);
+        }
+        Snapshot staged = container.ResourcePool.CreateSnapshot(persisted, headAncestor, ResourcePool.Usage.ReadOnlyProcessingEnv);
+        Assert.That(container.Repository.TryAdd(staged, SnapshotTier.InMemoryBase), Is.True);
+        container.Repository.AddStateId(headAncestor);
+        container.Repository.SetLastCommittedStateId(headAncestor);
 
         (PersistedSnapshot? persistedToPersist, Snapshot? toPersist, _) = pm.DetermineSnapshotAction(latest);
         using Snapshot? toDispose = toPersist; // dispose if the buggy underflow path returned a snapshot
 
-        Assert.That(persistedToPersist, Is.Null);
-        Assert.That(toPersist, Is.Null);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(persistedToPersist, Is.Null);
+            Assert.That(toPersist, Is.Null);
+            logger.Received(triggerAvailable ? 1 : 0).Warn(Arg.Is<string>(message => message.Contains("persisted base may be on an orphaned fork")));
+            logger.Received(triggerAvailable ? 0 : 1).Debug(Arg.Is<string>(message => message.Contains("Persistence trigger") && message.Contains("no longer available")));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State.Flat.Test/ReadOnlySnapshotBundleTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/ReadOnlySnapshotBundleTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -30,6 +31,82 @@ public class ReadOnlySnapshotBundleTests
     private static ReadOnlySnapshotBundle Bundle(SnapshotPooledList snapshots, IPersistence.IPersistenceReader? reader = null, bool recordDetailedMetrics = false) =>
         new(snapshots, reader ?? Substitute.For<IPersistence.IPersistenceReader>(), recordDetailedMetrics,
             PersistedSnapshotStack.Empty(recordDetailedMetrics));
+
+    [Test]
+    public async Task SiblingPruning_PreservesLeasedReads_AndBackstopResumesAfterRelease([Values] bool persistedFork)
+    {
+        using FlatTestContainer tier = new();
+        SnapshotRepository repository = tier.Repository;
+        SnapshotRetention retention = tier.Resolve<SnapshotRetention>();
+        StateId start = new(0, TestItem.KeccakA);
+        StateId canonicalParent = new(1, TestItem.KeccakA);
+        StateId canonicalHead = new(2, TestItem.KeccakA);
+        StateId forkParent = new(1, TestItem.KeccakB);
+        StateId readerHead = new(2, TestItem.KeccakB);
+        StateId unrelated = new(2, TestItem.KeccakC);
+        Account account = new(1, 100);
+        foreach ((StateId from, StateId to) in new[]
+                 { (start, canonicalParent), (canonicalParent, canonicalHead), (start, forkParent), (forkParent, readerHead), (canonicalParent, unrelated) })
+        {
+            using Snapshot snapshot = tier.ResourcePool.CreateSnapshot(from, to, ResourcePool.Usage.ReadOnlyProcessingEnv);
+            snapshot.Content.Accounts[TestItem.AddressA] = account;
+            if (persistedFork && (to == forkParent || to == readerHead))
+            {
+                tier.Loader.ConvertAndRegister(snapshot);
+            }
+            else
+            {
+                snapshot.AcquireLease();
+                if (!repository.TryAdd(snapshot, SnapshotTier.InMemoryBase))
+                {
+                    snapshot.Dispose();
+                    Assert.Fail($"Duplicate snapshot {to}");
+                }
+                repository.AddStateId(to);
+            }
+        }
+        repository.SetLastCommittedStateId(canonicalHead);
+
+        retention.Register(readerHead);
+        ReadOnlySnapshotBundle bundle;
+        try
+        {
+            AssembledSnapshotResult assembled = repository.AssembleSnapshots(readerHead, start, 2);
+            bundle = new ReadOnlySnapshotBundle(assembled.InMemory, Substitute.For<IPersistence.IPersistenceReader>(),
+                false, new PersistedSnapshotStack(assembled.Persisted, false), retention, readerHead);
+        }
+        catch
+        {
+            retention.Release(readerHead);
+            throw;
+        }
+
+        using (bundle)
+        {
+            await Task.Run(() => repository.RemoveSiblingAndDescendents(canonicalParent));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(repository.HasState(readerHead), Is.False);
+                Assert.That(bundle.SnapshotCount, Is.EqualTo(2));
+                Assert.That(bundle.GetAccount(TestItem.AddressA), Is.EqualTo(account));
+                Assert.That(repository.HasState(unrelated), Is.True);
+            }
+
+            using AssembledSnapshotResult retry = repository.AssembleSnapshots(readerHead, start, 2);
+            Assert.That(retry.SnapshotCount, Is.Zero, "a later assembly cannot use the removed branch");
+            Assert.That(repository.RemoveOrphanedStates(canonicalHead, canonicalHead, 1), Is.Zero,
+                "the missing registered head makes ancestry classification conservative");
+        }
+
+        Assert.That(repository.RemoveOrphanedStates(canonicalHead, canonicalHead, 1), Is.EqualTo(2));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(repository.HasState(forkParent), Is.False);
+            Assert.That(repository.HasState(unrelated), Is.False);
+            Assert.That(repository.HasState(canonicalHead), Is.True);
+        }
+    }
 
     [Test]
     public void GetAccount_FoundInSnapshot_ReturnsIt([Values] bool detailedMetrics)

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -816,10 +816,10 @@ public class SnapshotRepositoryTests
     }
 
     [Test]
-    public void RemoveOrphanedStates_ReportsCandidatesPreservedByCompactionGaps([Values] bool hasOrphan)
+    public void RemoveOrphanedStates_ReportsCandidatesPreservedByCompactionGaps([Values] bool hasOrphan, [Values] bool debugEnabled)
     {
         InterfaceLogger logger = Substitute.For<InterfaceLogger>();
-        logger.IsDebug.Returns(true);
+        logger.IsDebug.Returns(debugEnabled);
         ILogManager logs = Substitute.For<ILogManager>();
         ILogger wrappedLogger = new(logger);
         logs.GetClassLogger<SnapshotRepository>().Returns(wrappedLogger);
@@ -841,13 +841,15 @@ public class SnapshotRepositoryTests
         }
         repository.SetLastCommittedStateId(head);
 
+        long ambiguousBefore = Metrics.SnapshotOrphanAmbiguousCandidates;
         int pruned = repository.RemoveOrphanedStates(head, head);
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(pruned, Is.EqualTo(hasOrphan ? 1 : 0));
             Assert.That(repository.HasState(interior), Is.True);
-            logger.Received().Debug(Arg.Is<string>(message => message.Contains("Preserved 1 snapshot candidate entries") && message.Contains("compaction gaps")));
+            Assert.That(Metrics.SnapshotOrphanAmbiguousCandidates, Is.GreaterThanOrEqualTo(ambiguousBefore + 1));
+            logger.Received(debugEnabled ? 1 : 0).Debug(Arg.Is<string>(message => message.Contains("Preserved 1 snapshot candidate entries") && message.Contains("compaction gaps")));
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -862,6 +862,36 @@ public class SnapshotRepositoryTests
     }
 
     [Test]
+    public void RemoveOrphanedStates_UnknownProtectedAncestry_RateLimitsWarnings([Values] bool missingCommittedHead)
+    {
+        InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+        logger.IsWarn.Returns(true);
+        ILogManager logs = Substitute.For<ILogManager>();
+        ILogger wrappedLogger = new(logger);
+        logs.GetClassLogger<SnapshotRepository>().Returns(wrappedLogger);
+        using FlatTestContainer tier = new(configure: builder => builder.AddSingleton(logs));
+        SnapshotRepository repository = tier.Repository;
+        StateId head = CreateStateId(2);
+        Assert.That(repository.TryAdd(tier.ResourcePool.CreateSnapshot(CreateStateId(1), head, ResourcePool.Usage.ReadOnlyProcessingEnv), SnapshotTier.InMemoryBase), Is.True);
+        repository.AddStateId(head);
+        StateId committed = missingCommittedHead ? CreateStateId(3) : head;
+        StateId start = CreateStateId(0);
+        Assert.That(repository.TryAdd(tier.ResourcePool.CreateSnapshot(StateId.PreGenesis, start, ResourcePool.Usage.ReadOnlyProcessingEnv), SnapshotTier.InMemoryBase), Is.True);
+        repository.AddStateId(start);
+        long skipped = Metrics.SnapshotOrphanPruningSkipped;
+
+        Assert.That(repository.RemoveOrphanedStates(committed, committed), Is.Zero);
+        Assert.That(repository.RemoveOrphanedStates(committed, committed), Is.Zero);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(repository.HasState(head), Is.True);
+            Assert.That(Metrics.SnapshotOrphanPruningSkipped, Is.GreaterThanOrEqualTo(skipped + 2));
+            logger.Received(1).Warn(Arg.Is<string>(message => message.Contains("Skipped snapshot orphan pruning") && message.Contains("protected ancestry")));
+        }
+    }
+
+    [Test]
     public void RemoveOrphanedStates_AncestryGapAboveTheLowerBound_PrunesNothing()
     {
         AddSnapshotToRepository(CreateStateId(0), CreateStateId(1));

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -1,13 +1,18 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using Collections.Pooled;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.State.Flat.PersistedSnapshots;
+using Nethermind.State.Flat.Persistence.BloomFilter;
 using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
@@ -610,7 +615,7 @@ public class SnapshotRepositoryTests
         }
     }
     [Test]
-    public void RemoveOrphanedStates_PreservesHistoryBelowTheInMemoryWindow()
+    public void RemoveOrphanedStates_PreservesHistorySkippedByCompaction([Values] bool insideWindow)
     {
         using Snapshot oldBase = CreateSnapshot(CreateStateId(0), CreateStateId(1), withData: true);
         using Snapshot compacted = CreateSnapshot(CreateStateId(0), CreateStateId(2), withData: true);
@@ -618,6 +623,7 @@ public class SnapshotRepositoryTests
         _tier.ConvertToPersistedBase(compacted).Dispose();
         AddSnapshotToRepository(CreateStateId(2), CreateStateId(3));
         AddSnapshotToRepository(CreateStateId(2), CreateStateId(3, rootByte: 1));
+        if (insideWindow) AddSnapshotToRepository(CreateStateId(0), CreateStateId(1, rootByte: 1));
         _repository.SetLastCommittedStateId(CreateStateId(3));
 
         int pruned = _repository.RemoveOrphanedStates(CreateStateId(3), CreateStateId(3));
@@ -626,8 +632,152 @@ public class SnapshotRepositoryTests
         {
             Assert.That(pruned, Is.EqualTo(1));
             Assert.That(_repository.HasState(CreateStateId(3, rootByte: 1)), Is.False);
-            Assert.That(_repository.HasState(CreateStateId(1)), Is.True, "older reorg history need not be on the compacted ancestry walk");
+            Assert.That(_repository.HasState(CreateStateId(1)), Is.True, "compacted ancestry cannot classify skipped history as orphaned");
             Assert.That(_repository.HasState(CreateStateId(2)), Is.True);
+            if (insideWindow) Assert.That(_repository.HasState(CreateStateId(1, rootByte: 1)), Is.True);
+        }
+    }
+
+    [Test]
+    public void RemoveOrphanedStates_AnotherProtectedBranchDoesNotClassifySkippedCanonicalHistory()
+    {
+        StateId start = CreateStateId(0);
+        StateId canonicalInterior = CreateStateId(5);
+        StateId compactedTip = CreateStateId(10);
+        StateId otherBranch = CreateStateId(5, 1);
+        StateId head = CreateStateId(11);
+        using Snapshot interior = CreateSnapshot(start, canonicalInterior, withData: true);
+        using Snapshot compacted = CreateSnapshot(start, compactedTip, withData: true);
+        using Snapshot competing = CreateSnapshot(start, otherBranch, withData: true);
+        _tier.ConvertToPersistedBase(interior).Dispose();
+        _tier.ConvertToPersistedBase(compacted).Dispose();
+        _tier.ConvertToPersistedBase(competing).Dispose();
+        AddSnapshotToRepository(compactedTip, head);
+        AddSnapshotToRepository(compactedTip, CreateStateId(11, 1));
+        _repository.SetLastCommittedStateId(otherBranch);
+        _repository.SetLastCommittedStateId(head);
+
+        int pruned = _repository.RemoveOrphanedStates(head, head);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.EqualTo(1));
+            Assert.That(_repository.HasState(canonicalInterior), Is.True);
+            Assert.That(_repository.HasState(otherBranch), Is.True);
+            Assert.That(_repository.HasState(CreateStateId(11, 1)), Is.False);
+        }
+    }
+
+    [Test]
+    public void RemoveOrphanedStates_RemovesDescendantsWithoutAnAlternativeParent([Values] bool alternativeParent, [Values] bool childInMemory)
+    {
+        StateId start = CreateStateId(4);
+        StateId parent = CreateStateId(5);
+        StateId head = CreateStateId(8);
+        StateId orphanParent = CreateStateId(5, 1);
+        StateId orphanChild = CreateStateId(6, 1);
+        StateId orphanGrandchild = CreateStateId(7, 1);
+        using Snapshot canonicalParent = CreateSnapshot(start, parent, withData: true);
+        using Snapshot canonicalInterior = CreateSnapshot(parent, CreateStateId(6), withData: true);
+        using Snapshot competingParent = CreateSnapshot(start, orphanParent, withData: true);
+        using Snapshot competingChild = CreateSnapshot(orphanParent, orphanChild, withData: true);
+        using Snapshot competingGrandchild = CreateSnapshot(orphanChild, orphanGrandchild, withData: true);
+        _tier.ConvertToPersistedBase(canonicalParent).Dispose();
+        _tier.ConvertToPersistedBase(canonicalInterior).Dispose();
+        _tier.ConvertToPersistedBase(competingParent).Dispose();
+        using PersistedSnapshot child = _tier.ConvertToPersistedBase(competingChild);
+        _tier.ConvertToPersistedBase(competingGrandchild).Dispose();
+        if (childInMemory)
+        {
+            _repository.RemovePersistedStateExact(orphanChild);
+            AddSnapshotToRepository(orphanParent, orphanChild);
+        }
+        if (alternativeParent)
+        {
+            using PersistedSnapshot alternative = new(parent, orphanChild, child.Reservation, _tier.Blobs,
+                SnapshotTier.PersistedSmallCompacted, RefCountedBloomFilter.AlwaysTrue());
+            _repository.AddPersistedSnapshot(alternative, SnapshotTier.PersistedSmallCompacted);
+        }
+        AddSnapshotToRepository(parent, head);
+        AddSnapshotToRepository(start, CreateStateId(5, 2));
+        _repository.SetLastCommittedStateId(head);
+
+        int pruned = _repository.RemoveOrphanedStates(head, head);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.EqualTo(alternativeParent ? 2 : 4));
+            Assert.That(_repository.HasState(orphanParent), Is.False);
+            Assert.That(_repository.HasState(orphanChild), Is.EqualTo(alternativeParent));
+            Assert.That(_repository.HasState(orphanGrandchild), Is.EqualTo(alternativeParent));
+            Assert.That(_repository.HasState(CreateStateId(6)), Is.True);
+        }
+        if (alternativeParent)
+        {
+            using AssembledSnapshotResult assembled = _repository.AssembleSnapshots(orphanChild, start, 2);
+            Assert.That(assembled.SnapshotCount, Is.EqualTo(2));
+        }
+    }
+
+    [Test]
+    public async Task RemoveOrphanedStates_CleanupDoesNotBlockRegistrationOrCommit([Values] bool cleanupThrows)
+    {
+        StateId head = CreateStateId(1);
+        StateId orphan = CreateStateId(1, 1);
+        StateId anotherOrphan = CreateStateId(1, 2);
+        AddSnapshotToRepository(CreateStateId(0), head);
+        _repository.SetLastCommittedStateId(head);
+        TaskCompletionSource cleanupStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource releaseCleanup = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool otherCleaned = false;
+        Snapshot blocked = new CleanupSnapshot(CreateStateId(0), orphan, _resourcePool, () =>
+        {
+            cleanupStarted.TrySetResult();
+            releaseCleanup.Task.GetAwaiter().GetResult();
+            if (cleanupThrows) throw new InvalidOperationException("Cleanup failed");
+        });
+        Snapshot other = new CleanupSnapshot(CreateStateId(0), anotherOrphan, _resourcePool, () => otherCleaned = true);
+        Assert.That(_repository.TryAdd(blocked, SnapshotTier.InMemoryBase), Is.True);
+        _repository.AddStateId(orphan);
+        Assert.That(_repository.TryAdd(other, SnapshotTier.InMemoryBase), Is.True);
+        _repository.AddStateId(anotherOrphan);
+
+        Task<int> pruning = Task.Run(() => _repository.RemoveOrphanedStates(head, head));
+        try
+        {
+            await cleanupStarted.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Task publish = Task.Run(() =>
+            {
+                SnapshotRetention retention = _tier.Resolve<SnapshotRetention>();
+                using Lock.Scope scope = retention.Sync.EnterScope();
+                retention.Register(head);
+                try
+                {
+                    Assert.That(_repository.HasState(orphan), Is.False);
+                    _repository.SetLastCommittedStateId(head);
+                }
+                finally { retention.Release(head); }
+            });
+            await publish.WaitAsync(TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            releaseCleanup.TrySetResult();
+            if (cleanupThrows)
+                await Assert.ThatAsync(async () => await pruning, Throws.TypeOf<AggregateException>());
+            else
+                Assert.That(await pruning, Is.EqualTo(2));
+        }
+        Assert.That(otherCleaned, Is.True, "all detached leases must be released even when one cleanup throws");
+    }
+
+    private sealed class CleanupSnapshot(StateId from, StateId to, IResourcePool pool, Action cleanup)
+        : Snapshot(from, to, new SnapshotContent(), pool, ResourcePool.Usage.ReadOnlyProcessingEnv)
+    {
+        protected override void CleanUp()
+        {
+            try { cleanup(); }
+            finally { base.CleanUp(); }
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using Collections.Pooled;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
@@ -524,23 +525,27 @@ public class SnapshotRepositoryTests
     }
 
     [Test]
-    public void RemoveOrphanedStates_RecentlyCommittedSibling_KeepsItsAncestry()
+    public void RemoveOrphanedStates_RecentlyCommittedSibling_KeepsItsAncestry([Values(2, 17, 48, 80)] int commits)
     {
         BuildSnapshotChain(0, 3);
-        for (byte fork = 1; fork <= 2; fork++)
+        for (byte fork = 1; fork <= commits; fork++)
         {
             AddSnapshotToRepository(CreateStateId(3), CreateStateId(4, fork));
             AddSnapshotToRepository(CreateStateId(4, fork), CreateStateId(5, fork));
             _repository.SetLastCommittedStateId(CreateStateId(5, fork));
         }
 
-        int pruned = _repository.RemoveOrphanedStates(CreateStateId(5, rootByte: 2), CreateStateId(5, rootByte: 2));
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(5, (byte)commits), CreateStateId(5, (byte)commits));
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(pruned, Is.Zero);
-            Assert.That(_repository.HasState(CreateStateId(4, rootByte: 1)), Is.True, "the parent of a recently committed state stays readable");
-            Assert.That(_repository.HasState(CreateStateId(5, rootByte: 1)), Is.True);
+            Assert.That(pruned, Is.EqualTo(commits > 16 ? 2 * (commits - 16) : 0));
+            for (byte fork = 1; fork <= commits; fork++)
+            {
+                bool retained = fork > commits - 16;
+                Assert.That(_repository.HasState(CreateStateId(4, fork)), Is.EqualTo(retained), $"parent of committed sibling {fork}");
+                Assert.That(_repository.HasState(CreateStateId(5, fork)), Is.EqualTo(retained), $"committed sibling {fork}");
+            }
         }
     }
 
@@ -566,28 +571,32 @@ public class SnapshotRepositoryTests
     }
 
     [Test]
-    public void IsOnCommittedAncestry_DistinguishesTheCommittedChainFromOrphans()
+    public void CollectCommittedAncestry_DistinguishesTheCommittedChainFromOrphans()
     {
         BuildSnapshotChain(0, 4);
         AddSnapshotToRepository(CreateStateId(2), CreateStateId(3, rootByte: 1));
 
-        Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(3, rootByte: 1), CreateStateId(3, rootByte: 1)), Is.True, "nothing committed yet: nothing can be called an orphan");
+        using PooledSet<StateId> retained = new();
+        _repository.CollectCommittedAncestry(CreateStateId(3, rootByte: 1), retained);
+        Assert.That(retained, Is.Empty, "nothing committed yet: ancestry is unknown");
 
         _repository.SetLastCommittedStateId(CreateStateId(4));
+        _repository.CollectCommittedAncestry(CreateStateId(4), retained);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(2), CreateStateId(4)), Is.True);
-            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(4), CreateStateId(4)), Is.True);
-            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(3, rootByte: 1), CreateStateId(4)), Is.False);
+            Assert.That(retained.Contains(CreateStateId(2)), Is.True);
+            Assert.That(retained.Contains(CreateStateId(4)), Is.True);
+            Assert.That(retained.Contains(CreateStateId(3, rootByte: 1)), Is.False);
         }
     }
     [Test]
-    public void RemoveOrphanedStates_ConvertedSibling_IsDroppedFromThePersistedTier()
+    public void RemoveOrphanedStates_ConvertedSibling_IsDroppedWithOrWithoutInMemoryOrphans([Values] bool inMemoryOrphan)
     {
         BuildSnapshotChain(0, 3);
-        Snapshot orphan = CreateSnapshot(CreateStateId(2), CreateStateId(3, rootByte: 1), withData: true);
+        using Snapshot orphan = CreateSnapshot(CreateStateId(2), CreateStateId(3, rootByte: 1), withData: true);
         _tier.ConvertToPersistedBase(orphan).Dispose();
+        if (inMemoryOrphan) AddSnapshotToRepository(CreateStateId(2), CreateStateId(3, rootByte: 2));
         _repository.SetLastCommittedStateId(CreateStateId(3));
         Assert.That(_repository.HasState(CreateStateId(3, rootByte: 1)), Is.True, "precondition: the sibling lives in the persisted tier");
 
@@ -595,11 +604,52 @@ public class SnapshotRepositoryTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(pruned, Is.EqualTo(1));
+            Assert.That(pruned, Is.EqualTo(inMemoryOrphan ? 2 : 1));
             Assert.That(_repository.HasState(CreateStateId(3, rootByte: 1)), Is.False);
             Assert.That(_repository.HasState(CreateStateId(3)), Is.True);
         }
     }
+    [Test]
+    public void RemoveOrphanedStates_PreservesHistoryBelowTheInMemoryWindow()
+    {
+        using Snapshot oldBase = CreateSnapshot(CreateStateId(0), CreateStateId(1), withData: true);
+        using Snapshot compacted = CreateSnapshot(CreateStateId(0), CreateStateId(2), withData: true);
+        _tier.ConvertToPersistedBase(oldBase).Dispose();
+        _tier.ConvertToPersistedBase(compacted).Dispose();
+        AddSnapshotToRepository(CreateStateId(2), CreateStateId(3));
+        AddSnapshotToRepository(CreateStateId(2), CreateStateId(3, rootByte: 1));
+        _repository.SetLastCommittedStateId(CreateStateId(3));
+
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(3), CreateStateId(3));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.EqualTo(1));
+            Assert.That(_repository.HasState(CreateStateId(3, rootByte: 1)), Is.False);
+            Assert.That(_repository.HasState(CreateStateId(1)), Is.True, "older reorg history need not be on the compacted ancestry walk");
+            Assert.That(_repository.HasState(CreateStateId(2)), Is.True);
+        }
+    }
+
+    [Test]
+    public void RemoveOrphanedStates_AncestryGapAboveTheLowerBound_PrunesNothing()
+    {
+        AddSnapshotToRepository(CreateStateId(0), CreateStateId(1));
+        AddSnapshotToRepository(CreateStateId(2), CreateStateId(3));
+        AddSnapshotToRepository(CreateStateId(2), CreateStateId(3, rootByte: 1));
+        _repository.SetLastCommittedStateId(CreateStateId(3));
+
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(3), CreateStateId(3));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.Zero);
+            Assert.That(_repository.HasState(CreateStateId(1)), Is.True);
+            Assert.That(_repository.HasState(CreateStateId(3)), Is.True);
+            Assert.That(_repository.HasState(CreateStateId(3, rootByte: 1)), Is.True, "incomplete ancestry cannot prove a sibling is orphaned");
+        }
+    }
+
     [Test]
     public void RemoveOrphanedStates_ForkChoiceHead_IsRetainedWithItsAncestry()
     {

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -11,8 +11,11 @@ using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
+using Nethermind.Logging;
 using Nethermind.State.Flat.PersistedSnapshots;
+using Nethermind.State.Flat.PersistedSnapshots.Storage;
 using Nethermind.State.Flat.Persistence.BloomFilter;
+using NSubstitute;
 using NUnit.Framework;
 
 namespace Nethermind.State.Flat.Test;
@@ -769,6 +772,81 @@ public class SnapshotRepositoryTests
                 Assert.That(await pruning, Is.EqualTo(2));
         }
         Assert.That(otherCleaned, Is.True, "all detached leases must be released even when one cleanup throws");
+    }
+
+    [Test]
+    public void RemoveOrphanedStates_PreservesPrimaryFailure([Values] bool cleanupThrows)
+    {
+        ISnapshotCatalog catalog = Substitute.For<ISnapshotCatalog>();
+        using FlatTestContainer tier = new(configure: builder => builder.AddSingleton(catalog));
+        SnapshotRepository repository = tier.Repository;
+        StateId start = CreateStateId(0);
+        StateId head = CreateStateId(1);
+        StateId orphan = CreateStateId(1, 1);
+        StateId persistedOrphan = CreateStateId(1, 2);
+        InvalidOperationException primary = new("Catalog removal failed");
+        InvalidOperationException cleanup = new("Snapshot cleanup failed");
+        bool cleaned = false;
+        Snapshot snapshot = new CleanupSnapshot(start, orphan, tier.ResourcePool, () =>
+        {
+            cleaned = true;
+            if (cleanupThrows) throw cleanup;
+        });
+        Assert.That(repository.TryAdd(snapshot, SnapshotTier.InMemoryBase), Is.True);
+        repository.AddStateId(orphan);
+        Assert.That(repository.TryAdd(tier.ResourcePool.CreateSnapshot(start, head, ResourcePool.Usage.ReadOnlyProcessingEnv), SnapshotTier.InMemoryBase), Is.True);
+        repository.AddStateId(head);
+        repository.SetLastCommittedStateId(head);
+        using Snapshot persisted = tier.ResourcePool.CreateSnapshot(start, persistedOrphan, ResourcePool.Usage.ReadOnlyProcessingEnv);
+        tier.ConvertToPersistedBase(persisted).Dispose();
+        catalog.Remove(persistedOrphan, 1).Returns(_ => throw primary);
+
+        Exception? failure = Assert.Catch(() => repository.RemoveOrphanedStates(head, head));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(cleaned, Is.True);
+            if (cleanupThrows)
+                Assert.That((failure as AggregateException)?.InnerExceptions, Is.EqualTo(new Exception[] { primary, cleanup }));
+            else
+                Assert.That(failure, Is.SameAs(primary));
+        }
+    }
+
+    [Test]
+    public void RemoveOrphanedStates_ReportsCandidatesPreservedByCompactionGaps([Values] bool hasOrphan)
+    {
+        InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+        logger.IsDebug.Returns(true);
+        ILogManager logs = Substitute.For<ILogManager>();
+        ILogger wrappedLogger = new(logger);
+        logs.GetClassLogger<SnapshotRepository>().Returns(wrappedLogger);
+        using FlatTestContainer tier = new(configure: builder => builder.AddSingleton(logs));
+        SnapshotRepository repository = tier.Repository;
+        StateId start = CreateStateId(0);
+        StateId head = CreateStateId(2);
+        StateId interior = CreateStateId(1);
+        foreach (StateId to in new[] { head, interior })
+        {
+            Assert.That(repository.TryAdd(tier.ResourcePool.CreateSnapshot(start, to, ResourcePool.Usage.ReadOnlyProcessingEnv), SnapshotTier.InMemoryBase), Is.True);
+            repository.AddStateId(to);
+        }
+        if (hasOrphan)
+        {
+            StateId orphan = CreateStateId(2, 1);
+            Assert.That(repository.TryAdd(tier.ResourcePool.CreateSnapshot(start, orphan, ResourcePool.Usage.ReadOnlyProcessingEnv), SnapshotTier.InMemoryBase), Is.True);
+            repository.AddStateId(orphan);
+        }
+        repository.SetLastCommittedStateId(head);
+
+        int pruned = repository.RemoveOrphanedStates(head, head);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.EqualTo(hasOrphan ? 1 : 0));
+            Assert.That(repository.HasState(interior), Is.True);
+            logger.Received().Debug(Arg.Is<string>(message => message.Contains("Preserved 1 snapshot candidate entries") && message.Contains("compaction gaps")));
+        }
     }
 
     private sealed class CleanupSnapshot(StateId from, StateId to, IResourcePool pool, Action cleanup)

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -598,6 +598,7 @@ public class SnapshotRepositoryTests
             Assert.That(retained.Contains(CreateStateId(3, rootByte: 1)), Is.False);
         }
     }
+
     [Test]
     public void RemoveOrphanedStates_ConvertedSibling_IsDroppedWithOrWithoutInMemoryOrphans([Values] bool inMemoryOrphan)
     {
@@ -617,6 +618,7 @@ public class SnapshotRepositoryTests
             Assert.That(_repository.HasState(CreateStateId(3)), Is.True);
         }
     }
+
     [Test]
     public void RemoveOrphanedStates_PreservesHistorySkippedByCompaction([Values] bool insideWindow)
     {

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -497,5 +497,118 @@ public class SnapshotRepositoryTests
         Assert.That(_repository.HasState(CreateStateId(7, rootByte: 1)), Is.True);
     }
 
+    [Test]
+    public void RemoveOrphanedStates_PinnedParent_DropsSiblingsOffTheCommittedAncestry()
+    {
+        // Canonical 0..3, then three sibling pairs (4, 5) under block 3; only the last pair was committed.
+        BuildSnapshotChain(0, 3);
+        for (byte fork = 1; fork <= 3; fork++)
+        {
+            AddSnapshotToRepository(CreateStateId(3), CreateStateId(4, fork));
+            AddSnapshotToRepository(CreateStateId(4, fork), CreateStateId(5, fork));
+        }
+        _repository.SetLastCommittedStateId(CreateStateId(5, rootByte: 3));
+
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(5, rootByte: 3));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.EqualTo(4));
+            Assert.That(_repository.HasState(CreateStateId(4, rootByte: 1)), Is.False);
+            Assert.That(_repository.HasState(CreateStateId(5, rootByte: 2)), Is.False);
+            Assert.That(_repository.HasState(CreateStateId(4, rootByte: 3)), Is.True, "the committed pair stays");
+            Assert.That(_repository.HasState(CreateStateId(5, rootByte: 3)), Is.True);
+            Assert.That(_repository.HasState(CreateStateId(1)), Is.True, "canonical ancestry stays");
+            Assert.That(_repository.HasState(CreateStateId(3)), Is.True);
+        }
+    }
+
+    [Test]
+    public void RemoveOrphanedStates_RecentlyCommittedSibling_KeepsItsAncestry()
+    {
+        BuildSnapshotChain(0, 3);
+        for (byte fork = 1; fork <= 2; fork++)
+        {
+            AddSnapshotToRepository(CreateStateId(3), CreateStateId(4, fork));
+            AddSnapshotToRepository(CreateStateId(4, fork), CreateStateId(5, fork));
+            _repository.SetLastCommittedStateId(CreateStateId(5, fork));
+        }
+
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(5, rootByte: 2));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.Zero);
+            Assert.That(_repository.HasState(CreateStateId(4, rootByte: 1)), Is.True, "the parent of a recently committed state stays readable");
+            Assert.That(_repository.HasState(CreateStateId(5, rootByte: 1)), Is.True);
+        }
+    }
+
+    [Test]
+    public void RemoveOrphanedStates_CompactedEdge_KeepsTheBasesItSpans()
+    {
+        BuildSnapshotChain(0, 4);
+        AddSnapshotToRepository(CreateStateId(0), CreateStateId(3), compacted: true);
+        AddSnapshotToRepository(CreateStateId(1), CreateStateId(2, rootByte: 1));
+        _repository.SetLastCommittedStateId(CreateStateId(4));
+
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(4));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.EqualTo(1));
+            Assert.That(_repository.HasState(CreateStateId(2, rootByte: 1)), Is.False);
+            Assert.That(_repository.HasState(CreateStateId(1)), Is.True);
+            Assert.That(_repository.HasState(CreateStateId(2)), Is.True);
+            Assert.That(TryLease(CreateStateId(3), compacted: true, out Snapshot? compacted), Is.True);
+            compacted?.Dispose();
+        }
+    }
+
+    [Test]
+    public void IsOnCommittedAncestry_DistinguishesTheCommittedChainFromOrphans()
+    {
+        BuildSnapshotChain(0, 4);
+        AddSnapshotToRepository(CreateStateId(2), CreateStateId(3, rootByte: 1));
+
+        Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(3, rootByte: 1)), Is.True, "nothing committed yet: nothing can be called an orphan");
+
+        _repository.SetLastCommittedStateId(CreateStateId(4));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(2)), Is.True);
+            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(4)), Is.True);
+            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(3, rootByte: 1)), Is.False);
+        }
+    }
+    [Test]
+    public void RemoveOrphanedStates_ConvertedSibling_IsDroppedFromThePersistedTier()
+    {
+        BuildSnapshotChain(0, 3);
+        Snapshot orphan = CreateSnapshot(CreateStateId(2), CreateStateId(3, rootByte: 1), withData: true);
+        _tier.ConvertToPersistedBase(orphan).Dispose();
+        _repository.SetLastCommittedStateId(CreateStateId(3));
+        Assert.That(_repository.HasState(CreateStateId(3, rootByte: 1)), Is.True, "precondition: the sibling lives in the persisted tier");
+
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(3));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.EqualTo(1));
+            Assert.That(_repository.HasState(CreateStateId(3, rootByte: 1)), Is.False);
+            Assert.That(_repository.HasState(CreateStateId(3)), Is.True);
+        }
+    }
+    [Test]
+    public void RemoveOrphanedStates_HeadWithoutInMemorySnapshot_PrunesNothing()
+    {
+        BuildSnapshotChain(0, 3);
+        AddSnapshotToRepository(CreateStateId(1), CreateStateId(2, rootByte: 1));
+
+        Assert.That(_repository.RemoveOrphanedStates(CreateStateId(9)), Is.Zero);
+        Assert.That(_repository.HasState(CreateStateId(2, rootByte: 1)), Is.True);
+    }
+
     #endregion
 }

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotRepositoryTests.cs
@@ -509,7 +509,7 @@ public class SnapshotRepositoryTests
         }
         _repository.SetLastCommittedStateId(CreateStateId(5, rootByte: 3));
 
-        int pruned = _repository.RemoveOrphanedStates(CreateStateId(5, rootByte: 3));
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(5, rootByte: 3), CreateStateId(5, rootByte: 3));
 
         using (Assert.EnterMultipleScope())
         {
@@ -534,7 +534,7 @@ public class SnapshotRepositoryTests
             _repository.SetLastCommittedStateId(CreateStateId(5, fork));
         }
 
-        int pruned = _repository.RemoveOrphanedStates(CreateStateId(5, rootByte: 2));
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(5, rootByte: 2), CreateStateId(5, rootByte: 2));
 
         using (Assert.EnterMultipleScope())
         {
@@ -552,7 +552,7 @@ public class SnapshotRepositoryTests
         AddSnapshotToRepository(CreateStateId(1), CreateStateId(2, rootByte: 1));
         _repository.SetLastCommittedStateId(CreateStateId(4));
 
-        int pruned = _repository.RemoveOrphanedStates(CreateStateId(4));
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(4), CreateStateId(4));
 
         using (Assert.EnterMultipleScope())
         {
@@ -571,15 +571,15 @@ public class SnapshotRepositoryTests
         BuildSnapshotChain(0, 4);
         AddSnapshotToRepository(CreateStateId(2), CreateStateId(3, rootByte: 1));
 
-        Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(3, rootByte: 1)), Is.True, "nothing committed yet: nothing can be called an orphan");
+        Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(3, rootByte: 1), CreateStateId(3, rootByte: 1)), Is.True, "nothing committed yet: nothing can be called an orphan");
 
         _repository.SetLastCommittedStateId(CreateStateId(4));
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(2)), Is.True);
-            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(4)), Is.True);
-            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(3, rootByte: 1)), Is.False);
+            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(2), CreateStateId(4)), Is.True);
+            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(4), CreateStateId(4)), Is.True);
+            Assert.That(_repository.IsOnCommittedAncestry(CreateStateId(3, rootByte: 1), CreateStateId(4)), Is.False);
         }
     }
     [Test]
@@ -591,7 +591,7 @@ public class SnapshotRepositoryTests
         _repository.SetLastCommittedStateId(CreateStateId(3));
         Assert.That(_repository.HasState(CreateStateId(3, rootByte: 1)), Is.True, "precondition: the sibling lives in the persisted tier");
 
-        int pruned = _repository.RemoveOrphanedStates(CreateStateId(3));
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(3), CreateStateId(3));
 
         using (Assert.EnterMultipleScope())
         {
@@ -601,12 +601,52 @@ public class SnapshotRepositoryTests
         }
     }
     [Test]
+    public void RemoveOrphanedStates_ForkChoiceHead_IsRetainedWithItsAncestry()
+    {
+        // The chain follows 4 while every later payload is a sibling of it that was executed but never selected.
+        BuildSnapshotChain(0, 4);
+        for (byte fork = 1; fork <= 3; fork++)
+        {
+            AddSnapshotToRepository(CreateStateId(3), CreateStateId(4, fork));
+            _repository.SetLastCommittedStateId(CreateStateId(4, fork));
+        }
+
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(4, rootByte: 3), CreateStateId(4));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.Zero, "recently committed siblings and the fork-choice head all stay");
+            Assert.That(_repository.HasState(CreateStateId(4)), Is.True, "the fork-choice head is not an orphan");
+        }
+    }
+
+    [Test]
+    public void RemoveOrphanedStates_ForkAboveTheCommittedHead_IsDroppedWhole()
+    {
+        // An orphaned fork 3'->4'->5' reaches above the committed head at 4; keeping 5' would leave a tip whose chain
+        // cannot be assembled.
+        BuildSnapshotChain(0, 4);
+        BuildSnapshotChain(CreateStateId(2), 5, rootByte: 1);
+        _repository.SetLastCommittedStateId(CreateStateId(4));
+
+        int pruned = _repository.RemoveOrphanedStates(CreateStateId(4), CreateStateId(4));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pruned, Is.EqualTo(3));
+            Assert.That(_repository.HasState(CreateStateId(5, rootByte: 1)), Is.False);
+            Assert.That(_repository.HasState(CreateStateId(3, rootByte: 1)), Is.False);
+            Assert.That(_repository.HasState(CreateStateId(4)), Is.True);
+        }
+    }
+
+    [Test]
     public void RemoveOrphanedStates_HeadWithoutInMemorySnapshot_PrunesNothing()
     {
         BuildSnapshotChain(0, 3);
         AddSnapshotToRepository(CreateStateId(1), CreateStateId(2, rootByte: 1));
 
-        Assert.That(_repository.RemoveOrphanedStates(CreateStateId(9)), Is.Zero);
+        Assert.That(_repository.RemoveOrphanedStates(CreateStateId(9), CreateStateId(9)), Is.Zero);
         Assert.That(_repository.HasState(CreateStateId(2, rootByte: 1)), Is.True);
     }
 

--- a/src/Nethermind/Nethermind.State.Flat.Test/TestFixtureHelpers.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/TestFixtureHelpers.cs
@@ -44,28 +44,6 @@ internal static class TestFixtureHelpers
     }
 
     /// <summary>
-    /// Read the <c>ref_ids</c> list from the metadata inside <paramref name="reservation"/>
-    /// and acquire a lease per id on <paramref name="blobs"/>. Mirrors what
-    /// <c>SnapshotRepository</c> does at load time — the resulting
-    /// <see cref="PersistedSnapshot"/>'s <c>CleanUp</c> drops one lease per id, keeping
-    /// refcounts balanced. No-op when there are no ref_ids (raw test bytes that aren't
-    /// a real sorted table).
-    /// </summary>
-    public static void LeaseBlobIds(ArenaReservation reservation, BlobArenaManager blobs)
-    {
-        using WholeReadSession session = reservation.BeginWholeReadSession();
-        WholeReadSessionReader reader = session.CreateReader();
-        ushort[]? ids = ReadRefIdsFromMetadata<WholeReadSessionReader, NoOpPin>(in reader);
-        if (ids is null) return;
-        foreach (ushort id in ids)
-        {
-            if (!blobs.TryLeaseFile(id, out _))
-                throw new System.InvalidOperationException(
-                    $"Test fixture's BlobArenaManager has no slot for id {id}; did Build() use a different manager?");
-        }
-    }
-
-    /// <summary>
     /// Read the snapshot's referenced blob-arena ids (the ref-id records in column
     /// <see cref="PersistedSnapshotKey.RefIdColumn"/>) as a <c>ushort[]</c>, or <c>null</c> when
     /// there are none (e.g. raw test bytes that aren't a real table). Test-only convenience for
@@ -120,22 +98,19 @@ internal static class TestFixtureHelpers
     }
 
     /// <summary>
-    /// Write <paramref name="data"/> into a fresh reservation on <paramref name="arena"/>,
-    /// lease the blob ids referenced by its metadata (skipped when
-    /// <paramref name="leaseBlobIds"/> is false) and wrap the result in a
-    /// <see cref="PersistedSnapshot"/> over <paramref name="blobs"/>.
+    /// Write <paramref name="data"/> into a fresh reservation on <paramref name="arena"/>
+    /// and wrap the result in a <see cref="PersistedSnapshot"/> over <paramref name="blobs"/>.
     /// </summary>
     public static PersistedSnapshot CreatePersistedSnapshot(
-        IArenaManager arena, BlobArenaManager blobs, StateId from, StateId to, byte[] data,
-        bool leaseBlobIds = true)
+        IArenaManager arena, BlobArenaManager blobs, StateId from, StateId to, byte[] data)
     {
         using ArenaWriter writer = arena.CreateWriter(data.Length);
         Span<byte> span = writer.GetWriter().GetSpan(data.Length);
         data.CopyTo(span);
         writer.GetWriter().Advance(data.Length);
         (_, ArenaReservation reservation) = writer.Complete();
-        if (leaseBlobIds) LeaseBlobIds(reservation, blobs);
-        return new PersistedSnapshot(from, to, reservation, blobs, SnapshotTier.PersistedBase, RefCountedBloomFilter.AlwaysTrue());
+        using (reservation)
+            return new PersistedSnapshot(from, to, reservation, blobs, SnapshotTier.PersistedBase, RefCountedBloomFilter.AlwaysTrue());
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -26,6 +26,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
     private readonly ISnapshotRepository _snapshotRepository;
     private readonly ITrieNodeCache _trieNodeCache;
     private readonly IResourcePool _resourcePool;
+    private readonly SnapshotRetention _retention;
 
     // Cache for assembling `ReadOnlySnapshotBundle`. Its not actually slow, but its called 1.8k per sec so caching
     // it save a decent amount of CPU.
@@ -65,12 +66,14 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         IFlatDbConfig config,
         IBlocksConfig blocksConfig,
         ILogManager logManager,
-        bool enableDetailedMetrics)
+        bool enableDetailedMetrics,
+        SnapshotRetention retention)
     {
         _trieNodeCache = trieNodeCache;
         _snapshotCompactor = snapshotCompactor;
         _snapshotRepository = snapshotRepository;
         _resourcePool = resourcePool;
+        _retention = retention;
         _persistenceManager = persistenceManager;
         _logger = logManager.GetClassLogger<FlatDbManager>();
         _enableDetailedMetrics = enableDetailedMetrics;
@@ -128,12 +131,26 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
     private async Task RunCompactJob(StateId stateId, CancellationToken cancellationToken)
     {
-        // We do this async because of the lock
-        _snapshotRepository.AddStateId(stateId);
-
-        if (_snapshotCompactor.DoCompactSnapshot(stateId))
+        using (_retention.Sync.EnterScope())
         {
-            ClearReadOnlyBundleCache();
+            if (!_snapshotRepository.TryLeaseInMemoryState(stateId, SnapshotTier.InMemoryBase, out Snapshot? snapshot)) return;
+            using (snapshot)
+            {
+                _snapshotRepository.AddStateId(stateId);
+                _retention.Register(stateId);
+            }
+        }
+
+        try
+        {
+            if (_snapshotCompactor.DoCompactSnapshot(stateId))
+            {
+                ClearReadOnlyBundleCache();
+            }
+        }
+        finally
+        {
+            _retention.Release(stateId);
         }
 
         // Trigger persistence job.
@@ -254,13 +271,28 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             return new ReadOnlySnapshotBundle(new SnapshotPooledList(0), new NoopPersistenceReader(), _enableDetailedMetrics, PersistedSnapshotStack.Empty(_enableDetailedMetrics));
         }
 
+        if (_readonlySnapshotBundleCache.TryGetValue(baseBlock, out ReadOnlySnapshotBundle? bundle) && bundle.TryLease()) return bundle;
+
+        _retention.Register(baseBlock);
+        try
+        {
+            ReadOnlySnapshotBundle result = AssembleReadOnlySnapshotBundle(baseBlock);
+            result.Retain(_retention, baseBlock);
+            return result;
+        }
+        catch
+        {
+            _retention.Release(baseBlock);
+            throw;
+        }
+    }
+
+    private ReadOnlySnapshotBundle AssembleReadOnlySnapshotBundle(in StateId baseBlock)
+    {
         long sw = 0;
         int attempt = 0;
         while (true)
         {
-            // Fastpath: Share a recently created ReadOnlySnapshotBundle
-            if (_readonlySnapshotBundleCache.TryGetValue(baseBlock, out ReadOnlySnapshotBundle? bundle) && bundle.TryLease()) return bundle;
-
             if (attempt == 1) sw = Stopwatch.GetTimestamp();
             if (attempt != 0)
             {
@@ -356,16 +388,19 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             return;
         }
 
-        if (!_snapshotRepository.TryAdd(snapshot, SnapshotTier.InMemoryBase))
+        using (_retention.Sync.EnterScope())
         {
-            if (_logger.IsWarn) _logger.Warn($"State {snapshot.To} already added");
-            transientResource.ReleaseLease();
-            snapshot.Dispose();
-            return;
-        }
+            if (!_snapshotRepository.TryAdd(snapshot, SnapshotTier.InMemoryBase))
+            {
+                if (_logger.IsWarn) _logger.Warn($"State {snapshot.To} already added");
+                transientResource.ReleaseLease();
+                snapshot.Dispose();
+                return;
+            }
 
-        // The latest block the main processing scope committed; used as the head for forced persists.
-        _snapshotRepository.SetLastCommittedStateId(endBlock);
+            // Publish the head with the snapshot so pruning cannot observe an unprotected insertion.
+            _snapshotRepository.SetLastCommittedStateId(endBlock);
+        }
 
         if (_inlineCompaction)
         {

--- a/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/FlatDbManager.cs
@@ -131,26 +131,33 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
 
     private async Task RunCompactJob(StateId stateId, CancellationToken cancellationToken)
     {
+        bool canCompact;
         using (_retention.Sync.EnterScope())
         {
-            if (!_snapshotRepository.TryLeaseInMemoryState(stateId, SnapshotTier.InMemoryBase, out Snapshot? snapshot)) return;
-            using (snapshot)
+            canCompact = _snapshotRepository.TryLeaseInMemoryState(stateId, SnapshotTier.InMemoryBase, out Snapshot? snapshot);
+            if (canCompact)
             {
-                _snapshotRepository.AddStateId(stateId);
-                _retention.Register(stateId);
+                using (snapshot)
+                {
+                    _snapshotRepository.AddStateId(stateId);
+                    _retention.Register(stateId);
+                }
             }
         }
 
-        try
+        if (canCompact)
         {
-            if (_snapshotCompactor.DoCompactSnapshot(stateId))
+            try
             {
-                ClearReadOnlyBundleCache();
+                if (_snapshotCompactor.DoCompactSnapshot(stateId))
+                {
+                    ClearReadOnlyBundleCache();
+                }
             }
-        }
-        finally
-        {
-            _retention.Release(stateId);
+            finally
+            {
+                _retention.Release(stateId);
+            }
         }
 
         // Trigger persistence job.
@@ -276,9 +283,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
         _retention.Register(baseBlock);
         try
         {
-            ReadOnlySnapshotBundle result = AssembleReadOnlySnapshotBundle(baseBlock);
-            result.Retain(_retention, baseBlock);
-            return result;
+            return AssembleReadOnlySnapshotBundle(baseBlock);
         }
         catch
         {
@@ -341,7 +346,7 @@ public class FlatDbManager : IFlatDbManager, IAsyncDisposable
             ReportBundleMetrics(assembled);
 
             ReadOnlySnapshotBundle res = new(assembled.InMemory, persistenceReader, _enableDetailedMetrics,
-                new PersistedSnapshotStack(assembled.Persisted, _enableDetailedMetrics));
+                new PersistedSnapshotStack(assembled.Persisted, _enableDetailedMetrics), _retention, baseBlock);
 
             res.TryLease();
             if (!_readonlySnapshotBundleCache.TryAdd(baseBlock, res))

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -167,11 +167,11 @@ public interface ISnapshotRepository
     /// <param name="committedHead">The last state the main processing scope committed.</param>
     /// <param name="forkChoiceHead">The state the chain currently follows; equal to <paramref name="committedHead"/> when unknown.</param>
     /// <param name="minBlockNumber">The first eligible height; callers must exclude the current persisted state and older history.</param>
-    int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead, ulong minBlockNumber = 0) => 0;
+    int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead, ulong minBlockNumber = 0);
 
     /// <summary>Collects the committed, fork-choice, recent-commit, and active-view ancestry in memory.</summary>
     /// <remarks>An empty set means ancestry is unknown and candidates must not be rejected.</remarks>
     /// <param name="forkChoiceHead">The state currently selected by fork choice.</param>
     /// <param name="retained">An initially empty set populated once for a conversion pass.</param>
-    void CollectCommittedAncestry(in StateId forkChoiceHead, ISet<StateId> retained) { }
+    void CollectCommittedAncestry(in StateId forkChoiceHead, ISet<StateId> retained);
 }

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -158,7 +158,11 @@ public interface ISnapshotRepository
     /// it, so without this every sibling's snapshot lives for the life of the process, in memory or converted on
     /// disk. New-payload and fork-choice handlers can re-execute removed branches from available state.
     /// Active state views and their ancestry are retained. Persisted history below the in-memory and recent-commit
-    /// window is never removed. Persisted deletion candidates are enumerated only after in-memory removal or a persisted fork is found.
+    /// window is never removed. Within that window, skipped persisted heights remain available unless every
+    /// parent is already orphaned; compacted edges can otherwise hide canonical history even when another
+    /// protected branch identifies a root at that height. Persisted deletion candidates are enumerated only
+    /// after in-memory candidates or a persisted fork are found. Snapshot cleanup
+    /// runs after releasing the reader/commit retention gate.
     /// </remarks>
     /// <param name="committedHead">The last state the main processing scope committed.</param>
     /// <param name="forkChoiceHead">The state the chain currently follows; equal to <paramref name="committedHead"/> when unknown.</param>

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -147,4 +147,25 @@ public interface ISnapshotRepository
     /// </remarks>
     /// <param name="canonicalStateId">The canonical state being persisted.</param>
     void RemoveSiblingAndDescendents(in StateId canonicalStateId);
+
+    /// <summary>
+    /// Removes snapshots in both tiers at or below <paramref name="committedHead"/>'s block that are neither on its
+    /// ancestry nor on the ancestry of a recently committed state, and returns how many were removed.
+    /// </summary>
+    /// <remarks>
+    /// Persistence reclaims snapshots only when the chain advances past the persisted state. A head that stays put
+    /// while sibling blocks keep arriving (an engine client replaying payloads against one parent) never advances
+    /// it, so without this every sibling's snapshot lives for the life of the process, in memory or converted on
+    /// disk. A later reorg to a removed state re-executes its block from the parent, which <see cref="HasState"/>
+    /// reporting false triggers.
+    /// </remarks>
+    /// <param name="committedHead">The last state the main processing scope committed.</param>
+    int RemoveOrphanedStates(in StateId committedHead);
+
+    /// <summary>
+    /// True when <paramref name="stateId"/> is on the ancestry of the last committed state or of a recently
+    /// committed one; also true while nothing has been committed or the committed state is not in memory,
+    /// so callers cannot mistake an unknown chain for an orphan.
+    /// </summary>
+    bool IsOnCommittedAncestry(in StateId stateId);
 }

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -156,17 +156,18 @@ public interface ISnapshotRepository
     /// Persistence reclaims snapshots only when the chain advances past the persisted state. A head that stays put
     /// while sibling blocks keep arriving (an engine client replaying payloads against one parent) never advances
     /// it, so without this every sibling's snapshot lives for the life of the process, in memory or converted on
-    /// disk. A payload extending a removed block re-executes the branch down to the nearest state; a fork choice
-    /// that selects a removed block itself serves no state until such a payload arrives.
+    /// disk. New-payload and fork-choice handlers can re-execute removed branches from available state.
+    /// Active state views and their ancestry are retained. Persisted history below the in-memory and recent-commit
+    /// window is never removed. Persisted deletion candidates are enumerated only after in-memory removal or a persisted fork is found.
     /// </remarks>
     /// <param name="committedHead">The last state the main processing scope committed.</param>
     /// <param name="forkChoiceHead">The state the chain currently follows; equal to <paramref name="committedHead"/> when unknown.</param>
-    int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead);
+    /// <param name="minBlockNumber">The first eligible height; callers must exclude the current persisted state and older history.</param>
+    int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead, ulong minBlockNumber = 0) => 0;
 
-    /// <summary>
-    /// True when <paramref name="stateId"/> is on the ancestry of the last committed state, of
-    /// <paramref name="forkChoiceHead"/>, or of a recently committed state; also true while nothing has been
-    /// committed or the committed state has no snapshot, so callers cannot mistake an unknown chain for an orphan.
-    /// </summary>
-    bool IsOnCommittedAncestry(in StateId stateId, in StateId forkChoiceHead);
+    /// <summary>Collects the committed, fork-choice, recent-commit, and active-view ancestry in memory.</summary>
+    /// <remarks>An empty set means ancestry is unknown and candidates must not be rejected.</remarks>
+    /// <param name="forkChoiceHead">The state currently selected by fork choice.</param>
+    /// <param name="retained">An initially empty set populated once for a conversion pass.</param>
+    void CollectCommittedAncestry(in StateId forkChoiceHead, ISet<StateId> retained) { }
 }

--- a/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ISnapshotRepository.cs
@@ -149,23 +149,24 @@ public interface ISnapshotRepository
     void RemoveSiblingAndDescendents(in StateId canonicalStateId);
 
     /// <summary>
-    /// Removes snapshots in both tiers at or below <paramref name="committedHead"/>'s block that are neither on its
-    /// ancestry nor on the ancestry of a recently committed state, and returns how many were removed.
+    /// Removes the snapshots, in both tiers, that are on the ancestry of neither <paramref name="committedHead"/>,
+    /// <paramref name="forkChoiceHead"/>, nor a recently committed state, and returns how many were removed.
     /// </summary>
     /// <remarks>
     /// Persistence reclaims snapshots only when the chain advances past the persisted state. A head that stays put
     /// while sibling blocks keep arriving (an engine client replaying payloads against one parent) never advances
     /// it, so without this every sibling's snapshot lives for the life of the process, in memory or converted on
-    /// disk. A later reorg to a removed state re-executes its block from the parent, which <see cref="HasState"/>
-    /// reporting false triggers.
+    /// disk. A payload extending a removed block re-executes the branch down to the nearest state; a fork choice
+    /// that selects a removed block itself serves no state until such a payload arrives.
     /// </remarks>
     /// <param name="committedHead">The last state the main processing scope committed.</param>
-    int RemoveOrphanedStates(in StateId committedHead);
+    /// <param name="forkChoiceHead">The state the chain currently follows; equal to <paramref name="committedHead"/> when unknown.</param>
+    int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead);
 
     /// <summary>
-    /// True when <paramref name="stateId"/> is on the ancestry of the last committed state or of a recently
-    /// committed one; also true while nothing has been committed or the committed state is not in memory,
-    /// so callers cannot mistake an unknown chain for an orphan.
+    /// True when <paramref name="stateId"/> is on the ancestry of the last committed state, of
+    /// <paramref name="forkChoiceHead"/>, or of a recently committed state; also true while nothing has been
+    /// committed or the committed state has no snapshot, so callers cannot mistake an unknown chain for an orphan.
     /// </summary>
-    bool IsOnCommittedAncestry(in StateId stateId);
+    bool IsOnCommittedAncestry(in StateId stateId, in StateId forkChoiceHead);
 }

--- a/src/Nethermind/Nethermind.State.Flat/Metrics.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Metrics.cs
@@ -61,6 +61,16 @@ public static class Metrics
         set => Volatile.Write(ref _snapshotOrphanPruningSkipped, value);
     }
 
+    internal static long _snapshotOrphanAmbiguousCandidates;
+
+    [CounterMetric]
+    [Description("Snapshot candidates retained due to compaction gaps, counted again on each pruning sweep that examines them")]
+    public static long SnapshotOrphanAmbiguousCandidates
+    {
+        get => Volatile.Read(ref _snapshotOrphanAmbiguousCandidates);
+        set => Volatile.Write(ref _snapshotOrphanAmbiguousCandidates, value);
+    }
+
     internal static long _snapshotOrphanPrunedEntries;
 
     [CounterMetric]

--- a/src/Nethermind/Nethermind.State.Flat/Metrics.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Metrics.cs
@@ -51,6 +51,26 @@ public static class Metrics
     [Description("Number of snapshots")]
     public static long SnapshotCount { get; set; }
 
+    internal static long _snapshotOrphanPruningSkipped;
+
+    [CounterMetric]
+    [Description("Snapshot orphan pruning sweeps skipped because protected ancestry is unavailable")]
+    public static long SnapshotOrphanPruningSkipped
+    {
+        get => Volatile.Read(ref _snapshotOrphanPruningSkipped);
+        set => Volatile.Write(ref _snapshotOrphanPruningSkipped, value);
+    }
+
+    internal static long _snapshotOrphanPrunedEntries;
+
+    [CounterMetric]
+    [Description("Orphaned snapshot entries removed across in-memory and persisted tiers")]
+    public static long SnapshotOrphanPrunedEntries
+    {
+        get => Volatile.Read(ref _snapshotOrphanPrunedEntries);
+        set => Volatile.Write(ref _snapshotOrphanPrunedEntries, value);
+    }
+
     [GaugeMetric]
     [Description("Number of compacted snapshots")]
     public static long CompactedSnapshotCount { get; set; }

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshot.cs
@@ -337,6 +337,9 @@ public sealed class PersistedSnapshot : SmallRefCountingDisposable
 
     public bool TryAcquire() => TryAcquireLease();
 
+    /// <summary>True while a reader other than the caller holds a lease; the caller must hold exactly one lease.</summary>
+    internal bool HasOtherReaders => CurrentLeases > 2 * RefCountingLease.Single;
+
     /// <summary>
     /// Advise this snapshot's mmap range cold and clear the per-arena page-tracker entries that
     /// cover it. A hook for callers that have superseded this snapshot but want to drop its resident

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshot.cs
@@ -73,10 +73,7 @@ public sealed class PersistedSnapshot : SmallRefCountingDisposable
     private ArenaByteReader CreateReader() => _reservation.CreateReader();
 
     /// <summary>
-    /// Construct a snapshot over a pre-leased metadata reservation. The caller MUST have already
-    /// acquired one lease per blob arena id referenced by the snapshot's <c>ref_ids</c> metadata,
-    /// and is responsible for rolling those leases back on construction failure. This ctor bumps the
-    /// metadata reservation lease and stashes the manager ref for later id → file resolution.
+    /// Constructs a snapshot retaining its own leases on the metadata reservation and referenced blob arenas.
     /// </summary>
     public PersistedSnapshot(StateId from, StateId to, ArenaReservation reservation,
         BlobArenaManager blobManager, SnapshotTier tier, RefCountedBloomFilter bloom)
@@ -336,9 +333,6 @@ public sealed class PersistedSnapshot : SmallRefCountingDisposable
     }
 
     public bool TryAcquire() => TryAcquireLease();
-
-    /// <summary>True while a reader other than the caller holds a lease; the caller must hold exactly one lease.</summary>
-    internal bool HasOtherReaders => CurrentLeases > 2 * RefCountingLease.Single;
 
     /// <summary>
     /// Advise this snapshot's mmap range cold and clear the per-arena page-tracker entries that

--- a/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotBucket.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistedSnapshots/PersistedSnapshotBucket.cs
@@ -120,10 +120,10 @@ internal sealed class PersistedSnapshotBucket(ISnapshotCatalog catalog, Snapshot
 
     /// <summary>Remove the entry at <paramref name="to"/> (catalog + index + leases) under this
     /// bucket's lock. Returns <c>true</c> when an entry was present.</summary>
-    public bool RemoveExact(in StateId to)
+    public bool RemoveExact(in StateId to, ArrayPoolList<IDisposable>? deferred = null)
     {
         using Lock.Scope scope = _lock.EnterScope();
-        return RemoveLocked(to);
+        return RemoveLocked(to, deferred);
     }
 
     /// <summary>
@@ -184,10 +184,11 @@ internal sealed class PersistedSnapshotBucket(ISnapshotCatalog catalog, Snapshot
     /// Remove <paramref name="to"/> from the index + catalog, dispose its leases, and roll back
     /// the bucket and global totals (bumping the prune metric). This bucket's lock must be held.
     /// </summary>
-    private bool RemoveLocked(in StateId to)
+    private bool RemoveLocked(in StateId to, ArrayPoolList<IDisposable>? deferred = null)
     {
         _ordered.Remove(to);
         if (!_byTo.TryRemove(to, out PersistedSnapshot? snapshot)) return false;
+        deferred?.Add(snapshot);
         // Capture depth before Dispose — From/To stay valid on the still-alive object, but the
         // underlying reservation/file leases are released by Dispose. The catalog key scopes the
         // removal to this bucket's entry (the other buckets' entries at the same To carry a
@@ -199,9 +200,10 @@ internal sealed class PersistedSnapshotBucket(ISnapshotCatalog catalog, Snapshot
         Metrics.PersistedSnapshotMemory.AddBy(label, -snapshot.Size);
         Metrics.PersistedSnapshotCount.AddBy(label, -1);
         Interlocked.Increment(ref Metrics._persistedSnapshotPrunes);
+        // Catalog removal stays with detachment so it cannot erase a subsequently re-registered key.
         catalog.Remove(to, depth);
         if (logger.IsDebug) logger.Debug($"Released persisted snapshot {_tierName} {snapshot.From.BlockNumber}->{to.BlockNumber}");
-        snapshot.Dispose();
+        if (deferred is null) snapshot.Dispose();
         return true;
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -106,7 +106,8 @@ public class PersistenceManager(
     ///   <item>Otherwise → no candidate; Phase 1 doesn't run, fall through to Phase 2.</item>
     /// </list>
     /// Phase 2 runs only with <see cref="_enableLongFinality"/> enabled AND
-    /// <c>SnapshotCount &gt; MaxInMemoryBaseSnapshotCount</c>.
+    /// <c>SnapshotCount &gt; MaxInMemoryBaseSnapshotCount</c>, and converts only states on the committed
+    /// ancestry; orphans are left for <see cref="PruneOrphansAboveBudget"/>.
     /// </remarks>
     internal (PersistedSnapshot? ToPersistPersistedSnapshot, Snapshot? ToPersist, ConversionCandidate? ToConvert) DetermineSnapshotAction(StateId latestSnapshot)
     {
@@ -195,6 +196,7 @@ public class PersistenceManager(
         // GetStatesUpToBlock treats as "before any state" (returns empty). long.MaxValue is above every
         // real block height, so this returns every in-memory state, ascending.
         using ArrayPoolList<StateId> ordered = snapshotRepository.GetStatesUpToBlock(long.MaxValue);
+        StateId forkChoiceHead = ForkChoiceHead(snapshotRepository.GetLastCommittedStateId() ?? currentPersistedState);
 
         // Pass 1 (global): boundary-CompactSize in-memory compacted → Branch A.
         // Orphans are never converted: a sibling the chain did not follow would only fill the persisted tier
@@ -205,7 +207,7 @@ public class PersistenceManager(
 
             if (compacted!.To.BlockNumber - compacted.From.BlockNumber == _compactSize
                 && IsOnDisk(compacted.From, currentPersistedState)
-                && snapshotRepository.IsOnCommittedAncestry(X))
+                && snapshotRepository.IsOnCommittedAncestry(X, forkChoiceHead))
             {
                 return new ConversionCandidate(compacted, Base: null);
             }
@@ -217,7 +219,7 @@ public class PersistenceManager(
         {
             if (!snapshotRepository.TryLeaseInMemoryState(X, SnapshotTier.InMemoryBase, out Snapshot? baseSnap)) continue;
 
-            if (IsOnDisk(baseSnap!.From, currentPersistedState) && snapshotRepository.IsOnCommittedAncestry(X))
+            if (IsOnDisk(baseSnap!.From, currentPersistedState) && snapshotRepository.IsOnCommittedAncestry(X, forkChoiceHead))
             {
                 return new ConversionCandidate(Compacted: null, baseSnap);
             }
@@ -297,10 +299,14 @@ public class PersistenceManager(
         StateId? committedHead = snapshotRepository.GetLastCommittedStateId();
         if (committedHead is null) return;
 
-        int pruned = snapshotRepository.RemoveOrphanedStates(committedHead.Value);
+        int pruned = snapshotRepository.RemoveOrphanedStates(committedHead.Value, ForkChoiceHead(committedHead.Value));
         if (pruned > 0 && _logger.IsDebug)
             _logger.Debug($"Pruned {pruned} orphaned snapshot(s) below committed head {committedHead.Value}; {snapshotRepository.SnapshotCount} base snapshot(s) remain.");
     }
+
+    /// <summary>The state the chain follows, which the last executed payload need not be; falls back to the committed head.</summary>
+    private StateId ForkChoiceHead(in StateId committedHead) =>
+        finalizedStateProvider.Head is { StateRoot: not null } head ? new StateId(head.Number, head.StateRoot) : committedHead;
 
     // Runs before the persist and the prune: the flat head must never advance past durable history, or a crash in
     // between leaves a permanently uncapturable range. Failures propagate and abort this iteration (retried next).

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -318,8 +318,22 @@ public class PersistenceManager(
             hasCompetingStates = ordered[i - 1].BlockNumber == ordered[i].BlockNumber;
         if (!hasCompetingStates)
         {
+            // A sibling's rival may already be on disk, leaving no duplicate in-memory height.
+            using PooledSet<StateId> retained = [];
+            snapshotRepository.CollectCommittedAncestry(ForkChoiceHead(committedHead.Value), retained);
+            hasCompetingStates = retained.Count == 0;
+            if (retained.Count > 0)
+                foreach (StateId state in ordered)
+                    if (!retained.Contains(state))
+                    {
+                        hasCompetingStates = true;
+                        break;
+                    }
+        }
+        if (!hasCompetingStates)
+        {
             if (_logger.IsTrace)
-                _logger.Trace($"Skipped orphan pruning: {snapshotCount} in-memory base snapshots exceed budget {_maxInMemoryBaseSnapshotCount}, but indexed states have no competing roots at the same height.");
+                _logger.Trace($"Skipped orphan pruning: {snapshotCount} in-memory base snapshots exceed budget {_maxInMemoryBaseSnapshotCount}, but all indexed states belong to protected ancestry.");
             return;
         }
 

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -295,7 +295,8 @@ public class PersistenceManager(
     /// </summary>
     private void PruneOrphansAboveBudget()
     {
-        if (snapshotRepository.SnapshotCount <= _maxInMemoryBaseSnapshotCount) return;
+        int snapshotCount = snapshotRepository.SnapshotCount;
+        if (snapshotCount <= _maxInMemoryBaseSnapshotCount) return;
 
         StateId? committedHead = snapshotRepository.GetLastCommittedStateId();
         if (committedHead is null) return;
@@ -304,15 +305,21 @@ public class PersistenceManager(
         using ArrayPoolList<StateId> ordered = snapshotRepository.GetStatesUpToBlock(long.MaxValue);
         // With a zero budget, every earlier sibling may already be on disk.
         bool hasCompetingStates = _maxInMemoryBaseSnapshotCount == 0;
+        // The index is sorted by height and deduplicated by StateId, so adjacent equal heights imply distinct roots.
         for (int i = 1; i < ordered.Count && !hasCompetingStates; i++)
             hasCompetingStates = ordered[i - 1].BlockNumber == ordered[i].BlockNumber;
-        if (!hasCompetingStates) return;
+        if (!hasCompetingStates)
+        {
+            if (_logger.IsTrace)
+                _logger.Trace($"Skipped orphan pruning: {snapshotCount} in-memory base snapshots exceed budget {_maxInMemoryBaseSnapshotCount}, but indexed states have no competing roots at the same height.");
+            return;
+        }
 
         StateId persisted = GetCurrentPersistedStateId();
         ulong minBlockNumber = persisted == StateId.PreGenesis ? 0 : persisted.BlockNumber + 1;
         int pruned = snapshotRepository.RemoveOrphanedStates(committedHead.Value, ForkChoiceHead(committedHead.Value), minBlockNumber);
         if (pruned > 0 && _logger.IsDebug)
-            _logger.Debug($"Pruned {pruned} orphaned snapshot(s) below committed head {committedHead.Value}; {snapshotRepository.SnapshotCount} base snapshot(s) remain.");
+            _logger.Debug($"Pruned {pruned} orphaned snapshot entries across in-memory and persisted tiers with committed head {committedHead.Value}; {snapshotRepository.SnapshotCount} in-memory base snapshots remain.");
     }
 
     /// <summary>The state the chain follows, which the last executed payload need not be; falls back to the committed head.</summary>

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -197,12 +197,15 @@ public class PersistenceManager(
         using ArrayPoolList<StateId> ordered = snapshotRepository.GetStatesUpToBlock(long.MaxValue);
 
         // Pass 1 (global): boundary-CompactSize in-memory compacted → Branch A.
+        // Orphans are never converted: a sibling the chain did not follow would only fill the persisted tier
+        // until the next persist prunes it, and PruneOrphansAboveBudget drops it once it ages out.
         foreach (StateId X in ordered)
         {
             if (!snapshotRepository.TryLeaseInMemoryState(X, SnapshotTier.InMemoryCompacted, out Snapshot? compacted)) continue;
 
             if (compacted!.To.BlockNumber - compacted.From.BlockNumber == _compactSize
-                && IsOnDisk(compacted.From, currentPersistedState))
+                && IsOnDisk(compacted.From, currentPersistedState)
+                && snapshotRepository.IsOnCommittedAncestry(X))
             {
                 return new ConversionCandidate(compacted, Base: null);
             }
@@ -214,7 +217,7 @@ public class PersistenceManager(
         {
             if (!snapshotRepository.TryLeaseInMemoryState(X, SnapshotTier.InMemoryBase, out Snapshot? baseSnap)) continue;
 
-            if (IsOnDisk(baseSnap!.From, currentPersistedState))
+            if (IsOnDisk(baseSnap!.From, currentPersistedState) && snapshotRepository.IsOnCommittedAncestry(X))
             {
                 return new ConversionCandidate(Compacted: null, baseSnap);
             }
@@ -234,6 +237,8 @@ public class PersistenceManager(
         await _persistenceLock.WaitAsync();
         try
         {
+            PruneOrphansAboveBudget();
+
             // Bound the drain per invocation so a deep backlog (e.g. early catch-up sync) does
             // not block the processing thread for an unbounded time. The caller re-enters on
             // every block, so the remaining backlog is consumed across subsequent invocations.
@@ -279,6 +284,22 @@ public class PersistenceManager(
         {
             _persistenceLock.Release();
         }
+    }
+
+    /// <summary>
+    /// Bounds the snapshot tiers when neither persistence nor conversion can: both need the chain to climb past
+    /// the persisted state, which a pinned head fed a stream of sibling blocks never does.
+    /// </summary>
+    private void PruneOrphansAboveBudget()
+    {
+        if (snapshotRepository.SnapshotCount <= _maxInMemoryBaseSnapshotCount) return;
+
+        StateId? committedHead = snapshotRepository.GetLastCommittedStateId();
+        if (committedHead is null) return;
+
+        int pruned = snapshotRepository.RemoveOrphanedStates(committedHead.Value);
+        if (pruned > 0 && _logger.IsDebug)
+            _logger.Debug($"Pruned {pruned} orphaned snapshot(s) below committed head {committedHead.Value}; {snapshotRepository.SnapshotCount} base snapshot(s) remain.");
     }
 
     // Runs before the persist and the prune: the flat head must never advance past durable history, or a crash in

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -114,12 +114,20 @@ public class PersistenceManager(
     {
         StateId currentPersistedState = GetCurrentPersistedStateId();
         // PreGenesis (nothing persisted) carries the ulong.MaxValue sentinel, so subtracting it would
-        // wrap; the in-memory depth from genesis is then latestSnapshot.BlockNumber + 1. A latest below
-        // the persisted block means a deep reorg stranded the persisted base on an orphaned fork;
-        // persistence stalls until the chain climbs back. SaturatingSub keeps the depth at 0 rather than
-        // underflowing, so the keep-in-memory guard returns early.
-        if (currentPersistedState != StateId.PreGenesis && latestSnapshot.BlockNumber < currentPersistedState.BlockNumber && _logger.IsWarn)
-            _logger.Warn($"Latest snapshot {latestSnapshot} is below persisted state {currentPersistedState}; persisted base may be on an orphaned fork. Skipping persistence.");
+        // wrap; the in-memory depth from genesis is then latestSnapshot.BlockNumber + 1. A queued trigger
+        // can outlive its snapshot; a still-available state below the persisted block may instead mean a
+        // deep reorg stranded the persisted base. SaturatingSub prevents either case from underflowing
+        // into the force-persist backstop.
+        if (currentPersistedState != StateId.PreGenesis && latestSnapshot.BlockNumber < currentPersistedState.BlockNumber)
+        {
+            if (snapshotRepository.HasState(latestSnapshot))
+            {
+                if (_logger.IsWarn)
+                    _logger.Warn($"Latest snapshot {latestSnapshot} is below persisted state {currentPersistedState}; persisted base may be on an orphaned fork. Skipping persistence.");
+            }
+            else if (_logger.IsDebug)
+                _logger.Debug($"Persistence trigger {latestSnapshot} is no longer available and is below persisted state {currentPersistedState}.");
+        }
 
         ulong snapshotsDepth = currentPersistedState == StateId.PreGenesis
             ? latestSnapshot.BlockNumber + 1

--- a/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
+++ b/src/Nethermind/Nethermind.State.Flat/PersistenceManager.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using Collections.Pooled;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Attributes;
@@ -106,8 +107,8 @@ public class PersistenceManager(
     ///   <item>Otherwise → no candidate; Phase 1 doesn't run, fall through to Phase 2.</item>
     /// </list>
     /// Phase 2 runs only with <see cref="_enableLongFinality"/> enabled AND
-    /// <c>SnapshotCount &gt; MaxInMemoryBaseSnapshotCount</c>, and converts only states on the committed
-    /// ancestry; orphans are left for <see cref="PruneOrphansAboveBudget"/>.
+    /// <c>SnapshotCount &gt; MaxInMemoryBaseSnapshotCount</c>, and selects conversion candidates from retained
+    /// ancestry; older orphans are left for <see cref="PruneOrphansAboveBudget"/>.
     /// </remarks>
     internal (PersistedSnapshot? ToPersistPersistedSnapshot, Snapshot? ToPersist, ConversionCandidate? ToConvert) DetermineSnapshotAction(StateId latestSnapshot)
     {
@@ -197,17 +198,17 @@ public class PersistenceManager(
         // real block height, so this returns every in-memory state, ascending.
         using ArrayPoolList<StateId> ordered = snapshotRepository.GetStatesUpToBlock(long.MaxValue);
         StateId forkChoiceHead = ForkChoiceHead(snapshotRepository.GetLastCommittedStateId() ?? currentPersistedState);
+        using PooledSet<StateId> retained = new();
+        snapshotRepository.CollectCommittedAncestry(forkChoiceHead, retained);
 
         // Pass 1 (global): boundary-CompactSize in-memory compacted → Branch A.
-        // Orphans are never converted: a sibling the chain did not follow would only fill the persisted tier
-        // until the next persist prunes it, and PruneOrphansAboveBudget drops it once it ages out.
         foreach (StateId X in ordered)
         {
             if (!snapshotRepository.TryLeaseInMemoryState(X, SnapshotTier.InMemoryCompacted, out Snapshot? compacted)) continue;
 
             if (compacted!.To.BlockNumber - compacted.From.BlockNumber == _compactSize
                 && IsOnDisk(compacted.From, currentPersistedState)
-                && snapshotRepository.IsOnCommittedAncestry(X, forkChoiceHead))
+                && (retained.Count == 0 || retained.Contains(X)))
             {
                 return new ConversionCandidate(compacted, Base: null);
             }
@@ -219,7 +220,7 @@ public class PersistenceManager(
         {
             if (!snapshotRepository.TryLeaseInMemoryState(X, SnapshotTier.InMemoryBase, out Snapshot? baseSnap)) continue;
 
-            if (IsOnDisk(baseSnap!.From, currentPersistedState) && snapshotRepository.IsOnCommittedAncestry(X, forkChoiceHead))
+            if (IsOnDisk(baseSnap!.From, currentPersistedState) && (retained.Count == 0 || retained.Contains(X)))
             {
                 return new ConversionCandidate(Compacted: null, baseSnap);
             }
@@ -299,7 +300,17 @@ public class PersistenceManager(
         StateId? committedHead = snapshotRepository.GetLastCommittedStateId();
         if (committedHead is null) return;
 
-        int pruned = snapshotRepository.RemoveOrphanedStates(committedHead.Value, ForkChoiceHead(committedHead.Value));
+        // A linear chain routinely exceeds the budget before conversion; only competing states need orphan pruning.
+        using ArrayPoolList<StateId> ordered = snapshotRepository.GetStatesUpToBlock(long.MaxValue);
+        // With a zero budget, every earlier sibling may already be on disk.
+        bool hasCompetingStates = _maxInMemoryBaseSnapshotCount == 0;
+        for (int i = 1; i < ordered.Count && !hasCompetingStates; i++)
+            hasCompetingStates = ordered[i - 1].BlockNumber == ordered[i].BlockNumber;
+        if (!hasCompetingStates) return;
+
+        StateId persisted = GetCurrentPersistedStateId();
+        ulong minBlockNumber = persisted == StateId.PreGenesis ? 0 : persisted.BlockNumber + 1;
+        int pruned = snapshotRepository.RemoveOrphanedStates(committedHead.Value, ForkChoiceHead(committedHead.Value), minBlockNumber);
         if (pruned > 0 && _logger.IsDebug)
             _logger.Debug($"Pruned {pruned} orphaned snapshot(s) below committed head {committedHead.Value}; {snapshotRepository.SnapshotCount} base snapshot(s) remain.");
     }

--- a/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
@@ -39,6 +39,14 @@ public sealed class ReadOnlySnapshotBundle(
     /// </summary>
     public bool IsHistorical { get; } = isHistorical;
     private bool _isDisposed;
+    private SnapshotRetention? _retention;
+    private StateId _retainedHead;
+
+    internal void Retain(SnapshotRetention retention, in StateId head)
+    {
+        _retention = retention;
+        _retainedHead = head;
+    }
 
     private static readonly StringLabel _readAccountSnapshotLabel = new("account_snapshot");
     private static readonly StringLabel _readAccountPersistenceLabel = new("account_persistence");
@@ -228,10 +236,17 @@ public sealed class ReadOnlySnapshotBundle(
     {
         if (Interlocked.CompareExchange(ref _isDisposed, true, false)) return;
 
-        snapshots.Dispose();
-        persistedSnapshots.Dispose();
+        try
+        {
+            snapshots.Dispose();
+            persistedSnapshots.Dispose();
 
-        // Null them in case unexpected mutation from trie warmer
-        persistenceReader.Dispose();
+            // Null them in case unexpected mutation from trie warmer
+            persistenceReader.Dispose();
+        }
+        finally
+        {
+            _retention?.Release(_retainedHead);
+        }
     }
 }

--- a/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ReadOnlySnapshotBundle.cs
@@ -39,10 +39,12 @@ public sealed class ReadOnlySnapshotBundle(
     /// </summary>
     public bool IsHistorical { get; } = isHistorical;
     private bool _isDisposed;
-    private SnapshotRetention? _retention;
-    private StateId _retainedHead;
+    private readonly SnapshotRetention? _retention;
+    private readonly StateId _retainedHead;
 
-    internal void Retain(SnapshotRetention retention, in StateId head)
+    internal ReadOnlySnapshotBundle(SnapshotPooledList snapshots, IPersistence.IPersistenceReader persistenceReader,
+        bool recordDetailedMetrics, PersistedSnapshotStack persistedSnapshots, SnapshotRetention retention, in StateId head)
+        : this(snapshots, persistenceReader, recordDetailedMetrics, persistedSnapshots)
     {
         _retention = retention;
         _retainedHead = head;

--- a/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
@@ -121,9 +121,6 @@ public class Snapshot : RefCountingDisposable
     }
 
     public bool TryAcquire() => TryAcquireLease();
-
-    /// <summary>True while a reader other than the caller holds a lease; the caller must hold exactly one lease.</summary>
-    internal bool HasOtherReaders => Volatile.Read(ref _leases.Value) > 2 * RefCountingLease.Single;
 }
 
 public sealed class SnapshotContent : IDisposable, IResettable

--- a/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
+++ b/src/Nethermind/Nethermind.State.Flat/Snapshot.cs
@@ -121,6 +121,9 @@ public class Snapshot : RefCountingDisposable
     }
 
     public bool TryAcquire() => TryAcquireLease();
+
+    /// <summary>True while a reader other than the caller holds a lease; the caller must hold exactly one lease.</summary>
+    internal bool HasOtherReaders => Volatile.Read(ref _leases.Value) > 2 * RefCountingLease.Single;
 }
 
 public sealed class SnapshotContent : IDisposable, IResettable

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -57,6 +57,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
     private readonly StateId[] _recentlyCommitted = new StateId[RecentlyCommittedRetention];
     private int _recentlyCommittedCount;
     private int _recentlyCommittedNext;
+    private long? _lastSkippedPruningWarning;
 
     public SnapshotRepository(
         IArenaManager arenaManager,
@@ -498,7 +499,17 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         using PooledSet<StateId> retained = [];
         using ArrayPoolList<(long First, long Last)> gaps = new(0);
         CollectRetainedAncestry(retained, committedHead, forkChoiceHead, includePersisted: true, minBlockNumber, gaps);
-        if (retained.Count == 0) return 0;
+        if (retained.Count == 0)
+        {
+            Interlocked.Increment(ref Metrics._snapshotOrphanPruningSkipped);
+            long now = Stopwatch.GetTimestamp();
+            if (_logger.IsWarn && (_lastSkippedPruningWarning is not { } last || Stopwatch.GetElapsedTime(last, now) >= TimeSpan.FromMinutes(1)))
+            {
+                _lastSkippedPruningWarning = now;
+                _logger.Warn($"Skipped snapshot orphan pruning because protected ancestry is unavailable above boundary {minBlockNumber}; snapshot memory may exceed its budget. Committed head: {committedHead}, fork-choice head: {forkChoiceHead}.");
+            }
+            return 0;
+        }
         ReadOnlySpan<(long First, long Last)> ambiguousHeights = MergeGaps(gaps.AsSpan());
 
         int gapIndex = 0;
@@ -559,6 +570,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         foreach (StateId stateId in persisted)
             if (orphans.Contains(stateId) && RemovePersistedStateExact(stateId, deferred)) pruned++;
         LogAmbiguousCandidates();
+        Interlocked.Add(ref Metrics._snapshotOrphanPrunedEntries, pruned);
         return pruned;
 
         void LogAmbiguousCandidates()

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -449,10 +449,16 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
     public int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead, ulong minBlockNumber = 0)
     {
         using ArrayPoolList<IDisposable> deferred = new(0);
+        Exception? primaryFailure = null;
         try
         {
             using Lock.Scope scope = _retention.Sync.EnterScope();
             return RemoveOrphanedStates(committedHead, forkChoiceHead, minBlockNumber, deferred);
+        }
+        catch (Exception exception)
+        {
+            primaryFailure = exception;
+            throw;
         }
         finally
         {
@@ -464,7 +470,11 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
                 try { snapshot.Dispose(); }
                 catch (Exception exception) { (failures ??= []).Add(exception); }
             }
-            if (failures is not null) throw new AggregateException(failures);
+            if (failures is not null)
+            {
+                if (primaryFailure is not null) failures.Insert(0, primaryFailure);
+                throw new AggregateException(failures);
+            }
         }
     }
 
@@ -492,16 +502,25 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         ReadOnlySpan<(long First, long Last)> ambiguousHeights = MergeGaps(gaps.AsSpan());
 
         int gapIndex = 0;
+        int ambiguousCandidates = 0;
         using PooledSet<StateId> orphans = [];
         foreach (StateId stateId in inMemory)
         {
             if (retained.Contains(stateId)) continue;
-            if (IsAmbiguousHeight(Height(stateId), ambiguousHeights, ref gapIndex) && !HasOnlyOrphanedParents(stateId, orphans)) continue;
+            if (IsAmbiguousHeight(Height(stateId), ambiguousHeights, ref gapIndex) && !HasOnlyOrphanedParents(stateId, orphans))
+            {
+                ambiguousCandidates++;
+                continue;
+            }
             orphans.Add(stateId);
         }
         // With no in-memory orphan, head-height probes cover recently converted payload siblings;
         // other persisted fork heights are left to normal persistence pruning.
-        if (orphans.Count == 0 && !HasPersistedForkAt(committedHead) && !HasPersistedForkAt(forkChoiceHead)) return 0;
+        if (orphans.Count == 0 && !HasPersistedForkAt(committedHead) && !HasPersistedForkAt(forkChoiceHead))
+        {
+            LogAmbiguousCandidates();
+            return 0;
+        }
 
         // A sibling may have been converted before it aged out of recent-commit retention.
         using ArrayPoolList<StateId> persisted = GetPersistedStatesInRange(minBlockNumber, long.MaxValue);
@@ -511,6 +530,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         // orphan; ascending traversal then propagates that decision through its descendants.
         persisted.AsSpan().Sort();
         gapIndex = 0;
+        ambiguousCandidates = 0;
         int memoryIndex = 0;
         int persistedIndex = 0;
         while (memoryIndex < inMemory.Count || persistedIndex < persisted.Count)
@@ -519,9 +539,13 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
                 && (persistedIndex == persisted.Count || inMemory[memoryIndex].CompareTo(persisted[persistedIndex]) <= 0);
             StateId stateId = fromMemory ? inMemory[memoryIndex++] : persisted[persistedIndex++];
             if (retained.Contains(stateId)) continue;
-            bool competingHeight = (fromMemory || retainedHeights.Contains(stateId.BlockNumber))
-                && !IsAmbiguousHeight(Height(stateId), ambiguousHeights, ref gapIndex);
-            if (!orphans.Contains(stateId) && !competingHeight && !HasOnlyOrphanedParents(stateId, orphans)) continue;
+            bool ambiguous = IsAmbiguousHeight(Height(stateId), ambiguousHeights, ref gapIndex);
+            bool competingHeight = (fromMemory || retainedHeights.Contains(stateId.BlockNumber)) && !ambiguous;
+            if (!orphans.Contains(stateId) && !competingHeight && !HasOnlyOrphanedParents(stateId, orphans))
+            {
+                if (ambiguous) ambiguousCandidates++;
+                continue;
+            }
             orphans.Add(stateId);
         }
 
@@ -534,7 +558,14 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         }
         foreach (StateId stateId in persisted)
             if (orphans.Contains(stateId) && RemovePersistedStateExact(stateId, deferred)) pruned++;
+        LogAmbiguousCandidates();
         return pruned;
+
+        void LogAmbiguousCandidates()
+        {
+            if (ambiguousCandidates > 0 && _logger.IsDebug)
+                _logger.Debug($"Preserved {ambiguousCandidates} snapshot candidate entries during orphan pruning because compaction gaps leave their ancestry ambiguous.");
+        }
     }
 
     private static ReadOnlySpan<(long First, long Last)> MergeGaps(Span<(long First, long Last)> gaps)

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -436,61 +436,95 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         }
     }
 
-    public int RemoveOrphanedStates(in StateId committedHead)
+    public int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead)
     {
-        using PooledSet<StateId> retained = CollectRetainedAncestry(committedHead);
+        // Candidates are listed before the ancestry is collected: a block committed in between is then either
+        // absent from the candidates or, having been committed, present in the retained set. The reverse order
+        // could list a just-committed sibling that the already collected ancestry does not know. No height bound:
+        // a fork is dropped whole, or a surviving tip would report a state its broken chain cannot assemble.
+        using ArrayPoolList<StateId> inMemory = GetStatesUpToBlock(long.MaxValue);
+        // A sibling converted while it was the committed head is an orphan on disk once the chain moves on.
+        using ArrayPoolList<StateId> persisted = GetPersistedStatesInRange(0, long.MaxValue);
+
+        using PooledSet<StateId> retained = CollectRetainedAncestry(committedHead, forkChoiceHead, includePersisted: true);
         if (retained.Count == 0) return 0;
 
         int pruned = 0;
-        using (ArrayPoolList<StateId> inMemory = GetStatesUpToBlock(committedHead.BlockNumber))
+        foreach (StateId stateId in inMemory)
         {
-            foreach (StateId stateId in inMemory)
-            {
-                if (retained.Contains(stateId)) continue;
-                if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryCompacted)) pruned++;
-                if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryBase)) pruned++;
-            }
+            if (retained.Contains(stateId)) continue;
+            pruned += RemoveOrphanUnlessRead(stateId, SnapshotTier.InMemoryCompacted);
+            pruned += RemoveOrphanUnlessRead(stateId, SnapshotTier.InMemoryBase);
         }
 
-        // A sibling converted while it was the committed head is an orphan on disk once the chain moves on.
-        using (ArrayPoolList<StateId> persisted = GetPersistedStatesInRange(0, committedHead.BlockNumber))
+        foreach (StateId stateId in persisted)
         {
-            foreach (StateId stateId in persisted)
-            {
-                if (!retained.Contains(stateId) && RemovePersistedStateExact(stateId)) pruned++;
-            }
+            if (retained.Contains(stateId) || IsPersistedStateRead(stateId)) continue;
+            if (RemovePersistedStateExact(stateId)) pruned++;
         }
 
-        if (pruned > 0 && _logger.IsDebug)
-            _logger.Debug($"Pruned {pruned} orphaned snapshot(s) below committed head {committedHead}.");
         return pruned;
     }
 
-    public bool IsOnCommittedAncestry(in StateId stateId)
+    /// <summary>
+    /// A snapshot some scope is reading is the parent of a block being executed, which will commit with its
+    /// <c>From</c> pointing here; dropping it now would leave that block without an ancestry.
+    /// </summary>
+    private int RemoveOrphanUnlessRead(in StateId stateId, SnapshotTier tier)
+    {
+        if (TryLeaseInMemoryState(stateId, tier, out Snapshot? snapshot))
+        {
+            bool read = snapshot.HasOtherReaders;
+            snapshot.Dispose();
+            if (read) return 0;
+        }
+
+        return RemoveAndReleaseInMemoryKnownState(stateId, tier) ? 1 : 0;
+    }
+
+    private bool IsPersistedStateRead(in StateId stateId)
+    {
+        ReadOnlySpan<SnapshotTier> persistedTiers = [SnapshotTier.PersistedBase, SnapshotTier.PersistedSmallCompacted, SnapshotTier.PersistedLargeCompacted, SnapshotTier.PersistedCompactSized];
+        foreach (SnapshotTier tier in persistedTiers)
+        {
+            if (!TryLeasePersistedState(stateId, tier, out PersistedSnapshot? snapshot)) continue;
+            bool read = snapshot.HasOtherReaders;
+            snapshot.Dispose();
+            if (read) return true;
+        }
+
+        return false;
+    }
+
+    public bool IsOnCommittedAncestry(in StateId stateId, in StateId forkChoiceHead)
     {
         StateId? committedHead = GetLastCommittedStateId();
         if (committedHead is null) return true;
 
-        using PooledSet<StateId> retained = CollectRetainedAncestry(committedHead.Value);
+        // Callers ask about in-memory states, and nothing in memory hangs below a persisted edge, so the walk
+        // can stop at the persisted tier instead of descending to the database state.
+        using PooledSet<StateId> retained = CollectRetainedAncestry(committedHead.Value, forkChoiceHead, includePersisted: false);
         return retained.Count == 0 || retained.Contains(stateId);
     }
 
     /// <summary>
-    /// Every state, in either tier, on the ancestry of <paramref name="committedHead"/> or of a recently committed
-    /// state. Empty when <paramref name="committedHead"/> has no in-memory snapshot, so a stale head prunes nothing.
+    /// Every state on the ancestry of <paramref name="committedHead"/>, of <paramref name="forkChoiceHead"/>, or of
+    /// a recently committed state, in memory and, when <paramref name="includePersisted"/> is set, in the persisted
+    /// tier. Empty when <paramref name="committedHead"/> has no snapshot in any tier, so a stale head prunes nothing.
     /// </summary>
     /// <remarks>
-    /// Every tier is followed: a compacted edge skips the bases it spans, and those bases are ancestors too. The
-    /// walk ends where <c>From</c> has no snapshot left, which is the state persisted to the database.
+    /// Every followed tier contributes edges: a compacted edge skips the bases it spans, and those bases are
+    /// ancestors too. The walk ends where <c>From</c> has no snapshot left, which is the state persisted to the database.
     /// </remarks>
-    private PooledSet<StateId> CollectRetainedAncestry(in StateId committedHead)
+    private PooledSet<StateId> CollectRetainedAncestry(in StateId committedHead, in StateId forkChoiceHead, bool includePersisted)
     {
         PooledSet<StateId> retained = [];
-        if (!_snapshots.ContainsKey(committedHead) && !_compactedSnapshots.ContainsKey(committedHead)) return retained;
+        if (!HasState(committedHead) && !_compactedSnapshots.ContainsKey(committedHead)) return retained;
 
         using PooledStack<StateId> pending = new();
         retained.Add(committedHead);
         pending.Push(committedHead);
+        if (retained.Add(forkChoiceHead)) pending.Push(forkChoiceHead);
         using (_lastCommittedLock.EnterScope())
         {
             int recent = Math.Min(_recentlyCommittedCount, RecentlyCommittedRetention);
@@ -512,6 +546,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
                 snapshot.Dispose();
                 if (retained.Add(from)) pending.Push(from);
             }
+            if (!includePersisted) continue;
             foreach (SnapshotTier tier in persistedTiers)
             {
                 if (!TryLeasePersistedState(current, tier, out PersistedSnapshot? snapshot)) continue;

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -506,7 +506,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
             if (_logger.IsWarn && (_lastSkippedPruningWarning is not { } last || Stopwatch.GetElapsedTime(last, now) >= TimeSpan.FromMinutes(1)))
             {
                 _lastSkippedPruningWarning = now;
-                _logger.Warn($"Skipped snapshot orphan pruning because protected ancestry is unavailable above boundary {minBlockNumber}; snapshot memory may exceed its budget. Committed head: {committedHead}, fork-choice head: {forkChoiceHead}.");
+                _logger.Warn($"Skipped snapshot orphan pruning because protected ancestry is unavailable above boundary {minBlockNumber}; this sweep retained all candidates. A stale protected head may clear after reader release or subsequent commits. Committed head: {committedHead}, fork-choice head: {forkChoiceHead}.");
             }
             return 0;
         }
@@ -575,6 +575,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
 
         void LogAmbiguousCandidates()
         {
+            Interlocked.Add(ref Metrics._snapshotOrphanAmbiguousCandidates, ambiguousCandidates);
             if (ambiguousCandidates > 0 && _logger.IsDebug)
                 _logger.Debug($"Preserved {ambiguousCandidates} snapshot candidate entries during orphan pruning because compaction gaps leave their ancestry ambiguous.");
         }

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -294,12 +294,16 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
     }
 
     public bool RemoveAndReleaseInMemoryKnownState(in StateId stateId, SnapshotTier tier)
+        => RemoveAndReleaseInMemoryKnownState(stateId, tier, null);
+
+    private bool RemoveAndReleaseInMemoryKnownState(in StateId stateId, SnapshotTier tier, ArrayPoolList<IDisposable>? deferred)
     {
         tier.EnsureInMemory();
         if (tier == SnapshotTier.InMemoryCompacted)
         {
             if (_compactedSnapshots.TryRemove(stateId, out Snapshot? existingState))
             {
+                deferred?.Add(existingState);
                 Interlocked.Decrement(ref _compactedSnapshotCount);
                 Metrics.CompactedSnapshotCount--;
 
@@ -307,7 +311,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
                 Metrics.CompactedSnapshotMemory -= compactedBytes;
                 Metrics.TotalSnapshotMemory -= compactedBytes;
 
-                existingState.Dispose();
+                if (deferred is null) existingState.Dispose();
 
                 return true;
             }
@@ -317,6 +321,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
 
         if (_snapshots.TryRemove(stateId, out Snapshot? existing))
         {
+            deferred?.Add(existing);
             Interlocked.Decrement(ref _snapshotCount);
             Metrics.SnapshotCount--;
 
@@ -327,7 +332,7 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
             Metrics.SnapshotMemory -= totalBytes;
             Metrics.TotalSnapshotMemory -= totalBytes;
 
-            existing.Dispose();
+            if (deferred is null) existing.Dispose();
 
             return true;
         }
@@ -443,7 +448,28 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
 
     public int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead, ulong minBlockNumber = 0)
     {
-        using Lock.Scope scope = _retention.Sync.EnterScope();
+        using ArrayPoolList<IDisposable> deferred = new(0);
+        try
+        {
+            using Lock.Scope scope = _retention.Sync.EnterScope();
+            return RemoveOrphanedStates(committedHead, forkChoiceHead, minBlockNumber, deferred);
+        }
+        finally
+        {
+            // Detached repository leases now belong to this list. Final pool returns and file cleanup
+            // must not hold the gate used to register readers and publish commits.
+            List<Exception>? failures = null;
+            foreach (IDisposable snapshot in deferred)
+            {
+                try { snapshot.Dispose(); }
+                catch (Exception exception) { (failures ??= []).Add(exception); }
+            }
+            if (failures is not null) throw new AggregateException(failures);
+        }
+    }
+
+    private int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead, ulong minBlockNumber, ArrayPoolList<IDisposable> deferred)
+    {
         using ArrayPoolListRef<StateId> inMemory = GetStatesInRange(minBlockNumber, long.MaxValue);
         if (inMemory.Count == 0) return 0;
 
@@ -460,26 +486,99 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         }
         minBlockNumber = Math.Max(minBlockNumber, activeStart);
         using PooledSet<StateId> retained = [];
-        CollectRetainedAncestry(retained, committedHead, forkChoiceHead, includePersisted: true, minBlockNumber);
+        using ArrayPoolList<(long First, long Last)> gaps = new(0);
+        CollectRetainedAncestry(retained, committedHead, forkChoiceHead, includePersisted: true, minBlockNumber, gaps);
         if (retained.Count == 0) return 0;
+        ReadOnlySpan<(long First, long Last)> ambiguousHeights = MergeGaps(gaps.AsSpan());
+
+        int gapIndex = 0;
+        using PooledSet<StateId> orphans = [];
+        foreach (StateId stateId in inMemory)
+        {
+            if (retained.Contains(stateId)) continue;
+            if (IsAmbiguousHeight(Height(stateId), ambiguousHeights, ref gapIndex) && !HasOnlyOrphanedParents(stateId, orphans)) continue;
+            orphans.Add(stateId);
+        }
+        // With no in-memory orphan, head-height probes cover recently converted payload siblings;
+        // other persisted fork heights are left to normal persistence pruning.
+        if (orphans.Count == 0 && !HasPersistedForkAt(committedHead) && !HasPersistedForkAt(forkChoiceHead)) return 0;
+
+        // A sibling may have been converted before it aged out of recent-commit retention.
+        using ArrayPoolList<StateId> persisted = GetPersistedStatesInRange(minBlockNumber, long.MaxValue);
+        using PooledSet<ulong> retainedHeights = [];
+        foreach (StateId stateId in retained) retainedHeights.Add(stateId.BlockNumber);
+        // Compacted edges can bypass canonical history. Only known competing heights establish an
+        // orphan; ascending traversal then propagates that decision through its descendants.
+        persisted.AsSpan().Sort();
+        gapIndex = 0;
+        int memoryIndex = 0;
+        int persistedIndex = 0;
+        while (memoryIndex < inMemory.Count || persistedIndex < persisted.Count)
+        {
+            bool fromMemory = memoryIndex < inMemory.Count
+                && (persistedIndex == persisted.Count || inMemory[memoryIndex].CompareTo(persisted[persistedIndex]) <= 0);
+            StateId stateId = fromMemory ? inMemory[memoryIndex++] : persisted[persistedIndex++];
+            if (retained.Contains(stateId)) continue;
+            bool competingHeight = (fromMemory || retainedHeights.Contains(stateId.BlockNumber))
+                && !IsAmbiguousHeight(Height(stateId), ambiguousHeights, ref gapIndex);
+            if (!orphans.Contains(stateId) && !competingHeight && !HasOnlyOrphanedParents(stateId, orphans)) continue;
+            orphans.Add(stateId);
+        }
 
         int pruned = 0;
         foreach (StateId stateId in inMemory)
         {
-            if (retained.Contains(stateId)) continue;
-            if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryCompacted)) pruned++;
-            if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryBase)) pruned++;
+            if (!orphans.Contains(stateId)) continue;
+            if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryCompacted, deferred)) pruned++;
+            if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryBase, deferred)) pruned++;
         }
-        // A small memory budget can convert siblings before they become eligible for in-memory pruning.
-        if (pruned == 0 && !HasPersistedForkAt(committedHead) && !HasPersistedForkAt(forkChoiceHead)) return 0;
-
-        // A sibling may have been converted before it aged out of recent-commit retention.
-        using ArrayPoolList<StateId> persisted = GetPersistedStatesInRange(minBlockNumber, long.MaxValue);
         foreach (StateId stateId in persisted)
-        {
-            if (!retained.Contains(stateId) && RemovePersistedStateExact(stateId)) pruned++;
-        }
+            if (orphans.Contains(stateId) && RemovePersistedStateExact(stateId, deferred)) pruned++;
         return pruned;
+    }
+
+    private static ReadOnlySpan<(long First, long Last)> MergeGaps(Span<(long First, long Last)> gaps)
+    {
+        gaps.Sort();
+        int count = 0;
+        foreach ((long first, long last) in gaps)
+        {
+            if (count > 0 && first <= gaps[count - 1].Last)
+                gaps[count - 1].Last = Math.Max(gaps[count - 1].Last, last);
+            else
+                gaps[count++] = (first, last);
+        }
+        return gaps[..count];
+    }
+
+    private static bool IsAmbiguousHeight(long height, ReadOnlySpan<(long First, long Last)> gaps, ref int index)
+    {
+        while (index < gaps.Length && gaps[index].Last < height) index++;
+        return index < gaps.Length && gaps[index].First <= height;
+    }
+
+    private bool HasOnlyOrphanedParents(in StateId stateId, ISet<StateId> orphans)
+    {
+        ReadOnlySpan<SnapshotTier> tiers = [SnapshotTier.PersistedBase, SnapshotTier.PersistedSmallCompacted, SnapshotTier.PersistedLargeCompacted, SnapshotTier.PersistedCompactSized];
+        bool found = false;
+        if (_snapshots.TryGetValue(stateId, out Snapshot? inMemory))
+        {
+            if (!orphans.Contains(inMemory.From)) return false;
+            found = true;
+        }
+        if (_compactedSnapshots.TryGetValue(stateId, out Snapshot? compacted))
+        {
+            if (!orphans.Contains(compacted.From)) return false;
+            found = true;
+        }
+        foreach (SnapshotTier tier in tiers)
+        {
+            // From is immutable and does not access the snapshot's disposable storage.
+            if (!BucketFor(tier).TryGet(stateId, out PersistedSnapshot? snapshot)) continue;
+            if (!orphans.Contains(snapshot.From)) return false;
+            found = true;
+        }
+        return found;
     }
 
     public void CollectCommittedAncestry(in StateId forkChoiceHead, ISet<StateId> retained)
@@ -497,9 +596,13 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
     /// cannot establish that another state is an orphan. The caller holds the retention gate.
     /// </remarks>
     private void CollectRetainedAncestry(ISet<StateId> retained, in StateId committedHead,
-        in StateId forkChoiceHead, bool includePersisted, ulong minBlockNumber)
+        in StateId forkChoiceHead, bool includePersisted, ulong minBlockNumber, ArrayPoolList<(long First, long Last)>? gaps = null)
     {
-        if (!HasState(committedHead) && !_compactedSnapshots.ContainsKey(committedHead)) return;
+        if (!HasState(committedHead) && !_compactedSnapshots.ContainsKey(committedHead))
+        {
+            if (_logger.IsDebug) _logger.Debug($"Cannot determine retained snapshot ancestry: committed head {committedHead} is unavailable.");
+            return;
+        }
 
         using PooledStack<StateId> pending = new();
         AddHead(committedHead);
@@ -517,28 +620,36 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
             StateId current = pending.Pop();
             if (Height(current) < (long)minBlockNumber) continue;
             bool found = false;
+            long nearestParent = long.MinValue;
             foreach (SnapshotTier tier in inMemoryTiers)
             {
-                if (!TryLeaseInMemoryState(current, tier, out Snapshot? snapshot)) continue;
-                StateId from = snapshot.From;
-                snapshot.Dispose();
+                ConcurrentDictionary<StateId, Snapshot> snapshots = tier == SnapshotTier.InMemoryBase ? _snapshots : _compactedSnapshots;
+                if (!snapshots.TryGetValue(current, out Snapshot? snapshot)) continue;
                 found = true;
-                AddHead(from);
+                nearestParent = Math.Max(nearestParent, Height(snapshot.From));
+                AddHead(snapshot.From);
             }
             if (!includePersisted) continue;
             foreach (SnapshotTier tier in persistedTiers)
             {
-                if (!TryLeasePersistedState(current, tier, out PersistedSnapshot? snapshot)) continue;
-                StateId from = snapshot.From;
-                snapshot.Dispose();
+                // Immutable parent metadata survives disposal; probe leases could finalize a replaced
+                // snapshot under the retention gate when the probe releases its last reference.
+                if (!BucketFor(tier).TryGet(current, out PersistedSnapshot? snapshot)) continue;
                 found = true;
-                AddHead(from);
+                nearestParent = Math.Max(nearestParent, Height(snapshot.From));
+                AddHead(snapshot.From);
             }
             if (!found)
             {
+                if (_logger.IsDebug) _logger.Debug($"Cannot determine retained snapshot ancestry: state {current} is unavailable above pruning boundary {minBlockNumber}.");
                 retained.Clear();
                 return;
             }
+            // Only the narrowest available edge establishes a gap; a wider compacted edge must not
+            // hide roots still identified by a base chain. Other protected branches cannot fill this gap.
+            long firstUnknown = Math.Max((long)minBlockNumber, nearestParent + 1);
+            long lastUnknown = Height(current) - 1;
+            if (firstUnknown <= lastUnknown) gaps?.Add((firstUnknown, lastUnknown));
         }
 
         void AddHead(in StateId head)
@@ -785,6 +896,9 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
     // `|` (not `||`): every bucket must be attempted — a `To` can appear in more than one.
     public bool RemovePersistedStateExact(in StateId toState) =>
         _base.RemoveExact(toState) | _smallCompacted.RemoveExact(toState) | _largeCompacted.RemoveExact(toState) | _compactSized.RemoveExact(toState);
+
+    private bool RemovePersistedStateExact(in StateId toState, ArrayPoolList<IDisposable> deferred) =>
+        _base.RemoveExact(toState, deferred) | _smallCompacted.RemoveExact(toState, deferred) | _largeCompacted.RemoveExact(toState, deferred) | _compactSized.RemoveExact(toState, deferred);
 
     public bool HasBasePersistedSnapshot(in StateId stateId) => _base.ContainsKey(stateId);
 

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -50,6 +50,11 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
     private readonly Lock _lastCommittedLock = new();
     private StateId _lastCommittedStateId;
     private bool _hasLastCommitted;
+    // Competing tip blocks flip within a few slots; re-executing one costs a whole block, so the last
+    // few committed states and their ancestry are exempt from orphan pruning.
+    private const int RecentlyCommittedRetention = 16;
+    private readonly StateId[] _recentlyCommitted = new StateId[RecentlyCommittedRetention];
+    private int _recentlyCommittedCount;
 
     public SnapshotRepository(
         IArenaManager arenaManager,
@@ -273,6 +278,8 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         using Lock.Scope _ = _lastCommittedLock.EnterScope();
         _lastCommittedStateId = stateId;
         _hasLastCommitted = true;
+        _recentlyCommitted[_recentlyCommittedCount % RecentlyCommittedRetention] = stateId;
+        _recentlyCommittedCount++;
     }
 
     public StateId? GetLastCommittedStateId()
@@ -427,6 +434,94 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         {
             _logger.Info($"Pruned {totalPruned} orphaned non-canonical snapshot(s) above persisted state {canonicalStateId}.");
         }
+    }
+
+    public int RemoveOrphanedStates(in StateId committedHead)
+    {
+        using PooledSet<StateId> retained = CollectRetainedAncestry(committedHead);
+        if (retained.Count == 0) return 0;
+
+        int pruned = 0;
+        using (ArrayPoolList<StateId> inMemory = GetStatesUpToBlock(committedHead.BlockNumber))
+        {
+            foreach (StateId stateId in inMemory)
+            {
+                if (retained.Contains(stateId)) continue;
+                if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryCompacted)) pruned++;
+                if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryBase)) pruned++;
+            }
+        }
+
+        // A sibling converted while it was the committed head is an orphan on disk once the chain moves on.
+        using (ArrayPoolList<StateId> persisted = GetPersistedStatesInRange(0, committedHead.BlockNumber))
+        {
+            foreach (StateId stateId in persisted)
+            {
+                if (!retained.Contains(stateId) && RemovePersistedStateExact(stateId)) pruned++;
+            }
+        }
+
+        if (pruned > 0 && _logger.IsDebug)
+            _logger.Debug($"Pruned {pruned} orphaned snapshot(s) below committed head {committedHead}.");
+        return pruned;
+    }
+
+    public bool IsOnCommittedAncestry(in StateId stateId)
+    {
+        StateId? committedHead = GetLastCommittedStateId();
+        if (committedHead is null) return true;
+
+        using PooledSet<StateId> retained = CollectRetainedAncestry(committedHead.Value);
+        return retained.Count == 0 || retained.Contains(stateId);
+    }
+
+    /// <summary>
+    /// Every state, in either tier, on the ancestry of <paramref name="committedHead"/> or of a recently committed
+    /// state. Empty when <paramref name="committedHead"/> has no in-memory snapshot, so a stale head prunes nothing.
+    /// </summary>
+    /// <remarks>
+    /// Every tier is followed: a compacted edge skips the bases it spans, and those bases are ancestors too. The
+    /// walk ends where <c>From</c> has no snapshot left, which is the state persisted to the database.
+    /// </remarks>
+    private PooledSet<StateId> CollectRetainedAncestry(in StateId committedHead)
+    {
+        PooledSet<StateId> retained = [];
+        if (!_snapshots.ContainsKey(committedHead) && !_compactedSnapshots.ContainsKey(committedHead)) return retained;
+
+        using PooledStack<StateId> pending = new();
+        retained.Add(committedHead);
+        pending.Push(committedHead);
+        using (_lastCommittedLock.EnterScope())
+        {
+            int recent = Math.Min(_recentlyCommittedCount, RecentlyCommittedRetention);
+            for (int i = 0; i < recent; i++)
+            {
+                if (retained.Add(_recentlyCommitted[i])) pending.Push(_recentlyCommitted[i]);
+            }
+        }
+
+        ReadOnlySpan<SnapshotTier> inMemoryTiers = [SnapshotTier.InMemoryCompacted, SnapshotTier.InMemoryBase];
+        ReadOnlySpan<SnapshotTier> persistedTiers = [SnapshotTier.PersistedBase, SnapshotTier.PersistedSmallCompacted, SnapshotTier.PersistedLargeCompacted, SnapshotTier.PersistedCompactSized];
+        while (pending.Count > 0)
+        {
+            StateId current = pending.Pop();
+            foreach (SnapshotTier tier in inMemoryTiers)
+            {
+                if (!TryLeaseInMemoryState(current, tier, out Snapshot? snapshot)) continue;
+                StateId from = snapshot.From;
+                snapshot.Dispose();
+                if (retained.Add(from)) pending.Push(from);
+            }
+            foreach (SnapshotTier tier in persistedTiers)
+            {
+                if (!TryLeasePersistedState(current, tier, out PersistedSnapshot? snapshot)) continue;
+                StateId from = snapshot.From;
+                snapshot.Dispose();
+                if (retained.Add(from)) pending.Push(from);
+            }
+        }
+
+        return retained;
     }
 
     /// <summary>True when the persisted tier holds a non-canonical state at

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRepository.cs
@@ -50,19 +50,23 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
     private readonly Lock _lastCommittedLock = new();
     private StateId _lastCommittedStateId;
     private bool _hasLastCommitted;
+    private readonly SnapshotRetention _retention;
     // Competing tip blocks flip within a few slots; re-executing one costs a whole block, so the last
     // few committed states and their ancestry are exempt from orphan pruning.
     private const int RecentlyCommittedRetention = 16;
     private readonly StateId[] _recentlyCommitted = new StateId[RecentlyCommittedRetention];
     private int _recentlyCommittedCount;
+    private int _recentlyCommittedNext;
 
     public SnapshotRepository(
         IArenaManager arenaManager,
         BlobArenaManager blobArenaManager,
         ISnapshotCatalog catalog,
         IFlatDbConfig config,
-        ILogManager logManager)
+        ILogManager logManager,
+        SnapshotRetention retention)
     {
+        _retention = retention;
         _catalog = catalog;
         _logger = logManager.GetClassLogger<SnapshotRepository>();
         _base = new PersistedSnapshotBucket(_catalog, SnapshotTier.PersistedBase, _logger);
@@ -278,8 +282,9 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         using Lock.Scope _ = _lastCommittedLock.EnterScope();
         _lastCommittedStateId = stateId;
         _hasLastCommitted = true;
-        _recentlyCommitted[_recentlyCommittedCount % RecentlyCommittedRetention] = stateId;
-        _recentlyCommittedCount++;
+        _recentlyCommitted[_recentlyCommittedNext] = stateId;
+        _recentlyCommittedNext = (_recentlyCommittedNext + 1) % RecentlyCommittedRetention;
+        _recentlyCommittedCount = Math.Min(_recentlyCommittedCount + 1, RecentlyCommittedRetention);
     }
 
     public StateId? GetLastCommittedStateId()
@@ -436,115 +441,89 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
         }
     }
 
-    public int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead)
+    public int RemoveOrphanedStates(in StateId committedHead, in StateId forkChoiceHead, ulong minBlockNumber = 0)
     {
-        // Candidates are listed before the ancestry is collected: a block committed in between is then either
-        // absent from the candidates or, having been committed, present in the retained set. The reverse order
-        // could list a just-committed sibling that the already collected ancestry does not know. No height bound:
-        // a fork is dropped whole, or a surviving tip would report a state its broken chain cannot assemble.
-        using ArrayPoolList<StateId> inMemory = GetStatesUpToBlock(long.MaxValue);
-        // A sibling converted while it was the committed head is an orphan on disk once the chain moves on.
-        using ArrayPoolList<StateId> persisted = GetPersistedStatesInRange(0, long.MaxValue);
+        using Lock.Scope scope = _retention.Sync.EnterScope();
+        using ArrayPoolListRef<StateId> inMemory = GetStatesInRange(minBlockNumber, long.MaxValue);
+        if (inMemory.Count == 0) return 0;
 
-        using PooledSet<StateId> retained = CollectRetainedAncestry(committedHead, forkChoiceHead, includePersisted: true);
+        // Include recently converted commits in the active window. Older persisted history remains
+        // available for deep reorgs even when compaction has removed intermediate ancestry edges.
+        ulong activeStart = inMemory[0].BlockNumber;
+        using (_lastCommittedLock.EnterScope())
+        {
+            for (int i = 0; i < _recentlyCommittedCount; i++)
+            {
+                ulong height = _recentlyCommitted[i].BlockNumber;
+                if (height >= minBlockNumber) activeStart = Math.Min(activeStart, height);
+            }
+        }
+        minBlockNumber = Math.Max(minBlockNumber, activeStart);
+        using PooledSet<StateId> retained = [];
+        CollectRetainedAncestry(retained, committedHead, forkChoiceHead, includePersisted: true, minBlockNumber);
         if (retained.Count == 0) return 0;
 
         int pruned = 0;
         foreach (StateId stateId in inMemory)
         {
             if (retained.Contains(stateId)) continue;
-            pruned += RemoveOrphanUnlessRead(stateId, SnapshotTier.InMemoryCompacted);
-            pruned += RemoveOrphanUnlessRead(stateId, SnapshotTier.InMemoryBase);
+            if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryCompacted)) pruned++;
+            if (RemoveAndReleaseInMemoryKnownState(stateId, SnapshotTier.InMemoryBase)) pruned++;
         }
+        // A small memory budget can convert siblings before they become eligible for in-memory pruning.
+        if (pruned == 0 && !HasPersistedForkAt(committedHead) && !HasPersistedForkAt(forkChoiceHead)) return 0;
 
+        // A sibling may have been converted before it aged out of recent-commit retention.
+        using ArrayPoolList<StateId> persisted = GetPersistedStatesInRange(minBlockNumber, long.MaxValue);
         foreach (StateId stateId in persisted)
         {
-            if (retained.Contains(stateId) || IsPersistedStateRead(stateId)) continue;
-            if (RemovePersistedStateExact(stateId)) pruned++;
+            if (!retained.Contains(stateId) && RemovePersistedStateExact(stateId)) pruned++;
         }
-
         return pruned;
     }
 
-    /// <summary>
-    /// A snapshot some scope is reading is the parent of a block being executed, which will commit with its
-    /// <c>From</c> pointing here; dropping it now would leave that block without an ancestry.
-    /// </summary>
-    private int RemoveOrphanUnlessRead(in StateId stateId, SnapshotTier tier)
+    public void CollectCommittedAncestry(in StateId forkChoiceHead, ISet<StateId> retained)
     {
-        if (TryLeaseInMemoryState(stateId, tier, out Snapshot? snapshot))
-        {
-            bool read = snapshot.HasOtherReaders;
-            snapshot.Dispose();
-            if (read) return 0;
-        }
-
-        return RemoveAndReleaseInMemoryKnownState(stateId, tier) ? 1 : 0;
-    }
-
-    private bool IsPersistedStateRead(in StateId stateId)
-    {
-        ReadOnlySpan<SnapshotTier> persistedTiers = [SnapshotTier.PersistedBase, SnapshotTier.PersistedSmallCompacted, SnapshotTier.PersistedLargeCompacted, SnapshotTier.PersistedCompactSized];
-        foreach (SnapshotTier tier in persistedTiers)
-        {
-            if (!TryLeasePersistedState(stateId, tier, out PersistedSnapshot? snapshot)) continue;
-            bool read = snapshot.HasOtherReaders;
-            snapshot.Dispose();
-            if (read) return true;
-        }
-
-        return false;
-    }
-
-    public bool IsOnCommittedAncestry(in StateId stateId, in StateId forkChoiceHead)
-    {
+        using Lock.Scope scope = _retention.Sync.EnterScope();
         StateId? committedHead = GetLastCommittedStateId();
-        if (committedHead is null) return true;
-
-        // Callers ask about in-memory states, and nothing in memory hangs below a persisted edge, so the walk
-        // can stop at the persisted tier instead of descending to the database state.
-        using PooledSet<StateId> retained = CollectRetainedAncestry(committedHead.Value, forkChoiceHead, includePersisted: false);
-        return retained.Count == 0 || retained.Contains(stateId);
+        if (committedHead is not null)
+            CollectRetainedAncestry(retained, committedHead.Value, forkChoiceHead, includePersisted: false, 0);
     }
 
-    /// <summary>
-    /// Every state on the ancestry of <paramref name="committedHead"/>, of <paramref name="forkChoiceHead"/>, or of
-    /// a recently committed state, in memory and, when <paramref name="includePersisted"/> is set, in the persisted
-    /// tier. Empty when <paramref name="committedHead"/> has no snapshot in any tier, so a stale head prunes nothing.
-    /// </summary>
+    /// <summary>Collects protected ancestry, stopping at the lower bound or the persisted tier.</summary>
     /// <remarks>
-    /// Every followed tier contributes edges: a compacted edge skips the bases it spans, and those bases are
-    /// ancestors too. The walk ends where <c>From</c> has no snapshot left, which is the state persisted to the database.
+    /// Every followed tier contributes edges so compacted jumps also retain the bases they span.
+    /// An unknown head or a gap above the pruning boundary leaves the set empty: incomplete ancestry
+    /// cannot establish that another state is an orphan. The caller holds the retention gate.
     /// </remarks>
-    private PooledSet<StateId> CollectRetainedAncestry(in StateId committedHead, in StateId forkChoiceHead, bool includePersisted)
+    private void CollectRetainedAncestry(ISet<StateId> retained, in StateId committedHead,
+        in StateId forkChoiceHead, bool includePersisted, ulong minBlockNumber)
     {
-        PooledSet<StateId> retained = [];
-        if (!HasState(committedHead) && !_compactedSnapshots.ContainsKey(committedHead)) return retained;
+        if (!HasState(committedHead) && !_compactedSnapshots.ContainsKey(committedHead)) return;
 
         using PooledStack<StateId> pending = new();
-        retained.Add(committedHead);
-        pending.Push(committedHead);
-        if (retained.Add(forkChoiceHead)) pending.Push(forkChoiceHead);
+        AddHead(committedHead);
+        AddHead(forkChoiceHead);
         using (_lastCommittedLock.EnterScope())
         {
-            int recent = Math.Min(_recentlyCommittedCount, RecentlyCommittedRetention);
-            for (int i = 0; i < recent; i++)
-            {
-                if (retained.Add(_recentlyCommitted[i])) pending.Push(_recentlyCommitted[i]);
-            }
+            for (int i = 0; i < _recentlyCommittedCount; i++) AddHead(_recentlyCommitted[i]);
         }
+        foreach (StateId head in _retention.ActiveHeads) AddHead(head);
 
         ReadOnlySpan<SnapshotTier> inMemoryTiers = [SnapshotTier.InMemoryCompacted, SnapshotTier.InMemoryBase];
         ReadOnlySpan<SnapshotTier> persistedTiers = [SnapshotTier.PersistedBase, SnapshotTier.PersistedSmallCompacted, SnapshotTier.PersistedLargeCompacted, SnapshotTier.PersistedCompactSized];
         while (pending.Count > 0)
         {
             StateId current = pending.Pop();
+            if (Height(current) < (long)minBlockNumber) continue;
+            bool found = false;
             foreach (SnapshotTier tier in inMemoryTiers)
             {
                 if (!TryLeaseInMemoryState(current, tier, out Snapshot? snapshot)) continue;
                 StateId from = snapshot.From;
                 snapshot.Dispose();
-                if (retained.Add(from)) pending.Push(from);
+                found = true;
+                AddHead(from);
             }
             if (!includePersisted) continue;
             foreach (SnapshotTier tier in persistedTiers)
@@ -552,11 +531,20 @@ public class SnapshotRepository : ISnapshotRepository, IDisposable
                 if (!TryLeasePersistedState(current, tier, out PersistedSnapshot? snapshot)) continue;
                 StateId from = snapshot.From;
                 snapshot.Dispose();
-                if (retained.Add(from)) pending.Push(from);
+                found = true;
+                AddHead(from);
+            }
+            if (!found)
+            {
+                retained.Clear();
+                return;
             }
         }
 
-        return retained;
+        void AddHead(in StateId head)
+        {
+            if (retained.Add(head)) pending.Push(head);
+        }
     }
 
     /// <summary>True when the persisted tier holds a non-canonical state at

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRetention.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRetention.cs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+namespace Nethermind.State.Flat;
+
+/// <summary>Coordinates snapshot pruning with the lifetime of assembled state views.</summary>
+public sealed class SnapshotRetention
+{
+    private readonly Dictionary<StateId, int> _activeHeads = [];
+
+    internal Lock Sync { get; } = new();
+
+    /// <summary>Heads whose ancestry must remain available; the caller must hold <see cref="Sync"/>.</summary>
+    internal Dictionary<StateId, int>.KeyCollection ActiveHeads => _activeHeads.Keys;
+
+    internal void Register(in StateId head)
+    {
+        using Lock.Scope scope = Sync.EnterScope();
+        _activeHeads.TryGetValue(head, out int count);
+        _activeHeads[head] = count + 1;
+    }
+
+    internal void Release(in StateId head)
+    {
+        using Lock.Scope scope = Sync.EnterScope();
+        int count = _activeHeads[head];
+        if (count == 1) _activeHeads.Remove(head);
+        else _activeHeads[head] = count - 1;
+    }
+}

--- a/src/Nethermind/Nethermind.State.Flat/SnapshotRetention.cs
+++ b/src/Nethermind/Nethermind.State.Flat/SnapshotRetention.cs
@@ -4,6 +4,11 @@
 namespace Nethermind.State.Flat;
 
 /// <summary>Coordinates snapshot pruning with the lifetime of assembled state views.</summary>
+/// <remarks>
+/// Budget-driven orphan pruning retains registered heads and their ancestry. Persistence may still
+/// remove repository entries as the durable boundary advances; assembled views keep independent
+/// snapshot leases, so removing those entries does not invalidate their reads.
+/// </remarks>
 public sealed class SnapshotRetention
 {
     private readonly Dictionary<StateId, int> _activeHeads = [];

--- a/src/Nethermind/Nethermind.Taiko.Test/TaikoEngineApiTests.cs
+++ b/src/Nethermind/Nethermind.Taiko.Test/TaikoEngineApiTests.cs
@@ -7,6 +7,8 @@ using Nethermind.Consensus.Producers;
 using Nethermind.Merge.Plugin.Handlers;
 using System.Threading.Tasks;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.State;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus;
 using Nethermind.Core.Crypto;
@@ -50,6 +52,8 @@ public class TaikoEngineApiTests
             Substitute.For<ISpecProvider>(),
             Substitute.For<ISyncPeerPool>(),
             new MergeConfig(),
+            Substitute.For<IReceiptConfig>(),
+            StateReaderWithState(),
             Substitute.For<ILogManager>()
         );
 
@@ -98,6 +102,8 @@ public class TaikoEngineApiTests
             Substitute.For<ISpecProvider>(),
             Substitute.For<ISyncPeerPool>(),
             new MergeConfig(),
+            Substitute.For<IReceiptConfig>(),
+            StateReaderWithState(),
             Substitute.For<ILogManager>()
         );
 
@@ -120,4 +126,13 @@ public class TaikoEngineApiTests
             Assert.That(result.Result.Error, Does.Contain("Invalid payload timestamp"));
         }
     }
+
+    // Every head in these tests is processed with its state present; the handler only re-executes when it is not.
+    private static IStateReader StateReaderWithState()
+    {
+        IStateReader stateReader = Substitute.For<IStateReader>();
+        stateReader.HasStateForBlock(Arg.Any<BlockHeader?>()).Returns(true);
+        return stateReader;
+    }
+
 }

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoForkchoiceUpdatedHandler.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Receipts;
 using Nethermind.Consensus;
 using Nethermind.Consensus.Processing;
 using Nethermind.Consensus.Producers;
@@ -17,6 +18,7 @@ using Nethermind.Merge.Plugin.Data;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Merge.Plugin.InvalidChainTracker;
 using Nethermind.Merge.Plugin.Synchronization;
+using Nethermind.State;
 using Nethermind.Synchronization.Peers;
 
 namespace Nethermind.Taiko.Rpc;
@@ -34,6 +36,8 @@ internal class TaikoForkchoiceUpdatedHandler(
     ISpecProvider specProvider,
     ISyncPeerPool syncPeerPool,
     IMergeConfig mergeConfig,
+    IReceiptConfig receiptConfig,
+    IStateReader stateReader,
     ILogManager logManager) : ForkchoiceUpdatedHandler(
     blockTree,
     poSSwitcher,
@@ -47,6 +51,8 @@ internal class TaikoForkchoiceUpdatedHandler(
     specProvider,
     syncPeerPool,
     mergeConfig,
+    receiptConfig,
+    stateReader,
     logManager)
 {
     protected override bool IsOnMainChainBehindFinalized(BlockHeader newHeadHeader, ForkchoiceStateV1 forkchoiceState,

--- a/src/Nethermind/Nethermind.Taiko/Rpc/TaikoForkchoiceUpdatedHandler.cs
+++ b/src/Nethermind/Nethermind.Taiko/Rpc/TaikoForkchoiceUpdatedHandler.cs
@@ -10,6 +10,7 @@ using Nethermind.Consensus.Producers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
+using Nethermind.Init;
 using Nethermind.JsonRpc;
 using Nethermind.Logging;
 using Nethermind.Merge.Plugin;
@@ -38,7 +39,9 @@ internal class TaikoForkchoiceUpdatedHandler(
     IMergeConfig mergeConfig,
     IReceiptConfig receiptConfig,
     IStateReader stateReader,
-    ILogManager logManager) : ForkchoiceUpdatedHandler(
+    ILogManager logManager,
+    FlatStateActivationPolicy? flatStateActivationPolicy = null,
+    ITimestamper? timestamper = null) : ForkchoiceUpdatedHandler(
     blockTree,
     poSSwitcher,
     payloadPreparationService,
@@ -51,9 +54,11 @@ internal class TaikoForkchoiceUpdatedHandler(
     specProvider,
     syncPeerPool,
     mergeConfig,
+    logManager,
     receiptConfig,
     stateReader,
-    logManager)
+    flatStateActivationPolicy,
+    timestamper)
 {
     protected override bool IsOnMainChainBehindFinalized(BlockHeader newHeadHeader, ForkchoiceStateV1 forkchoiceState,
         [NotNullWhen(true)] out ResultWrapper<ForkchoiceUpdatedV1Result>? result)

--- a/src/Nethermind/Nethermind.Trie/Pruning/IFinalizedStateProvider.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/IFinalizedStateProvider.cs
@@ -16,5 +16,5 @@ public interface IFinalizedStateProvider
     /// Distinct from the last block executed: an engine client can execute payloads it never selects, so
     /// state bounding that keys off execution history alone would drop the state the head still serves.
     /// </remarks>
-    BlockHeader? Head { get; }
+    BlockHeader? Head => null;
 }

--- a/src/Nethermind/Nethermind.Trie/Pruning/IFinalizedStateProvider.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/IFinalizedStateProvider.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using Nethermind.Core;
 using Nethermind.Core.Crypto;
 
 namespace Nethermind.Trie.Pruning;
@@ -9,4 +10,11 @@ public interface IFinalizedStateProvider
 {
     ulong FinalizedBlockNumber { get; }
     Hash256? GetFinalizedStateRootAt(ulong blockNumber);
+
+    /// <summary>The block the chain currently follows, or null when no head has been chosen yet.</summary>
+    /// <remarks>
+    /// Distinct from the last block executed: an engine client can execute payloads it never selects, so
+    /// state bounding that keys off execution history alone would drop the state the head still serves.
+    /// </remarks>
+    BlockHeader? Head { get; }
 }


### PR DESCRIPTION
## Changes

Root cause of the OOM in the benchmarkoor `compute` runs ([34104257992](https://github.com/ethpandaops/benchmarkoor-tests/actions/runs/34104257992), [34210184789](https://github.com/ethpandaops/benchmarkoor-tests/actions/runs/34210184789)): the run pins the head at H and streams ~4,200 sibling payloads at H+1/H+2 with finalization parked, and FlatDB kept a full snapshot (accounts, storage, trie nodes) for every one of them. Nothing could evict them: the finalized trigger and the force-persist backstop need the chain to move past the persisted state, and long-finality conversion needs the parent on disk, which H is not under `MinReorgDepth=1024`. At 10k-30k account changes per sibling that is the 24 GB GC limit; the 26 "failed tests" are fallout after the first `OutOfMemoryException`. Confirmed with a ClrMD-rooted engine-API harness (every retained `Account`/`TrieNode` hung off `SnapshotRepository._snapshots`) after ruling out the tx pool head channel, the block caches and the deferred write overlay.

- Over-budget sibling pruning preserves committed, fork-choice, recent-commit, and active-view ancestry. A shared retention coordinator protects bundle assembly, snapshot publication, and compaction against budget-driven orphan removal. Canonical persistence can still remove repository entries; independently leased views remain readable, and a missing registered head conservatively pauses budget pruning until its last lease releases. Bundles acquire their retention ownership before cache publication, and detached snapshots release their resources outside the reader/commit gate.

- Normal over-budget linear chains skip orphan pruning with positive budgets. The persisted sweep excludes the database's current state and older history, and stays within the in-memory/recent-commit window. Missing protected ancestry above that boundary cancels deletion. Ambiguous states skipped by compacted edges are preserved unless all available parents are proven orphaned. Classification spans both memory and persisted tiers before removal. Persisted siblings at either head height can also trigger cleanup when a small budget converted them before in-memory eviction.

- Phase-2 conversion collects retained ancestry once per candidate scan. A queued compaction whose base disappeared still triggers persistence. Trace/debug diagnostics explain pruning gates, ancestry failures, and candidate entries preserved by compaction gaps. Stale queued triggers below the persisted boundary log at Debug; live lower states retain the warning. Cleanup attempts every detached lease and preserves the primary failure if cleanup also fails.

- `IFinalizedStateProvider.Head` has a default null implementation for existing implementers. The recent-commit cursor and count are bounded.

- Recovery is enabled only for the actual FlatDB backend. New-payload recovery keeps its eight-block lookback. Fork-choice recovery searches up to 8,192 stored headers and replays eight-block segments across requests, briefly caching failed searches and missing-body failures to suppress burst retries. SYNCING updates only cached head/finality hints; block-tree finality changes after branch adoption. Unavailable local recovery registers the existing beacon-sync path; canonical historical FCUs retain their previous behavior. Existing fork-choice constructor calls remain source-compatible.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Validation at 4a40a86545:

- Focused flat-state repository, persistence, and read-only bundle suites: 153 passed, 0 failed/skipped.

- Focused Engine API backend/cache, pinned-head, and evicted-sibling recovery tests: 14 passed, 0 failed/skipped.

- New regression coverage checks primary plus cleanup failures, ambiguity diagnostics with and without other orphans, stale versus live persistence triggers, both snapshot tiers across canonical pruning, and missing-body cache reuse/expiry/head invalidation.

- Whitespace formatting and git diff --check passed.

Earlier validation at a9bcb69221:

- Full merge-plugin suite: 1,875 passed, 2 skipped (external RPC required).

- Targeted flat-state repository, persistence, manager, long-finality, and persisted-bucket tests: 180 passed.

- Taiko engine tests: 4 passed.

- Full benchmarks solution build: zero warnings and errors, including the earlier constructor-call CI fix.

- Regression coverage includes SYNCING finality isolation during partial replay, actual FlatDB/Patricia behavior, failed-search cache expiry/invalidation, compaction-skipped history across protected branches, mixed-tier orphan descendants with alternate parents, cleanup outside the retention gate (including exceptions), and persistence progress after a queued base disappears.

- Earlier full flat-state run: 1,068 passed, 10 skipped, 13 failed in Windows arena-test teardown. Source inspection traced all 13 to existing discarded reservations or undisposed writers in unchanged tests; these paths do not use the modified persisted-snapshot helper. That full suite was not rerun for the latest changes.

- Earlier historical trace re-execution test: 1 passed.

- Whitespace formatting and `git diff --check` passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Fixes an out-of-memory crash when a consensus client keeps executing sibling payloads against one parent without advancing finality (for example repricing benchmark runs); FlatDB now bounds the retained sibling state and re-executes a pruned block if fork choice returns to it.

## Remarks

- The memory-count threshold can be reached during normal conversion; the competing-state gate avoids the historical sweep on ordinary linear chains. A zero budget has a separate path because all prior siblings may already be on disk.

- Recent commits and active state views take precedence over the configured snapshot count.

- Re-execution is bounded per request. Registering the existing sync path is not a guarantee of recovering arbitrary unavailable historical state.
