### PR TITLE
chore(deps): update Nethermind.Crypto.SecP256k1 package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -60,7 +60,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.3" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Nethermind.Crypto.Bls" Version="1.1.0" />
-    <PackageVersion Include="Nethermind.Crypto.SecP256k1" Version="1.6.0" />
+    <PackageVersion Include="Nethermind.Crypto.SecP256k1" Version="1.7.0" />
     <PackageVersion Include="Nethermind.Crypto.SecP256r1" Version="1.1.0" />
     <PackageVersion Include="Nethermind.DotNetty.Buffers" Version="1.0.2.76" />
     <PackageVersion Include="Nethermind.DotNetty.Handlers" Version="1.0.2.76" />

--- a/nix/nuget-deps.json
+++ b/nix/nuget-deps.json
@@ -691,8 +691,8 @@
   },
   {
     "pname": "Nethermind.Crypto.SecP256k1",
-    "version": "1.6.0",
-    "hash": "sha256-t0ESYOPFQ2OXhadHENIfXvXsX4GfRIX+N/LrNzjnoyg="
+    "version": "1.7.0",
+    "hash": "sha256-WHAnlQapZkCwo7Z4a9cY3Awkku/6LRZgKDA3JhcQ7j0="
   },
   {
     "pname": "Nethermind.Crypto.SecP256r1",

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -717,12 +717,11 @@
           "FastEnum": "[2.0.7, )",
           "Microsoft.IO.RecyclableMemoryStream": "[3.0.1, )",
           "Microsoft.IdentityModel.JsonWebTokens": "[8.22.0, )",
-          "Nethermind.Crypto.SecP256k1": "[1.6.0, )",
+          "Nethermind.Crypto.SecP256k1": "[1.7.0, )",
           "Nethermind.Logging": "[1.40.0-unstable, )",
           "Nethermind.Numerics.Int256": "[1.7.0, )",
           "Nethermind.Serialization.Ssz": "[1.40.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
-          "System.IO.Hashing": "[10.0.11, )",
           "Testably.Abstractions": "[10.3.0, )"
         }
       },
@@ -1542,9 +1541,9 @@
       },
       "Nethermind.Crypto.SecP256k1": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "KUOJyQ+bGrCgNvmNux4GLXafas7GKq/LK9dNZhWC+PhCwm35wT1CDpI7Q0n7xaSCSiUtiDNeWVRcP1VAoEhTGg=="
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "mF200wb8fOBDHz449QkGUUSsW9wGGfngqObckMYZ9PFuXugdpbaGPN1Udy73mpct/i+1GIHGQLmFkXb131arRw=="
       },
       "Nethermind.Crypto.SecP256r1": {
         "type": "CentralTransitive",
@@ -1817,9 +1816,9 @@
       },
       "Nethermind.Crypto.SecP256k1": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "KUOJyQ+bGrCgNvmNux4GLXafas7GKq/LK9dNZhWC+PhCwm35wT1CDpI7Q0n7xaSCSiUtiDNeWVRcP1VAoEhTGg=="
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "mF200wb8fOBDHz449QkGUUSsW9wGGfngqObckMYZ9PFuXugdpbaGPN1Udy73mpct/i+1GIHGQLmFkXb131arRw=="
       },
       "Nethermind.Crypto.SecP256r1": {
         "type": "CentralTransitive",
@@ -1915,9 +1914,9 @@
       },
       "Nethermind.Crypto.SecP256k1": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "KUOJyQ+bGrCgNvmNux4GLXafas7GKq/LK9dNZhWC+PhCwm35wT1CDpI7Q0n7xaSCSiUtiDNeWVRcP1VAoEhTGg=="
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "mF200wb8fOBDHz449QkGUUSsW9wGGfngqObckMYZ9PFuXugdpbaGPN1Udy73mpct/i+1GIHGQLmFkXb131arRw=="
       },
       "Nethermind.Crypto.SecP256r1": {
         "type": "CentralTransitive",
@@ -2013,9 +2012,9 @@
       },
       "Nethermind.Crypto.SecP256k1": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "KUOJyQ+bGrCgNvmNux4GLXafas7GKq/LK9dNZhWC+PhCwm35wT1CDpI7Q0n7xaSCSiUtiDNeWVRcP1VAoEhTGg=="
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "mF200wb8fOBDHz449QkGUUSsW9wGGfngqObckMYZ9PFuXugdpbaGPN1Udy73mpct/i+1GIHGQLmFkXb131arRw=="
       },
       "Nethermind.Crypto.SecP256r1": {
         "type": "CentralTransitive",
@@ -2111,9 +2110,9 @@
       },
       "Nethermind.Crypto.SecP256k1": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "KUOJyQ+bGrCgNvmNux4GLXafas7GKq/LK9dNZhWC+PhCwm35wT1CDpI7Q0n7xaSCSiUtiDNeWVRcP1VAoEhTGg=="
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "mF200wb8fOBDHz449QkGUUSsW9wGGfngqObckMYZ9PFuXugdpbaGPN1Udy73mpct/i+1GIHGQLmFkXb131arRw=="
       },
       "Nethermind.Crypto.SecP256r1": {
         "type": "CentralTransitive",
@@ -2209,9 +2208,9 @@
       },
       "Nethermind.Crypto.SecP256k1": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "KUOJyQ+bGrCgNvmNux4GLXafas7GKq/LK9dNZhWC+PhCwm35wT1CDpI7Q0n7xaSCSiUtiDNeWVRcP1VAoEhTGg=="
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "mF200wb8fOBDHz449QkGUUSsW9wGGfngqObckMYZ9PFuXugdpbaGPN1Udy73mpct/i+1GIHGQLmFkXb131arRw=="
       },
       "Nethermind.Crypto.SecP256r1": {
         "type": "CentralTransitive",


### PR DESCRIPTION
## Changes

Updated libsecp256k1 to [v0.8.0](https://github.com/bitcoin-core/secp256k1/releases/tag/v0.8.0) with some potential performance improvements.

## Types of changes

#### What types of changes does your code introduce?

- [x] Other: Package update

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Needs manual testing
