### PR TITLE
test(eip8141): make four frame-transaction tests prove what they claim

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxPrefixSimulatorCodeCacheTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxPrefixSimulatorCodeCacheTests.cs
@@ -34,7 +34,7 @@ public class FrameTxPrefixSimulatorCodeCacheTests
     [Test]
     public async Task A_simulated_deploy_frame_does_not_deposit_into_the_main_processing_code_cache()
     {
-        // Marked so the assertion cannot be satisfied by a hash the process-wide cache never held anyway.
+        // Marked so that a failure can only be this deployment's deposit, not another fixture's.
         byte[] deployedCode = Prepare.EvmCode
             .PushData(0x8141).Op(Instruction.POP)
             .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
@@ -45,6 +45,9 @@ public class FrameTxPrefixSimulatorCodeCacheTests
         using BasicTestBlockchain chain = await BasicTestBlockchain.Create(builder =>
         {
             builder.AddSingleton<ISpecProvider>(new TestSpecProvider(Eip8141Prototype.Instance));
+            // Isolated from StaticCodeCache.Instance, whose contents no test in this assembly controls;
+            // a shared-cache simulator would still deposit into this instance.
+            builder.AddSingleton<ICodeCache>(new StaticCodeCache(Evm.MemoryAllowance.CodeCacheSize));
             builder.AddScoped<IGenesisPostProcessor, IWorldState, ISpecProvider>((worldState, specProvider) =>
                 new FunctionalGenesisPostProcessor(_ =>
                 {

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxPrefixSimulatorCodeCacheTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxPrefixSimulatorCodeCacheTests.cs
@@ -7,7 +7,6 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
-using Nethermind.Core.Test;
 using Nethermind.Core.Test.Blockchain;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Container;

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxPrefixSimulatorCodeCacheTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxPrefixSimulatorCodeCacheTests.cs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading.Tasks;
+using Autofac;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Blockchain;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Container;
+using Nethermind.Evm;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.TxPool;
+using NUnit.Framework;
+
+namespace Nethermind.Blockchain.Test;
+
+/// <summary>EIP-8141 in-pool validation-prefix simulation over the node's own wiring.</summary>
+/// <remarks>A deploy frame deposits code into the env's <see cref="ICodeCache"/>, and nothing journals a code
+/// cache, so the deposit outlives the rollback that discards the prefix. What keeps that off the main
+/// processing cache is the registration giving the simulator an env with its own cache; only a simulator
+/// resolved from the container exercises it.</remarks>
+[TestFixture]
+public class FrameTxPrefixSimulatorCodeCacheTests
+{
+    private static readonly Address Factory = TestItem.AddressB;
+    private static readonly byte[] Salt = new byte[32];
+
+    [Test]
+    public async Task A_simulated_deploy_frame_does_not_deposit_into_the_main_processing_code_cache()
+    {
+        // Marked so the assertion cannot be satisfied by a hash the process-wide cache never held anyway.
+        byte[] deployedCode = Prepare.EvmCode
+            .PushData(0x8141).Op(Instruction.POP)
+            .PushData(TxFrame.ApproveExecutionAndPayment).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+        byte[] initCode = Prepare.EvmCode.ForInitOf(deployedCode).Done;
+        Address deployed = ContractAddress.From(Factory, Salt, initCode);
+        ValueHash256 depositedHash = Keccak.Compute(deployedCode).ValueHash256;
+
+        using BasicTestBlockchain chain = await BasicTestBlockchain.Create(builder =>
+        {
+            builder.AddSingleton<ISpecProvider>(new TestSpecProvider(Eip8141Prototype.Instance));
+            builder.AddScoped<IGenesisPostProcessor, IWorldState, ISpecProvider>((worldState, specProvider) =>
+                new FunctionalGenesisPostProcessor(_ =>
+                {
+                    worldState.CreateAccount(Factory, UInt256.Zero);
+                    worldState.InsertCode(Factory, Prepare.EvmCode.Create2(initCode, Salt, 0).Done, specProvider.GenesisSpec);
+                    worldState.CreateAccount(deployed, 10.Ether);
+                    worldState.RecalculateStateRoot();
+                }));
+        });
+
+        IFrameTxPrefixSimulator simulator = chain.Container.Resolve<IFrameTxPrefixSimulator>();
+        ICodeCache mainCache = chain.Container.Resolve<ICodeCache>();
+
+        FrameTxSimulationResult result = simulator.Simulate(DeployTx(deployed), local: true);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Acceptance is what proves the create ran: the payer resolves only from the deployed code's APPROVE.
+            Assert.That(result.Payer, Is.EqualTo(deployed), result.Reason);
+            Assert.That(mainCache.Get(in depositedHash), Is.Null,
+                "the simulated deployment reached the cache block processing reads");
+        }
+    }
+
+    private static Transaction DeployTx(Address deployed) => new()
+    {
+        Type = TxType.FrameTx,
+        ChainId = TestBlockchainIds.ChainId,
+        Nonce = 0,
+        SenderAddress = deployed,
+        Frames =
+        [
+            new TxFrame(TxFrame.ModeDefault, TxFrame.ApproveScopeNone, Factory, executionGasLimit: 200_000, stateGasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default),
+        ],
+        FrameSignatures = [],
+        GasPrice = 1.GWei,
+        DecodedMaxFeePerGas = 1.GWei,
+    };
+}

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -777,16 +777,27 @@ public class FrameTxProcessorTests
     public void Execute_FrameParamStatusOfCurrentFrame_ExceptionallyHalts()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        // The sentinel write past the FRAMEPARAM separates the halt from an implementation that pushes
+        // zero and runs on, which would leave slot 0 at zero either way.
         DeployContract(Observer, Prepare.EvmCode
             .PushData(0x05).PushData(1).Op(Instruction.FRAMEPARAM).PushData(0).Op(Instruction.SSTORE)
+            .PushData(0xff).PushData(1).Op(Instruction.SSTORE)
             .Op(Instruction.STOP).Done);
-        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        TxFrame frame = Frame(TxFrame.ModeDefault, target: Observer);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), frame);
+        FrameReceiptTracer tracer = new();
 
-        TransactionResult result = Process(tx);
+        TransactionResult result = Process(tx, tracer: tracer);
 
         // Reading the current frame's status halts it, which discards its writes but leaves the tx valid.
         Assert.That(result.TransactionExecuted, Is.True);
-        AssertStorage(Observer, 0, UInt256.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
+            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(frame.ExecutionGasLimit),
+                "an exceptional halt consumes the frame's gas limit");
+            AssertStorage(Observer, 1, UInt256.Zero, "the halt is what stopped the frame, not a zero-valued read");
+        }
     }
 
     [Test]
@@ -888,16 +899,27 @@ public class FrameTxProcessorTests
     public void Execute_SigParamResolvedSignerOfArbitraryEntry_ExceptionallyHalts()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        // The sentinel write past the SIGPARAM separates the halt from an implementation that pushes the
+        // absent signer as zero and runs on, which would leave slot 0 at zero either way.
         DeployContract(Observer, Prepare.EvmCode
             .PushData(0x00).PushData(0).Op(Instruction.SIGPARAM).PushData(0).Op(Instruction.SSTORE)
+            .PushData(0xff).PushData(1).Op(Instruction.SSTORE)
             .Op(Instruction.STOP).Done);
-        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        TxFrame frame = Frame(TxFrame.ModeDefault, target: Observer);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), frame);
         tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, new byte[] { 1, 2, 3 })];
+        FrameReceiptTracer tracer = new();
 
-        TransactionResult result = Process(tx);
+        TransactionResult result = Process(tx, tracer: tracer);
 
         Assert.That(result.TransactionExecuted, Is.True);
-        AssertStorage(Observer, 0, UInt256.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
+            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(frame.ExecutionGasLimit),
+                "an exceptional halt consumes the frame's gas limit");
+            AssertStorage(Observer, 1, UInt256.Zero, "the halt is what stopped the frame, not a zero-valued read");
+        }
     }
 
     [Test]
@@ -1967,21 +1989,30 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_SecondPostTxFrameFails_UnwindsTheWholeBody()
     {
+        // APPROVE is banned in POST_TX, so the passing assertion cannot be the smart sender's own code.
+        Address passingAssertion = TestItem.AddressF;
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+        DeployContract(passingAssertion, Prepare.EvmCode.Op(Instruction.STOP).Done);
         DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
 
         Transaction tx = FrameTx(nonce: 0,
             SelfVerifyFrame(),
             Frame(TxFrame.ModeSender, target: Observer),
-            Frame(TxFrame.ModePostTx, target: Sender),
+            Frame(TxFrame.ModePostTx, target: passingAssertion),
             Frame(TxFrame.ModePostTx, target: Recipient));
 
-        CallOutputTracer tracer = new();
+        FrameReceiptTracer tracer = new();
 
         Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
-        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure));
-        AssertStorage(Observer, 0, UInt256.Zero, "a failure in the second assertion unwinds the body the first one passed on");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure));
+            Assert.That(tracer.FrameReceipts![2].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess),
+                "the first assertion has to pass for the second to be the one that unwinds");
+            Assert.That(tracer.FrameReceipts[3].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
+            AssertStorage(Observer, 0, UInt256.Zero, "a failure in the second assertion unwinds the body the first one passed on");
+        }
     }
 
     /// <summary>A frame transaction's <c>CallAndRestore</c> must leave nothing behind.</summary>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -777,9 +777,10 @@ public class FrameTxProcessorTests
     public void Execute_FrameParamStatusOfCurrentFrame_ExceptionallyHalts()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
-        // The sentinel write past the FRAMEPARAM separates the halt from an implementation that pushes
-        // zero and runs on, which would leave slot 0 at zero either way.
+        // Sentinels either side of the FRAMEPARAM separate the halt from an implementation that pushes zero
+        // and runs on, which would leave slot 0 at zero either way: slot 2 is rolled back, slot 1 never runs.
         DeployContract(Observer, Prepare.EvmCode
+            .PushData(0xaa).PushData(2).Op(Instruction.SSTORE)
             .PushData(0x05).PushData(1).Op(Instruction.FRAMEPARAM).PushData(0).Op(Instruction.SSTORE)
             .PushData(0xff).PushData(1).Op(Instruction.SSTORE)
             .Op(Instruction.STOP).Done);
@@ -794,9 +795,10 @@ public class FrameTxProcessorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
-            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(frame.ExecutionGasLimit),
-                "an exceptional halt consumes the frame's gas limit");
+            Assert.That(tracer.FrameReceipts[1].ExecutionGasUsed, Is.EqualTo(frame.ExecutionGasLimit),
+                "an exceptional halt consumes the frame's execution gas limit");
             AssertStorage(Observer, 1, UInt256.Zero, "the halt is what stopped the frame, not a zero-valued read");
+            AssertStorage(Observer, 2, UInt256.Zero, "the halted frame's earlier write is rolled back");
         }
     }
 
@@ -899,9 +901,10 @@ public class FrameTxProcessorTests
     public void Execute_SigParamResolvedSignerOfArbitraryEntry_ExceptionallyHalts()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
-        // The sentinel write past the SIGPARAM separates the halt from an implementation that pushes the
-        // absent signer as zero and runs on, which would leave slot 0 at zero either way.
+        // Sentinels either side of the SIGPARAM separate the halt from an implementation that pushes the absent
+        // signer as zero and runs on, which would leave slot 0 at zero either way.
         DeployContract(Observer, Prepare.EvmCode
+            .PushData(0xaa).PushData(2).Op(Instruction.SSTORE)
             .PushData(0x00).PushData(0).Op(Instruction.SIGPARAM).PushData(0).Op(Instruction.SSTORE)
             .PushData(0xff).PushData(1).Op(Instruction.SSTORE)
             .Op(Instruction.STOP).Done);
@@ -916,9 +919,10 @@ public class FrameTxProcessorTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusFailure));
-            Assert.That(tracer.FrameReceipts[1].GasUsed, Is.EqualTo(frame.ExecutionGasLimit),
-                "an exceptional halt consumes the frame's gas limit");
+            Assert.That(tracer.FrameReceipts[1].ExecutionGasUsed, Is.EqualTo(frame.ExecutionGasLimit),
+                "an exceptional halt consumes the frame's execution gas limit");
             AssertStorage(Observer, 1, UInt256.Zero, "the halt is what stopped the frame, not a zero-valued read");
+            AssertStorage(Observer, 2, UInt256.Zero, "the halted frame's earlier write is rolled back");
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -554,8 +554,9 @@ public class FrameTxValidationPrefixSimulationTests
             : Is.Null);
     }
 
-    // Nothing journals the code cache, so a deposit outlives the rollback that discards the prefix. Over the
-    // process-wide instance that lets a peer fill the cache block processing reads from, for code never deployed.
+    // Nothing journals the code cache, so a deposit outlives the rollback that discards the prefix. That the
+    // node's own wiring keeps this off the main processing cache is covered by
+    // FrameTxPrefixSimulatorCodeCacheTests, which can resolve the production simulator.
     [TestCase(false, TestName = "an accepted prefix deposits into the cache")]
     [TestCase(true, TestName = "a prefix rejected after the create deposits too")]
     public void Simulate_DeployFrameDeposit_EscapesTheRollbackIntoTheCodeCache(bool violates)
@@ -572,7 +573,6 @@ public class FrameTxValidationPrefixSimulationTests
         ValueHash256 depositedHash = Keccak.Compute(deployedCode).ValueHash256;
 
         StaticCodeCache given = new(MemoryAllowance.CodeCacheSize);
-        StaticCodeCache other = new(MemoryAllowance.CodeCacheSize);
 
         FrameTxValidationTracer tracer = RunUnder(given, DeployTx(deployed));
 
@@ -583,11 +583,7 @@ public class FrameTxValidationPrefixSimulationTests
             Assert.That(tracer.ViolationReason, violates
                 ? Does.Contain("banned opcode SELFBALANCE")
                 : Is.Null);
-            // Contained rather than suppressed: the prefix keeps its read memoization, and the deposit is
-            // confined to the env's own instance — which is what wiring the simulator away from the
-            // process-wide one buys, since nothing journals either.
             Assert.That(given.Get(in depositedHash), Is.Not.Null, "a deposit lands in the cache the env was given");
-            Assert.That(other.Get(in depositedHash), Is.Null, "and in no other, which is what the isolation rests on");
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPrefixRetryMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPrefixRetryMeasurement.cs
@@ -65,6 +65,14 @@ public class FrameTxPrefixRetryMeasurement
         _stateProvider.CreateAccount(TestItem.AddressA, UInt256.MaxValue);
     }
 
+    // Each case times its own pool, so the previous one's head, revalidation and retry work has to stop
+    // before the next one starts.
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_txPool is not null) await _txPool.DisposeAsync();
+    }
+
     /// <summary>Positive control: without it the retention case below cannot tell "the pool keeps it" from
     /// "the harness never advanced the head".</summary>
     [Test]


### PR DESCRIPTION
## Changes

Four `P2` review threads on #12526, all of them tests that passed without exercising the mechanism they name. Each fix is backed by a mutation that breaks exactly that mechanism.

**`Execute_SecondPostTxFrameFails_UnwindsTheWholeBody`** — the first `POST_TX` targeted `Sender`, whose installed code is `APPROVE`; that opcode returns `BadInstruction` in `POST_TX`, so the first assertion halted and the second never ran. It now targets an inert contract and asserts both frame statuses.

**`Execute_FrameParamStatusOfCurrentFrame_ExceptionallyHalts`** and **`Execute_SigParamResolvedSignerOfArbitraryEntry_ExceptionallyHalts`** — both asserted only that slot 0 stayed zero, which an implementation that pushes zero and continues through `SSTORE`/`STOP` also satisfies. Both now write a nonzero sentinel past the opcode and assert the frame receipt's failure status and gas outcome.

**Code-cache isolation** — `Simulate_DeployFrameDeposit_EscapesTheRollbackIntoTheCodeCache` compared two locally constructed caches over a locally built processor, so it held regardless of how the node wires the prefix simulator. The production property now has its own regression (`FrameTxPrefixSimulatorCodeCacheTests`) resolving `IFrameTxPrefixSimulator` and `ICodeCache` from a chain container; the unit test keeps the deposit-escapes-rollback half and drops the vacuous one.

**`FrameTxPrefixRetryMeasurement`** — setup built a pool per case with no teardown, so head, revalidation and retry work ran on into the next measurement. Added an async teardown awaiting `DisposeAsync`.

## Mutations used

| Mutation | Result |
|---|---|
| `FrameStatus` pushes zero instead of `BadInstruction` | 1 failure / 10,862 — the FRAMEPARAM test; its previous body passed |
| `SIGPARAM` param `0x00` pushes zero for an ARBITRARY entry | 1 failure / 10,862 — the SIGPARAM test; its previous body passed |
| A passed `POST_TX` becomes the unwind baseline | 1 failure / 10,862 — the second-assertion test; its previous body passed |
| `shareCodeCache: true` on the simulator registration | 1 failure / 2,024 — the new isolation test |

## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactoring
- [ ] Documentation update
- [x] Tests
- [ ] Remove unused code

## Testing

Requires testing

- [ ] Yes
- [x] No

`Nethermind.Evm.Test`, `Nethermind.Blockchain.Test` and `Nethermind.TxPool.Test` are green in both release and checked (`-p:DefineConstants=TRACE;DEBUG`). Discovered cases are unchanged apart from the one added: Evm.Test 10,863, TxPool.Test 1,118, Blockchain.Test 2,024 to 2,025. The `[Explicit]` retry measurement was run directly in both configurations.
