### PR TITLE
EIP-8141: address the P3 review round on the frame transaction tests

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
@@ -978,7 +978,6 @@ public class FrameTxFloodMeasurement
         return PrefixCode(shape);
     }
 
-
     private static byte[] Groth16Artifact(Groth16Sweep sweep, string fileName)
     {
         string root = Groth16ArtifactRoot();

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxFloodMeasurement.cs
@@ -18,7 +18,6 @@ using Nethermind.Blockchain.Tracing;
 using Nethermind.Config;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Blockchain;
@@ -967,7 +966,8 @@ public class FrameTxFloodMeasurement
         if (shape == "signature-stuffed")
         {
             _frameCalldataPrefix = [];
-            _frameSignatures = BuildSecp256k1Signatures(StuffedSignatureCount(ceiling));
+            _frameSignatures = FrameTxTestFrames.RecoveredSecp256k1Signatures(
+                new EthereumEcdsa(TestBlockchainIds.ChainId), StuffedSignatureCount(ceiling));
             _frameExecutionGasLimit = MinimalFrameGas;
             return PrefixCode("banned-opcode");
         }
@@ -978,27 +978,6 @@ public class FrameTxFloodMeasurement
         return PrefixCode(shape);
     }
 
-    /// <summary>Builds signature entries whose final mismatch occurs only after curve recovery.</summary>
-    private static TxFrameSignature[] BuildSecp256k1Signatures(int count)
-    {
-        EthereumEcdsa ecdsa = new(TestBlockchainIds.ChainId);
-        TxFrameSignature[] entries = new TxFrameSignature[count];
-        for (int i = 0; i < count; i++)
-        {
-            byte[] msg = ValueKeccak.Compute(BitConverter.GetBytes(i)).ToByteArray();
-            byte[] signed = i == count - 1 ? ValueKeccak.Compute("mismatch"u8).ToByteArray() : msg;
-            Signature signature = ecdsa.Sign(TestItem.PrivateKeyA, new Hash256(signed));
-
-            byte[] raw = new byte[TxFrameSignature.Secp256k1SignatureLength];
-            raw[0] = signature.RecoveryId;
-            signature.RAsSpan.CopyTo(raw.AsSpan(1));
-            signature.SAsSpan.CopyTo(raw.AsSpan(33));
-            entries[i] = new TxFrameSignature(
-                TxFrameSignature.SchemeSecp256k1, TestItem.PrivateKeyA.Address, msg, raw);
-        }
-
-        return entries;
-    }
 
     private static byte[] Groth16Artifact(Groth16Sweep sweep, string fileName)
     {

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
@@ -5,15 +5,17 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
-using Nethermind.Core.Test;
-using Nethermind.Crypto;
+using Nethermind.Core.Test.Blockchain;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Container;
+using Nethermind.Crypto;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.TransactionProcessing;
@@ -47,23 +49,42 @@ public class FrameTxProducerRetryMeasurement
     private ISpecProvider _specProvider = null!;
     private IWorldState _stateProvider = null!;
     private ITransactionProcessor _transactionProcessor = null!;
-    private IDisposable _stateCloser = null!;
+    private BasicTestBlockchain? _chain;
+    private IReadOnlyTxProcessorSource? _source;
+    private IReadOnlyTxProcessingScope? _scope;
 
     private IReleaseSpec Spec => _specProvider.GenesisSpec;
 
-    [SetUp]
-    public void Setup()
+    /// <summary>Takes the processing stack from the chain's production wiring, with the measured sender's code
+    /// placed in genesis; only the executor under measurement and the gates it drives are built here.</summary>
+    private async Task BuildChain(byte[] senderCode)
     {
         _specProvider = new TestSpecProvider(Eip8141Prototype.Instance);
-        _stateProvider = TestWorldStateFactory.CreateForTest();
-        _stateCloser = _stateProvider.BeginScope(IWorldState.PreGenesis);
-        EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
-        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
-        _transactionProcessor = new EthereumTransactionProcessor(BlobBaseFeeCalculator.Instance, _specProvider, _stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+        _chain = await BasicTestBlockchain.Create(builder =>
+        {
+            builder.AddSingleton(_specProvider);
+            builder.AddScoped<IGenesisPostProcessor, IWorldState, ISpecProvider>((worldState, specProvider) =>
+                new FunctionalGenesisPostProcessor(_ =>
+                {
+                    worldState.CreateAccount(Sender, 100.Ether);
+                    worldState.InsertCode(Sender, senderCode, specProvider.GenesisSpec);
+                    worldState.RecalculateStateRoot();
+                }));
+        });
+
+        _source = _chain.ReadOnlyTxProcessingEnvFactory.Create();
+        _scope = _source.Build(_chain.BlockTree.Head?.Header);
+        _stateProvider = _scope.WorldState;
+        _transactionProcessor = _scope.TransactionProcessor;
     }
 
     [TearDown]
-    public void TearDown() => _stateCloser?.Dispose();
+    public void TearDown()
+    {
+        _scope?.Dispose();
+        _source?.Dispose();
+        _chain?.Dispose();
+    }
 
     /// <summary>A prefix that never approves: it loops until the frame's gas limit is exhausted.</summary>
     private static byte[] NeverApproves() =>
@@ -84,12 +105,9 @@ public class FrameTxProducerRetryMeasurement
     [TestCase(true, 236_285ul, TestName = "control: a prefix that approves is included and paid for")]
     [TestCase(false, 300_000ul, TestName = "never approves, at the default MAX_VERIFY_GAS")]
     [TestCase(false, 236_285ul, TestName = "never approves, at a measured private-pool prefix")]
-    public void ProducerRetriesAFailingPrefix(bool approves, ulong verifyGas)
+    public async Task ProducerRetriesAFailingPrefix(bool approves, ulong verifyGas)
     {
-        _stateProvider.CreateAccount(Sender, 100.Ether);
-        _stateProvider.InsertCode(Sender, approves ? Approves() : NeverApproves(), Spec);
-        _stateProvider.Commit(Spec);
-        _stateProvider.CommitTree(0);
+        await BuildChain(approves ? Approves() : NeverApproves());
 
         CountingAdapter adapter = new(new BuildUpTransactionProcessorAdapter(_transactionProcessor));
         BlockProcessor.BlockProductionTransactionPicker picker = new(_specProvider);
@@ -177,12 +195,9 @@ public class FrameTxProducerRetryMeasurement
     /// that is evicted after <paramref name="kRetry"/> failed attempts.
     /// </summary>
     [TestCaseSource(nameof(RetryCases))]
-    public void ProducerRetriesAreBoundedByKRetry(ulong verifyGas, int kRetry)
+    public async Task ProducerRetriesAreBoundedByKRetry(ulong verifyGas, int kRetry)
     {
-        _stateProvider.CreateAccount(Sender, 100.Ether);
-        _stateProvider.InsertCode(Sender, NeverApproves(), Spec);
-        _stateProvider.Commit(Spec);
-        _stateProvider.CommitTree(0);
+        await BuildChain(NeverApproves());
 
         CountingAdapter adapter = new(new BuildUpTransactionProcessorAdapter(_transactionProcessor));
         BlockProcessor.BlockProductionTransactionPicker picker = new(_specProvider);

--- a/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement.cs
@@ -63,13 +63,14 @@ public class FrameTxProducerRetryMeasurement
         _chain = await BasicTestBlockchain.Create(builder =>
         {
             builder.AddSingleton(_specProvider);
-            builder.AddScoped<IGenesisPostProcessor, IWorldState, ISpecProvider>((worldState, specProvider) =>
-                new FunctionalGenesisPostProcessor(_ =>
-                {
-                    worldState.CreateAccount(Sender, 100.Ether);
-                    worldState.InsertCode(Sender, senderCode, specProvider.GenesisSpec);
-                    worldState.RecalculateStateRoot();
-                }));
+            builder.WithGenesisPostProcessor((_, worldState, specProvider) =>
+            {
+                // Replaces the account TestBlockchain funds in genesis, clearing the placeholder code and
+                // storage slot it puts on this address so only the measured code is reachable.
+                worldState.CreateAccount(Sender, 100.Ether);
+                worldState.InsertCode(Sender, senderCode, specProvider.GenesisSpec);
+                worldState.RecalculateStateRoot();
+            });
         });
 
         _source = _chain.ReadOnlyTxProcessingEnvFactory.Create();

--- a/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/TxPoolSourceTests.cs
@@ -213,7 +213,12 @@ public class TxPoolSourceTests
         BlockHeader targetBlock = Build.A.BlockHeader.WithNumber(1).TestObject;
         Transaction[] result = txSource.GetTransactions(parent, targetBlock, long.MaxValue).ToArray();
 
-        ulong selectedBlobs = result.Aggregate(0UL, (sum, tx) => sum + (ulong)tx.GetBlobCount());
+        ulong selectedBlobs = 0;
+        foreach (Transaction selected in result)
+        {
+            selectedBlobs += (ulong)selected.GetBlobCount();
+        }
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Contains(frameBlobTx), Is.EqualTo(expectSelected));
@@ -240,11 +245,14 @@ public class TxPoolSourceTests
             proofs[i] = [];
         }
 
+        byte[] senderBytes = new byte[Address.Size];
+        senderBytes[^1] = senderByte;
+
         Transaction tx = new()
         {
             Type = TxType.FrameTx,
             ChainId = TestBlockchainIds.ChainId,
-            SenderAddress = new Address(new byte[19].Concat(new[] { senderByte }).ToArray()),
+            SenderAddress = new Address(senderBytes),
             Nonce = 0,
             GasLimit = 1_000_000,
             GasPrice = 1,

--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
@@ -348,13 +348,16 @@ public class FrameTxPrefixSimulatorTests
         Task<FrameTxSimulationResult> local = Task.Run(() => simulator.Simulate(FrameTx(), local: true));
         // Reading the head is the last step before contending for the env, so the env is still held here.
         Assert.That(secondCallerReachedTheLock.Wait(TimeSpan.FromSeconds(10)), Is.True, "the local submission never ran");
-        Assert.That(local.IsCompleted, Is.False, "a local submission must not be shed while the simulator is busy");
+        // Necessary but not sufficient: a shed caller may simply not have returned yet. The guard that
+        // fails deterministically on a zero wait is the reason check below.
+        Assert.That(local.IsCompleted, Is.False, "the local submission resolved before the env was released");
 
         release.Set();
         Assert.That(local.Wait(TimeSpan.FromSeconds(10)), Is.True);
         holder.Wait(TimeSpan.FromSeconds(10));
 
-        Assert.That(local.Result.Reason, Does.Not.Contain("busy"));
+        Assert.That(local.Result.Reason, Does.Not.Contain("busy"),
+            "a local submission must wait for a busy simulator rather than being shed");
     }
 
     // The budget rejects nearly everything under spam, so it is read before the lock; reading it after would

--- a/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Processing/FrameTxPrefixSimulatorTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Blockchain.Find;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Threading;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
@@ -258,11 +259,12 @@ public class FrameTxPrefixSimulatorTests
     {
         // The prefix's own wall clock trips the timeout, so revalidation retains it, but it still counts
         // against the sender rather than reading as this node shedding load.
-        using FrameTxPrefixSimulator simulator = CreateOverBuiltEnv(out _, out ITransactionProcessor processor, timeoutMs: 1);
+        ManualTimeProvider time = new();
+        using FrameTxPrefixSimulator simulator = CreateOverBuiltEnv(out _, out ITransactionProcessor processor, timeoutMs: 1, time: time);
         processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
-            .Returns<TransactionResult>(static _ =>
+            .Returns<TransactionResult>(_ =>
             {
-                Thread.Sleep(50);
+                time.Advance(TimeSpan.FromMilliseconds(50));
                 throw new OperationCanceledException();
             });
 
@@ -336,15 +338,16 @@ public class FrameTxPrefixSimulatorTests
             release.Wait(TimeSpan.FromSeconds(30));
             throw new TestEnvUnavailableException();
         });
+        using ManualResetEventSlim secondCallerReachedTheLock = new(false);
         using FrameTxPrefixSimulator simulator = CreateSimulator(
-            envFactory, BlockFinderAtHead(), budgetPerHeadMs: 0, timeoutMs: 30_000);
+            envFactory, BlockFinderAtHead(secondCallerReachedTheLock), budgetPerHeadMs: 0, timeoutMs: 30_000);
 
         Task<FrameTxSimulationResult> holder = Task.Run(() => simulator.Simulate(FrameTx()));
         Assert.That(inside.Wait(TimeSpan.FromSeconds(10)), Is.True, "the first simulation never took the env");
 
         Task<FrameTxSimulationResult> local = Task.Run(() => simulator.Simulate(FrameTx(), local: true));
-        // Long enough that a zero wait would already have shed it, so what follows measures the wait.
-        Thread.Sleep(200);
+        // Reading the head is the last step before contending for the env, so the env is still held here.
+        Assert.That(secondCallerReachedTheLock.Wait(TimeSpan.FromSeconds(10)), Is.True, "the local submission never ran");
         Assert.That(local.IsCompleted, Is.False, "a local submission must not be shed while the simulator is busy");
 
         release.Set();
@@ -362,6 +365,7 @@ public class FrameTxPrefixSimulatorTests
         using ManualResetEventSlim inside = new(false);
         using ManualResetEventSlim release = new(false);
         int calls = 0;
+        ManualTimeProvider time = new();
         IReadOnlyTxProcessingEnvFactory envFactory = Substitute.For<IReadOnlyTxProcessingEnvFactory>();
         envFactory.Create().Returns(_ =>
         {
@@ -373,13 +377,13 @@ public class FrameTxPrefixSimulatorTests
             }
             else
             {
-                Thread.Sleep(5);
+                time.Advance(TimeSpan.FromMilliseconds(5));
             }
 
             throw new TestEnvUnavailableException();
         });
         using FrameTxPrefixSimulator simulator = CreateSimulator(
-            envFactory, BlockFinderAtHead(), budgetPerHeadMs: 1, timeoutMs: 30_000);
+            envFactory, BlockFinderAtHead(), budgetPerHeadMs: 1, timeoutMs: 30_000, time: time);
 
         simulator.Simulate(FrameTx());
         Task<FrameTxSimulationResult> holder = Task.Run(() => simulator.Simulate(FrameTx(), local: true));
@@ -399,13 +403,14 @@ public class FrameTxPrefixSimulatorTests
         int budgetPerHeadMs = 1000)
     {
         blockFinder = BlockFinderAtHead();
-        // Stands in for a simulation past the bounds: observable, and slow enough to drive the budget.
+        ManualTimeProvider time = new();
+        // Stands in for a simulation past the bounds: observable, and it spends enough of the clock to drive the budget.
         envFactory.Create().Returns(_ =>
         {
-            Thread.Sleep(5);
+            time.Advance(TimeSpan.FromMilliseconds(5));
             throw new TestEnvUnavailableException();
         });
-        return CreateSimulator(envFactory, blockFinder, budgetPerHeadMs);
+        return CreateSimulator(envFactory, blockFinder, budgetPerHeadMs, time: time);
     }
 
     [TestCase(false, ExecutionOptions.FrameValidationPrefixOnly)]
@@ -424,7 +429,8 @@ public class FrameTxPrefixSimulatorTests
         out IReadOnlyTxProcessorSource source,
         out ITransactionProcessor processor,
         InterfaceLogger? logSink = null,
-        int timeoutMs = 250)
+        int timeoutMs = 250,
+        TimeProvider? time = null)
     {
         processor = Substitute.For<ITransactionProcessor>();
         IReadOnlyTxProcessingScope scope = Substitute.For<IReadOnlyTxProcessingScope>();
@@ -437,13 +443,28 @@ public class FrameTxPrefixSimulatorTests
         IReadOnlyTxProcessingEnvFactory envFactory = Substitute.For<IReadOnlyTxProcessingEnvFactory>();
         envFactory.Create().Returns(source);
 
-        return CreateSimulator(envFactory, BlockFinderAtHead(), budgetPerHeadMs: 1000, logSink, timeoutMs);
+        return CreateSimulator(envFactory, BlockFinderAtHead(), budgetPerHeadMs: 1000, logSink, timeoutMs, time);
     }
 
-    private static IBlockFinder BlockFinderAtHead()
+    /// <param name="secondCallerReachedTheLock">Set when a second caller reads the head, which is the last
+    /// step before it contends for the env.</param>
+    private static IBlockFinder BlockFinderAtHead(ManualResetEventSlim? secondCallerReachedTheLock = null)
     {
         IBlockFinder blockFinder = Substitute.For<IBlockFinder>();
-        blockFinder.Head.Returns(Build.A.Block.WithNumber(1).TestObject);
+        Block head = Build.A.Block.WithNumber(1).TestObject;
+        if (secondCallerReachedTheLock is null)
+        {
+            blockFinder.Head.Returns(head);
+            return blockFinder;
+        }
+
+        int reads = 0;
+        blockFinder.Head.Returns(_ =>
+        {
+            if (Interlocked.Increment(ref reads) > 1) secondCallerReachedTheLock.Set();
+            return head;
+        });
+
         return blockFinder;
     }
 
@@ -452,12 +473,14 @@ public class FrameTxPrefixSimulatorTests
         IBlockFinder blockFinder,
         int budgetPerHeadMs,
         InterfaceLogger? logSink = null,
-        int timeoutMs = 250) =>
+        int timeoutMs = 250,
+        TimeProvider? time = null) =>
         new(envFactory,
             blockFinder,
             new TestSpecProvider(Eip8141Prototype.Instance),
             new TxPoolConfig { FrameTxSimulationBudgetPerHeadMs = budgetPerHeadMs, FrameTxSimulationTimeoutMs = timeoutMs },
-            logSink is null ? LimboLogs.Instance : new OneLoggerLogManager(new ILogger(logSink)));
+            logSink is null ? LimboLogs.Instance : new OneLoggerLogManager(new ILogger(logSink)),
+            time);
 
     private static Transaction FrameTx() => new()
     {

--- a/src/Nethermind/Nethermind.Consensus/Processing/FrameTxPrefixSimulator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/FrameTxPrefixSimulator.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using Nethermind.Blockchain;
@@ -26,17 +25,22 @@ namespace Nethermind.Consensus.Processing;
 /// <para>Every prefix simulation node-wide serialises on one lock and runs with instruction/stack tracing on
 /// (the slow interpreter path), so frame-transaction admission throughput is capped at one simulation at a
 /// time. Under real frame-transaction volume this lock, not <c>MAX_VERIFY_GAS</c>, is the admission bottleneck.</para></remarks>
+/// <param name="timeProvider">The clock the timeout and the per-head budget are measured against; the system
+/// clock by default.</param>
 public sealed class FrameTxPrefixSimulator(
     IReadOnlyTxProcessingEnvFactory envFactory,
     IBlockFinder blockFinder,
     ISpecProvider specProvider,
     ITxPoolConfig txPoolConfig,
-    ILogManager logManager) : IFrameTxPrefixSimulator, IDisposable
+    ILogManager logManager,
+    TimeProvider? timeProvider = null) : IFrameTxPrefixSimulator, IDisposable
 {
     private readonly ILogger _logger = logManager.GetClassLogger<FrameTxPrefixSimulator>();
     private readonly object _lock = new();
+    private readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
     private readonly TimeSpan _timeout = TimeSpan.FromMilliseconds(txPoolConfig.FrameTxSimulationTimeoutMs);
-    private readonly long _headBudgetTicks = (long)(txPoolConfig.FrameTxSimulationBudgetPerHeadMs / 1000d * Stopwatch.Frequency);
+    private readonly long _headBudgetTicks =
+        (long)(txPoolConfig.FrameTxSimulationBudgetPerHeadMs / 1000d * (timeProvider ?? TimeProvider.System).TimestampFrequency);
     private IReadOnlyTxProcessorSource? _source;
     private Hash256? _budgetHead;
     private long _budgetSpentTicks;
@@ -97,7 +101,7 @@ public sealed class FrameTxPrefixSimulator(
                 return FrameTxSimulationResult.RejectIndeterminate("validation-prefix simulation budget exhausted for this head");
             }
 
-            long startedAt = Stopwatch.GetTimestamp();
+            long startedAt = _time.GetTimestamp();
             try
             {
                 return SimulateLocked(tx, head, signaturesPreValidated, token);
@@ -106,7 +110,7 @@ public sealed class FrameTxPrefixSimulator(
             {
                 // Charged only to the share it drew on. Narrow, since only HasHeadBudget claims a head and
                 // local skips it, so an unclaimed head resets on the next gossip call and wipes the charge.
-                if (!local) Volatile.Write(ref _budgetSpentTicks, _budgetSpentTicks + Stopwatch.GetTimestamp() - startedAt);
+                if (!local) Volatile.Write(ref _budgetSpentTicks, _budgetSpentTicks + _time.GetTimestamp() - startedAt);
             }
         }
         finally
@@ -128,7 +132,7 @@ public sealed class FrameTxPrefixSimulator(
             processor.SetBlockExecutionContext(head);
 
             IReleaseSpec spec = specProvider.GetSpec(head);
-            tracer = new FrameTxValidationTracer(tx.SenderAddress!, Eip8141Constants.ExpiryVerifierAddress, scope.WorldState, spec, token, _timeout);
+            tracer = new FrameTxValidationTracer(tx.SenderAddress!, Eip8141Constants.ExpiryVerifierAddress, scope.WorldState, spec, token, _timeout, _time);
             ExecutionOptions opts = ExecutionOptions.FrameValidationPrefixOnly;
             if (signaturesPreValidated) opts |= ExecutionOptions.FrameSignaturesPreValidated;
             TransactionResult result = processor.Process(tx, tracer, opts);

--- a/src/Nethermind/Nethermind.Core.Test/Builders/FrameTxTestFrames.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Builders/FrameTxTestFrames.cs
@@ -50,6 +50,27 @@ public static class FrameTxTestFrames
         return bytes;
     }
 
+    /// <summary>A chain of secp256k1 entries that all require curve recovery, the last one failing signer
+    /// validation.</summary>
+    /// <remarks>The admission measurements need the worst case: no entry short-circuits before the mismatch,
+    /// so the whole chain is recovered before the transaction is rejected.</remarks>
+    public static TxFrameSignature[] RecoveredSecp256k1Signatures(EthereumEcdsa ecdsa, int count)
+    {
+        TxFrameSignature[] entries = new TxFrameSignature[count];
+        for (int i = 0; i < count; i++)
+        {
+            byte[] msg = ValueKeccak.Compute(BitConverter.GetBytes(i)).ToByteArray();
+            byte[] signed = i == count - 1 ? ValueKeccak.Compute("mismatch"u8).ToByteArray() : msg;
+            entries[i] = new TxFrameSignature(
+                TxFrameSignature.SchemeSecp256k1,
+                TestItem.PrivateKeyA.Address,
+                msg,
+                Secp256k1SignatureBytes(ecdsa.Sign(TestItem.PrivateKeyA, new Hash256(signed))));
+        }
+
+        return entries;
+    }
+
     public static TxFrame SelfVerify(ulong gasLimit = 1_000) =>
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit, UInt256.Zero, default);
 

--- a/src/Nethermind/Nethermind.Core/TxFrame.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrame.cs
@@ -11,20 +11,44 @@ namespace Nethermind.Core;
 /// where <c>limits = [execution, state]</c>.
 /// https://eips.ethereum.org/EIPS/eip-8141
 /// </summary>
+/// <param name="mode">One of the <c>Mode*</c> constants; it fixes both the caller the frame runs as and where
+/// the frame may appear in the transaction.</param>
+/// <param name="flags">The approval scope the frame may grant, plus <see cref="AtomicBatchFlag"/>.</param>
+/// <param name="target">The frame's target, or <see langword="null"/> for the transaction sender.</param>
+/// <param name="executionGasLimit">EIP-8141 <c>limits.execution</c>.</param>
+/// <param name="stateGasLimit">EIP-8141 <c>limits.state</c>.</param>
+/// <param name="value">Wei moved from the frame's caller to its target.</param>
+/// <param name="data">The frame's calldata.</param>
 public class TxFrame(byte mode, byte flags, Address? target, ulong executionGasLimit, ulong stateGasLimit, UInt256 value, ReadOnlyMemory<byte> data)
 {
+    /// <summary>An ordinary frame, called by the transaction sender.</summary>
     public const byte ModeDefault = 0;
+
+    /// <summary>A validation-prefix frame: it may approve execution or payment, and runs before any body frame.</summary>
     public const byte ModeVerify = 1;
+
+    /// <summary>A frame whose calls appear to come from the transaction sender rather than from the frame's caller.</summary>
     public const byte ModeSender = 2;
 
     /// <summary>EIP-7906: a read-only trailing frame that asserts the transaction's outcome.</summary>
     public const byte ModePostTx = 3;
 
+    /// <summary>The frame may approve nothing; an <c>APPROVE</c> from it always reverts.</summary>
     public const byte ApproveScopeNone = 0x0;
+
+    /// <summary>The frame may nominate its target as the transaction's payer.</summary>
     public const byte ApprovePayment = 0x1;
+
+    /// <summary>The frame may authorize the transaction on the sender's behalf.</summary>
     public const byte ApproveExecution = 0x2;
+
+    /// <summary>The frame may grant both scopes, together or one at a time.</summary>
     public const byte ApproveExecutionAndPayment = 0x3;
+
+    /// <summary>The bits of <see cref="Flags"/> that carry the approval scope.</summary>
     public const byte ApproveScopeMask = ApproveExecutionAndPayment;
+
+    /// <summary>Ties the frame to the batch it opens or continues: any member failing unrolls them all.</summary>
     public const byte AtomicBatchFlag = 0x4;
 
     /// <summary>Constructs a frame whose entire budget is execution gas, with <c>limits.state == 0</c>.</summary>
@@ -33,7 +57,11 @@ public class TxFrame(byte mode, byte flags, Address? target, ulong executionGasL
     {
     }
 
+    /// <summary>The frame's <c>Mode*</c> kind.</summary>
     public byte Mode { get; } = mode;
+
+    /// <summary>The frame's approval scope and batch membership; read through <see cref="AllowedApproveScope"/>
+    /// and <see cref="IsAtomicBatch"/> rather than directly.</summary>
     public byte Flags { get; } = flags;
 
     /// <summary>Null resolves to the transaction sender during execution.</summary>
@@ -48,9 +76,15 @@ public class TxFrame(byte mode, byte flags, Address? target, ulong executionGasL
     /// <summary>The combined gas the frame reserves against the payer, <c>limits.execution + limits.state</c>.</summary>
     public ulong GasLimit => ExecutionGasLimit + StateGasLimit;
 
+    /// <summary>Wei the frame moves from its caller to <see cref="Target"/>.</summary>
     public UInt256 Value { get; } = value;
+
+    /// <summary>The frame's calldata.</summary>
     public ReadOnlyMemory<byte> Data { get; } = data;
 
+    /// <summary>The widest scope an <c>APPROVE</c> from this frame may request.</summary>
     public byte AllowedApproveScope => (byte)(Flags & ApproveScopeMask);
+
+    /// <summary>Whether the frame belongs to an atomic batch, whose members stand or fall together.</summary>
     public bool IsAtomicBatch => (Flags & AtomicBatchFlag) != 0;
 }

--- a/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrameReceipt.cs
@@ -10,14 +10,22 @@ namespace Nethermind.Core;
 /// where <c>gas_used = [execution, state]</c>.
 /// https://eips.ethereum.org/EIPS/eip-8141
 /// </summary>
+/// <param name="status">One of <see cref="StatusSuccess"/>, <see cref="StatusFailure"/> or <see cref="StatusSkipped"/>.</param>
+/// <param name="executionGasUsed">The frame's <c>gas_used.execution</c>, before refunds.</param>
+/// <param name="stateGasUsed">The frame's <c>gas_used.state</c>, after refills and rollbacks.</param>
+/// <param name="logs">The logs the frame committed, empty when its state was discarded.</param>
 public class TxFrameReceipt(byte status, ulong executionGasUsed, ulong stateGasUsed, LogEntry[] logs)
 {
+    /// <summary>The frame reverted or halted; its state and logs did not survive.</summary>
     public const byte StatusFailure = 0;
+
+    /// <summary>The frame ran to completion.</summary>
     public const byte StatusSuccess = 1;
 
     /// <summary>Frames skipped by a failed atomic batch.</summary>
     public const byte StatusSkipped = 2;
 
+    /// <summary>The frame's outcome, as encoded in the receipt payload.</summary>
     public byte Status { get; } = status;
 
     /// <summary>Execution gas used by the frame (<c>gas_used.execution</c>), not accounting for refunds.</summary>
@@ -29,6 +37,7 @@ public class TxFrameReceipt(byte status, ulong executionGasUsed, ulong stateGasU
     /// <summary>The frame's combined gas: execution plus state.</summary>
     public ulong GasUsed => ExecutionGasUsed + StateGasUsed;
 
+    /// <summary>The logs this frame committed; empty for a frame whose state was discarded.</summary>
     public LogEntry[] Logs { get; } = logs;
 
     /// <summary>The transaction-level status reported for a frame transaction with these frame receipts.</summary>

--- a/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8141ScenarioTests.cs
@@ -70,18 +70,21 @@ public class Eip8141ScenarioTests
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
-        Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Success));
-        Assert.That(receipt.Payer, Is.EqualTo(Sender));
-        Assert.That(FrameStatuses(receipt), Is.EqualTo(new[] { TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess }));
-        Assert.That(_stateProvider.GetBalance(Recipient), Is.EqualTo(transferred));
-        Assert.That(_stateProvider.GetBalance(Sender),
-            Is.EqualTo(1.Ether - transferred - (UInt256)receipt.GasUsed),
-            "payer covers gas at the effective price on top of the transferred value");
-        Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That(receipt.Payer, Is.EqualTo(Sender));
+            Assert.That(FrameStatuses(receipt), Is.EqualTo(new[] { TxFrameReceipt.StatusSuccess, TxFrameReceipt.StatusSuccess }));
+            Assert.That(_stateProvider.GetBalance(Recipient), Is.EqualTo(transferred));
+            Assert.That(_stateProvider.GetBalance(Sender),
+                Is.EqualTo(1.Ether - transferred - (UInt256)receipt.GasUsed),
+                "payer covers gas at the effective price on top of the transferred value");
+            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1UL));
+        }
     }
 
-    // EIP-7708: a codeless SENDER frame transfers through default code, not the VM, so its log must
-    // still reach the frame receipt and the transaction log union.
+    // EIP-7708: a codeless SENDER frame runs empty code through the VM, so nothing but the transfer itself
+    // emits, and that log must still reach the frame receipt and the transaction log union.
     [Test]
     public void CodelessSenderFrameTransfer_EmitsEip7708TransferLog()
     {
@@ -162,11 +165,16 @@ public class Eip8141ScenarioTests
 
         static ulong CalldataTokens(byte[] bytes)
         {
-            ulong zeros = (ulong)bytes.Count(static b => b == 0);
+            ulong zeros = 0;
+            foreach (byte b in bytes)
+            {
+                if (b == 0) zeros++;
+            }
+
             return zeros + ((ulong)bytes.Length - zeros) * 4;
         }
 
-        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong frameGasUsed = FrameGasUsed(receipt);
         ulong tokens = CalldataTokens(frameData) + CalldataTokens(witnessBytes);
         ulong floorTokens = (ulong)(frameData.Length + witnessBytes.Length) * 4;
         ulong expected = (ulong)Eip8141Constants.IntrinsicGasCost
@@ -211,7 +219,7 @@ public class Eip8141ScenarioTests
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
-        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong frameGasUsed = FrameGasUsed(receipt);
         ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost + 2 * 475UL;
         using (Assert.EnterMultipleScope())
         {
@@ -236,7 +244,7 @@ public class Eip8141ScenarioTests
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
-        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong frameGasUsed = FrameGasUsed(receipt);
         ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost + 2 * 475UL;
         ulong standardTokenCost = 64 * 4UL;
         using (Assert.EnterMultipleScope())
@@ -293,7 +301,7 @@ public class Eip8141ScenarioTests
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
-        ulong frameGasUsed = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong frameGasUsed = FrameGasUsed(receipt);
         ulong mandatoryGas = (ulong)Eip8141Constants.IntrinsicGasCost + 2 * 475UL;
         ulong floorGas = mandatoryGas + (ulong)frameData.Length * 64UL;
         ulong grossGas = mandatoryGas + (ulong)frameData.Length * 4UL + frameGasUsed;
@@ -324,7 +332,7 @@ public class Eip8141ScenarioTests
 
         TxReceipt receipt = ProcessBlock(tx)[0];
 
-        ulong grossFrameGas = receipt.FrameReceipts!.Aggregate(0UL, static (sum, f) => sum + f.GasUsed);
+        ulong grossFrameGas = FrameGasUsed(receipt);
         ulong gross = (ulong)Eip8141Constants.IntrinsicGasCost + 2 * 475UL + grossFrameGas;
         ulong applied = gross - (ulong)receipt.GasUsed;
         using (Assert.EnterMultipleScope())
@@ -360,9 +368,8 @@ public class Eip8141ScenarioTests
 
     // Spec Example 2: an ERC-20-style approval batched with a swap — if the swap reverts, neither the
     // approval state nor its log may survive.
-    [TestCase(true)]
-    [TestCase(false)]
-    public void AtomicApproveAndSwap_NoDanglingApprovalWhenSwapReverts(bool swapReverts)
+    [Test]
+    public void AtomicApproveAndSwap_NoDanglingApprovalWhenSwapReverts([Values] bool swapReverts)
     {
         Address token = TestItem.AddressE;
         Address dex = TestItem.AddressF;
@@ -461,9 +468,8 @@ public class Eip8141ScenarioTests
 
     // Two batches in one transaction: batch B's bounds depend on batchStartIndex being re-seeded, which
     // rests on inBatch being reset when batch A closes. A stale start would wipe the between frame's log.
-    [TestCase(false)]
-    [TestCase(true)]
-    public void TwoBatches_EachClearsOnlyItsOwnFrames_CommittedLogsBetweenSurvive(bool secondBatchReverts)
+    [Test]
+    public void TwoBatches_EachClearsOnlyItsOwnFrames_CommittedLogsBetweenSurvive([Values] bool secondBatchReverts)
     {
         Address logger = TestItem.AddressD;
         Address tokenA = TestItem.AddressE;
@@ -540,9 +546,8 @@ public class Eip8141ScenarioTests
 
     // EIP-8141 § Expiry Verifier Frame: reverts unless block.timestamp <= the 8-byte calldata expiry,
     // and a reverted VERIFY invalidates the whole transaction.
-    [TestCase(false)]
-    [TestCase(true)]
-    public void ExpiryVerifierFrame_GatesTransactionOnBlockTimestamp(bool expired)
+    [Test]
+    public void ExpiryVerifierFrame_GatesTransactionOnBlockTimestamp([Values] bool expired)
     {
         DeployContract(Sender, ApproveCode(TxFrame.ApproveExecutionAndPayment), 1.Ether);
         DeployContract(Eip8141Constants.ExpiryVerifierAddress, ExpiryVerifierCode());
@@ -857,8 +862,28 @@ public class Eip8141ScenarioTests
         Assert.That(actual, Is.EqualTo(expected), message);
     }
 
-    private static byte[] FrameStatuses(TxReceipt receipt) =>
-        receipt.FrameReceipts!.Select(static frameReceipt => frameReceipt.Status).ToArray();
+    private static byte[] FrameStatuses(TxReceipt receipt)
+    {
+        byte[] statuses = new byte[receipt.FrameReceipts!.Length];
+        for (int i = 0; i < statuses.Length; i++)
+        {
+            statuses[i] = receipt.FrameReceipts[i].Status;
+        }
+
+        return statuses;
+    }
+
+    /// <summary>The transaction's gross frame gas: the per-frame receipts summed, before refunds and the floor.</summary>
+    private static ulong FrameGasUsed(TxReceipt receipt)
+    {
+        ulong total = 0;
+        foreach (TxFrameReceipt frameReceipt in receipt.FrameReceipts!)
+        {
+            total += frameReceipt.GasUsed;
+        }
+
+        return total;
+    }
 
     private static byte[] ApproveCode(byte scope) =>
         Prepare.EvmCode.PushData(scope).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
@@ -224,6 +224,8 @@ public class FrameTxBlockReceiptsTests
 
         Assert.That(result.TransactionExecuted, Is.True);
         TxReceipt receipt = receiptsTracer.TxReceipts[0];
+        // Ahead of the scope: the frame receipts are indexed below.
+        Assert.That(receipt.FrameReceipts, Has.Length.EqualTo(5));
         using (Assert.EnterMultipleScope())
         {
             Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Failure));

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxBlockReceiptsTests.cs
@@ -40,23 +40,27 @@ public class FrameTxBlockReceiptsTests
 
         (TxReceipt receipt, Block block, IReleaseSpec spec) = RunFrameTx(emitLog);
 
-        Assert.That(receipt.TxType, Is.EqualTo(TxType.FrameTx));
-        Assert.That(receipt.Payer, Is.EqualTo(Sender));
-        // Naming either would invent an address, and the receipt-recovery path derives them independently.
-        Assert.That(receipt.ContractAddress, Is.Null);
-        Assert.That(receipt.Recipient, Is.Null);
+        // Ahead of the scope: the frame receipts are indexed below.
         Assert.That(receipt.FrameReceipts, Has.Length.EqualTo(2));
-        Assert.That(receipt.FrameReceipts![0].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
-        Assert.That(receipt.FrameReceipts[1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
-        Assert.That(receipt.FrameReceipts[1].Logs, Has.Length.EqualTo(1), "SENDER frame log must land in its frame receipt");
-        Assert.That(receipt.Logs, Has.Length.EqualTo(1), "receipt logs must be the union of frame logs");
-        Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusSuccess));
-        Assert.That(receipt.GasUsed, Is.GreaterThanOrEqualTo((long)Eip8141Constants.IntrinsicGasCost),
-            "spec gas includes the frame tx intrinsic cost");
-        Assert.That(block.Header.GasUsed, Is.EqualTo(receipt.GasUsedTotal),
-            "block header GasUsed must equal the cumulative receipt gas (production/processing parity)");
-        Assert.That(block.Transactions[0].BlockGasUsed, Is.EqualTo((ulong)receipt.GasUsed),
-            "frame tx must report block gas via Transaction.BlockGasUsed for parallel block validation");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.TxType, Is.EqualTo(TxType.FrameTx));
+            Assert.That(receipt.Payer, Is.EqualTo(Sender));
+            // Naming either would invent an address, and the receipt-recovery path derives them independently.
+            Assert.That(receipt.ContractAddress, Is.Null);
+            Assert.That(receipt.Recipient, Is.Null);
+            Assert.That(receipt.FrameReceipts![0].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+            Assert.That(receipt.FrameReceipts[1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+            Assert.That(receipt.FrameReceipts[1].Logs, Has.Length.EqualTo(1), "SENDER frame log must land in its frame receipt");
+            Assert.That(receipt.Logs, Has.Length.EqualTo(1), "receipt logs must be the union of frame logs");
+            Assert.That(receipt.StatusCode, Is.EqualTo(TxFrameReceipt.StatusSuccess));
+            Assert.That(receipt.GasUsed, Is.GreaterThanOrEqualTo((long)Eip8141Constants.IntrinsicGasCost),
+                "spec gas includes the frame tx intrinsic cost");
+            Assert.That(block.Header.GasUsed, Is.EqualTo(receipt.GasUsedTotal),
+                "block header GasUsed must equal the cumulative receipt gas (production/processing parity)");
+            Assert.That(block.Transactions[0].BlockGasUsed, Is.EqualTo((ulong)receipt.GasUsed),
+                "frame tx must report block gas via Transaction.BlockGasUsed for parallel block validation");
+        }
 
         // The frame-aware wire encoding must produce a computable receipts root.
         Hash256 receiptsRoot = ReceiptTrie.CalculateRoot(spec, [receipt], new ReceiptMessageDecoder());
@@ -220,10 +224,13 @@ public class FrameTxBlockReceiptsTests
 
         Assert.That(result.TransactionExecuted, Is.True);
         TxReceipt receipt = receiptsTracer.TxReceipts[0];
-        Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Failure));
-        Assert.That(receipt.FrameReceipts![1].Logs, Has.Length.EqualTo(1), "the prefix frame keeps its log");
-        Assert.That(receipt.FrameReceipts[3].Logs, Is.Empty, "the body's log goes with the state that produced it");
-        Assert.That(receipt.Logs, Has.Length.EqualTo(1), "receipt logs must stay the union of frame logs");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Failure));
+            Assert.That(receipt.FrameReceipts![1].Logs, Has.Length.EqualTo(1), "the prefix frame keeps its log");
+            Assert.That(receipt.FrameReceipts[3].Logs, Is.Empty, "the body's log goes with the state that produced it");
+            Assert.That(receipt.Logs, Has.Length.EqualTo(1), "receipt logs must stay the union of frame logs");
+        }
     }
 
     private static byte[] Approve(byte scope) =>

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -3442,10 +3442,9 @@ public class FrameTxProcessorTests
             DecodedMaxFeePerGas = 1,
         };
 
-    [TestCase(Instruction.TXTRACE)]
-    [TestCase(Instruction.TXDIFF)]
-    [TestCase(Instruction.EVENTDATACOPY)]
-    public void Execute_AssertionOpcodeOutsidePostTxFrame_HaltsExceptionally(Instruction opcode)
+    [Test]
+    public void Execute_AssertionOpcodeOutsidePostTxFrame_HaltsExceptionally(
+        [Values(Instruction.TXTRACE, Instruction.TXDIFF, Instruction.EVENTDATACOPY)] Instruction opcode)
     {
         // Four operands cover the widest of the three; a halt leaves any surplus unread.
         DeploySmartSender(Prepare.EvmCode
@@ -3456,10 +3455,9 @@ public class FrameTxProcessorTests
     }
 
     // The opcodes are in the jump table for every transaction once EIP-7906 is on.
-    [TestCase(Instruction.TXTRACE)]
-    [TestCase(Instruction.TXDIFF)]
-    [TestCase(Instruction.EVENTDATACOPY)]
-    public void Execute_AssertionOpcodeInOrdinaryTransaction_HaltsExceptionally(Instruction opcode)
+    [Test]
+    public void Execute_AssertionOpcodeInOrdinaryTransaction_HaltsExceptionally(
+        [Values(Instruction.TXTRACE, Instruction.TXDIFF, Instruction.EVENTDATACOPY)] Instruction opcode)
     {
         DeployContract(Recipient, Prepare.EvmCode
             .PushData(0).PushData(0).PushData(0).PushData(0).Op(opcode).Op(Instruction.STOP).Done);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxSignatureValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxSignatureValidatorTests.cs
@@ -249,25 +249,8 @@ public class FrameTxSignatureValidatorTests
     [Test]
     public void Validate_P256ValidSignature_ReturnsTrue()
     {
-        using ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
-        ECParameters pub = key.ExportParameters(includePrivateParameters: false);
-        byte[] qx = Pad32(pub.Q.X!);
-        byte[] qy = Pad32(pub.Q.Y!);
-        Address signer = new(Keccak.Compute([.. qx, .. qy]).Bytes[12..]);
-
         Transaction tx = CreateFrameTx();
-        // Install the placeholder (scheme/signer/msg) so the sig hash is fixed before signing.
-        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeP256, signer, default, default)];
-        ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
-
-        byte[] rs = key.SignHash(sigHash.Bytes); // IEEE P1363: r || s
-        byte[] raw = new byte[TxFrameSignature.P256SignatureLength];
-        rs.CopyTo(raw.AsSpan(0));
-        qx.CopyTo(raw.AsSpan(64));
-        qy.CopyTo(raw.AsSpan(96));
-        // .NET does not guarantee low-s; the spec requires it, so normalize before validating.
-        NormalizeP256LowS(raw);
-        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeP256, signer, default, raw)];
+        SignP256(tx);
 
         Assert.That(Validate(tx, out string? error), Is.True, error);
     }
@@ -276,29 +259,42 @@ public class FrameTxSignatureValidatorTests
     public void Validate_P256WithHighS_RejectedAsNonCanonical()
     {
         // P256VERIFY accepts both s and N - s, so the low-s gate must reject the high-s encoding.
+        Transaction tx = CreateFrameTx();
+        byte[] raw = SignP256(tx);
+
+        // Flip the (now low) s to its high-s counterpart N - s, leaving the rest of the entry alone.
+        UInt256 lowS = new(raw.AsSpan(32, 32), isBigEndian: true);
+        (SecP256r1Curve.N - lowS).ToBigEndian(raw.AsSpan(32, 32));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Validate(tx, out string? error), Is.False);
+            Assert.That(error, Is.EqualTo(FrameTxSignatureValidator.NonCanonicalP256Signature));
+        }
+    }
+
+    /// <summary>Signs <paramref name="tx"/> with a fresh P-256 key and installs the low-s entry it produces,
+    /// returning the entry's signature bytes so a caller can corrupt them in place.</summary>
+    private static byte[] SignP256(Transaction tx)
+    {
         using ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         ECParameters pub = key.ExportParameters(includePrivateParameters: false);
         byte[] qx = Pad32(pub.Q.X!);
         byte[] qy = Pad32(pub.Q.Y!);
         Address signer = new(Keccak.Compute([.. qx, .. qy]).Bytes[12..]);
 
-        Transaction tx = CreateFrameTx();
+        // Install the placeholder (scheme/signer/msg) so the sig hash is fixed before signing.
         tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeP256, signer, default, default)];
         ValueHash256 sigHash = FrameTxSigHash.ComputeValue(tx);
 
-        byte[] rs = key.SignHash(sigHash.Bytes);
         byte[] raw = new byte[TxFrameSignature.P256SignatureLength];
-        rs.CopyTo(raw.AsSpan(0));
+        key.SignHash(sigHash.Bytes).CopyTo(raw.AsSpan(0)); // IEEE P1363: r || s
         qx.CopyTo(raw.AsSpan(64));
         qy.CopyTo(raw.AsSpan(96));
+        // .NET does not guarantee low-s; the spec requires it, so normalize before validating.
         NormalizeP256LowS(raw);
-        // Flip the (now low) s to its high-s counterpart N - s.
-        UInt256 lowS = new(raw.AsSpan(32, 32), isBigEndian: true);
-        (SecP256r1Curve.N - lowS).ToBigEndian(raw.AsSpan(32, 32));
         tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeP256, signer, default, raw)];
-
-        Assert.That(Validate(tx, out string? error), Is.False);
-        Assert.That(error, Is.EqualTo(FrameTxSignatureValidator.NonCanonicalP256Signature));
+        return raw;
     }
 
     private static void NormalizeP256LowS(byte[] raw)

--- a/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
@@ -15,6 +15,20 @@ namespace Nethermind.Evm;
 
 /// <summary>Transaction-scoped context for an in-flight EIP-8141 frame transaction: the read-only envelope
 /// plus the approval state the outer loop advances and the <c>APPROVE</c> opcode writes.</summary>
+/// <remarks>One instance per transaction, not thread-safe: it is mutated by the single frame loop executing it.</remarks>
+/// <param name="sender">The transaction sender, and the default target and signer of frames and entries that name none.</param>
+/// <param name="nonce">The nonce the envelope was signed at: the account nonce, or the shared <c>nonce_seq</c> when
+/// <paramref name="nonceKeys"/> is set.</param>
+/// <param name="frames">The envelope's frames, in execution order.</param>
+/// <param name="signatures">The envelope's signature entries, already validated when execution begins.</param>
+/// <param name="sigHash">The canonical signature hash the entries that carry no explicit <c>msg</c> sign.</param>
+/// <param name="maxCost">The gas and blob-gas cost the payer's approval reserves up front.</param>
+/// <param name="maxPriorityFeePerGas">EIP-1559 <c>max_priority_fee_per_gas</c> of the envelope.</param>
+/// <param name="maxFeePerGas">EIP-1559 <c>max_fee_per_gas</c> of the envelope.</param>
+/// <param name="maxFeePerBlobGas">EIP-4844 <c>max_fee_per_blob_gas</c> of the envelope, zero when it carries no blobs.</param>
+/// <param name="legacyNonce">The sender's account nonce before any frame executed.</param>
+/// <param name="recentRootReferences">EIP-8272 recent-root references of the signed envelope.</param>
+/// <param name="nonceKeys">EIP-8250 nonce keys, or <see langword="null"/> for a plain account nonce.</param>
 public sealed class FrameTxContext(
     Address sender,
     ulong nonce,
@@ -29,7 +43,10 @@ public sealed class FrameTxContext(
     RecentRootReference[]? recentRootReferences = null,
     UInt256[]? nonceKeys = null)
 {
+    /// <summary>The transaction sender: the default target of a frame and signer of an entry that names none.</summary>
     public Address Sender { get; } = sender;
+
+    /// <summary>The nonce the envelope was signed at; with <see cref="NonceKeys"/> set, the shared <c>nonce_seq</c>.</summary>
     public ulong Nonce { get; } = nonce;
 
     /// <summary>The EIP-8250 nonce keys this transaction consumes, or <see langword="null"/> for a plain account nonce.</summary>
@@ -49,12 +66,26 @@ public sealed class FrameTxContext(
 
     private static readonly ValueHash256 AccountNonceKeySetHash = ComputeNonceKeysHash([UInt256.Zero]);
 
+    /// <summary>The envelope's frames, in execution order.</summary>
     public TxFrame[] Frames { get; } = frames;
+
+    /// <summary>The envelope's signature entries, validated before the first frame runs.</summary>
     public TxFrameSignature[] Signatures { get; } = signatures;
+
+    /// <summary>The hash entries carrying no explicit <c>msg</c> are taken to have signed.</summary>
     public ValueHash256 SigHash { get; } = sigHash;
+
+    /// <summary>The cost an approving payer reserves up front: the whole gas budget plus blob gas at the
+    /// envelope's maximum prices.</summary>
     public UInt256 MaxCost { get; } = maxCost;
+
+    /// <summary>EIP-1559 <c>max_priority_fee_per_gas</c> of the envelope.</summary>
     public UInt256 MaxPriorityFeePerGas { get; } = maxPriorityFeePerGas;
+
+    /// <summary>EIP-1559 <c>max_fee_per_gas</c> of the envelope.</summary>
     public UInt256 MaxFeePerGas { get; } = maxFeePerGas;
+
+    /// <summary>EIP-4844 <c>max_fee_per_blob_gas</c> of the envelope; zero when it carries no blobs.</summary>
     public UInt256 MaxFeePerBlobGas { get; } = maxFeePerBlobGas;
 
     /// <summary>The EIP-8272 recent-root references of the signed envelope, empty when it carries none.</summary>
@@ -71,25 +102,37 @@ public sealed class FrameTxContext(
     /// <summary>EVM code only runs while some frame executes, so completed means strictly earlier.</summary>
     public bool IsFrameCompleted(int frameIndex) => frameIndex < CurrentFrameIndex;
 
+    /// <summary>Whether a completed frame ran to success; meaningless for a frame that has not completed.</summary>
     public bool HasFrameSucceeded(int frameIndex) => (_frameSucceededBits & (1UL << frameIndex)) != 0;
 
+    /// <summary>Records that <paramref name="frameIndex"/> completed successfully.</summary>
     public void MarkFrameSucceeded(int frameIndex) => _frameSucceededBits |= 1UL << frameIndex;
 
+    /// <summary>Whether a frame was skipped rather than run, as a failed atomic batch's remaining members are.</summary>
     public bool WasFrameSkipped(int frameIndex) => (_frameSkippedBits & (1UL << frameIndex)) != 0;
 
+    /// <summary>Records that <paramref name="frameIndex"/> was skipped rather than run.</summary>
     public void MarkFrameSkipped(int frameIndex) => _frameSkippedBits |= 1UL << frameIndex;
 
 
+    /// <summary>Whether some frame has authorized the transaction on the sender's behalf.</summary>
+    /// <remarks>Set through <see cref="ApplyApproval"/>, which journals it; assigning it directly skips the undo record.</remarks>
     public bool SenderApproved { get; set; }
+
+    /// <summary>The account whose balance covers the transaction, once a frame has approved payment.</summary>
+    /// <remarks>Write-once for the life of the transaction, apart from a journal restore.</remarks>
     public Address? Payer { get; set; }
 
+    /// <summary>The frame the outer loop is currently executing.</summary>
     public TxFrame CurrentFrame => Frames[CurrentFrameIndex];
 
     /// <summary>EIP-7906: lazily-built, sorted view of this transaction's state diff and logs, shared by its POST_TX frames.</summary>
     internal TransactionDiffView? PostTxDiffView { get; set; }
 
+    /// <summary>A frame's target with the omitted-target encoding resolved to the sender.</summary>
     public Address ResolvedTarget(int frameIndex) => Frames[frameIndex].Target ?? Sender;
 
+    /// <summary>An entry's signer with the omitted-signer encoding resolved to the sender.</summary>
     public Address ResolvedSigner(int signatureIndex) => Signatures[signatureIndex].Signer ?? Sender;
 
     private const int NoOwner = -1;

--- a/src/Nethermind/Nethermind.Evm/Tracing/FrameTxValidationTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/FrameTxValidationTracer.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics;
 using System.Threading;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -15,18 +14,23 @@ namespace Nethermind.Evm.Tracing;
 /// and captures the resolved payer.</summary>
 /// <param name="token">Cancels the simulation cooperatively; polled by the interpreter.</param>
 /// <param name="timeout">Wall-clock bound on the simulation, or <see cref="TimeSpan.Zero"/> for none.</param>
+/// <param name="timeProvider">The clock <paramref name="timeout"/> is measured against; the system clock by default.</param>
 public sealed class FrameTxValidationTracer(
     Address sender,
     Address expiryVerifier,
     IReadOnlyStateProvider state,
     IReleaseSpec spec,
     CancellationToken token = default,
-    TimeSpan timeout = default)
+    TimeSpan timeout = default,
+    TimeProvider? timeProvider = null)
     : TxTracer, ITxTracer, IFrameTxReceiptTracer, IFrameTxPrefixTracer
 {
-    private readonly long _deadline = timeout > TimeSpan.Zero
-        ? Stopwatch.GetTimestamp() + (long)(timeout.TotalSeconds * Stopwatch.Frequency)
-        : 0;
+    private readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+
+    private readonly long _deadline = Deadline(timeProvider ?? TimeProvider.System, timeout);
+
+    private static long Deadline(TimeProvider time, TimeSpan timeout) =>
+        timeout > TimeSpan.Zero ? time.GetTimestamp() + (long)(timeout.TotalSeconds * time.TimestampFrequency) : 0;
 
     // Stack slots holding the current CALL*/EXTCODE* target and value operands, or -1. Set in StartOperation
     // and consumed in SetOperationStack, as the operands aren't available any earlier.
@@ -55,7 +59,7 @@ public sealed class FrameTxValidationTracer(
     bool ITxTracer.IsCancelled => Violated || TimedOut || token.IsCancellationRequested;
 
     /// <summary>True once the wall-clock bound was reached; the transaction is then rejected, not cancelled.</summary>
-    public bool TimedOut => _deadline != 0 && Stopwatch.GetTimestamp() > _deadline;
+    public bool TimedOut => _deadline != 0 && _time.GetTimestamp() > _deadline;
 
     // The VM reports the address a creation frame is entered at; recomputing it here would duplicate
     // CREATE2's initcode hashing for no gain.

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxFilterTestPools.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxFilterTestPools.cs
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using Nethermind.Blockchain;
+using Nethermind.Consensus.Comparers;
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.TxPool.Collections;
+using NSubstitute;
+
+namespace Nethermind.TxPool.Test;
+
+/// <summary>Pending-pool fixtures for the frame-transaction admission filters, which walk the pool a
+/// displaced transaction would sit in.</summary>
+public static class FrameTxFilterTestPools
+{
+    /// <summary>The real pool type for the shape, so the visitor's ascending-nonce exit is exercised as wired.</summary>
+    public static TxDistinctSortedPool Pool(bool blobs, params Transaction[] pending)
+    {
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(new ReleaseSpec { IsEip1559Enabled = false });
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
+
+        IComparer<Transaction> comparer = new TransactionComparerProvider(specProvider, blockTree).GetDefaultComparer();
+        TxDistinctSortedPool pool = blobs
+            ? new BlobTxDistinctSortedPool(pending.Length + 1, comparer, LimboLogs.Instance)
+            : new TxDistinctSortedPool(pending.Length + 1, comparer, LimboLogs.Instance);
+        foreach (Transaction tx in pending)
+        {
+            pool.TryInsert(tx.Hash!, tx);
+        }
+
+        return pool;
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
@@ -697,13 +697,14 @@ public class FrameTxMempoolDosMeasurement
         _chain = await BasicTestBlockchain.Create(builder =>
         {
             builder.AddSingleton(_specProvider);
-            builder.AddScoped<IGenesisPostProcessor, IWorldState, ISpecProvider>((worldState, specProvider) =>
-                new FunctionalGenesisPostProcessor(_ =>
-                {
-                    worldState.CreateAccount(Sender, SenderBalance);
-                    if (senderCode.Length > 0) worldState.InsertCode(Sender, senderCode, specProvider.GenesisSpec);
-                    worldState.RecalculateStateRoot();
-                }));
+            builder.WithGenesisPostProcessor((_, worldState, specProvider) =>
+            {
+                // Replaces the account TestBlockchain funds in genesis, clearing the placeholder code and
+                // storage slot it puts on this address so only the measured code is reachable.
+                worldState.CreateAccount(Sender, SenderBalance);
+                if (senderCode.Length > 0) worldState.InsertCode(Sender, senderCode, specProvider.GenesisSpec);
+                worldState.RecalculateStateRoot();
+            });
         });
 
         // The pool refuses everything while the tree reports a zero best-suggested block, so the head has to
@@ -716,7 +717,12 @@ public class FrameTxMempoolDosMeasurement
 
         _blockTree = _chain.BlockTree;
 
-        AssertSeededCodeIsVisibleAtHead(_blockTree.Head!.Header, senderCode);
+        // The container registration shares the process-wide code cache; production hands the simulator its
+        // own env (BlockProcessingModule) so a rolled-back deposit cannot outlive its scope.
+        IReadOnlyTxProcessingEnvFactory envFactory = new AutoReadOnlyTxProcessingEnvFactory(
+            _chain.Container, _chain.WorldStateManager, _specProvider, shareCodeCache: false);
+
+        AssertSeededCodeIsVisibleAtHead(envFactory, _blockTree.Head!.Header, senderCode);
 
         // The per-head budget sheds admission after a second of simulation against one head. This harness
         // times single rejections against a fixed head, so leaving it at the default would measure the
@@ -728,7 +734,7 @@ public class FrameTxMempoolDosMeasurement
             FrameTxSimulationBudgetPerHeadMs = int.MaxValue,
         };
         _realSimulator = new FrameTxPrefixSimulator(
-            _chain.ReadOnlyTxProcessingEnvFactory,
+            envFactory,
             _blockTree,
             _specProvider,
             txPoolConfig,
@@ -738,14 +744,15 @@ public class FrameTxMempoolDosMeasurement
     }
 
     /// <summary>Confirms that both pool and EVM views contain the sender code before measurement.</summary>
-    private void AssertSeededCodeIsVisibleAtHead(BlockHeader head, byte[] senderCode)
+    /// <param name="envFactory">The same factory the simulator under measurement is given.</param>
+    private void AssertSeededCodeIsVisibleAtHead(IReadOnlyTxProcessingEnvFactory envFactory, BlockHeader head, byte[] senderCode)
     {
         if (senderCode.Length == 0) return;
 
         Assert.That(_poolState.GetCode(Sender), Is.EqualTo(senderCode),
             "the pool's chain-head view does not carry the sender's code, so the two stores disagree");
 
-        using IReadOnlyTxProcessorSource source = _chain!.ReadOnlyTxProcessingEnvFactory.Create();
+        using IReadOnlyTxProcessorSource source = envFactory.Create();
         using IReadOnlyTxProcessingScope scope = source.Build(head);
         Assert.That(scope.WorldState.GetCode(Sender), Is.EqualTo(senderCode),
             "the simulator's view of the head does not carry the sender's code, so the EVM would run "

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
@@ -20,10 +20,10 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
+using Nethermind.Core.Test.Blockchain;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Db;
+using Nethermind.Core.Test.Container;
 using Nethermind.Crypto;
-using Nethermind.Db;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
@@ -32,7 +32,6 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
-using Nethermind.State;
 using NUnit.Framework;
 
 namespace Nethermind.TxPool.Test;
@@ -58,8 +57,6 @@ public class FrameTxMempoolDosMeasurement
     private const int Warmup = 600;
     private const int Samples = 1_000;
     private const long BlockGasLimit = 30_000_000;
-    private const long HeadNumber = 1;
-    private const ulong HeadTimestamp = 1_700_000_000;
 
     /// <summary>Maximum per-frame verification budget enforced by the processor.</summary>
     private const ulong VerifyGas = Eip8141Constants.MaxVerifyGas;
@@ -160,10 +157,9 @@ public class FrameTxMempoolDosMeasurement
     private ILogManager _logManager = null!;
     private ISpecProvider _specProvider = null!;
     private EthereumEcdsa _ethereumEcdsa = null!;
-    private IDbProvider _dbProvider = null!;
-    private WorldStateManager _worldStateManager = null!;
+    private BasicTestBlockchain? _chain;
     private TestReadOnlyStateProvider _poolState = null!;
-    private TestBlockTree _blockTree = null!;
+    private IBlockTree _blockTree = null!;
     private TxPool _txPool = null!;
     private FrameTxPrefixSimulator? _realSimulator;
     private List<double> _simulateMicros = null!;
@@ -173,8 +169,6 @@ public class FrameTxMempoolDosMeasurement
     private TxFrameSignature[] _frameSignatures = [];
 
     private byte[] _frameCalldataPrefix = [];
-
-    private IReleaseSpec Spec => _specProvider.GenesisSpec;
 
     [SetUp]
     public void Setup()
@@ -189,7 +183,7 @@ public class FrameTxMempoolDosMeasurement
 
         _txPool = null!;
         _realSimulator = null;
-        _dbProvider = null!;
+        _chain = null;
     }
 
     [TearDown]
@@ -197,7 +191,7 @@ public class FrameTxMempoolDosMeasurement
     {
         if (_txPool is not null) await _txPool.DisposeAsync();
         _realSimulator?.Dispose();
-        _dbProvider?.Dispose();
+        _chain?.Dispose();
     }
 
     /// <summary>
@@ -205,22 +199,22 @@ public class FrameTxMempoolDosMeasurement
     /// of gas while keeping their behavior stable across ceilings.
     /// </summary>
     [TestCaseSource(nameof(BudgetBurningCases))]
-    public void Reject_cost_of_a_budget_burning_prefix(string shape, ulong ceiling) => MeasureFrameRejection(shape, ceiling);
+    public Task Reject_cost_of_a_budget_burning_prefix(string shape, ulong ceiling) => MeasureFrameRejection(shape, ceiling);
 
     /// <summary>Measures immediate rejection caused by a banned validation-prefix opcode.</summary>
     [TestCase(Ceiling100k)]
-    public void Reject_cost_of_a_banned_opcode_prefix(ulong ceiling) => MeasureFrameRejection("banned-opcode", ceiling);
+    public Task Reject_cost_of_a_banned_opcode_prefix(ulong ceiling) => MeasureFrameRejection("banned-opcode", ceiling);
 
     /// <summary>Measures rejection after a complete Groth16 verification with an invalid proof or input.</summary>
     [TestCaseSource(nameof(Groth16Cases))]
-    public void Reject_cost_of_a_groth16_verifier_prefix(string shape) =>
+    public Task Reject_cost_of_a_groth16_verifier_prefix(string shape) =>
         MeasureFrameRejection(shape, Groth16Sweeps[shape].Ceiling);
 
     /// <summary>Measures ordinary transaction rejection as the non-frame admission baseline.</summary>
     [Test]
-    public void Reject_cost_of_an_ordinary_transaction()
+    public async Task Reject_cost_of_an_ordinary_transaction()
     {
-        BuildHarness(senderCode: []);
+        await BuildHarness(senderCode: []);
 
         Transaction probe = OrdinaryTx(0);
         AcceptTxResult probeResult = _txPool.SubmitTx(probe, TxHandlingOptions.None);
@@ -248,7 +242,7 @@ public class FrameTxMempoolDosMeasurement
              + $"simulate_samples=0 rejected_by=InsufficientFunds");
     }
 
-    private void MeasureFrameRejection(string shape, ulong ceiling)
+    private async Task MeasureFrameRejection(string shape, ulong ceiling)
     {
         bool isGroth16 = Groth16Sweeps.TryGetValue(shape, out Groth16Sweep sweep);
         byte[] code;
@@ -263,7 +257,7 @@ public class FrameTxMempoolDosMeasurement
             code = PrefixCode(shape);
         }
 
-        BuildHarness(code);
+        await BuildHarness(code);
 
         // Probe outside the timed loop to verify that the intended workload entered the EVM.
         FrameGasReadout gas = isGroth16
@@ -396,13 +390,13 @@ public class FrameTxMempoolDosMeasurement
             .Done;
 
     [TestCaseSource(nameof(CeilingCases))]
-    public void Reject_cost_of_a_signature_stuffed_prefix(ulong ceiling)
+    public async Task Reject_cost_of_a_signature_stuffed_prefix(ulong ceiling)
     {
         int count = StuffedSignatureCount(ceiling);
 
-        BuildHarness(PrefixCode("banned-opcode"), ceiling);
+        await BuildHarness(PrefixCode("banned-opcode"), ceiling);
         _frameExecutionGasLimit = MinimalFrameGas;
-        _frameSignatures = BuildSecp256k1Signatures(count);
+        _frameSignatures = FrameTxTestFrames.RecoveredSecp256k1Signatures(_ethereumEcdsa, count);
 
         ulong declaredGas = FrameTxValidation.ValidationWorkGas(FrameTx(0));
         Assert.That(declaredGas, Is.LessThanOrEqualTo(ceiling),
@@ -410,13 +404,13 @@ public class FrameTxMempoolDosMeasurement
             + "transaction never asked for");
 
         long gasRefusalsBefore = Metrics.PendingTransactionsFrameTxVerifyGasTooHigh;
-        _frameSignatures = BuildSecp256k1Signatures(count + 1);
+        _frameSignatures = FrameTxTestFrames.RecoveredSecp256k1Signatures(_ethereumEcdsa, count + 1);
         Assert.That(_txPool.SubmitTx(FrameTx(0), TxHandlingOptions.None),
             Is.EqualTo(AcceptTxResult.FrameTxVerifyGasTooHigh),
             $"{count + 1} entries declare more than {ceiling} and must be refused by the declared-gas gate; "
             + "if they are not, the pool is not enforcing the ceiling this row claims");
         Assert.That(Metrics.PendingTransactionsFrameTxVerifyGasTooHigh, Is.EqualTo(gasRefusalsBefore + 1));
-        _frameSignatures = BuildSecp256k1Signatures(count);
+        _frameSignatures = FrameTxTestFrames.RecoveredSecp256k1Signatures(_ethereumEcdsa, count);
 
         long signatureFailuresBefore = Metrics.PendingTransactionsFrameTxSignatureInvalid;
         Assert.That(_txPool.SubmitTx(FrameTx(0), TxHandlingOptions.None),
@@ -473,29 +467,6 @@ public class FrameTxMempoolDosMeasurement
 
         micros.Sort();
         return Percentile(micros, 0.50);
-    }
-
-    /// <summary>
-    /// Builds secp256k1 entries that all require recovery, with the final entry failing signer validation.
-    /// </summary>
-    private TxFrameSignature[] BuildSecp256k1Signatures(int count)
-    {
-        TxFrameSignature[] entries = new TxFrameSignature[count];
-        for (int i = 0; i < count; i++)
-        {
-            byte[] msg = ValueKeccak.Compute(BitConverter.GetBytes(i)).ToByteArray();
-            byte[] signed = i == count - 1 ? ValueKeccak.Compute("mismatch"u8).ToByteArray() : msg;
-            Signature signature = _ethereumEcdsa.Sign(TestItem.PrivateKeyA, new Hash256(signed));
-
-            byte[] raw = new byte[TxFrameSignature.Secp256k1SignatureLength];
-            raw[0] = signature.RecoveryId;
-            signature.RAsSpan.CopyTo(raw.AsSpan(1));
-            signature.SAsSpan.CopyTo(raw.AsSpan(33));
-            entries[i] = new TxFrameSignature(
-                TxFrameSignature.SchemeSecp256k1, TestItem.PrivateKeyA.Address, msg, raw);
-        }
-
-        return entries;
     }
 
     private static byte[] PrefixCode(string shape) => shape switch
@@ -564,7 +535,7 @@ public class FrameTxMempoolDosMeasurement
         BlockHeader head = _blockTree.Head!.Header;
         FrameGasProbeTracer probe = tracer ?? new FrameGasProbeTracer();
 
-        using IReadOnlyTxProcessorSource source = new HarnessEnvFactory(_worldStateManager, _specProvider, _logManager).Create();
+        using IReadOnlyTxProcessorSource source = _chain!.ReadOnlyTxProcessingEnvFactory.Create();
         using (IReadOnlyTxProcessingScope scope = source.Build(head))
         {
             scope.TransactionProcessor.SetBlockExecutionContext(head);
@@ -718,39 +689,34 @@ public class FrameTxMempoolDosMeasurement
     /// <summary>
     /// Creates a TxPool and real frame simulator backed by equivalent pool-state and EVM-state views.
     /// </summary>
-    private void BuildHarness(byte[] senderCode, ulong verifyGasCeiling = 0)
+    /// <remarks>The EVM side is the chain's production processing wiring, so the code cache and blockhash
+    /// policy the simulation runs under are the ones a node uses; only the pool's chain-head view is seeded
+    /// separately, which is what the two views existing at all is here to check.</remarks>
+    private async Task BuildHarness(byte[] senderCode, ulong verifyGasCeiling = 0)
     {
-        _dbProvider = TestMemDbProvider.Init();
-        _worldStateManager = TestWorldStateFactory.CreateWorldStateManagerForTest(_dbProvider, _logManager);
-
-        Hash256 stateRoot;
-        IWorldState seedState = new WorldState(_worldStateManager.GlobalWorldState, _logManager);
-        using (seedState.BeginScope(IWorldState.PreGenesis))
+        _chain = await BasicTestBlockchain.Create(builder =>
         {
-            seedState.CreateAccount(Sender, SenderBalance);
-            if (senderCode.Length > 0) seedState.InsertCode(Sender, senderCode, Spec);
-            seedState.Commit(Spec);
-            seedState.CommitTree(HeadNumber);
-            stateRoot = seedState.StateRoot;
-        }
+            builder.AddSingleton(_specProvider);
+            builder.AddScoped<IGenesisPostProcessor, IWorldState, ISpecProvider>((worldState, specProvider) =>
+                new FunctionalGenesisPostProcessor(_ =>
+                {
+                    worldState.CreateAccount(Sender, SenderBalance);
+                    if (senderCode.Length > 0) worldState.InsertCode(Sender, senderCode, specProvider.GenesisSpec);
+                    worldState.RecalculateStateRoot();
+                }));
+        });
+
+        // The pool refuses everything while the tree reports a zero best-suggested block, so the head has to
+        // be a block rather than genesis before anything is submitted.
+        await _chain.AddBlock();
 
         _poolState = new TestReadOnlyStateProvider();
         _poolState.CreateAccount(Sender, SenderBalance);
         if (senderCode.Length > 0) _poolState.InsertCode(senderCode, Sender);
 
-        _blockTree = new TestBlockTree();
-        Block head = Build.A.Block
-            .WithNumber(HeadNumber)
-            .WithTimestamp(HeadTimestamp)
-            .WithBaseFeePerGas(0)
-            .WithBeneficiary(TestItem.AddressE)
-            .WithGasLimit(BlockGasLimit)
-            .WithStateRoot(stateRoot)
-            .TestObject;
-        _blockTree.Head = head;
-        _blockTree.BestSuggestedHeader = head.Header;
+        _blockTree = _chain.BlockTree;
 
-        AssertSeededCodeIsVisibleAtHead(head.Header, senderCode);
+        AssertSeededCodeIsVisibleAtHead(_blockTree.Head!.Header, senderCode);
 
         // The per-head budget sheds admission after a second of simulation against one head. This harness
         // times single rejections against a fixed head, so leaving it at the default would measure the
@@ -762,7 +728,7 @@ public class FrameTxMempoolDosMeasurement
             FrameTxSimulationBudgetPerHeadMs = int.MaxValue,
         };
         _realSimulator = new FrameTxPrefixSimulator(
-            new HarnessEnvFactory(_worldStateManager, _specProvider, _logManager),
+            _chain.ReadOnlyTxProcessingEnvFactory,
             _blockTree,
             _specProvider,
             txPoolConfig,
@@ -779,13 +745,11 @@ public class FrameTxMempoolDosMeasurement
         Assert.That(_poolState.GetCode(Sender), Is.EqualTo(senderCode),
             "the pool's chain-head view does not carry the sender's code, so the two stores disagree");
 
-        IWorldState headView = new WorldState(_worldStateManager.CreateResettableWorldState(), _logManager);
-        using (headView.BeginScope(head))
-        {
-            Assert.That(headView.GetCode(Sender), Is.EqualTo(senderCode),
-                "the simulator's view of the head does not carry the sender's code, so the EVM would run "
-                + "default verify code and the measurement would describe the wrong work");
-        }
+        using IReadOnlyTxProcessorSource source = _chain!.ReadOnlyTxProcessingEnvFactory.Create();
+        using IReadOnlyTxProcessingScope scope = source.Build(head);
+        Assert.That(scope.WorldState.GetCode(Sender), Is.EqualTo(senderCode),
+            "the simulator's view of the head does not carry the sender's code, so the EVM would run "
+            + "default verify code and the measurement would describe the wrong work");
     }
 
     private TxPool CreatePool(IFrameTxPrefixSimulator frameTxPrefixSimulator, TxPoolConfig txPoolConfig)
@@ -930,31 +894,6 @@ public class FrameTxMempoolDosMeasurement
         {
             if (_depth == 1) { CloseOp(remainingGas); TopLevelFrameGas = _entryGas - remainingGas; }
             if (_depth > 0) _depth--;
-        }
-    }
-
-    /// <summary>Minimal read-only environment matching the production transaction-processing setup.</summary>
-    private sealed class HarnessEnvFactory(
-        IWorldStateManager worldStateManager,
-        ISpecProvider specProvider,
-        ILogManager logManager) : IReadOnlyTxProcessingEnvFactory
-    {
-        public IReadOnlyTxProcessorSource Create()
-        {
-            IWorldState worldState = new WorldState(worldStateManager.CreateResettableWorldState(), logManager);
-            EthereumCodeInfoRepository codeInfoRepository = new(worldState);
-            EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(specProvider), specProvider, logManager);
-            EthereumTransactionProcessor processor = new(
-                BlobBaseFeeCalculator.Instance, specProvider, worldState, virtualMachine, codeInfoRepository, logManager);
-            return new HarnessEnv(processor, worldState);
-        }
-
-        private sealed class HarnessEnv(ITransactionProcessor processor, IWorldState worldState) : IReadOnlyTxProcessorSource
-        {
-            public IReadOnlyTxProcessingScope Build(BlockHeader? baseBlock) =>
-                new ReadOnlyTxProcessingScope(processor, worldState.BeginScope(baseBlock), worldState);
-
-            public void Dispose() { }
         }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxMempoolDosMeasurement.cs
@@ -699,8 +699,8 @@ public class FrameTxMempoolDosMeasurement
             builder.AddSingleton(_specProvider);
             builder.WithGenesisPostProcessor((_, worldState, specProvider) =>
             {
-                // Replaces the account TestBlockchain funds in genesis, clearing the placeholder code and
-                // storage slot it puts on this address so only the measured code is reachable.
+                // Replaces the account TestBlockchain funds in genesis, dropping the placeholder code so only
+                // the measured code is reachable. Its storage slot survives; no measured shape reads storage.
                 worldState.CreateAccount(Sender, SenderBalance);
                 if (senderCode.Length > 0) worldState.InsertCode(Sender, senderCode, specProvider.GenesisSpec);
                 worldState.RecalculateStateRoot();

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
@@ -3,23 +3,20 @@
 
 #nullable enable
 
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Nethermind.Blockchain;
-using Nethermind.Consensus.Comparers;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.TxPool.Collections;
 using Nethermind.TxPool.Filters;
 using NSubstitute;
 using NUnit.Framework;
+using static Nethermind.TxPool.Test.FrameTxFilterTestPools;
 
 namespace Nethermind.TxPool.Test;
 
@@ -368,25 +365,5 @@ public class FrameTxPayerExposureFilterTests
         FrameTxPayerExposureFilter filter = new(specProvider, state, standard, blob, cache, LimboLogs.Instance.GetClassLogger<FrameTxPayerExposureFilterTests>());
         TxFilteringState filteringState = new(tx, senderAccounts ?? Substitute.For<IAccountStateProvider>(), Spec);
         return filter.Accept(tx, ref filteringState, TxHandlingOptions.None);
-    }
-
-    /// <summary>The real pool type for the shape, so the visitor's ascending-nonce exit is exercised as wired.</summary>
-    private static TxDistinctSortedPool Pool(bool blobs, params Transaction[] pending)
-    {
-        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(new ReleaseSpec { IsEip1559Enabled = false });
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
-
-        IComparer<Transaction> comparer = new TransactionComparerProvider(specProvider, blockTree).GetDefaultComparer();
-        TxDistinctSortedPool pool = blobs
-            ? new BlobTxDistinctSortedPool(pending.Length + 1, comparer, LimboLogs.Instance)
-            : new TxDistinctSortedPool(pending.Length + 1, comparer, LimboLogs.Instance);
-        foreach (Transaction tx in pending)
-        {
-            pool.TryInsert(tx.Hash!, tx);
-        }
-
-        return pool;
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPaymasterFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPaymasterFilterTests.cs
@@ -6,21 +6,18 @@
 using Nethermind.Specs.Forks;
 using System;
 using System.Collections.Generic;
-using Nethermind.Blockchain;
-using Nethermind.Consensus.Comparers;
 using Nethermind.Core;
-using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Crypto;
 using Nethermind.Int256;
 using Nethermind.Logging;
-using Nethermind.Specs;
 using Nethermind.TxPool.Collections;
 using Nethermind.TxPool.Filters;
 using NSubstitute;
 using NUnit.Framework;
 using static Nethermind.Core.Test.Builders.FrameTxTestFrames;
+using static Nethermind.TxPool.Test.FrameTxFilterTestPools;
 
 namespace Nethermind.TxPool.Test;
 
@@ -259,26 +256,6 @@ public class FrameTxPaymasterFilterTests
         FrameTxPaymasterFilter filter = new(state, standard, blob, cache, LimboLogs.Instance.GetClassLogger<FrameTxPaymasterFilterTests>());
         TxFilteringState filteringState = new(tx, Substitute.For<IAccountStateProvider>(), Eip8141Prototype.Instance);
         return filter.Accept(tx, ref filteringState, TxHandlingOptions.None);
-    }
-
-    /// <summary>The real pool type for the shape, so the visitor's ascending-nonce exit is exercised as wired.</summary>
-    private static TxDistinctSortedPool Pool(bool blobs, params Transaction[] pending)
-    {
-        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(new ReleaseSpec { IsEip1559Enabled = false });
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
-
-        IComparer<Transaction> comparer = new TransactionComparerProvider(specProvider, blockTree).GetDefaultComparer();
-        TxDistinctSortedPool pool = blobs
-            ? new BlobTxDistinctSortedPool(pending.Length + 1, comparer, LimboLogs.Instance)
-            : new TxDistinctSortedPool(pending.Length + 1, comparer, LimboLogs.Instance);
-        foreach (Transaction tx in pending)
-        {
-            pool.TryInsert(tx.Hash!, tx);
-        }
-
-        return pool;
     }
 
     private static Transaction FrameTx(TxFrame[] frames, ulong nonce = 0, uint gasPrice = 1, bool carriesBlobs = false)

--- a/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/LightTxDecoderTests.cs
@@ -25,9 +25,8 @@ namespace Nethermind.TxPool.Test;
 [TestFixture]
 public class LightTxDecoderTests
 {
-    [TestCase(TxType.Blob)]
-    [TestCase(TxType.FrameTx)]
-    public void Round_trip_preserves_the_type_and_proof_version(TxType type)
+    [Test]
+    public void Round_trip_preserves_the_type_and_proof_version([Values(TxType.Blob, TxType.FrameTx)] TxType type)
     {
         Transaction tx = BlobCarryingTx(type);
 
@@ -63,9 +62,8 @@ public class LightTxDecoderTests
     }
 
     // ProofVersion.V0 encodes as the RLP empty string, which a raw byte read returns as 128.
-    [TestCase(ProofVersion.V0)]
-    [TestCase(ProofVersion.V1)]
-    public void Round_trip_preserves_the_proof_version(ProofVersion version)
+    [Test]
+    public void Round_trip_preserves_the_proof_version([Values(ProofVersion.V0, ProofVersion.V1)] ProofVersion version)
     {
         Transaction tx = BlobCarryingTx(TxType.Blob);
         tx.NetworkWrapper = new ShardBlobNetworkWrapper([[1]], [[2]], [[3]], version);
@@ -123,7 +121,7 @@ public class LightTxDecoderTests
     public void Unreadable_record_is_skipped_and_leaves_the_rest_of_the_pool_loadable(TxType type, ulong? deadline)
     {
         Transaction readable = BlobCarryingTx(TxType.Blob);
-        MemColumnsDb<BlobTxsColumns> database = new();
+        using MemColumnsDb<BlobTxsColumns> database = new();
         IDb lightBlobTxs = database.GetColumnDb(BlobTxsColumns.LightBlobTxs);
         lightBlobTxs.Set(UnreadableRecordKey, EncodeWithBlobFieldsLast(BlobCarryingTx(type, deadline)));
         lightBlobTxs.Set(ReadableRecordKey, LightTxDecoder.Encode(readable));
@@ -140,7 +138,7 @@ public class LightTxDecoderTests
     public void Unreadable_records_are_reported_as_one_warning()
     {
         const int unreadableCount = 5;
-        MemColumnsDb<BlobTxsColumns> database = new();
+        using MemColumnsDb<BlobTxsColumns> database = new();
         IDb lightBlobTxs = database.GetColumnDb(BlobTxsColumns.LightBlobTxs);
         for (int i = 0; i < unreadableCount; i++)
         {
@@ -187,7 +185,7 @@ public class LightTxDecoderTests
             $"these records must span the roots the catch filter lists, but they only produced: {string.Join(", ", shapes)}");
 
         Transaction readable = BlobCarryingTx(TxType.Blob);
-        MemColumnsDb<BlobTxsColumns> database = new();
+        using MemColumnsDb<BlobTxsColumns> database = new();
         IDb lightBlobTxs = database.GetColumnDb(BlobTxsColumns.LightBlobTxs);
         for (int i = 0; i < corrupt.Length; i++)
         {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -886,9 +886,12 @@ public class TxBroadcasterTests
 
         _broadcaster.OnNewHead(this, Build.A.Block.WithTimestamp(1_000).TestObject);
 
-        Assert.That(_broadcaster.ContainsTx(frameTx.Hash!), Is.EqualTo(!shouldBeDropped));
-        Assert.That(_broadcaster.ContainsTx(regularTx.Hash!), Is.True,
-            "a transaction without a frame expiry deadline must never be swept");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_broadcaster.ContainsTx(frameTx.Hash!), Is.EqualTo(!shouldBeDropped));
+            Assert.That(_broadcaster.ContainsTx(regularTx.Hash!), Is.True,
+                "a transaction without a frame expiry deadline must never be swept");
+        }
     }
 
     private Transaction FrameTxWithDeadline(ulong deadline, bool carriesBlobs = false)

--- a/src/Nethermind/Nethermind.TxPool/IFrameTxPrefixSimulator.cs
+++ b/src/Nethermind/Nethermind.TxPool/IFrameTxPrefixSimulator.cs
@@ -10,6 +10,10 @@ namespace Nethermind.TxPool;
 /// <remarks>Optional: with no simulator wired, such transactions are admitted unresolved and hold no exposure reservation.</remarks>
 public interface IFrameTxPrefixSimulator
 {
+    /// <summary>Runs <paramref name="tx"/>'s validation prefix at chain head and reports the payer it resolves.</summary>
+    /// <remarks>Serialized node-wide and bounded by a per-simulation timeout, a cumulative per-head budget and
+    /// <c>MAX_VERIFY_GAS</c>; the result says which of those, if any, ended it.</remarks>
+    /// <param name="tx">The frame transaction to simulate. Any other type is rejected rather than executed.</param>
     /// <param name="signaturesPreValidated">Assert only if this exact transaction has already passed
     /// <c>validate_signature</c> at chain head; the simulation then trusts its signatures. The two sides read
     /// the head separately, so a head change between them can only mis-admit, never mis-reject.</param>
@@ -22,6 +26,7 @@ public interface IFrameTxPrefixSimulator
     FrameTxSimulationResult Simulate(Transaction tx, bool signaturesPreValidated = false, CancellationToken token = default, bool local = false);
 }
 
+/// <summary>How far a validation-prefix simulation got.</summary>
 public enum FrameTxSimulationOutcome
 {
     /// <summary>A node-side fault stopped the simulation before it could judge the transaction.</summary>
@@ -35,6 +40,14 @@ public enum FrameTxSimulationOutcome
     Rejected,
 }
 
+/// <summary>The verdict of one validation-prefix simulation.</summary>
+/// <remarks>Construct through the static factories rather than this constructor: they are the combinations
+/// admission and revalidation are written against.</remarks>
+/// <param name="outcome">How far the simulation got.</param>
+/// <param name="payer">The resolved payer, for an accepted prefix only.</param>
+/// <param name="reason">A human-readable explanation, for anything but an acceptance.</param>
+/// <param name="indeterminate">Whether the outcome reflects a bound or a fault rather than the prefix.</param>
+/// <param name="nodeBound">Whether that bound was one this node imposed on itself.</param>
 public readonly struct FrameTxSimulationResult(
     FrameTxSimulationOutcome outcome,
     Address? payer,
@@ -42,11 +55,13 @@ public readonly struct FrameTxSimulationResult(
     bool indeterminate = false,
     bool nodeBound = false)
 {
+    /// <summary>How far the simulation got.</summary>
     public FrameTxSimulationOutcome Outcome { get; } = outcome;
 
     /// <summary>Non-null only when <see cref="Outcome"/> is <see cref="FrameTxSimulationOutcome.Accepted"/>.</summary>
     public Address? Payer { get; } = payer;
 
+    /// <summary>Why the prefix was not accepted; <see langword="null"/> when it was.</summary>
     public string? Reason { get; } = reason;
 
     /// <summary>
@@ -63,7 +78,10 @@ public readonly struct FrameTxSimulationResult(
     /// </summary>
     public bool NodeBound { get; } = nodeBound;
 
+    /// <summary>The prefix ran to <paramref name="payer"/>.</summary>
     public static FrameTxSimulationResult Accept(Address payer) => new(FrameTxSimulationOutcome.Accepted, payer, null);
+
+    /// <summary>The prefix itself is invalid, so the transaction can be dropped.</summary>
     public static FrameTxSimulationResult Reject(string reason) => new(FrameTxSimulationOutcome.Rejected, null, reason);
 
     /// <summary>A rejection caused by a bound this node spent on itself, not by the prefix. Still charged to


### PR DESCRIPTION
Follow-ups to the P3 threads of the 2026-09-08 review round on #12526.

## Changes

**Production wiring for the measurement harnesses** (`[P3 — Repository DI rule]`)

- `FrameTxMempoolDosMeasurement` and `FrameTxProducerRetryMeasurement` now take their processing stack from a chain's `ReadOnlyTxProcessingEnvFactory`, matching the `ProducerRig` precedent; the hand-rolled world state / code repository / VM / processor stacks are gone. The measured contract code now goes into genesis through an `IGenesisPostProcessor`.
- This closes a real divergence, not only a style point: production wires the prefix simulator through `AutoReadOnlyTxProcessingEnvFactory(..., shareCodeCache: false)`, so it gets its own code cache and the real blockhash provider; the hand-built factory had neither, and its comment claimed it matched production.
- Declined, with reasons on the threads: `FrameTxBlockProductionTests` (plain unit fixture, and it needs two independently built pre-states), `FrameTxValidationPrefixSimulationTests.RunUnder` (it exists to inject and then assert on a specific `ICodeCache` instance — it is the regression test for that isolation), and `FrameTxApproveAuthorizationTests` (pure EVM-semantics fixture following the `VirtualMachineTestsBase` convention).

**Controllable time in the prefix simulator tests** (`[P3 — Deterministic tests]`)

- `FrameTxPrefixSimulator` and `FrameTxValidationTracer` take an optional `TimeProvider`, defaulting to `TimeProvider.System`, so their `Stopwatch` statics become injectable without touching the DI registration.
- Three of the four `Thread.Sleep` calls are replaced by `ManualTimeProvider.Advance`. The fourth is a negative observation that no clock removes, so it now waits on a block-finder hook that fires when a second caller reads the head — the last step before it contends for the env.

**Test hygiene**

- Shared setup extracted: `FrameTxFilterTestPools.Pool`, `FrameTxTestFrames.RecoveredSecp256k1Signatures`, and a `SignP256` helper in `FrameTxSignatureValidatorTests`.
- Positional-only `[TestCase]` groups converted to `[Test]` + `[Values]` in `LightTxDecoderTests`, `Eip8141ScenarioTests` and `FrameTxProcessorTests`.
- Independent read-only assertions grouped under `Assert.EnterMultipleScope()` in `FrameTxBlockReceiptsTests`, `Eip8141ScenarioTests` and `TxBroadcasterTests`; guards stay outside the scopes.
- Simple LINQ replaced with loops in `Eip8141ScenarioTests` and `TxPoolSourceTests` (new code only).
- The `MemColumnsDb` instances in `LightTxDecoderTests` are `using`-scoped.

**Documentation** (`[P3 — Public API documentation]`)

- XML docs for the new public members of `TxFrameReceipt`, `TxFrame`, `FrameTxContext`, `IFrameTxPrefixSimulator`, `FrameTxSimulationOutcome` and `FrameTxSimulationResult`, with invariants in `<remarks>`.
- Corrected the `Eip8141ScenarioTests` comment about codeless SENDER frames: the default-code path applies to a codeless VERIFY target, not to SENDER.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

No coverage was given up. Case counts are unchanged in every fixture touched — `Eip8141ScenarioTests` 27, `FrameTxProcessorTests` 261, `FrameTxBlockReceiptsTests` 4, `FrameTxSignatureValidatorTests` 20, `LightTxDecoderTests` 48, `FrameTxPayerExposureFilterTests` 23, `FrameTxPaymasterFilterTests` 20, `TxBroadcasterTests` 137, `TxPoolSourceTests` 87, `FrameTxPrefixSimulatorTests` 29, `FrameTxFloodMeasurement` 126, `FrameTxMempoolDosMeasurement` 20, `FrameTxProducerRetryMeasurement` 19 — and the generated test-name sets are identical before and after, not just the totals. (`Eip2565Tests` and `SecP256r1PrecompileTests` generate randomised case names and differ between two listings of the same binary, so they are excluded.)

`Nethermind.Core.Test`, `Nethermind.Evm.Test`, `Nethermind.TxPool.Test`, `Nethermind.Blockchain.Test` and `Nethermind.Consensus.Test` are green in both release and checked builds, and the two converted `[Explicit]` measurement fixtures were run directly under both.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
