### PR TITLE
refactor(rlp): share the EIP-8141 frame receipt codec

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -73,7 +73,7 @@ namespace Nethermind.Serialization.Rlp
             {
                 txReceipt.TxType = TxType.FrameTx;
                 txReceipt.Payer = decoderContext.DecodeAddress();
-                txReceipt.FrameReceipts = DecodeFrameReceipts(ref decoderContext);
+                txReceipt.FrameReceipts = FrameReceiptRlp<CompactLogEntryCodec>.Decode(ref decoderContext);
             }
 
             // Handle any remaining extra bytes
@@ -178,76 +178,8 @@ namespace Nethermind.Serialization.Rlp
                 // Repeats the logs the top-level union already holds, at the cost noted above: DecodeStructRef
                 // hands eth_getLogs one contiguous LogsRlp span, which N per-frame sequences cannot supply.
                 writer.Encode(item.Payer);
-                EncodeFrameReceipts(ref writer, item.FrameReceipts ?? []);
+                FrameReceiptRlp<CompactLogEntryCodec>.Encode(ref writer, item.FrameReceipts ?? []);
             }
-        }
-
-        private static TxFrameReceipt[] DecodeFrameReceipts(ref RlpReader decoderContext)
-        {
-            int framesEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
-            using ArrayPoolListRef<TxFrameReceipt> frameReceipts = new(Eip8141Constants.MaxFrames);
-            while (decoderContext.Position < framesEnd)
-            {
-                int frameEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
-                byte status = decoderContext.DecodeByte();
-                FrameReceiptGasRlp.DecodeGasUsed(ref decoderContext, out ulong executionGasUsed, out ulong stateGasUsed);
-
-                int logsEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
-                using ArrayPoolListRef<LogEntry> frameLogs = new(4);
-                while (decoderContext.Position < logsEnd)
-                {
-                    frameLogs.Add(CompactLogEntryDecoder.Instance.DecodeGuardNotNull(ref decoderContext, RlpBehaviors.AllowExtraBytes));
-                }
-
-                frameReceipts.Add(new TxFrameReceipt(status, executionGasUsed, stateGasUsed, frameLogs.ToArray()));
-                decoderContext.Check(frameEnd);
-            }
-
-            return frameReceipts.ToArray();
-        }
-
-        private static void EncodeFrameReceipts<TWriter>(ref TWriter writer, TxFrameReceipt[] frameReceipts)
-            where TWriter : struct, IRlpWriteBackend, allows ref struct
-        {
-            int framesLength = 0;
-            for (int i = 0; i < frameReceipts.Length; i++)
-            {
-                framesLength += Rlp.LengthOfSequence(GetFrameReceiptContentLength(frameReceipts[i]));
-            }
-
-            writer.StartSequence(framesLength);
-            for (int i = 0; i < frameReceipts.Length; i++)
-            {
-                TxFrameReceipt frameReceipt = frameReceipts[i];
-                int logsLength = GetFrameLogsLength(frameReceipt);
-                int gasUsedLength = Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed);
-                writer.StartSequence(Rlp.LengthOf((ulong)frameReceipt.Status) + Rlp.LengthOfSequence(gasUsedLength) + Rlp.LengthOfSequence(logsLength));
-                writer.Encode((ulong)frameReceipt.Status);
-                writer.StartSequence(gasUsedLength);
-                writer.Encode(frameReceipt.ExecutionGasUsed);
-                writer.Encode(frameReceipt.StateGasUsed);
-                writer.StartSequence(logsLength);
-                for (int j = 0; j < frameReceipt.Logs.Length; j++)
-                {
-                    CompactLogEntryDecoder.Instance.Encode(ref writer, frameReceipt.Logs[j]);
-                }
-            }
-        }
-
-        private static int GetFrameReceiptContentLength(TxFrameReceipt frameReceipt) =>
-            Rlp.LengthOf((ulong)frameReceipt.Status)
-            + Rlp.LengthOfSequence(Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed))
-            + Rlp.LengthOfSequence(GetFrameLogsLength(frameReceipt));
-
-        private static int GetFrameLogsLength(TxFrameReceipt frameReceipt)
-        {
-            int logsLength = 0;
-            for (int i = 0; i < frameReceipt.Logs.Length; i++)
-            {
-                logsLength += CompactLogEntryDecoder.Instance.GetLength(frameReceipt.Logs[i]);
-            }
-
-            return logsLength;
         }
 
         private static (int Total, int Logs) GetContentLength(TxReceipt? item, RlpBehaviors rlpBehaviors)
@@ -277,14 +209,7 @@ namespace Nethermind.Serialization.Rlp
             if (item.TxType == TxType.FrameTx)
             {
                 contentLength += Rlp.LengthOf(item.Payer);
-                TxFrameReceipt[] frameReceipts = item.FrameReceipts ?? [];
-                int framesLength = 0;
-                for (int i = 0; i < frameReceipts.Length; i++)
-                {
-                    framesLength += Rlp.LengthOfSequence(GetFrameReceiptContentLength(frameReceipts[i]));
-                }
-
-                contentLength += Rlp.LengthOfSequence(framesLength);
+                contentLength += FrameReceiptRlp<CompactLogEntryCodec>.GetLength(item.FrameReceipts ?? []);
             }
 
             return (contentLength, logsLength);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/FrameReceiptGasRlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/FrameReceiptGasRlp.cs
@@ -29,4 +29,8 @@ internal static class FrameReceiptGasRlp
             state = 0;
         }
     }
+
+    /// <summary>Returns the content length of a frame receipt's <c>gas_used</c> list.</summary>
+    public static int GetGasUsedContentLength(ulong execution, ulong state) =>
+        Rlp.LengthOf(execution) + Rlp.LengthOf(state);
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/FrameReceiptRlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/FrameReceiptRlp.cs
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+
+namespace Nethermind.Serialization.Rlp;
+
+/// <summary>
+/// Static-abstract policy naming the log codec that a receipt storage format encodes its logs with.
+/// </summary>
+/// <typeparam name="TSelf">The implementing policy type.</typeparam>
+/// <remarks>
+/// Implemented by empty structs so that <see cref="FrameReceiptRlp{TLogCodec}"/> gets a JIT instantiation
+/// per storage format and the log codec calls stay direct rather than going through a virtual dispatch.
+/// </remarks>
+internal interface ILogEntryCodec<TSelf> where TSelf : struct, ILogEntryCodec<TSelf>
+{
+    static abstract LogEntry Decode(ref RlpReader reader, RlpBehaviors rlpBehaviors);
+
+    static abstract void Encode<TWriter>(ref TWriter writer, LogEntry log)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct;
+
+    static abstract int GetLength(LogEntry log);
+}
+
+/// <summary>The log codec of <see cref="ReceiptStorageDecoder"/>.</summary>
+internal readonly struct StandardLogEntryCodec : ILogEntryCodec<StandardLogEntryCodec>
+{
+    public static LogEntry Decode(ref RlpReader reader, RlpBehaviors rlpBehaviors)
+        => LogEntryDecoder.Instance.DecodeGuardNotNull(ref reader, rlpBehaviors);
+
+    public static void Encode<TWriter>(ref TWriter writer, LogEntry log)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+        => LogEntryDecoder.Instance.Encode(ref writer, log);
+
+    public static int GetLength(LogEntry log) => LogEntryDecoder.Instance.GetLength(log);
+}
+
+/// <summary>The log codec of <see cref="CompactReceiptStorageDecoder"/>.</summary>
+internal readonly struct CompactLogEntryCodec : ILogEntryCodec<CompactLogEntryCodec>
+{
+    public static LogEntry Decode(ref RlpReader reader, RlpBehaviors rlpBehaviors)
+        => CompactLogEntryDecoder.Instance.DecodeGuardNotNull(ref reader, rlpBehaviors);
+
+    public static void Encode<TWriter>(ref TWriter writer, LogEntry log)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+        => CompactLogEntryDecoder.Instance.Encode(ref writer, log);
+
+    public static int GetLength(LogEntry log) => CompactLogEntryDecoder.Instance.GetLength(log);
+}
+
+/// <summary>
+/// Codec for the EIP-8141 per-frame receipt sequence
+/// <c>[[status, [execution_gas_used, state_gas_used], [log, ...]], ...]</c> that a frame-tx receipt carries
+/// after the standard storage fields.
+/// </summary>
+/// <typeparam name="TLogCodec">The log codec of the enclosing storage format.</typeparam>
+/// <remarks>
+/// Shared by <see cref="ReceiptStorageDecoder"/> and <see cref="CompactReceiptStorageDecoder"/>. The two
+/// storage formats differ only in how a single log entry is encoded, so the frame layout lives here to stop
+/// them drifting apart.
+/// </remarks>
+internal static class FrameReceiptRlp<TLogCodec> where TLogCodec : struct, ILogEntryCodec<TLogCodec>
+{
+    public static TxFrameReceipt[] Decode(ref RlpReader reader)
+    {
+        int framesEnd = reader.ReadSequenceLength() + reader.Position;
+        using ArrayPoolListRef<TxFrameReceipt> frameReceipts = new(Eip8141Constants.MaxFrames);
+        while (reader.Position < framesEnd)
+        {
+            int frameEnd = reader.ReadSequenceLength() + reader.Position;
+            byte status = reader.DecodeByte();
+            FrameReceiptGasRlp.DecodeGasUsed(ref reader, out ulong executionGasUsed, out ulong stateGasUsed);
+
+            int logsEnd = reader.ReadSequenceLength() + reader.Position;
+            using ArrayPoolListRef<LogEntry> frameLogs = new(4);
+            while (reader.Position < logsEnd)
+            {
+                frameLogs.Add(TLogCodec.Decode(ref reader, RlpBehaviors.AllowExtraBytes));
+            }
+
+            frameReceipts.Add(new TxFrameReceipt(status, executionGasUsed, stateGasUsed, frameLogs.ToArray()));
+            reader.Check(frameEnd);
+        }
+
+        return frameReceipts.ToArray();
+    }
+
+    public static void Encode<TWriter>(ref TWriter writer, TxFrameReceipt[] frameReceipts)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+    {
+        writer.StartSequence(GetContentLength(frameReceipts));
+        for (int i = 0; i < frameReceipts.Length; i++)
+        {
+            TxFrameReceipt frameReceipt = frameReceipts[i];
+            int gasUsedLength = FrameReceiptGasRlp.GetGasUsedContentLength(frameReceipt.ExecutionGasUsed, frameReceipt.StateGasUsed);
+            int logsLength = GetLogsLength(frameReceipt);
+            writer.StartSequence(GetFrameReceiptContentLength(frameReceipt, gasUsedLength, logsLength));
+            writer.Encode((ulong)frameReceipt.Status);
+            writer.StartSequence(gasUsedLength);
+            writer.Encode(frameReceipt.ExecutionGasUsed);
+            writer.Encode(frameReceipt.StateGasUsed);
+            writer.StartSequence(logsLength);
+            for (int j = 0; j < frameReceipt.Logs.Length; j++)
+            {
+                TLogCodec.Encode(ref writer, frameReceipt.Logs[j]);
+            }
+        }
+    }
+
+    /// <summary>Returns the encoded length of <paramref name="frameReceipts"/>, including the sequence prefix.</summary>
+    public static int GetLength(TxFrameReceipt[] frameReceipts) => Rlp.LengthOfSequence(GetContentLength(frameReceipts));
+
+    private static int GetContentLength(TxFrameReceipt[] frameReceipts)
+    {
+        int framesLength = 0;
+        for (int i = 0; i < frameReceipts.Length; i++)
+        {
+            framesLength += Rlp.LengthOfSequence(GetFrameReceiptContentLength(frameReceipts[i]));
+        }
+
+        return framesLength;
+    }
+
+    private static int GetFrameReceiptContentLength(TxFrameReceipt frameReceipt) =>
+        GetFrameReceiptContentLength(
+            frameReceipt,
+            FrameReceiptGasRlp.GetGasUsedContentLength(frameReceipt.ExecutionGasUsed, frameReceipt.StateGasUsed),
+            GetLogsLength(frameReceipt));
+
+    private static int GetFrameReceiptContentLength(TxFrameReceipt frameReceipt, int gasUsedLength, int logsLength) =>
+        Rlp.LengthOf((ulong)frameReceipt.Status) + Rlp.LengthOfSequence(gasUsedLength) + Rlp.LengthOfSequence(logsLength);
+
+    private static int GetLogsLength(TxFrameReceipt frameReceipt)
+    {
+        int logsLength = 0;
+        for (int i = 0; i < frameReceipt.Logs.Length; i++)
+        {
+            logsLength += TLogCodec.GetLength(frameReceipt.Logs[i]);
+        }
+
+        return logsLength;
+    }
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
-using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using System;
 using System.Collections.Generic;
@@ -101,7 +100,7 @@ namespace Nethermind.Serialization.Rlp
             if (txReceipt.TxType == TxType.FrameTx && decoderContext.Position < receiptEnd)
             {
                 txReceipt.Payer = decoderContext.DecodeAddress();
-                txReceipt.FrameReceipts = DecodeFrameReceipts(ref decoderContext);
+                txReceipt.FrameReceipts = FrameReceiptRlp<StandardLogEntryCodec>.Decode(ref decoderContext);
             }
 
             if (decoderContext.Position < receiptEnd && allowExtraBytes)
@@ -196,76 +195,8 @@ namespace Nethermind.Serialization.Rlp
                 // Repeats the logs the top-level union already holds: DecodeStructRef hands eth_getLogs one
                 // contiguous LogsRlp span, which N per-frame sequences cannot supply.
                 writer.Encode(item.Payer);
-                EncodeFrameReceipts(ref writer, item.FrameReceipts ?? []);
+                FrameReceiptRlp<StandardLogEntryCodec>.Encode(ref writer, item.FrameReceipts ?? []);
             }
-        }
-
-        private static TxFrameReceipt[] DecodeFrameReceipts(ref RlpReader decoderContext)
-        {
-            int framesEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
-            using ArrayPoolListRef<TxFrameReceipt> frameReceipts = new(Eip8141Constants.MaxFrames);
-            while (decoderContext.Position < framesEnd)
-            {
-                int frameEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
-                byte status = decoderContext.DecodeByte();
-                FrameReceiptGasRlp.DecodeGasUsed(ref decoderContext, out ulong executionGasUsed, out ulong stateGasUsed);
-
-                int logsEnd = decoderContext.ReadSequenceLength() + decoderContext.Position;
-                using ArrayPoolListRef<LogEntry> frameLogs = new(4);
-                while (decoderContext.Position < logsEnd)
-                {
-                    frameLogs.Add(LogEntryDecoder.Instance.DecodeGuardNotNull(ref decoderContext, RlpBehaviors.AllowExtraBytes));
-                }
-
-                frameReceipts.Add(new TxFrameReceipt(status, executionGasUsed, stateGasUsed, frameLogs.ToArray()));
-                decoderContext.Check(frameEnd);
-            }
-
-            return frameReceipts.ToArray();
-        }
-
-        private static void EncodeFrameReceipts<TWriter>(ref TWriter writer, TxFrameReceipt[] frameReceipts)
-            where TWriter : struct, IRlpWriteBackend, allows ref struct
-        {
-            int framesLength = 0;
-            for (int i = 0; i < frameReceipts.Length; i++)
-            {
-                framesLength += Rlp.LengthOfSequence(GetFrameReceiptContentLength(frameReceipts[i]));
-            }
-
-            writer.StartSequence(framesLength);
-            for (int i = 0; i < frameReceipts.Length; i++)
-            {
-                TxFrameReceipt frameReceipt = frameReceipts[i];
-                int logsLength = GetFrameLogsLength(frameReceipt);
-                int gasUsedLength = Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed);
-                writer.StartSequence(Rlp.LengthOf((ulong)frameReceipt.Status) + Rlp.LengthOfSequence(gasUsedLength) + Rlp.LengthOfSequence(logsLength));
-                writer.Encode((ulong)frameReceipt.Status);
-                writer.StartSequence(gasUsedLength);
-                writer.Encode(frameReceipt.ExecutionGasUsed);
-                writer.Encode(frameReceipt.StateGasUsed);
-                writer.StartSequence(logsLength);
-                for (int j = 0; j < frameReceipt.Logs.Length; j++)
-                {
-                    LogEntryDecoder.Instance.Encode(ref writer, frameReceipt.Logs[j]);
-                }
-            }
-        }
-
-        private static int GetFrameReceiptContentLength(TxFrameReceipt frameReceipt) =>
-            Rlp.LengthOf((ulong)frameReceipt.Status)
-            + Rlp.LengthOfSequence(Rlp.LengthOf(frameReceipt.ExecutionGasUsed) + Rlp.LengthOf(frameReceipt.StateGasUsed))
-            + Rlp.LengthOfSequence(GetFrameLogsLength(frameReceipt));
-
-        private static int GetFrameLogsLength(TxFrameReceipt frameReceipt)
-        {
-            int logsLength = 0;
-            for (int i = 0; i < frameReceipt.Logs.Length; i++)
-            {
-                logsLength += Rlp.LengthOf(frameReceipt.Logs[i]);
-            }
-
-            return logsLength;
         }
 
         private (int Total, int Logs) GetContentLength(TxReceipt? item, RlpBehaviors rlpBehaviors)
@@ -312,14 +243,7 @@ namespace Nethermind.Serialization.Rlp
             if (item.TxType == TxType.FrameTx)
             {
                 contentLength += Rlp.LengthOf(item.Payer);
-                TxFrameReceipt[] frameReceipts = item.FrameReceipts ?? [];
-                int framesLength = 0;
-                for (int i = 0; i < frameReceipts.Length; i++)
-                {
-                    framesLength += Rlp.LengthOfSequence(GetFrameReceiptContentLength(frameReceipts[i]));
-                }
-
-                contentLength += Rlp.LengthOfSequence(framesLength);
+                contentLength += FrameReceiptRlp<StandardLogEntryCodec>.GetLength(item.FrameReceipts ?? []);
             }
 
             return (contentLength, logsLength);


### PR DESCRIPTION
Addresses https://github.com/NethermindEth/nethermind/pull/12526#discussion_r3958917465 (P3, @benaadams) on #12526.

## Changes

- Add `FrameReceiptRlp<TLogCodec>` (`Nethermind.Serialization.Rlp/FrameReceiptRlp.cs`) holding the single copy of the EIP-8141 frame payload layout — `Decode`, `Encode`, and `GetLength` for the `[[status, [execution_gas_used, state_gas_used], [log, ...]], ...]` sequence a frame-tx receipt carries after the standard storage fields.
- Parameterize it on a `ILogEntryCodec<TSelf>` static-abstract policy, implemented by the empty structs `StandardLogEntryCodec` and `CompactLogEntryCodec`. The log codec was the only material difference between the two copies (three lines: decode, encode, and length of a single log entry). The struct constraint keeps a separate JIT instantiation per storage format, so the log codec calls stay direct as before.
- Drop the duplicated `DecodeFrameReceipts` / `EncodeFrameReceipts` / `GetFrameReceiptContentLength` / `GetFrameLogsLength` from `ReceiptStorageDecoder` and `CompactReceiptStorageDecoder`, and collapse the frames-length loop in both `GetContentLength` methods to one `FrameReceiptRlp<…>.GetLength` call.
- Move the `gas_used` content-length arithmetic next to its decoder as `FrameReceiptGasRlp.GetGasUsedContentLength`, so the one piece of the shared body that does not depend on the log codec is not instantiated per closed type.
- The frame prefix arithmetic now has exactly one expression (`GetFrameReceiptContentLength`), used by both the encode prefix and the length path; previously each file spelled it out twice.

Net: 157 duplicated lines removed, 145-line shared codec added. No wire-format or behaviour change — pure refactoring.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

No new tests: the existing round-trip suites already cover both storage formats through the same
frame payload — `FrameTxReceiptDecoderTests.StorageRoundtrip_PreservesPayerFrameReceiptsAndUnionLogs`
is parameterized `[Values(true, false)] bool compactEncoding`, exercising `ReceiptStorageDecoder`
and `CompactReceiptStorageDecoder` in turn.

`Nethermind.Core.Test` (where the `ReceiptStorageDecoder` / `CompactReceiptStorageDecoder`
round-trip tests live — there is no `Nethermind.Serialization.Rlp.Test` project), before vs. after,
identical in both configurations:

| Config | Base (`eip8141-frame-txs-devnet7`) | This branch |
| --- | --- | --- |
| `-c release` | 6403 total / 6267 passed / 0 failed / 136 skipped | 6403 / 6267 / 0 / 136 |
| `-c release -p:DefineConstants=TRACE;DEBUG` | 6404 total / 6267 passed / 0 failed / 137 skipped | 6404 / 6267 / 0 / 137 |

Also: full `Nethermind.slnx` build under the `code-lint.yml` flags — 0 warnings, 0 errors, 0
`IDE`/`CA` diagnostics; `dotnet format whitespace src/Nethermind/ --folder --verify-no-changes`
clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
