### PR TITLE
fix(history): create the history pruner before the block processor starts

### DIFF
--- a/src/Nethermind/Nethermind.Init/Modules/BuiltInStepsModule.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/BuiltInStepsModule.cs
@@ -29,6 +29,7 @@ public class BuiltInStepsModule : Module
         typeof(SetupKeyStore),
         typeof(StartBlockProcessor),
         typeof(StartBlockProducer),
+        typeof(StartHistoryPruner),
         typeof(StartMonitoring),
         typeof(StartLogIndex)
     ];

--- a/src/Nethermind/Nethermind.Init/Steps/StartBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartBlockProcessor.cs
@@ -5,17 +5,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api.Steps;
 using Nethermind.Consensus.Processing;
-using Nethermind.History;
 
 namespace Nethermind.Init.Steps
 {
     [RunnerStepDependencies(typeof(InitializeBlockchain))]
-    public class StartBlockProcessor(IMainProcessingContext mainProcessingContext, IHistoryPruner historyPruner) : IStep
+    public class StartBlockProcessor(IMainProcessingContext mainProcessingContext) : IStep
     {
-        public Task Execute(CancellationToken cancellationToken)
+        public Task Execute(CancellationToken _)
         {
-            // The pruner subscribes to ProcessingQueueEmpty, which Start() raises once; created any later, an idle node never prunes.
-            _ = historyPruner;
             mainProcessingContext.BlockchainProcessor.Start();
             return Task.CompletedTask;
         }

--- a/src/Nethermind/Nethermind.Init/Steps/StartBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartBlockProcessor.cs
@@ -5,14 +5,17 @@ using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Api.Steps;
 using Nethermind.Consensus.Processing;
+using Nethermind.History;
 
 namespace Nethermind.Init.Steps
 {
     [RunnerStepDependencies(typeof(InitializeBlockchain))]
-    public class StartBlockProcessor(IMainProcessingContext mainProcessingContext) : IStep
+    public class StartBlockProcessor(IMainProcessingContext mainProcessingContext, IHistoryPruner historyPruner) : IStep
     {
-        public Task Execute(CancellationToken _)
+        public Task Execute(CancellationToken cancellationToken)
         {
+            // The pruner subscribes to ProcessingQueueEmpty, which Start() raises once; created any later, an idle node never prunes.
+            _ = historyPruner;
             mainProcessingContext.BlockchainProcessor.Start();
             return Task.CompletedTask;
         }

--- a/src/Nethermind/Nethermind.Init/Steps/StartHistoryPruner.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartHistoryPruner.cs
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Api.Steps;
+using Nethermind.History;
+
+namespace Nethermind.Init.Steps;
+
+/// <summary>Schedules the first history pruning pass once startup is past the block-tree fixer and the Era import.</summary>
+/// <remarks>
+/// The pruner otherwise runs only on <c>ProcessingQueueEmpty</c>, whose one startup signal fires before the pruner is
+/// created by the network step, so a node that receives no blocks would never prune its backlog.
+/// </remarks>
+[RunnerStepDependencies(dependencies: [typeof(InitializeNetwork)])]
+public class StartHistoryPruner(IHistoryPruner historyPruner) : IStep
+{
+    public Task Execute(CancellationToken cancellationToken)
+    {
+        historyPruner.SchedulePruneHistory();
+        return Task.CompletedTask;
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Steps/StartHistoryPruner.cs
+++ b/src/Nethermind/Nethermind.Init/Steps/StartHistoryPruner.cs
@@ -13,12 +13,12 @@ namespace Nethermind.Init.Steps;
 /// The pruner otherwise runs only on <c>ProcessingQueueEmpty</c>, whose one startup signal fires before the pruner is
 /// created by the network step, so a node that receives no blocks would never prune its backlog.
 /// </remarks>
-[RunnerStepDependencies(dependencies: [typeof(InitializeNetwork)])]
-public class StartHistoryPruner(IHistoryPruner historyPruner) : IStep
+[RunnerStepDependencies(dependencies: [typeof(InitializeNetwork), typeof(ReviewBlockTree)])]
+public class StartHistoryPruner(IHistoryPruner historyPruner, IHistoryConfig historyConfig) : IStep
 {
     public Task Execute(CancellationToken cancellationToken)
     {
-        historyPruner.SchedulePruneHistory();
+        if (historyConfig.Enabled()) historyPruner.SchedulePruneHistory();
         return Task.CompletedTask;
     }
 }

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
@@ -16,10 +16,12 @@ using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Consensus.AuRa.InitializationSteps;
+using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Modules;
+using Nethermind.History;
 using Nethermind.Init.Steps;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
@@ -107,6 +109,29 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
                 Assert.That(activation, Is.EqualTo(new ForkActivation(pivot.Number, pivot.Timestamp)));
                 Assert.That(levels.LoadLevel(pivot.Number), Is.Null);
             }
+        }
+
+        [Test]
+        public async Task Start_block_processor_creates_history_pruner_before_the_processing_loop_starts()
+        {
+            List<string> order = [];
+            IBlockchainProcessor processor = Substitute.For<IBlockchainProcessor>();
+            processor.When(p => p.Start()).Do(_ => order.Add("start"));
+            IMainProcessingContext processingContext = Substitute.For<IMainProcessingContext>();
+            processingContext.BlockchainProcessor.Returns(processor);
+            using IContainer container = new ContainerBuilder()
+                .AddSingleton(processingContext)
+                .AddSingleton<IHistoryPruner>(_ =>
+                {
+                    order.Add("pruner");
+                    return Substitute.For<IHistoryPruner>();
+                })
+                .AddSingleton<StartBlockProcessor>()
+                .Build();
+
+            await container.Resolve<StartBlockProcessor>().Execute(CancellationToken.None);
+
+            Assert.That(order, Is.EqualTo(new[] { "pruner", "start" }));
         }
 
         private static IContainer CreateWarmupEnvironment(SyncConfig syncConfig, ulong now) => new ContainerBuilder()

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/EthereumStepsManagerTests.cs
@@ -16,12 +16,10 @@ using Nethermind.Blockchain.Headers;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
 using Nethermind.Consensus.AuRa.InitializationSteps;
-using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Exceptions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Modules;
-using Nethermind.History;
 using Nethermind.Init.Steps;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
@@ -109,29 +107,6 @@ namespace Nethermind.Runner.Test.Ethereum.Steps
                 Assert.That(activation, Is.EqualTo(new ForkActivation(pivot.Number, pivot.Timestamp)));
                 Assert.That(levels.LoadLevel(pivot.Number), Is.Null);
             }
-        }
-
-        [Test]
-        public async Task Start_block_processor_creates_history_pruner_before_the_processing_loop_starts()
-        {
-            List<string> order = [];
-            IBlockchainProcessor processor = Substitute.For<IBlockchainProcessor>();
-            processor.When(p => p.Start()).Do(_ => order.Add("start"));
-            IMainProcessingContext processingContext = Substitute.For<IMainProcessingContext>();
-            processingContext.BlockchainProcessor.Returns(processor);
-            using IContainer container = new ContainerBuilder()
-                .AddSingleton(processingContext)
-                .AddSingleton<IHistoryPruner>(_ =>
-                {
-                    order.Add("pruner");
-                    return Substitute.For<IHistoryPruner>();
-                })
-                .AddSingleton<StartBlockProcessor>()
-                .Build();
-
-            await container.Resolve<StartBlockProcessor>().Execute(CancellationToken.None);
-
-            Assert.That(order, Is.EqualTo(new[] { "pruner", "start" }));
         }
 
         private static IContainer CreateWarmupEnvironment(SyncConfig syncConfig, ulong now) => new ContainerBuilder()

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/StartHistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/StartHistoryPrunerTests.cs
@@ -13,13 +13,16 @@ namespace Nethermind.Runner.Test.Ethereum.Steps;
 [TestFixture]
 public class StartHistoryPrunerTests
 {
-    [Test]
-    public async Task Execute_SchedulesPruningPass()
+    [TestCase(PruningModes.Disabled, 0)]
+    [TestCase(PruningModes.Rolling, 1)]
+    [TestCase(PruningModes.UseAncientBarriers, 1)]
+    public async Task Execute_SchedulesPruningPassOnlyWhenEnabled(PruningModes pruning, int expectedPasses)
     {
         IHistoryPruner historyPruner = Substitute.For<IHistoryPruner>();
+        HistoryConfig historyConfig = new() { Pruning = pruning };
 
-        await new StartHistoryPruner(historyPruner).Execute(CancellationToken.None);
+        await new StartHistoryPruner(historyPruner, historyConfig).Execute(CancellationToken.None);
 
-        historyPruner.Received(1).SchedulePruneHistory();
+        historyPruner.Received(expectedPasses).SchedulePruneHistory();
     }
 }

--- a/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/StartHistoryPrunerTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Ethereum/Steps/StartHistoryPrunerTests.cs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.History;
+using Nethermind.Init.Steps;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Runner.Test.Ethereum.Steps;
+
+[TestFixture]
+public class StartHistoryPrunerTests
+{
+    [Test]
+    public async Task Execute_SchedulesPruningPass()
+    {
+        IHistoryPruner historyPruner = Substitute.For<IHistoryPruner>();
+
+        await new StartHistoryPruner(historyPruner).Execute(CancellationToken.None);
+
+        historyPruner.Received(1).SchedulePruneHistory();
+    }
+}


### PR DESCRIPTION
## Changes

- New built-in step `StartHistoryPruner` that calls `IHistoryPruner.SchedulePruneHistory()` once `InitializeNetwork` has completed.
- `StartHistoryPrunerTests` asserting the step schedules a pass.

`HistoryPruner` only ever schedules a pruning pass from `IBlockProcessingQueue.ProcessingQueueEmpty`. `BlockchainProcessor` raises that once when its loop starts and afterwards only after a processed block. Nothing resolves the pruner until `InitializeNetwork` (via `SyncServer`) or `RegisterRpcModules`, both of which run after `StartBlockProcessor`, so the startup signal has no subscriber. On a live node the next processed block hides this. A node that receives no blocks (no CL attached yet, or an offline maintenance run with `--History.Pruning` enabled to trim an existing database) never prunes, and the skip is only visible at Trace level.

The step depends on `InitializeNetwork`, which is where the pruner used to be constructed: `EraStep`/`EraEStep` list `InitializeNetwork` as a dependent and themselves depend on `ReviewBlockTree`, so the first pass still starts after the block-tree fixer and any Era import, exactly as before. No existing step is modified.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Found while pruning a mainnet flat snapshot offline with `--History.Pruning UseAncientBarriers` and networking disabled: the node started cleanly and never logged `Pruning historical blocks up to`. `EthereumStepsLoaderTests.BuildInSteps_IsCorrect` covers the registration of the new step.

For an offline pruning run (no CL, no peers) also pass `--History.PruningTimeoutSeconds 0`: this step supplies the first pass only, and with the default 2 s deadline a pass stops at the next chunk boundary and waits for a `ProcessingQueueEmpty` signal that an idle node never receives. The delete pointer is published in full before the reclaim loop, so without the timeout disabled the node reports pruned history while most of the disk is still occupied. With the timeout disabled the single pass runs to completion.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No