### PR TITLE
refactor(rpc): decompose JsonRpcProcessor into decoder, batch source and diagnostics

### DIFF
--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -783,22 +783,22 @@ public class JsonRpcProcessorTests
     }
 
     /// <remarks>
-    /// <paramref name="endpoint"/> picks the batch item source the limit is enforced from: an HTTP body arrives as
-    /// one complete document and takes the raw-bytes path, a WS body goes through the incremental parser and the
-    /// parsed-document path.
+    /// <paramref name="transport"/> picks the entry point, and with it the batch item source the limit is enforced
+    /// from: an HTTP body arrives as one complete document and takes the raw-bytes path - over the
+    /// <see cref="ReadOnlyMemory{T}"/> overload production HTTP calls as well as over a pipe - while a WS body goes
+    /// through the incremental parser and the parsed-document path.
     /// </remarks>
     [Test]
     public async Task Batch_size_limit_respects_authentication(
         [Values] bool isAuthenticated,
-        [Values(RpcEndpoint.Http, RpcEndpoint.Ws)] RpcEndpoint endpoint)
+        [Values] RequestTransport transport)
     {
         IJsonRpcService service = CreateEchoService();
         JsonRpcProcessor processor = CreateProcessor(service, new JsonRpcConfig { MaxBatchSize = 1 });
-        using JsonRpcContext context = isAuthenticated
-            ? new JsonRpcContext(endpoint, url: new JsonRpcUrl(string.Empty, string.Empty, 0, endpoint, true, []))
-            : new JsonRpcContext(endpoint);
+        using JsonRpcContext context = CreateContext(transport, isAuthenticated);
 
-        using CollectedJsonRpcResponses result = await ProcessAsync(processor, CreateTransactionCountBatchRequest(2), context);
+        using CollectedJsonRpcResponses result = await ProcessAsync(
+            processor, Encoding.UTF8.GetBytes(CreateTransactionCountBatchRequest(2)), transport, context: context);
 
         CollectedJsonRpcResult response = AssertOnlyResult(result);
         if (!isAuthenticated)
@@ -1035,21 +1035,140 @@ public class JsonRpcProcessorTests
         Assert.That(thrown, Is.SameAs(expected), "the server fault must surface, not be reframed as a client parse error");
     }
 
+    /// <summary>The endpoint a transport arrives on, optionally on an authenticated URL.</summary>
+    private static JsonRpcContext CreateContext(RequestTransport transport, bool isAuthenticated = false)
+    {
+        RpcEndpoint endpoint = transport == RequestTransport.WsPipe ? RpcEndpoint.Ws : RpcEndpoint.Http;
+        return isAuthenticated
+            ? new JsonRpcContext(endpoint, url: new JsonRpcUrl(string.Empty, string.Empty, 0, endpoint, true, []))
+            : new JsonRpcContext(endpoint);
+    }
+
+    /// <remarks>
+    /// The input mode is pinned per transport rather than derived from the context's endpoint, so an arm cannot
+    /// silently change which entry point and which batch item source it exercises.
+    /// </remarks>
     private static async ValueTask<CollectedJsonRpcResponses> ProcessAsync(
         JsonRpcProcessor processor,
         byte[] request,
         RequestTransport transport,
-        CollectingJsonRpcResponseSink? sink = null)
+        CollectingJsonRpcResponseSink? sink = null,
+        JsonRpcContext? context = null)
     {
+        sink ??= new CollectingJsonRpcResponseSink();
+        context ??= CreateContext(transport);
+        JsonRpcProcessingOptions options = new(transport == RequestTransport.WsPipe
+            ? JsonRpcInputMode.MultipleDocuments
+            : JsonRpcInputMode.SingleDocument);
+
         if (transport == RequestTransport.HttpMemory)
         {
-            sink ??= new CollectingJsonRpcResponseSink();
-            await processor.ProcessAsync(request.AsMemory(), CreateHttpContext(), sink, new JsonRpcProcessingOptions(JsonRpcInputMode.SingleDocument));
-            return sink.Responses;
+            await processor.ProcessAsync(request.AsMemory(), context, sink, options);
+        }
+        else
+        {
+            await processor.ProcessAsync(PipeReader.Create(new ReadOnlySequence<byte>(request)), context, sink, options);
         }
 
-        JsonRpcContext context = transport == RequestTransport.HttpPipe ? CreateHttpContext() : new JsonRpcContext(RpcEndpoint.Ws);
-        return await ProcessAsync(processor, PipeReader.Create(new ReadOnlySequence<byte>(request)), context, sink);
+        return sink.Responses;
+    }
+
+    /// <remarks>
+    /// A single-document body ends at its root value, so anything but whitespace after it is a framing error and not a
+    /// second request - the body is answered with one parse error and none of it is dispatched.
+    /// </remarks>
+    [Test]
+    public async Task Trailing_data_after_a_single_document_request_is_a_parse_error(
+        [Values(RequestTransport.HttpMemory, RequestTransport.HttpPipe)] RequestTransport transport)
+    {
+        bool dispatched = false;
+        IJsonRpcService service = CreateService(request =>
+        {
+            dispatched = true;
+            return new JsonRpcSuccessResponse { Id = request.Id };
+        });
+        JsonRpcProcessor processor = CreateProcessor(service);
+
+        using CollectedJsonRpcResponses result = await ProcessAsync(
+            processor, Encoding.UTF8.GetBytes(CreateRequest("1", "eth_blockNumber") + " garbage"), transport);
+
+        JsonRpcResponse response = AssertSingleResponse(result).Response!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(response, Is.TypeOf<JsonRpcErrorResponse>());
+            Assert.That(((JsonRpcErrorResponse)response).Error!.Code, Is.EqualTo(ErrorCodes.ParseError));
+            Assert.That(dispatched, Is.False, "a body that is not one document must not be dispatched");
+        }
+    }
+
+    /// <remarks>
+    /// The complete-body fast path reports its buffer consumed on the way out of a throwing dispatch as well: the read
+    /// loop ends either way, and reporting examined-only would ask a reader with nothing left to give for another read.
+    /// </remarks>
+    [Test]
+    public void Complete_body_is_reported_consumed_when_dispatch_throws()
+    {
+        Exception expected = new InvalidOperationException("module went away");
+        IJsonRpcService service = CreateService(_ => throw expected);
+        JsonRpcProcessor processor = CreateProcessor(service);
+        AdvanceRecordingPipeReader reader = new("""{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}"""u8.ToArray());
+
+        Exception? thrown = Assert.CatchAsync(async () =>
+        {
+            using CollectedJsonRpcResponses ignored = await ProcessAsync(processor, reader, CreateHttpContext());
+        });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(thrown, Is.SameAs(expected));
+            Assert.That(reader.ConsumedLength, Is.EqualTo(reader.ReadLength), "the dispatched body must be reported consumed");
+        }
+    }
+
+    /// <summary>Records how much of the last read buffer the processor reported consumed.</summary>
+    private sealed class AdvanceRecordingPipeReader(byte[] body) : PipeReader
+    {
+        private readonly PipeReader _inner = Create(new ReadOnlySequence<byte>(body));
+        private ReadOnlySequence<byte> _lastRead;
+
+        public long ReadLength { get; private set; }
+
+        public long? ConsumedLength { get; private set; }
+
+        public override void AdvanceTo(SequencePosition consumed) => AdvanceTo(consumed, consumed);
+
+        public override void AdvanceTo(SequencePosition consumed, SequencePosition examined)
+        {
+            ConsumedLength = _lastRead.Slice(_lastRead.Start, consumed).Length;
+            _inner.AdvanceTo(consumed, examined);
+        }
+
+        public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default) =>
+            Record(await _inner.ReadAsync(cancellationToken));
+
+        public override bool TryRead(out ReadResult result)
+        {
+            bool read = _inner.TryRead(out result);
+            if (read)
+            {
+                Record(result);
+            }
+
+            return read;
+        }
+
+        public override void CancelPendingRead() => _inner.CancelPendingRead();
+
+        public override void Complete(Exception? exception = null) => _inner.Complete(exception);
+
+        public override ValueTask CompleteAsync(Exception? exception = null) => _inner.CompleteAsync(exception);
+
+        private ReadResult Record(ReadResult result)
+        {
+            _lastRead = result.Buffer;
+            ReadLength = result.Buffer.Length;
+            return result;
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/JsonRpcProcessorTests.cs
@@ -782,15 +782,21 @@ public class JsonRpcProcessorTests
         }
     }
 
-    [TestCase(false, 0, TestName = "Unauthenticated batch over limit is rejected")]
-    [TestCase(true, 2, TestName = "Authenticated batch over limit is processed")]
-    public async Task Batch_size_limit_respects_authentication(bool isAuthenticated, int expectedDispatchCount)
+    /// <remarks>
+    /// <paramref name="endpoint"/> picks the batch item source the limit is enforced from: an HTTP body arrives as
+    /// one complete document and takes the raw-bytes path, a WS body goes through the incremental parser and the
+    /// parsed-document path.
+    /// </remarks>
+    [Test]
+    public async Task Batch_size_limit_respects_authentication(
+        [Values] bool isAuthenticated,
+        [Values(RpcEndpoint.Http, RpcEndpoint.Ws)] RpcEndpoint endpoint)
     {
         IJsonRpcService service = CreateEchoService();
         JsonRpcProcessor processor = CreateProcessor(service, new JsonRpcConfig { MaxBatchSize = 1 });
         using JsonRpcContext context = isAuthenticated
-            ? new JsonRpcContext(RpcEndpoint.Http, url: new JsonRpcUrl(string.Empty, string.Empty, 0, RpcEndpoint.Http, true, []))
-            : CreateHttpContext();
+            ? new JsonRpcContext(endpoint, url: new JsonRpcUrl(string.Empty, string.Empty, 0, endpoint, true, []))
+            : new JsonRpcContext(endpoint);
 
         using CollectedJsonRpcResponses result = await ProcessAsync(processor, CreateTransactionCountBatchRequest(2), context);
 
@@ -807,10 +813,10 @@ public class JsonRpcProcessorTests
 
         Assert.That(response.Response, Is.Null);
         List<JsonRpcResponse> batchItems = response.BatchItems!;
-        Assert.That(batchItems, Has.Count.EqualTo(expectedDispatchCount));
+        Assert.That(batchItems, Has.Count.EqualTo(2));
         Assert.That(batchItems[0].Id, Is.EqualTo(new JsonRpcId(67)));
         Assert.That(batchItems[1].Id, Is.EqualTo(new JsonRpcId(67)));
-        await service.Received(expectedDispatchCount).SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<JsonRpcContext>());
+        await service.Received(2).SendRequestAsync(Arg.Any<JsonRpcRequest>(), Arg.Any<JsonRpcContext>());
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcBatchItemSource.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcBatchItemSource.cs
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Text.Json;
+
+namespace Nethermind.JsonRpc;
+
+/// <summary>Enumerates and decodes the items of a JSON-RPC batch, hiding whether it arrived as bytes or as a parsed document.</summary>
+/// <remarks>
+/// Implementations are mutable structs and are used through a <c>struct</c>-constrained type parameter, so the
+/// shared batch loop dispatches without boxing and iterates one instance in place.
+/// </remarks>
+internal interface IJsonRpcBatchItemSource
+{
+    /// <summary>The item count if the source already knows it, otherwise <c>null</c> - see <see cref="ScanCount"/>.</summary>
+    int? KnownCount { get; }
+
+    /// <summary>Counts the items by scanning the batch. Only worth calling when <see cref="KnownCount"/> is <c>null</c> and the count is actually needed.</summary>
+    int ScanCount();
+
+    /// <summary>Advances to the next batch item and decodes it.</summary>
+    /// <param name="request">The decoded request, or <c>null</c> when the item is not a usable JSON-RPC request object.</param>
+    /// <param name="ownedDocument">A document whose lifetime the caller must extend to the end of the batch, or <c>null</c>.</param>
+    /// <param name="decodeException">Why the item could not be decoded, when that is the reason <paramref name="request"/> is <c>null</c>.</param>
+    /// <returns><c>false</c> once the batch is exhausted. An undecodable item still returns <c>true</c>, so the loop can answer it with -32600.</returns>
+    bool TryGetNext(out JsonRpcRequest? request, out JsonDocument? ownedDocument, out Exception? decodeException);
+}
+
+/// <summary>Batch items taken from an already-parsed JSON array.</summary>
+/// <remarks>
+/// <c>params</c> comes back as a <see cref="JsonElement"/> into the enclosing document, which the caller disposes,
+/// so this source never hands out an owned document and never leaves raw params behind.
+/// </remarks>
+internal struct DocumentBatchItemSource(JsonElement rootElement) : IJsonRpcBatchItemSource
+{
+    private readonly int _count = rootElement.GetArrayLength();
+    private JsonElement.ArrayEnumerator _items = rootElement.EnumerateArray();
+
+    public readonly int? KnownCount => _count;
+
+    public readonly int ScanCount() => _count;
+
+    public bool TryGetNext(out JsonRpcRequest? request, out JsonDocument? ownedDocument, out Exception? decodeException)
+    {
+        request = null;
+        ownedDocument = null;
+        decodeException = null;
+
+        if (!_items.MoveNext())
+        {
+            return false;
+        }
+
+        JsonElement item = _items.Current;
+        if (item.ValueKind != JsonValueKind.Object)
+        {
+            return true;
+        }
+
+        try
+        {
+            request = JsonRpcRequestDecoder.CreateRequest(item);
+        }
+        catch (Exception ex) when (JsonRpcRequestDecoder.IsRequestDecodingException(ex))
+        {
+            decodeException = ex;
+        }
+
+        return true;
+    }
+}
+
+/// <summary>Batch items sliced straight out of the request bytes, without parsing the array into a document first.</summary>
+internal struct MemoryBatchItemSource(ReadOnlyMemory<byte> batchBody) : IJsonRpcBatchItemSource
+{
+    private readonly ReadOnlyMemory<byte> _batchBody = batchBody;
+    private JsonReaderState _readerState;
+    private int _offset;
+    private bool _started;
+
+    /// <remarks>Null because counting means a second pass over the body; the caller decides whether that is worth it.</remarks>
+    public readonly int? KnownCount => null;
+
+    public readonly int ScanCount() => JsonRpcArrayReader.CountItems(_batchBody);
+
+    public bool TryGetNext(out JsonRpcRequest? request, out JsonDocument? ownedDocument, out Exception? decodeException)
+    {
+        request = null;
+        ownedDocument = null;
+        decodeException = null;
+
+        if (!JsonRpcArrayReader.TryReadNextItem(_batchBody, ref _offset, ref _readerState, ref _started, out ReadOnlyMemory<byte> itemBody))
+        {
+            return false;
+        }
+
+        JsonDocument? requestDocument = null;
+        try
+        {
+            if (JsonRpcRequestDecoder.TryReadObjectRequest(itemBody, out JsonRpcRequest? directRequest))
+            {
+                request = directRequest;
+                return true;
+            }
+
+            // The envelope reader refused it, so fall back to a full parse - the item may still be a valid object
+            // that only the general parser accepts.
+            requestDocument = JsonDocument.Parse(itemBody);
+            if (requestDocument.RootElement.ValueKind == JsonValueKind.Object)
+            {
+                request = JsonRpcRequestDecoder.CreateRequest(requestDocument.RootElement);
+                ownedDocument = requestDocument;
+                requestDocument = null;
+                return true;
+            }
+        }
+        catch (Exception ex) when (JsonRpcRequestDecoder.IsRequestDecodingException(ex))
+        {
+            decodeException = ex;
+        }
+        finally
+        {
+            // Non-null only when ownership was not handed over: a non-object root, or a throw part-way through.
+            requestDocument?.Dispose();
+        }
+
+        return true;
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcDiagnostics.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcDiagnostics.cs
@@ -24,7 +24,7 @@ namespace Nethermind.JsonRpc;
 /// <remarks>
 /// Every member is a no-op or a pass-through unless the corresponding diagnostic is switched on, so callers may
 /// invoke them unconditionally on the hot path. The recorder exists only for some values of
-/// <see cref="IJsonRpcConfig.RpcRecorderState"/>, so both <c>IsRecording</c> predicates test for it rather than
+/// <see cref="IJsonRpcConfig.RpcRecorderState"/>, so the <c>IsRecording</c> predicates test for it rather than
 /// inferring it from the flags.
 /// </remarks>
 internal sealed class JsonRpcDiagnostics
@@ -48,7 +48,7 @@ internal sealed class JsonRpcDiagnostics
         }
     }
 
-    public bool IsRecordingRequest => _recorder is not null && (_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Request) != 0;
+    private bool IsRecordingRequest => _recorder is not null && (_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Request) != 0;
 
     private bool IsRecordingResponse => _recorder is not null && (_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Response) != 0;
 
@@ -58,14 +58,32 @@ internal sealed class JsonRpcDiagnostics
     public JsonRpcResult.Entry RecordResponse(in JsonRpcResult.Entry result) =>
         !IsRecordingResponse ? result : RecordResponseSlow(result);
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public void RecordRequest(ReadOnlyMemory<byte> requestBody) =>
-        _recorder!.RecordRequest(Encoding.UTF8.GetString(requestBody.Span));
+    public void RecordRequest(ReadOnlyMemory<byte> requestBody)
+    {
+        if (IsRecordingRequest) RecordRequestSlow(requestBody);
+    }
 
     /// <summary>Records the whole request body, returning a reader positioned back at its start.</summary>
-    /// <remarks>The original reader is drained, so the caller must continue with the returned one.</remarks>
+    /// <remarks>The original reader is drained when recording is on, so the caller must continue with the returned one.</remarks>
+    public ValueTask<PipeReader> RecordRequest(PipeReader reader) =>
+        IsRecordingRequest ? RecordRequestSlow(reader) : new(reader);
+
+    public void TraceResult(in JsonRpcResult.Entry response)
+    {
+        if (_logger.IsTrace) TraceResultSlow(response);
+    }
+
+    public void TraceResult(JsonRpcErrorResponse response)
+    {
+        if (_logger.IsTrace) TraceResultSlow(response);
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public async ValueTask<PipeReader> RecordRequest(PipeReader reader)
+    private void RecordRequestSlow(ReadOnlyMemory<byte> requestBody) =>
+        _recorder!.RecordRequest(Encoding.UTF8.GetString(requestBody.Span));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private async ValueTask<PipeReader> RecordRequestSlow(PipeReader reader)
     {
         Stream memoryStream = RecyclableStream.GetStream("recorder");
         await reader.CopyToAsync(memoryStream);
@@ -81,11 +99,11 @@ internal sealed class JsonRpcDiagnostics
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void TraceResult(in JsonRpcResult.Entry response) =>
+    private void TraceResultSlow(in JsonRpcResult.Entry response) =>
         _logger.Trace($"Sending JSON RPC response: {SerializeForDiagnostics(response)}");
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public void TraceResult(JsonRpcErrorResponse response) =>
+    private void TraceResultSlow(JsonRpcErrorResponse response) =>
         _logger.Trace($"Sending JSON RPC response: {SerializeResponseForDiagnostics(response)}");
 
     public static string SerializeResponseForDiagnostics(JsonRpcResponse response)

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcDiagnostics.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcDiagnostics.cs
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Pipelines;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Resettables;
+using Nethermind.Logging;
+using Nethermind.Serialization.Json;
+
+namespace Nethermind.JsonRpc;
+
+/// <summary>
+/// The optional recording and tracing side of request processing: the <c>RpcRecorder</c> files and the Trace-level
+/// response dumps.
+/// </summary>
+/// <remarks>
+/// Every member is a no-op or a pass-through unless the corresponding diagnostic is switched on, so callers can
+/// invoke them unconditionally on the hot path. Split out of <c>JsonRpcProcessor</c> because none of it participates
+/// in parsing or dispatch, and because it is the only reason the processor had to own a recorder that exists for
+/// some values of <see cref="IJsonRpcConfig.RpcRecorderState"/> and not others.
+/// </remarks>
+internal sealed class JsonRpcDiagnostics
+{
+    private static readonly StreamPipeReaderOptions PipeReaderOptions = new(leaveOpen: false);
+
+    private readonly IJsonRpcConfig _jsonRpcConfig;
+    private readonly ILogger _logger;
+    private readonly Recorder? _recorder;
+
+    public JsonRpcDiagnostics(IJsonRpcConfig jsonRpcConfig, IFileSystem fileSystem, ILogger logger)
+    {
+        _jsonRpcConfig = jsonRpcConfig;
+        _logger = logger;
+
+        if (jsonRpcConfig.RpcRecorderState != RpcRecorderState.None)
+        {
+            if (_logger.IsWarn) _logger.Warn("Enabling JSON RPC diagnostics recorder - this will affect performance and should be only used in a diagnostics mode.");
+            string recorderBaseFilePath = jsonRpcConfig.RpcRecorderBaseFilePath.GetApplicationResourcePath();
+            _recorder = new Recorder(recorderBaseFilePath, fileSystem, _logger);
+        }
+    }
+
+    public bool IsRecordingRequest => _recorder is not null && (_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Request) != 0;
+
+    private bool IsRecordingResponse => _recorder is not null && (_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Response) != 0;
+
+    public JsonRpcResult.Entry RecordResponse(JsonRpcResponse response, in RpcReport report) =>
+        RecordResponse(new JsonRpcResult.Entry(response, report));
+
+    public JsonRpcResult.Entry RecordResponse(in JsonRpcResult.Entry result) =>
+        !IsRecordingResponse ? result : RecordResponseSlow(result);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public void RecordRequest(ReadOnlyMemory<byte> requestBody) =>
+        _recorder!.RecordRequest(Encoding.UTF8.GetString(requestBody.Span));
+
+    /// <summary>Records the whole request body, returning a reader positioned back at its start.</summary>
+    /// <remarks>The original reader is drained, so the caller must continue with the returned one.</remarks>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public async ValueTask<PipeReader> RecordRequest(PipeReader reader)
+    {
+        Stream memoryStream = RecyclableStream.GetStream("recorder");
+        await reader.CopyToAsync(memoryStream);
+        memoryStream.Seek(0, SeekOrigin.Begin);
+
+        StreamReader streamReader = new(memoryStream);
+
+        string requestString = await streamReader.ReadToEndAsync();
+        _recorder!.RecordRequest(requestString);
+
+        memoryStream.Seek(0, SeekOrigin.Begin);
+        return PipeReader.Create(memoryStream, PipeReaderOptions);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public void TraceResult(in JsonRpcResult.Entry response) =>
+        _logger.Trace($"Sending JSON RPC response: {SerializeForDiagnostics(response)}");
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public void TraceResult(JsonRpcErrorResponse response) =>
+        _logger.Trace($"Sending JSON RPC response: {SerializeResponseForDiagnostics(response)}");
+
+    public static string SerializeResponseForDiagnostics(JsonRpcResponse response)
+    {
+        ArrayBufferWriter<byte> writer = new();
+        JsonRpcResponseWriter.Write(writer, response, EthereumJsonSerializer.JsonOptionsIndented);
+        return Encoding.UTF8.GetString(writer.WrittenSpan);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private JsonRpcResult.Entry RecordResponseSlow(in JsonRpcResult.Entry result)
+    {
+        _recorder!.RecordResponse(SerializeForDiagnostics(result));
+        return result;
+    }
+
+    private static string SerializeForDiagnostics(in JsonRpcResult.Entry response)
+    {
+        JsonRpcResponse responseToSerialize = TryGetDiagnosticResponse(response.Response, out JsonRpcResponse? diagnosticResponse)
+            ? diagnosticResponse
+            : response.Response;
+
+        ArrayBufferWriter<byte> writer = new();
+        JsonRpcResponseWriter.Write(writer, responseToSerialize, EthereumJsonSerializer.JsonOptionsIndented);
+        using JsonDocument document = JsonDocument.Parse(writer.WrittenMemory);
+        return JsonSerializer.Serialize(new DiagnosticJsonRpcResult(document.RootElement, response.Report), EthereumJsonSerializer.JsonOptionsIndented);
+    }
+
+    /// <summary>Replaces a streamed result with a placeholder, since diagnostics must not consume the stream.</summary>
+    private static bool TryGetDiagnosticResponse(JsonRpcResponse response, [NotNullWhen(true)] out JsonRpcResponse? diagnosticResponse)
+    {
+        diagnosticResponse = response switch
+        {
+            _ when response.TryGetStreamableResult(out _) => new JsonRpcSuccessResponse
+            {
+                Id = response.Id,
+                Result = "# streamable response omitted #"
+            },
+            JsonRpcErrorResponse { Error.Data: IStreamableResult } errorResponse => new JsonRpcErrorResponse
+            {
+                Id = errorResponse.Id,
+                Error = new Error
+                {
+                    Code = errorResponse.Error.Code,
+                    Message = errorResponse.Error.Message,
+                    Data = "# streamable error data omitted #",
+                    SuppressWarning = errorResponse.Error.SuppressWarning
+                }
+            },
+            _ => null
+        };
+
+        return diagnosticResponse is not null;
+    }
+
+    private readonly record struct DiagnosticJsonRpcResult(JsonElement Response, RpcReport Report);
+}

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcDiagnostics.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcDiagnostics.cs
@@ -11,7 +11,6 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Nethermind.Core.Extensions;
 using Nethermind.Core.Resettables;
 using Nethermind.Logging;
 using Nethermind.Serialization.Json;
@@ -23,10 +22,10 @@ namespace Nethermind.JsonRpc;
 /// response dumps.
 /// </summary>
 /// <remarks>
-/// Every member is a no-op or a pass-through unless the corresponding diagnostic is switched on, so callers can
-/// invoke them unconditionally on the hot path. Split out of <c>JsonRpcProcessor</c> because none of it participates
-/// in parsing or dispatch, and because it is the only reason the processor had to own a recorder that exists for
-/// some values of <see cref="IJsonRpcConfig.RpcRecorderState"/> and not others.
+/// Every member is a no-op or a pass-through unless the corresponding diagnostic is switched on, so callers may
+/// invoke them unconditionally on the hot path. The recorder exists only for some values of
+/// <see cref="IJsonRpcConfig.RpcRecorderState"/>, so both <c>IsRecording</c> predicates test for it rather than
+/// inferring it from the flags.
 /// </remarks>
 internal sealed class JsonRpcDiagnostics
 {

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcDiagnostics.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcDiagnostics.cs
@@ -78,6 +78,11 @@ internal sealed class JsonRpcDiagnostics
         if (_logger.IsTrace) TraceResultSlow(response);
     }
 
+    public void TraceRequestError(JsonRpcRequest request, JsonRpcResponse response)
+    {
+        if (_logger.IsTrace) TraceRequestErrorSlow(request, response);
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void RecordRequestSlow(ReadOnlyMemory<byte> requestBody) =>
         _recorder!.RecordRequest(Encoding.UTF8.GetString(requestBody.Span));
@@ -106,7 +111,11 @@ internal sealed class JsonRpcDiagnostics
     private void TraceResultSlow(JsonRpcErrorResponse response) =>
         _logger.Trace($"Sending JSON RPC response: {SerializeResponseForDiagnostics(response)}");
 
-    public static string SerializeResponseForDiagnostics(JsonRpcResponse response)
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void TraceRequestErrorSlow(JsonRpcRequest request, JsonRpcResponse response) =>
+        _logger.Trace($"Error when handling {request} | {SerializeResponseForDiagnostics(response)}");
+
+    private static string SerializeResponseForDiagnostics(JsonRpcResponse response)
     {
         ArrayBufferWriter<byte> writer = new();
         JsonRpcResponseWriter.Write(writer, response, EthereumJsonSerializer.JsonOptionsIndented);

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
+﻿// SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
@@ -110,10 +110,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                 return;
             }
 
-            if (_diagnostics.IsRecordingRequest)
-            {
-                _diagnostics.RecordRequest(requestBody);
-            }
+            _diagnostics.RecordRequest(requestBody);
 
             await ProcessSingleDocumentMemoryToSink(requestBody, context, sink, options, cancellationToken);
         }
@@ -143,7 +140,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                 return;
             }
 
-            if (recordRequest && _diagnostics.IsRecordingRequest)
+            if (recordRequest)
             {
                 reader = await _diagnostics.RecordRequest(reader);
             }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -226,8 +226,9 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                             }
                             catch
                             {
-                                // Only dispatch throws out of that call - its decode steps are guarded - and a
-                                // dispatched body is spent, so report it consumed as a normal return would.
+                                // Whatever throws out of that call - a dispatch or a sink write - ends the read
+                                // loop, and this branch already knows the buffer holds the whole body, so report
+                                // it consumed as a normal return would.
                                 advance.Consumed(in buffer);
                                 throw;
                             }
@@ -783,7 +784,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
 
         JsonRpcErrorResponse response = _jsonRpcService.GetErrorResponse(ErrorCodes.ParseError, "parse error");
-        if (_logger.IsTrace) _diagnostics.TraceResult(response);
+        _diagnostics.TraceResult(response);
         return _diagnostics.RecordResponse(response, new RpcReport("# parsing error #", (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, false));
     }
 
@@ -852,7 +853,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                     if (_logger.IsWarn) _logger.Warn(DescribeErrorResponse(request, responseError));
                 }
 
-                if (_logger.IsTrace) _logger.Trace($"Error when handling {request} | {JsonRpcDiagnostics.SerializeResponseForDiagnostics(response)}");
+                _diagnostics.TraceRequestError(request, response);
             }
             Metrics.JsonRpcErrors++;
         }
@@ -864,7 +865,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
             response,
             new RpcReport(reportMethod, (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, isSuccess));
 
-        if (_logger.IsTrace) _diagnostics.TraceResult(result);
+        _diagnostics.TraceResult(result);
         return result;
     }
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -22,10 +22,10 @@ namespace Nethermind.JsonRpc;
 
 /// <summary>Reads JSON-RPC requests off a transport and writes the responses to a sink.</summary>
 /// <remarks>
-/// What is left here is the transport-facing state machine: the pipe read loop, the complete-body fast path, batch
-/// iteration and per-request dispatch classification. Decoding bytes into requests lives in
-/// <see cref="JsonRpcRequestDecoder"/>, batch enumeration behind <see cref="IJsonRpcBatchItemSource"/>, and
-/// recording and tracing in <see cref="JsonRpcDiagnostics"/>.
+/// Owns the transport-facing state machine only: the pipe read loop, the complete-body fast path, batch iteration
+/// and per-request dispatch classification. Decoding bytes into requests belongs to
+/// <see cref="JsonRpcRequestDecoder"/>, batch enumeration to <see cref="IJsonRpcBatchItemSource"/>, and recording
+/// and tracing to <see cref="JsonRpcDiagnostics"/>.
 /// </remarks>
 public sealed class JsonRpcProcessor : IJsonRpcProcessor
 {
@@ -407,10 +407,10 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
     /// <see cref="JsonRpcRequestDecoder.IsRequestDecodingException"/>); dispatching a decoded request happens outside
     /// it, so a node fault surfacing as an <see cref="InvalidOperationException"/> is not answered as a parse error.
     /// <para>
-    /// The <see cref="JsonException"/> catch around the batch run is wider than a decode. That is pre-existing and
-    /// left alone here: a serialization failure part-way through a batch is still answered -32700, after the array
-    /// has already been closed. Narrowing it turns a malformed 200 into a 500, so it wants its own change rather
-    /// than riding along with a refactor.
+    /// The <see cref="JsonException"/> catch around the batch run is knowingly wider than a decode: a serialization
+    /// failure part-way through a batch is answered -32700, which the sink appends after
+    /// <c>EndBatchAsync</c> has already closed the array. Narrowing it to the envelope decode would turn that
+    /// malformed 200 into a 500, so the scope is a client-visible contract and not to be changed incidentally.
     /// </para>
     /// </remarks>
     private async ValueTask<(CompleteBodyOutcome Outcome, JsonRpcResult.Entry? Entry)> TryProcessCompleteBodyAsync(
@@ -546,10 +546,10 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
 
     /// <summary>Runs one JSON-RPC batch: size limit, then decode-dispatch-write per item, then close the array.</summary>
     /// <remarks>
-    /// One loop for both transports. The raw-bytes and parsed-document paths differ only in how items are
-    /// enumerated, which <typeparamref name="TSource"/> supplies - constrained to <c>struct</c>, so this dispatches
-    /// without boxing and JITs once per source. They used to be two copies of this algorithm, which is why the
-    /// response-body-limit bug had to be fixed twice and why the two drifted on their Trace numbering.
+    /// One loop for both transports: the raw-bytes and parsed-document paths differ only in how items are
+    /// enumerated, which <typeparamref name="TSource"/> supplies. Constrained to <c>struct</c> so the calls into it
+    /// do not box and it JITs once per source; that also means <paramref name="source"/> is iterated in place, so
+    /// its cursor must be mutable state on the struct rather than a copy.
     /// </remarks>
     private async ValueTask RunBatchAsync<TSource>(
         TSource source,

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -5,8 +5,6 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.IO.Abstractions;
 using System.IO.Pipelines;
 using System.Runtime.CompilerServices;
@@ -18,20 +16,23 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Http;
 using Nethermind.Config;
 using Nethermind.Core.Extensions;
-using Nethermind.Core.Resettables;
 using Nethermind.Logging;
-using Nethermind.Serialization.Json;
 
 namespace Nethermind.JsonRpc;
 
+/// <summary>Reads JSON-RPC requests off a transport and writes the responses to a sink.</summary>
+/// <remarks>
+/// What is left here is the transport-facing state machine: the pipe read loop, the complete-body fast path, batch
+/// iteration and per-request dispatch classification. Decoding bytes into requests lives in
+/// <see cref="JsonRpcRequestDecoder"/>, batch enumeration behind <see cref="IJsonRpcBatchItemSource"/>, and
+/// recording and tracing in <see cref="JsonRpcDiagnostics"/>.
+/// </remarks>
 public sealed class JsonRpcProcessor : IJsonRpcProcessor
 {
-    private static readonly SearchValues<byte> JsonWhitespace = SearchValues.Create(" \t\r\n"u8);
-
     private readonly IJsonRpcConfig _jsonRpcConfig;
     private readonly ILogger _logger;
     private readonly IJsonRpcService _jsonRpcService;
-    private readonly Recorder _recorder;
+    private readonly JsonRpcDiagnostics _diagnostics;
     private readonly IProcessExitSource? _processExitSource;
 
     public JsonRpcProcessor(IJsonRpcService jsonRpcService, IJsonRpcConfig jsonRpcConfig, IFileSystem fileSystem, ILogManager logManager, IProcessExitSource? processExitSource = null)
@@ -43,18 +44,10 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         _jsonRpcConfig = jsonRpcConfig ?? throw new ArgumentNullException(nameof(jsonRpcConfig));
 
         _processExitSource = processExitSource;
-
-        if (_jsonRpcConfig.RpcRecorderState != RpcRecorderState.None)
-        {
-            if (_logger.IsWarn) _logger.Warn("Enabling JSON RPC diagnostics recorder - this will affect performance and should be only used in a diagnostics mode.");
-            string recorderBaseFilePath = _jsonRpcConfig.RpcRecorderBaseFilePath.GetApplicationResourcePath();
-            _recorder = new Recorder(recorderBaseFilePath, fileSystem, _logger);
-        }
+        _diagnostics = new JsonRpcDiagnostics(_jsonRpcConfig, fileSystem, _logger);
     }
 
     public CancellationToken ProcessExit => _processExitSource?.Token ?? default;
-
-    private static readonly JsonReaderOptions _socketJsonReaderOptions = new() { AllowMultipleValues = true };
 
     public ValueTask ProcessAsync(
         PipeReader reader,
@@ -63,12 +56,9 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         JsonRpcProcessingOptions options,
         CancellationToken cancellationToken = default)
     {
-        JsonRpcContext.Current.Value = context;
+        CancellationTokenSource? timeoutSource = BeginRequest(context);
 
-        CancellationTokenSource? timeoutSource = context.IsAuthenticated ? null : _jsonRpcConfig.BuildTimeoutCancellationToken();
-        CancellationToken timeoutToken = timeoutSource?.Token ?? CancellationToken.None;
-
-        return ProcessCoreAsync(reader, context, sink, options, timeoutSource, timeoutToken, cancellationToken);
+        return ProcessCoreAsync(reader, context, sink, options, timeoutSource, timeoutSource?.Token ?? CancellationToken.None, cancellationToken);
     }
 
     public ValueTask ProcessAsync(
@@ -78,12 +68,18 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         JsonRpcProcessingOptions options,
         CancellationToken cancellationToken = default)
     {
+        CancellationTokenSource? timeoutSource = BeginRequest(context);
+
+        return ProcessMemoryCoreAsync(requestBody, context, sink, options, timeoutSource, timeoutSource?.Token ?? CancellationToken.None, cancellationToken);
+    }
+
+    /// <summary>Publishes the ambient context and takes a timeout budget for callers that are subject to one.</summary>
+    /// <returns>The pooled source the caller must return, or <c>null</c> when the caller is not timed out.</returns>
+    private CancellationTokenSource? BeginRequest(JsonRpcContext context)
+    {
         JsonRpcContext.Current.Value = context;
 
-        CancellationTokenSource? timeoutSource = context.IsAuthenticated ? null : _jsonRpcConfig.BuildTimeoutCancellationToken();
-        CancellationToken timeoutToken = timeoutSource?.Token ?? CancellationToken.None;
-
-        return ProcessMemoryCoreAsync(requestBody, context, sink, options, timeoutSource, timeoutToken, cancellationToken);
+        return context.IsAuthenticated ? null : _jsonRpcConfig.BuildTimeoutCancellationToken();
     }
 
     private async ValueTask ProcessMemoryCoreAsync(
@@ -106,15 +102,17 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
             if (options.InputMode != JsonRpcInputMode.SingleDocument)
             {
                 PipeReader reader = PipeReader.Create(new ReadOnlySequence<byte>(requestBody));
+                // Hand the timeout budget over: ProcessCoreAsync returns it in its own finally, so this one must
+                // not return it a second time.
                 CancellationTokenSource? coreTimeoutSource = timeoutSource;
                 timeoutSource = null;
                 await ProcessCoreAsync(reader, context, sink, options, coreTimeoutSource, timeoutToken, cancellationToken);
                 return;
             }
 
-            if (IsRecordingRequest)
+            if (_diagnostics.IsRecordingRequest)
             {
-                RecordRequest(requestBody);
+                _diagnostics.RecordRequest(requestBody);
             }
 
             await ProcessSingleDocumentMemoryToSink(requestBody, context, sink, options, cancellationToken);
@@ -136,7 +134,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         CancellationToken cancellationToken,
         bool recordRequest = true)
     {
-        PipeJsonProcessingState processingState = new(CreateJsonReaderState(options));
+        using PipeJsonProcessingState processingState = new(JsonRpcRequestDecoder.CreateJsonReaderState(options));
         try
         {
             if (ProcessExit.IsCancellationRequested)
@@ -145,9 +143,9 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                 return;
             }
 
-            if (recordRequest && IsRecordingRequest)
+            if (recordRequest && _diagnostics.IsRecordingRequest)
             {
-                reader = await RecordRequest(reader);
+                reader = await _diagnostics.RecordRequest(reader);
             }
 
             while (!processingState.ShouldExit)
@@ -174,7 +172,6 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
         finally
         {
-            processingState.PendingSingleDocument?.Dispose();
             await reader.CompleteAsync();
             if (timeoutSource is not null)
                 JsonRpcConfigExtension.ReturnTimeoutCancellationToken(timeoutSource);
@@ -192,25 +189,18 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         CancellationToken cancellationToken)
     {
         ReadOnlySequence<byte> buffer = readResult.Buffer;
-        bool advanced = false;
+        PipeAdvance advance = new(reader);
 
         try
         {
             bool isCompleted = readResult.IsCompleted || readResult.IsCanceled;
             JsonRpcResult.Entry? result = null;
 
-            if (processingState.PendingSingleDocument is not null)
+            if (processingState.HasPendingSingleDocument)
             {
-                result = await ProcessPendingSingleDocumentToSink(
-                    processingState,
-                    buffer,
-                    isCompleted,
-                    context,
-                    sink,
-                    options,
-                    cancellationToken);
-                reader.AdvanceTo(buffer.End);
-                advanced = true;
+                JsonDocument pendingDocument = processingState.TakePendingSingleDocument(out long pendingStartTime);
+                result = await ProcessSingleDocumentToSink(processingState, pendingDocument, pendingStartTime, buffer, isCompleted, context, sink, options, cancellationToken);
+                advance.Consumed(in buffer);
             }
             else
             {
@@ -228,99 +218,63 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                 {
                     try
                     {
-                        if (options.InputMode == JsonRpcInputMode.SingleDocument &&
-                            isCompleted &&
-                            buffer.IsSingleSegment)
+                        bool handledAsCompleteBody = false;
+                        if (options.InputMode == JsonRpcInputMode.SingleDocument && isCompleted && buffer.IsSingleSegment)
                         {
-                            if (!TryDecodeSingleObjectRequest(buffer.First, out JsonRpcRequest? directRequest, out Exception? decodeException)
-                                && decodeException is not null)
+                            (CompleteBodyOutcome outcome, JsonRpcResult.Entry? entry) =
+                                await TryProcessCompleteBodyAsync(buffer.First, context, sink, startTime, cancellationToken);
+
+                            if (outcome != CompleteBodyOutcome.NotApplicable)
                             {
-                                result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation.", decodeException);
+                                // Answered, with responses or with a parse error: a complete single-segment body is
+                                // the whole request either way, so nothing is left for another read.
+                                handledAsCompleteBody = true;
                                 processingState.ShouldExit = true;
-                                reader.AdvanceTo(buffer.End);
-                                advanced = true;
-                                await WriteSingleEntryAsync(result.Value, sink, cancellationToken);
-                                return;
+                                result = entry;
+                                advance.Consumed(in buffer);
+                            }
+                        }
+
+                        if (!handledAsCompleteBody)
+                        {
+                            JsonDocument? jsonDocument = null;
+                            bool undecodable = false;
+                            try
+                            {
+                                // Decode only; see JsonRpcRequestDecoder.IsRequestDecodingException for why this
+                                // cannot be folded into the outer catch.
+                                processingState.FreshState = JsonRpcRequestDecoder.TryParseJson(ref buffer, isCompleted, ref processingState.ReaderState, out jsonDocument, options);
+                            }
+                            catch (Exception ex) when (JsonRpcRequestDecoder.IsRequestDecodingException(ex))
+                            {
+                                result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation.", ex);
+                                processingState.ShouldExit = true;
+                                undecodable = true;
+                                advance.Consumed(in buffer);
                             }
 
-                            if (directRequest is not null)
+                            if (!undecodable && processingState.FreshState)
                             {
-                                processingState.ShouldExit = true;
-
-                                try
+                                if (options.InputMode == JsonRpcInputMode.SingleDocument)
                                 {
-                                    await ProcessSingleRequestToSink(directRequest, context, sink, cancellationToken);
+                                    result = await ProcessSingleDocumentToSink(processingState, jsonDocument, startTime, buffer, isCompleted, context, sink, options, cancellationToken);
+                                    advance.Consumed(in buffer);
                                 }
-                                finally
+                                else
                                 {
-                                    reader.AdvanceTo(buffer.End);
-                                    advanced = true;
+                                    await ProcessJsonDocumentToSink(jsonDocument, context, sink, options, startTime, cancellationToken);
                                 }
-                                return;
                             }
-
-                            if (await TryProcessBatchRequestDirectly(buffer.First, context, sink, cancellationToken))
+                            else if (!undecodable && isCompleted && !buffer.IsEmpty)
                             {
+                                result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation: incomplete request.");
                                 processingState.ShouldExit = true;
-                                reader.AdvanceTo(buffer.End);
-                                advanced = true;
-                                return;
                             }
-                        }
 
-                        // Decode only; see IsRequestDecodingException for why this cannot be folded into the
-                        // outer catch.
-                        JsonDocument? jsonDocument = null;
-                        bool undecodable = false;
-                        try
-                        {
-                            processingState.FreshState = TryParseJson(ref buffer, isCompleted, ref processingState.ReaderState, out jsonDocument, options);
-                        }
-                        catch (Exception ex) when (IsRequestDecodingException(ex))
-                        {
-                            result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation.", ex);
-                            processingState.ShouldExit = true;
-                            undecodable = true;
-                            if (!advanced)
+                            if (!advance.Reported)
                             {
-                                reader.AdvanceTo(buffer.End);
-                                advanced = true;
+                                advance.Examined(in buffer);
                             }
-                        }
-
-                        if (!undecodable && processingState.FreshState)
-                        {
-                            if (options.InputMode == JsonRpcInputMode.SingleDocument)
-                            {
-                                result = await ProcessParsedSingleDocumentToSink(
-                                    processingState,
-                                    jsonDocument,
-                                    buffer,
-                                    isCompleted,
-                                    context,
-                                    sink,
-                                    options,
-                                    startTime,
-                                    cancellationToken);
-
-                                reader.AdvanceTo(buffer.End);
-                                advanced = true;
-                            }
-                            else
-                            {
-                                await ProcessJsonDocumentToSink(jsonDocument, context, sink, options, startTime, cancellationToken);
-                            }
-                        }
-                        else if (!undecodable && isCompleted && !buffer.IsEmpty)
-                        {
-                            result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation: incomplete request.");
-                            processingState.ShouldExit = true;
-                        }
-
-                        if (!advanced)
-                        {
-                            reader.AdvanceTo(buffer.Start, buffer.End);
-                            advanced = true;
                         }
                     }
                     catch (BadHttpRequestException e)
@@ -336,7 +290,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                     catch (JsonException ex)
                     {
                         // Deliberately NOT IsRequestDecodingException: this catch wraps request *execution* as
-                        // well as decoding. See IsRequestDecodingException.
+                        // well as decoding. See JsonRpcRequestDecoder.IsRequestDecodingException.
                         result = GetParsingError(startTime, in buffer, context, "Error during parsing/validation.", ex);
                         processingState.ShouldExit = true;
                     }
@@ -352,58 +306,34 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
         finally
         {
-            if (!advanced)
+            if (!advance.Reported)
             {
-                reader.AdvanceTo(buffer.Start, buffer.End);
+                advance.Examined(in buffer);
             }
         }
     }
 
-    private async ValueTask<JsonRpcResult.Entry?> ProcessPendingSingleDocumentToSink(
-        PipeJsonProcessingState processingState,
-        ReadOnlySequence<byte> buffer,
-        bool isCompleted,
-        JsonRpcContext context,
-        IJsonRpcResponseSink sink,
-        JsonRpcProcessingOptions options,
-        CancellationToken cancellationToken)
-    {
-        JsonDocument pendingSingleDocument = processingState.PendingSingleDocument!;
-        processingState.PendingSingleDocument = null;
-
-        ReadOnlySequence<byte> trailingBuffer = buffer.TrimStart();
-        if (!trailingBuffer.IsEmpty)
-        {
-            pendingSingleDocument.Dispose();
-            processingState.ShouldExit = true;
-            return GetParsingError(processingState.PendingSingleDocumentStartTime, in trailingBuffer, context, "Error during parsing/validation: trailing data after JSON-RPC request.");
-        }
-
-        if (isCompleted)
-        {
-            await ProcessJsonDocumentToSink(pendingSingleDocument, context, sink, options, processingState.PendingSingleDocumentStartTime, cancellationToken);
-            processingState.ShouldExit = true;
-        }
-        else
-        {
-            processingState.PendingSingleDocument = pendingSingleDocument;
-        }
-
-        return null;
-    }
-
-    private async ValueTask<JsonRpcResult.Entry?> ProcessParsedSingleDocumentToSink(
+    /// <summary>Ends a single-document read: reject trailing data, dispatch once the body is complete, or hold it.</summary>
+    /// <param name="startTime">When this document's request started - for a held document, the read that parsed it.</param>
+    /// <param name="trailingBuffer">Whatever follows the document. Anything but whitespace is an error.</param>
+    /// <returns>The parse error to write, or <c>null</c> when there is nothing to answer yet.</returns>
+    /// <remarks>
+    /// Takes ownership of <paramref name="jsonDocument"/>: it is disposed on the error path, handed to
+    /// <see cref="ProcessJsonDocumentToSink"/> (which disposes it) once the body is complete, or handed back to
+    /// <paramref name="processingState"/> to be disposed with it.
+    /// </remarks>
+    private async ValueTask<JsonRpcResult.Entry?> ProcessSingleDocumentToSink(
         PipeJsonProcessingState processingState,
         JsonDocument jsonDocument,
-        ReadOnlySequence<byte> remainingBuffer,
+        long startTime,
+        ReadOnlySequence<byte> trailingBuffer,
         bool isCompleted,
         JsonRpcContext context,
         IJsonRpcResponseSink sink,
         JsonRpcProcessingOptions options,
-        long startTime,
         CancellationToken cancellationToken)
     {
-        ReadOnlySequence<byte> trailingBuffer = remainingBuffer.TrimStart();
+        trailingBuffer = trailingBuffer.TrimStart();
         if (!trailingBuffer.IsEmpty)
         {
             jsonDocument.Dispose();
@@ -418,8 +348,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
         else
         {
-            processingState.PendingSingleDocument = jsonDocument;
-            processingState.PendingSingleDocumentStartTime = startTime;
+            processingState.SetPendingSingleDocument(jsonDocument, startTime);
         }
 
         return null;
@@ -433,35 +362,18 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         CancellationToken cancellationToken)
     {
         long startTime = Stopwatch.GetTimestamp();
-        JsonRpcRequest? directRequest;
-        try
+
+        (CompleteBodyOutcome outcome, JsonRpcResult.Entry? entry) =
+            await TryProcessCompleteBodyAsync(requestBody, context, sink, startTime, cancellationToken);
+
+        if (outcome == CompleteBodyOutcome.Handled)
         {
-            // Decode only; see IsRequestDecodingException. TryReadSingleObjectRequest nulls the out param on
-            // entry, so the false path needs no assignment of its own.
-            _ = TryReadSingleObjectRequest(requestBody, out directRequest);
-        }
-        catch (Exception ex) when (IsRequestDecodingException(ex))
-        {
-            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), context, sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
             return;
         }
 
-        if (directRequest is not null)
+        if (outcome == CompleteBodyOutcome.ParseError)
         {
-            await ProcessSingleRequestToSink(directRequest, context, sink, cancellationToken);
-            return;
-        }
-
-        try
-        {
-            if (await TryProcessBatchRequestDirectly(requestBody, context, sink, cancellationToken))
-            {
-                return;
-            }
-        }
-        catch (JsonException ex)
-        {
-            await WriteParsingErrorAsync(new ReadOnlySequence<byte>(requestBody), context, sink, startTime, "Error during parsing/validation.", cancellationToken, ex);
+            await WriteSingleEntryAsync(entry!.Value, sink, cancellationToken);
             return;
         }
 
@@ -476,147 +388,77 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
     }
 
-    /// <summary>
-    /// Decode-only wrapper around <see cref="TryReadSingleObjectRequest"/>: a decoding failure is reported through
-    /// <paramref name="decodeException"/> instead of being thrown.
-    /// </summary>
-    /// <remarks>
-    /// The guard has to sit around the decode alone; see <see cref="IsRequestDecodingException"/>. This mirrors
-    /// <see cref="TryDeserializeBatchItem"/> and <see cref="TryCreateBatchItemRequest"/>.
-    /// </remarks>
-    private static bool TryDecodeSingleObjectRequest(
-        ReadOnlyMemory<byte> memory,
-        out JsonRpcRequest? request,
-        out Exception? decodeException)
+    private enum CompleteBodyOutcome
     {
-        decodeException = null;
+        /// <summary>Not one complete JSON-RPC document; the caller must fall back to the incremental parser.</summary>
+        NotApplicable,
+
+        /// <summary>Answered in full - one request, or a whole batch.</summary>
+        Handled,
+
+        /// <summary>Undecodable; the returned entry is the parse error to write.</summary>
+        ParseError,
+    }
+
+    /// <summary>Answers a request body that is already complete in memory: one JSON-RPC object, or one batch array.</summary>
+    /// <remarks>
+    /// Shared by the direct-memory transport and the pipe loop's complete-body fast path, so the two cannot drift on
+    /// which shapes take the fast route or on where the decode guard sits. Only the decode is guarded (see
+    /// <see cref="JsonRpcRequestDecoder.IsRequestDecodingException"/>); dispatching a decoded request happens outside
+    /// it, so a node fault surfacing as an <see cref="InvalidOperationException"/> is not answered as a parse error.
+    /// <para>
+    /// The <see cref="JsonException"/> catch around the batch run is wider than a decode. That is pre-existing and
+    /// left alone here: a serialization failure part-way through a batch is still answered -32700, after the array
+    /// has already been closed. Narrowing it turns a malformed 200 into a 500, so it wants its own change rather
+    /// than riding along with a refactor.
+    /// </para>
+    /// </remarks>
+    private async ValueTask<(CompleteBodyOutcome Outcome, JsonRpcResult.Entry? Entry)> TryProcessCompleteBodyAsync(
+        ReadOnlyMemory<byte> body,
+        JsonRpcContext context,
+        IJsonRpcResponseSink sink,
+        long startTime,
+        CancellationToken cancellationToken)
+    {
+        ReadOnlySequence<byte> bodySequence = new(body);
+        JsonRpcRequest? directRequest = null;
+        ReadOnlyMemory<byte> batchBody = default;
+        bool isBatch = false;
+
         try
         {
-            return TryReadSingleObjectRequest(memory, out request);
+            if (!JsonRpcRequestDecoder.TryReadSingleObjectRequest(body, out directRequest))
+            {
+                isBatch = JsonRpcRequestDecoder.TryGetSingleDocumentBody(body, JsonTokenType.StartArray, out batchBody);
+            }
         }
-        catch (Exception ex) when (IsRequestDecodingException(ex))
+        catch (Exception ex) when (JsonRpcRequestDecoder.IsRequestDecodingException(ex))
         {
-            request = null;
-            decodeException = ex;
-            return false;
+            return (CompleteBodyOutcome.ParseError, GetParsingError(startTime, in bodySequence, context, "Error during parsing/validation.", ex));
         }
+
+        if (directRequest is not null)
+        {
+            await ProcessSingleRequestToSink(directRequest, context, sink, cancellationToken);
+            return (CompleteBodyOutcome.Handled, null);
+        }
+
+        if (!isBatch)
+        {
+            return (CompleteBodyOutcome.NotApplicable, null);
+        }
+
+        try
+        {
+            await RunBatchAsync(new MemoryBatchItemSource(batchBody), context, sink, cancellationToken);
+        }
+        catch (JsonException ex)
+        {
+            return (CompleteBodyOutcome.ParseError, GetParsingError(startTime, in bodySequence, context, "Error during parsing/validation.", ex));
+        }
+
+        return (CompleteBodyOutcome.Handled, null);
     }
-
-    private static bool TryReadSingleObjectRequest(
-        ReadOnlyMemory<byte> memory,
-        [NotNullWhen(true)] out JsonRpcRequest? request)
-    {
-        request = null;
-
-        return TryGetSingleDocumentBody(memory, JsonTokenType.StartObject, out ReadOnlyMemory<byte> objectBody)
-            && TryReadObjectRequest(objectBody, out request);
-    }
-
-    private static bool TryGetSingleDocumentBody(
-        ReadOnlyMemory<byte> memory,
-        JsonTokenType expectedRootToken,
-        out ReadOnlyMemory<byte> documentBody)
-    {
-        documentBody = default;
-
-        ReadOnlyMemory<byte> body = memory[CountLeadingJsonWhitespace(memory.Span)..];
-        if (body.IsEmpty)
-        {
-            return false;
-        }
-
-        Utf8JsonReader reader = new(body.Span, isFinalBlock: true, state: default);
-        if (!reader.Read() || reader.TokenType != expectedRootToken)
-        {
-            return false;
-        }
-
-        reader.Skip();
-        int documentLength = checked((int)reader.BytesConsumed);
-        if (HasNonWhitespace(body.Span[documentLength..]))
-        {
-            return false;
-        }
-
-        documentBody = body[..documentLength];
-        return true;
-    }
-
-    private static bool TryReadObjectRequest(
-        ReadOnlyMemory<byte> objectBody,
-        [NotNullWhen(true)] out JsonRpcRequest? request)
-    {
-        request = null;
-
-        JsonRpcEnvelopeReader envelopeReader = new(objectBody.Span);
-        if (!envelopeReader.TryRead(out JsonRpcEnvelope envelope))
-        {
-            return false;
-        }
-
-        ReadOnlyMemory<byte> paramsUtf8 = envelope.HasParams
-            ? objectBody.Slice(envelope.ParamsStart, envelope.ParamsLength)
-            : default;
-
-        request = CreateRequest(envelope, paramsElement: default, paramsUtf8);
-        return true;
-    }
-
-    private static JsonRpcRequest CreateRequest(JsonRpcEnvelope envelope, JsonElement paramsElement, ReadOnlyMemory<byte> paramsUtf8) =>
-        new()
-        {
-            JsonRpc = envelope.JsonRpc!,
-            Id = envelope.Id,
-            Method = envelope.Method!,
-            Params = paramsElement,
-            ParamsUtf8 = paramsUtf8,
-            ParamsKind = envelope.HasParams ? envelope.ParamsKind : JsonValueKind.Undefined
-        };
-
-    private static JsonRpcRequest CreateRequest(JsonElement element)
-    {
-        JsonRpcEnvelope envelope = JsonRpcEnvelopeReader.Read(element, out JsonElement paramsElement);
-        return CreateRequest(envelope, paramsElement, paramsUtf8: default);
-    }
-
-    private static int CountLeadingJsonWhitespace(ReadOnlySpan<byte> span)
-    {
-        if (span.IsEmpty || !IsJsonWhitespace(span[0]))
-        {
-            return 0;
-        }
-
-        if (span.Length == 1)
-        {
-            return 1;
-        }
-
-        int index = span.IndexOfAnyExcept(JsonWhitespace);
-        return index >= 0 ? index : span.Length;
-    }
-
-    private static bool HasNonWhitespace(ReadOnlySpan<byte> span)
-    {
-        if (span.IsEmpty)
-        {
-            return false;
-        }
-
-        if (!IsJsonWhitespace(span[0]))
-        {
-            return true;
-        }
-
-        if (span.Length == 1)
-        {
-            return false;
-        }
-
-        return span.IndexOfAnyExcept(JsonWhitespace) >= 0;
-    }
-
-    private static bool IsJsonWhitespace(byte value) =>
-        value is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n';
 
     private void Handle(ConnectionResetException e)
     {
@@ -628,44 +470,6 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         Metrics.JsonRpcRequestDeserializationFailures++;
         if (_logger.IsDebug) _logger.Debug($"Couldn't read request.{Environment.NewLine}{e}");
     }
-
-    /// <summary>Tells whether <paramref name="exception"/> means the request text could not be decoded into a JSON-RPC envelope.</summary>
-    /// <remarks>
-    /// System.Text.Json reports malformed syntax as <see cref="JsonException"/>, but invalid UTF-8 bytes and lone UTF-16
-    /// surrogate escapes inside a string value, as well as reading a non-object element as an object, surface as a bare
-    /// <see cref="InvalidOperationException"/>. Both are caller input errors and must become a JSON-RPC error response
-    /// instead of escaping to the transport as an unhandled exception.
-    /// <para>
-    /// Every use of this predicate wraps a <em>decode step</em> and nothing else, which is why the call sites look
-    /// repetitive. The outer catches in this file also cover request <em>execution</em>: widening one of those to
-    /// <see cref="InvalidOperationException"/> would swallow a module-side <see cref="InvalidOperationException"/> or
-    /// <see cref="ObjectDisposedException"/> and report it to the caller as -32700 parse error, hiding a real node
-    /// fault behind a client error. <see cref="ObjectDisposedException"/> derives from
-    /// <see cref="InvalidOperationException"/> and so matches here, which is correct within the decode-only scope.
-    /// </para>
-    /// </remarks>
-    private static bool IsRequestDecodingException(Exception exception) =>
-        exception is JsonException or InvalidOperationException;
-
-    private static bool TryParseJson(
-        ref ReadOnlySequence<byte> buffer,
-        bool isFinalBlock,
-        ref JsonReaderState readerState,
-        [NotNullWhen(true)] out JsonDocument? jsonDocument,
-        JsonRpcProcessingOptions options)
-    {
-        Utf8JsonReader jsonReader = new(buffer, isFinalBlock, readerState);
-        bool parsed = JsonDocument.TryParseValue(ref jsonReader, out jsonDocument);
-        buffer = buffer.Slice(jsonReader.BytesConsumed);
-        readerState = parsed
-            ? CreateJsonReaderState(options) // Reset state for the next document
-            : jsonReader.CurrentState; // Preserve state for resumption when more data arrives
-
-        return parsed;
-    }
-
-    private static JsonReaderState CreateJsonReaderState(JsonRpcProcessingOptions options) =>
-        new(options.InputMode == JsonRpcInputMode.MultipleDocuments ? _socketJsonReaderOptions : default);
 
     private async ValueTask ProcessJsonDocumentToSink(
         JsonDocument jsonDocument,
@@ -684,10 +488,10 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                     JsonRpcRequest request;
                     try
                     {
-                        // Decode only; see IsRequestDecodingException.
-                        request = CreateRequest(rootElement);
+                        // Decode only; see JsonRpcRequestDecoder.IsRequestDecodingException.
+                        request = JsonRpcRequestDecoder.CreateRequest(rootElement);
                     }
-                    catch (Exception ex) when (IsRequestDecodingException(ex))
+                    catch (Exception ex) when (JsonRpcRequestDecoder.IsRequestDecodingException(ex))
                     {
                         // -32700, not -32600: the bytes never decoded into a request, so there is nothing to
                         // call invalid. The raw buffer is not available here (the document is already parsed),
@@ -703,7 +507,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                     break;
 
                 case JsonValueKind.Array:
-                    await ProcessBatchDocumentToSink(rootElement, context, sink, cancellationToken);
+                    await RunBatchAsync(new DocumentBatchItemSource(rootElement), context, sink, cancellationToken);
                     break;
 
                 default:
@@ -740,88 +544,27 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
     private void DebugRequest(JsonRpcRequest request) =>
         _logger.Debug($"JSON RPC request {request.Method}");
 
-    private async ValueTask ProcessBatchDocumentToSink(
-        JsonElement rootElement,
+    /// <summary>Runs one JSON-RPC batch: size limit, then decode-dispatch-write per item, then close the array.</summary>
+    /// <remarks>
+    /// One loop for both transports. The raw-bytes and parsed-document paths differ only in how items are
+    /// enumerated, which <typeparamref name="TSource"/> supplies - constrained to <c>struct</c>, so this dispatches
+    /// without boxing and JITs once per source. They used to be two copies of this algorithm, which is why the
+    /// response-body-limit bug had to be fixed twice and why the two drifted on their Trace numbering.
+    /// </remarks>
+    private async ValueTask RunBatchAsync<TSource>(
+        TSource source,
         JsonRpcContext context,
         IJsonRpcResponseSink sink,
         CancellationToken cancellationToken)
+        where TSource : struct, IJsonRpcBatchItemSource
     {
-        int requestCount = rootElement.GetArrayLength();
-        if (_logger.IsDebug) _logger.Debug($"{requestCount} JSON RPC requests");
-
+        // Counting a batch of raw bytes means a second pass over them, so it is only paid for when the limit it
+        // feeds actually applies. A parsed document already knows its length.
+        int? requestCount = source.KnownCount ?? (context.IsAuthenticated ? null : source.ScanCount());
         if (!context.IsAuthenticated && requestCount > _jsonRpcConfig.MaxBatchSize)
         {
-            await WriteBatchSizeLimitErrorAsync(requestCount, sink, cancellationToken);
+            await WriteBatchSizeLimitErrorAsync(requestCount.Value, sink, cancellationToken);
             return;
-        }
-
-        await sink.BeginBatchAsync(cancellationToken);
-        long startTime = Stopwatch.GetTimestamp();
-        int requestIndex = 0;
-        bool isStopped = false;
-        try
-        {
-            foreach (JsonElement item in rootElement.EnumerateArray())
-            {
-                JsonRpcRequest? jsonRpcRequest = TryCreateBatchItemRequest(item);
-                if (jsonRpcRequest is null)
-                {
-                    await WriteBatchEntryAsync(CreateInvalidRequestEntry(startTime), sink, cancellationToken);
-                    // The entry still counts against the response body: skipping this read would let the next
-                    // valid element be dispatched in full after the sink already asked to stop.
-                    isStopped |= sink.StopRequested;
-                    continue;
-                }
-
-                JsonRpcResult.Entry response = isStopped
-                    ? CreateBatchResponseLimitEntry(jsonRpcRequest)
-                    : await HandleSingleRequest(jsonRpcRequest, context);
-
-                if (_logger.IsTrace) _logger.Trace($"  {++requestIndex}/{requestCount} JSON RPC request - {jsonRpcRequest} handled after {response.Report.HandlingTimeMicroseconds}");
-                if (_logger.IsTrace) TraceResult(response);
-
-                await WriteBatchEntryAsync(response, sink, cancellationToken);
-                isStopped |= sink.StopRequested;
-            }
-
-            if (_logger.IsTrace) _logger.Trace($"  {requestCount} requests handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
-        }
-        finally
-        {
-            await sink.EndBatchAsync(cancellationToken);
-        }
-    }
-
-    private async ValueTask<bool> TryProcessBatchRequestDirectly(
-        ReadOnlyMemory<byte> memory,
-        JsonRpcContext context,
-        IJsonRpcResponseSink sink,
-        CancellationToken cancellationToken)
-    {
-        if (!TryGetSingleDocumentBody(memory, JsonTokenType.StartArray, out ReadOnlyMemory<byte> batchBody))
-        {
-            return false;
-        }
-
-        await ProcessBatchMemoryToSink(batchBody, context, sink, cancellationToken);
-        return true;
-    }
-
-    private async ValueTask ProcessBatchMemoryToSink(
-        ReadOnlyMemory<byte> batchBody,
-        JsonRpcContext context,
-        IJsonRpcResponseSink sink,
-        CancellationToken cancellationToken)
-    {
-        int? requestCount = null;
-        if (!context.IsAuthenticated)
-        {
-            requestCount = JsonRpcArrayReader.CountItems(batchBody);
-            if (requestCount > _jsonRpcConfig.MaxBatchSize)
-            {
-                await WriteBatchSizeLimitErrorAsync(requestCount.Value, sink, cancellationToken);
-                return;
-            }
         }
 
         if (_logger.IsDebug)
@@ -833,19 +576,16 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         long startTime = Stopwatch.GetTimestamp();
         int requestIndex = 0;
         bool isStopped = false;
-        JsonReaderState readerState = default;
-        int offset = 0;
-        bool started = false;
         BatchRequestJsonLifetime batchRequestJsonLifetime = new();
 
         try
         {
-            while (JsonRpcArrayReader.TryReadNextItem(batchBody, ref offset, ref readerState, ref started, out ReadOnlyMemory<byte> itemBody))
+            while (source.TryGetNext(out JsonRpcRequest? request, out JsonDocument? ownedRequestDocument, out Exception? decodeException))
             {
                 requestIndex++;
-                JsonRpcRequest? jsonRpcRequest = TryDeserializeBatchItem(itemBody, out JsonDocument? ownedRequestDocument);
-                if (jsonRpcRequest is null)
+                if (request is null)
                 {
+                    if (decodeException is not null) LogInvalidBatchItem(decodeException);
                     await WriteBatchEntryAsync(CreateInvalidRequestEntry(startTime), sink, cancellationToken);
                     // The entry still counts against the response body: skipping this read would let the next
                     // valid element be dispatched in full after the sink already asked to stop.
@@ -853,17 +593,17 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                     continue;
                 }
 
-                batchRequestJsonLifetime.TrackUntilBatchEnd(jsonRpcRequest, ownedRequestDocument);
+                batchRequestJsonLifetime.TrackUntilBatchEnd(request, ownedRequestDocument);
 
                 JsonRpcResult.Entry response = isStopped
-                    ? CreateBatchResponseLimitEntry(jsonRpcRequest)
-                    : await HandleSingleRequest(jsonRpcRequest, context);
+                    ? CreateBatchResponseLimitEntry(request)
+                    : await HandleSingleRequest(request, context);
 
                 if (_logger.IsTrace)
                 {
                     string progress = requestCount is null ? requestIndex.ToString() : $"{requestIndex}/{requestCount}";
-                    _logger.Trace($"  {progress} JSON RPC request - {jsonRpcRequest} handled after {response.Report.HandlingTimeMicroseconds}");
-                    TraceResult(response);
+                    _logger.Trace($"  {progress} JSON RPC request - {request} handled after {response.Report.HandlingTimeMicroseconds}");
+                    _diagnostics.TraceResult(response);
                 }
 
                 await WriteBatchEntryAsync(response, sink, cancellationToken);
@@ -885,50 +625,6 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
     }
 
-    private JsonRpcRequest? TryDeserializeBatchItem(ReadOnlyMemory<byte> itemBody, out JsonDocument? requestDocument)
-    {
-        requestDocument = null;
-        try
-        {
-            if (TryReadObjectRequest(itemBody, out JsonRpcRequest? directRequest))
-            {
-                return directRequest;
-            }
-
-            requestDocument = JsonDocument.Parse(itemBody);
-            if (requestDocument.RootElement.ValueKind == JsonValueKind.Object)
-            {
-                return CreateRequest(requestDocument.RootElement);
-            }
-        }
-        catch (Exception ex) when (IsRequestDecodingException(ex))
-        {
-            LogInvalidBatchItem(ex);
-        }
-
-        requestDocument?.Dispose();
-        requestDocument = null;
-        return null;
-    }
-
-    private JsonRpcRequest? TryCreateBatchItemRequest(JsonElement item)
-    {
-        if (item.ValueKind != JsonValueKind.Object)
-        {
-            return null;
-        }
-
-        try
-        {
-            return CreateRequest(item);
-        }
-        catch (Exception ex) when (IsRequestDecodingException(ex))
-        {
-            LogInvalidBatchItem(ex);
-            return null;
-        }
-    }
-
     private void LogInvalidBatchItem(Exception exception)
     {
         if (_logger.IsDebug) _logger.Debug($"Invalid JSON-RPC batch item.{Environment.NewLine}{exception}");
@@ -947,7 +643,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
 
         if (_logger.IsTrace)
         {
-            TraceResult(invalidResponse);
+            _diagnostics.TraceResult(invalidResponse);
             _logger.Trace($"  Failed request handled in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
         }
 
@@ -957,7 +653,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
     private async ValueTask WriteShutdownResponseAsync(IJsonRpcResponseSink sink, CancellationToken cancellationToken)
     {
         JsonRpcErrorResponse response = _jsonRpcService.GetErrorResponse(ErrorCodes.ResourceUnavailable, "Shutting down");
-        using JsonRpcResult.Entry entry = RecordResponse(response, new RpcReport("Shutdown", 0, false));
+        using JsonRpcResult.Entry entry = _diagnostics.RecordResponse(response, new RpcReport("Shutdown", 0, false));
         await sink.WriteSingleAsync(entry.Response, entry.Report, cancellationToken);
     }
 
@@ -1004,7 +700,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
     {
         try
         {
-            JsonRpcResult.Entry recorded = RecordResponse(entry);
+            JsonRpcResult.Entry recorded = _diagnostics.RecordResponse(entry);
             ValueTask writeTask = isBatch
                 ? sink.WriteBatchItemAsync(recorded.Response, recorded.Report, cancellationToken)
                 : sink.WriteSingleAsync(recorded.Response, recorded.Report, cancellationToken);
@@ -1074,8 +770,8 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
 
         JsonRpcErrorResponse response = _jsonRpcService.GetErrorResponse(ErrorCodes.ParseError, "parse error");
-        if (_logger.IsTrace) TraceResult(response);
-        return RecordResponse(response, new RpcReport("# parsing error #", (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, false));
+        if (_logger.IsTrace) _diagnostics.TraceResult(response);
+        return _diagnostics.RecordResponse(response, new RpcReport("# parsing error #", (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, false));
     }
 
     private ValueTask<JsonRpcResult.Entry> HandleSingleRequest(JsonRpcRequest request, JsonRpcContext context)
@@ -1124,9 +820,13 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
 
     private JsonRpcResult.Entry CreateSingleRequestEntry(JsonRpcRequest request, JsonRpcResponse response, JsonRpcContext context, long startTime)
     {
-        bool isError = response.TryGetError(out Error? responseError);
-        bool isSuccess = !isError;
-        if (!isSuccess)
+        bool isSuccess = !response.TryGetError(out Error? responseError);
+        if (isSuccess)
+        {
+            if (_logger.IsTrace) _logger.Trace($"Responded to Id:{request.Id} Method:{request.Method} in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
+            Metrics.JsonRpcSuccesses++;
+        }
+        else
         {
             if (responseError?.SuppressWarning == false)
             {
@@ -1139,14 +839,9 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                     if (_logger.IsWarn) _logger.Warn(DescribeErrorResponse(request, responseError));
                 }
 
-                if (_logger.IsTrace) _logger.Trace($"Error when handling {request} | {SerializeResponseForDiagnostics(response)}");
+                if (_logger.IsTrace) _logger.Trace($"Error when handling {request} | {JsonRpcDiagnostics.SerializeResponseForDiagnostics(response)}");
             }
             Metrics.JsonRpcErrors++;
-        }
-        else
-        {
-            if (_logger.IsTrace) _logger.Trace($"Responded to Id:{request.Id} Method:{request.Method} in {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds:N0}ms");
-            Metrics.JsonRpcSuccesses++;
         }
 
         string reportMethod = responseError?.Code == ErrorCodes.MethodNotFound
@@ -1156,81 +851,65 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
             response,
             new RpcReport(reportMethod, (long)Stopwatch.GetElapsedTime(startTime).TotalMicroseconds, isSuccess));
 
-        if (_logger.IsTrace) TraceResult(result);
+        if (_logger.IsTrace) _diagnostics.TraceResult(result);
         return result;
     }
 
-    private bool IsRecordingRequest => (_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Request) != 0;
-    private bool IsRecordingResponse => (_jsonRpcConfig.RpcRecorderState & RpcRecorderState.Response) != 0;
-
-    private JsonRpcResult.Entry RecordResponse(JsonRpcResponse response, in RpcReport report) =>
-        RecordResponse(new JsonRpcResult.Entry(response, report));
-
-    private JsonRpcResult.Entry RecordResponse(in JsonRpcResult.Entry result) =>
-        !IsRecordingResponse ? result : RecordResponseSlow(result);
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private JsonRpcResult.Entry RecordResponseSlow(in JsonRpcResult.Entry result)
+    /// <summary>
+    /// Tracks whether this read has already told the <see cref="PipeReader"/> what it took, so the one
+    /// <c>finally</c> can default to "examined everything, consumed nothing" without risking a second call.
+    /// </summary>
+    /// <remarks>
+    /// The buffer is passed per call rather than captured, because the incremental parser slices it and the
+    /// post-parse report has to name the sliced remainder.
+    /// </remarks>
+    private struct PipeAdvance(PipeReader reader)
     {
-        _recorder.RecordResponse(SerializeForDiagnostics(result));
-        return result;
+        public bool Reported { get; private set; }
+
+        /// <summary>The buffer was turned into responses in full; nothing is left to read again.</summary>
+        public void Consumed(in ReadOnlySequence<byte> buffer)
+        {
+            reader.AdvanceTo(buffer.End);
+            Reported = true;
+        }
+
+        /// <summary>Everything was examined but nothing consumed, so the next read waits for more data.</summary>
+        public void Examined(in ReadOnlySequence<byte> buffer)
+        {
+            reader.AdvanceTo(buffer.Start, buffer.End);
+            Reported = true;
+        }
     }
 
-    private static readonly StreamPipeReaderOptions _pipeReaderOptions = new(leaveOpen: false);
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void RecordRequest(ReadOnlyMemory<byte> requestBody) =>
-        _recorder.RecordRequest(Encoding.UTF8.GetString(requestBody.Span));
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private async ValueTask<PipeReader> RecordRequest(PipeReader reader)
+    private sealed class PipeJsonProcessingState(JsonReaderState readerState) : IDisposable
     {
-        Stream memoryStream = RecyclableStream.GetStream("recorder");
-        await reader.CopyToAsync(memoryStream);
-        memoryStream.Seek(0, SeekOrigin.Begin);
+        private JsonDocument? _pendingSingleDocument;
+        private long _pendingSingleDocumentStartTime;
 
-        StreamReader streamReader = new(memoryStream);
-
-        string requestString = await streamReader.ReadToEndAsync();
-        _recorder.RecordRequest(requestString);
-
-        memoryStream.Seek(0, SeekOrigin.Begin);
-        return PipeReader.Create(memoryStream, _pipeReaderOptions);
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void TraceResult(in JsonRpcResult.Entry response)
-    {
-        string json = SerializeForDiagnostics(response);
-        _logger.Trace($"Sending JSON RPC response: {json}");
-    }
-
-    private static string SerializeForDiagnostics(in JsonRpcResult.Entry response)
-    {
-        JsonRpcResponse responseToSerialize = TryGetDiagnosticResponse(response.Response, out JsonRpcResponse? diagnosticResponse)
-            ? diagnosticResponse
-            : response.Response;
-
-        ArrayBufferWriter<byte> writer = new();
-        JsonRpcResponseWriter.Write(writer, responseToSerialize, EthereumJsonSerializer.JsonOptionsIndented);
-        using JsonDocument document = JsonDocument.Parse(writer.WrittenMemory);
-        return JsonSerializer.Serialize(new DiagnosticJsonRpcResult(document.RootElement, response.Report), EthereumJsonSerializer.JsonOptionsIndented);
-    }
-
-    private static string SerializeResponseForDiagnostics(JsonRpcResponse response)
-    {
-        ArrayBufferWriter<byte> writer = new();
-        JsonRpcResponseWriter.Write(writer, response, EthereumJsonSerializer.JsonOptionsIndented);
-        return Encoding.UTF8.GetString(writer.WrittenSpan);
-    }
-
-    private sealed class PipeJsonProcessingState(JsonReaderState readerState)
-    {
         public JsonReaderState ReaderState = readerState;
         public bool FreshState = true;
         public bool ShouldExit;
-        public JsonDocument? PendingSingleDocument;
-        public long PendingSingleDocumentStartTime;
+
+        /// <summary>A document parsed out of a body the transport has not ended yet, held until it does.</summary>
+        public bool HasPendingSingleDocument => _pendingSingleDocument is not null;
+
+        public void SetPendingSingleDocument(JsonDocument document, long startTime)
+        {
+            _pendingSingleDocument = document;
+            _pendingSingleDocumentStartTime = startTime;
+        }
+
+        /// <summary>Hands the held document and its start time over; the caller becomes responsible for disposing it.</summary>
+        public JsonDocument TakePendingSingleDocument(out long startTime)
+        {
+            JsonDocument document = _pendingSingleDocument!;
+            _pendingSingleDocument = null;
+            startTime = _pendingSingleDocumentStartTime;
+            return document;
+        }
+
+        public void Dispose() => _pendingSingleDocument?.Dispose();
     }
 
     private sealed class BatchRequestJsonLifetime : IDisposable
@@ -1270,40 +949,5 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                 }
             }
         }
-    }
-
-    private readonly record struct DiagnosticJsonRpcResult(JsonElement Response, RpcReport Report);
-
-    private static bool TryGetDiagnosticResponse(JsonRpcResponse response, [NotNullWhen(true)] out JsonRpcResponse? diagnosticResponse)
-    {
-        diagnosticResponse = response switch
-        {
-            _ when response.TryGetStreamableResult(out _) => new JsonRpcSuccessResponse
-            {
-                Id = response.Id,
-                Result = "# streamable response omitted #"
-            },
-            JsonRpcErrorResponse { Error.Data: IStreamableResult } errorResponse => new JsonRpcErrorResponse
-            {
-                Id = errorResponse.Id,
-                Error = new Error
-                {
-                    Code = errorResponse.Error.Code,
-                    Message = errorResponse.Error.Message,
-                    Data = "# streamable error data omitted #",
-                    SuppressWarning = errorResponse.Error.SuppressWarning
-                }
-            },
-            _ => null
-        };
-
-        return diagnosticResponse is not null;
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void TraceResult(JsonRpcErrorResponse response)
-    {
-        string json = SerializeResponseForDiagnostics(response);
-        _logger.Trace($"Sending JSON RPC response: {json}");
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcProcessor.cs
@@ -218,8 +218,19 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
                         bool handledAsCompleteBody = false;
                         if (options.InputMode == JsonRpcInputMode.SingleDocument && isCompleted && buffer.IsSingleSegment)
                         {
-                            (CompleteBodyOutcome outcome, JsonRpcResult.Entry? entry) =
-                                await TryProcessCompleteBodyAsync(buffer.First, context, sink, startTime, cancellationToken);
+                            CompleteBodyOutcome outcome;
+                            JsonRpcResult.Entry? entry;
+                            try
+                            {
+                                (outcome, entry) = await TryProcessCompleteBodyAsync(buffer.First, context, sink, startTime, cancellationToken);
+                            }
+                            catch
+                            {
+                                // Only dispatch throws out of that call - its decode steps are guarded - and a
+                                // dispatched body is spent, so report it consumed as a normal return would.
+                                advance.Consumed(in buffer);
+                                throw;
+                            }
 
                             if (outcome != CompleteBodyOutcome.NotApplicable)
                             {
@@ -417,7 +428,6 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         long startTime,
         CancellationToken cancellationToken)
     {
-        ReadOnlySequence<byte> bodySequence = new(body);
         JsonRpcRequest? directRequest = null;
         ReadOnlyMemory<byte> batchBody = default;
         bool isBatch = false;
@@ -431,7 +441,7 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
         catch (Exception ex) when (JsonRpcRequestDecoder.IsRequestDecodingException(ex))
         {
-            return (CompleteBodyOutcome.ParseError, GetParsingError(startTime, in bodySequence, context, "Error during parsing/validation.", ex));
+            return (CompleteBodyOutcome.ParseError, CreateBodyParsingError(body, context, startTime, ex));
         }
 
         if (directRequest is not null)
@@ -451,10 +461,16 @@ public sealed class JsonRpcProcessor : IJsonRpcProcessor
         }
         catch (JsonException ex)
         {
-            return (CompleteBodyOutcome.ParseError, GetParsingError(startTime, in bodySequence, context, "Error during parsing/validation.", ex));
+            return (CompleteBodyOutcome.ParseError, CreateBodyParsingError(body, context, startTime, ex));
         }
 
         return (CompleteBodyOutcome.Handled, null);
+    }
+
+    private JsonRpcResult.Entry CreateBodyParsingError(ReadOnlyMemory<byte> body, JsonRpcContext context, long startTime, Exception exception)
+    {
+        ReadOnlySequence<byte> bodySequence = new(body);
+        return GetParsingError(startTime, in bodySequence, context, "Error during parsing/validation.", exception);
     }
 
     private void Handle(ConnectionResetException e)

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcRequestDecoder.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcRequestDecoder.cs
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace Nethermind.JsonRpc;
+
+/// <summary>Turns request bytes into a <see cref="JsonRpcRequest"/>. Decoding only - nothing here executes a request.</summary>
+/// <remarks>
+/// The distinction matters because of <see cref="IsRequestDecodingException"/>: a bare
+/// <see cref="InvalidOperationException"/> means "the caller sent bytes we cannot decode" inside this class and
+/// "the node is broken" outside it, so the two must not share a <c>catch</c>. Keeping every decode step behind one
+/// type boundary makes that a structural property rather than a convention each call site has to restate.
+/// </remarks>
+internal static class JsonRpcRequestDecoder
+{
+    private static readonly SearchValues<byte> JsonWhitespace = SearchValues.Create(" \t\r\n"u8);
+
+    private static readonly JsonReaderOptions SocketJsonReaderOptions = new() { AllowMultipleValues = true };
+
+    /// <summary>Tells whether <paramref name="exception"/> means the request text could not be decoded into a JSON-RPC envelope.</summary>
+    /// <remarks>
+    /// System.Text.Json reports malformed syntax as <see cref="JsonException"/>, but invalid UTF-8 bytes and lone UTF-16
+    /// surrogate escapes inside a string value, as well as reading a non-object element as an object, surface as a bare
+    /// <see cref="InvalidOperationException"/>. Both are caller input errors and must become a JSON-RPC error response
+    /// instead of escaping to the transport as an unhandled exception.
+    /// <para>
+    /// This is only sound while the guarded scope is a decode step from this class and nothing else. Widening a
+    /// <c>catch</c> that also covers request <em>execution</em> to <see cref="InvalidOperationException"/> would
+    /// swallow a module-side <see cref="InvalidOperationException"/> or <see cref="ObjectDisposedException"/> and
+    /// report it to the caller as -32700 parse error, hiding a real node fault behind a client error.
+    /// <see cref="ObjectDisposedException"/> derives from <see cref="InvalidOperationException"/> and so matches
+    /// here, which is correct within the decode-only scope.
+    /// </para>
+    /// </remarks>
+    public static bool IsRequestDecodingException(Exception exception) =>
+        exception is JsonException or InvalidOperationException;
+
+    /// <summary>Reads <paramref name="memory"/> as a single complete JSON-RPC request object.</summary>
+    /// <returns><c>false</c> if the body is not exactly one JSON object, in which case the caller must parse it another way.</returns>
+    public static bool TryReadSingleObjectRequest(
+        ReadOnlyMemory<byte> memory,
+        [NotNullWhen(true)] out JsonRpcRequest? request)
+    {
+        request = null;
+
+        return TryGetSingleDocumentBody(memory, JsonTokenType.StartObject, out ReadOnlyMemory<byte> objectBody)
+            && TryReadObjectRequest(objectBody, out request);
+    }
+
+    /// <summary>
+    /// Narrows <paramref name="memory"/> to exactly one complete JSON document whose root is
+    /// <paramref name="expectedRootToken"/>, rejecting leading or trailing non-whitespace.
+    /// </summary>
+    public static bool TryGetSingleDocumentBody(
+        ReadOnlyMemory<byte> memory,
+        JsonTokenType expectedRootToken,
+        out ReadOnlyMemory<byte> documentBody)
+    {
+        documentBody = default;
+
+        ReadOnlyMemory<byte> body = memory[CountLeadingJsonWhitespace(memory.Span)..];
+        if (body.IsEmpty)
+        {
+            return false;
+        }
+
+        Utf8JsonReader reader = new(body.Span, isFinalBlock: true, state: default);
+        if (!reader.Read() || reader.TokenType != expectedRootToken)
+        {
+            return false;
+        }
+
+        reader.Skip();
+        int documentLength = checked((int)reader.BytesConsumed);
+        if (HasNonWhitespace(body.Span[documentLength..]))
+        {
+            return false;
+        }
+
+        documentBody = body[..documentLength];
+        return true;
+    }
+
+    /// <summary>Reads one JSON object body as a request, keeping <c>params</c> as a slice of <paramref name="objectBody"/>.</summary>
+    public static bool TryReadObjectRequest(
+        ReadOnlyMemory<byte> objectBody,
+        [NotNullWhen(true)] out JsonRpcRequest? request)
+    {
+        request = null;
+
+        JsonRpcEnvelopeReader envelopeReader = new(objectBody.Span);
+        if (!envelopeReader.TryRead(out JsonRpcEnvelope envelope))
+        {
+            return false;
+        }
+
+        ReadOnlyMemory<byte> paramsUtf8 = envelope.HasParams
+            ? objectBody.Slice(envelope.ParamsStart, envelope.ParamsLength)
+            : default;
+
+        request = CreateRequest(envelope, paramsElement: default, paramsUtf8);
+        return true;
+    }
+
+    /// <summary>Reads an already-parsed JSON object as a request.</summary>
+    public static JsonRpcRequest CreateRequest(JsonElement element)
+    {
+        JsonRpcEnvelope envelope = JsonRpcEnvelopeReader.Read(element, out JsonElement paramsElement);
+        return CreateRequest(envelope, paramsElement, paramsUtf8: default);
+    }
+
+    /// <summary>Parses the next complete JSON document out of <paramref name="buffer"/>, advancing it past what was read.</summary>
+    /// <remarks>
+    /// On success the reader state is reset for the next document; on failure it is preserved so the parse can resume
+    /// when more data arrives.
+    /// </remarks>
+    public static bool TryParseJson(
+        ref ReadOnlySequence<byte> buffer,
+        bool isFinalBlock,
+        ref JsonReaderState readerState,
+        [NotNullWhen(true)] out JsonDocument? jsonDocument,
+        JsonRpcProcessingOptions options)
+    {
+        Utf8JsonReader jsonReader = new(buffer, isFinalBlock, readerState);
+        bool parsed = JsonDocument.TryParseValue(ref jsonReader, out jsonDocument);
+        buffer = buffer.Slice(jsonReader.BytesConsumed);
+        readerState = parsed
+            ? CreateJsonReaderState(options)
+            : jsonReader.CurrentState;
+
+        return parsed;
+    }
+
+    public static JsonReaderState CreateJsonReaderState(JsonRpcProcessingOptions options) =>
+        new(options.InputMode == JsonRpcInputMode.MultipleDocuments ? SocketJsonReaderOptions : default);
+
+    private static JsonRpcRequest CreateRequest(JsonRpcEnvelope envelope, JsonElement paramsElement, ReadOnlyMemory<byte> paramsUtf8) =>
+        new()
+        {
+            JsonRpc = envelope.JsonRpc!,
+            Id = envelope.Id,
+            Method = envelope.Method!,
+            Params = paramsElement,
+            ParamsUtf8 = paramsUtf8,
+            ParamsKind = envelope.HasParams ? envelope.ParamsKind : JsonValueKind.Undefined
+        };
+
+    private static int CountLeadingJsonWhitespace(ReadOnlySpan<byte> span)
+    {
+        if (span.IsEmpty || !IsJsonWhitespace(span[0]))
+        {
+            return 0;
+        }
+
+        if (span.Length == 1)
+        {
+            return 1;
+        }
+
+        int index = span.IndexOfAnyExcept(JsonWhitespace);
+        return index >= 0 ? index : span.Length;
+    }
+
+    private static bool HasNonWhitespace(ReadOnlySpan<byte> span)
+    {
+        if (span.IsEmpty)
+        {
+            return false;
+        }
+
+        if (!IsJsonWhitespace(span[0]))
+        {
+            return true;
+        }
+
+        if (span.Length == 1)
+        {
+            return false;
+        }
+
+        return span.IndexOfAnyExcept(JsonWhitespace) >= 0;
+    }
+
+    private static bool IsJsonWhitespace(byte value) =>
+        value is (byte)' ' or (byte)'\t' or (byte)'\r' or (byte)'\n';
+}


### PR DESCRIPTION
Follow-up to #13251, implementing R1-R6 from [this proposal](https://github.com/NethermindEth/nethermind/pull/13251#issuecomment-5591043738). **Behaviour-preserving** apart from two log-level differences, both listed below. `JsonRpcProcessor.cs` goes 1309 -> 953 lines; +692 / -582 overall.

## Changes

**R3 - `JsonRpcRequestDecoder`** (190 lines, all static). Every bytes-to-request step, plus `IsRequestDecodingException`. The payoff is not line count: #13251 had to warn *in prose* that widening an outer catch to `InvalidOperationException` would swallow a node fault, because nothing structurally separated a decode step from an execution step. Now everything inside the type is a decode step by construction, and the three `// Decode only; see ...` call-site comments cite a type instead of a convention.

**R4 - `JsonRpcDiagnostics`** (146 lines, 12 members). The recorder and the Trace-level response dumps. Purely mechanical, and it lets `_recorder` be a checked nullable rather than a non-nullable field that is only assigned for some values of `RpcRecorderState`. The two `TraceResult` overloads that lived 100 lines apart now sit together.

**R1 - one batch loop.** `ProcessBatchDocumentToSink` and `ProcessBatchMemoryToSink` were the same algorithm; #13251's `isStopped |= sink.StopRequested` fix had to be applied to both, and they had already drifted on `requestIndex`. Now one `RunBatchAsync<TSource>` over `IJsonRpcBatchItemSource`, `struct`-constrained so dispatch does not box and JITs twice.

Moving `TrackUntilBatchEnd` into the shared loop unconditionally is safe, but not for the reason I first gave here: `DisposeParsedParamsDocument` disposes `_paramsDocument` unconditionally and only *guards the `ParamsUtf8` reset*, so my original argument was wrong. The correct one, [per review](https://github.com/NethermindEth/nethermind/pull/13290#issuecomment-5592198099): `TrackUntilBatchEnd` itself gates on `ownedRequestDocument is not null` or `!request.ParamsUtf8.IsEmpty`, and `CreateRequest(JsonElement)` passes `paramsUtf8: default`, so a document-path request is never added to either list. `_paramsDocument` is only ever created inside the `Params` getter behind that same `!ParamsUtf8.IsEmpty` check, so there is nothing to dispose either. Master's document loop did not track and did not need to; same end state.

The count stays lazy - `KnownCount ?? (IsAuthenticated ? null : ScanCount())` reproduces master exactly, including *not* re-scanning a byte batch for an authenticated caller.

**R2 - `TryProcessCompleteBodyAsync`.** The "single object, else batch, else fall back" policy existed twice, once in the pipe loop and once on the direct-memory path. One copy removes `TryDecodeSingleObjectRequest` and its `out Exception` entirely - it existed only because the pipe copy had to interleave `AdvanceTo` with its error path - and takes two nesting levels out of `ProcessReadResultToSink`. It also puts the array-envelope decode inside the same decode guard as the object decode. That is a structural tidy-up, **not** a bug fix, and my earlier wording claiming it closed an unhandled-exception hole was wrong: `TryGetSingleDocumentBody` builds its reader with `isFinalBlock: true` and only calls `Read()`/`Skip()`, and on a final block both raise `JsonException` only - the invalid-UTF-8 and lone-surrogate `InvalidOperationException` needs `GetString()` or element access, which happens in `JsonRpcEnvelopeReader` / `CreateRequest(JsonElement)`, already guarded on both master paths. So the widened guard covers an exception that cannot be raised there, and no reachable exception changes classification.

I did **not** fold in the Low at [`discussion_r3961557159`](https://github.com/NethermindEth/nethermind/pull/13251#discussion_r3961557159). Narrowing the `JsonException` catch to the envelope decode would stop a mid-batch serialization failure being answered `-32700` after `EndBatchAsync` has closed the array - but it turns a malformed 200 into a 500, which is a client-visible change that should not ride along inside a refactor. There is now exactly one place to make that decision, and a `<remarks>` saying so. Happy to file it as a follow-up issue.

**R5 - one `ProcessSingleDocumentToSink`** replaces the two ~90%-identical pending/parsed variants, stating the trailing-data rule once. `PipeJsonProcessingState` is `IDisposable` and owns its held document, so `ProcessCoreAsync` no longer disposes it by hand.

**R6** - `PipeAdvance` names the two `AdvanceTo` shapes the read loop uses instead of a bool the reader has to trace by eye; the duplicated `ProcessAsync` preamble becomes `BeginRequest`; the `coreTimeoutSource` / `timeoutSource = null` ownership transfer gets the comment it needed; `bool isError; bool isSuccess = !isError; if (!isSuccess)` becomes one negation with the success branch first.

### The two behaviour differences

Both log-only. No response body, status code or metric changes anywhere.

1. **Trace** - batch item numbering now counts every item on both paths. Master's document loop did `++requestIndex` *inside* its own `Trace` call, so its count both skipped invalid items **and** only advanced when Trace was enabled.
2. **Debug** - a *document* batch that trips `MaxBatchSize` no longer emits the `"{n} JSON RPC requests"` line, because the merged loop adopts the memory path's log-after-check order. Caught in review; the surviving order is the better one (it does not announce N requests it is about to reject), so I kept it rather than restoring master's.

No test asserts on either line.

### Two more differences, both on exception paths

Neither is reachable in production; both were missed in my first pass and are listed for completeness.

3. **Fast-path parse-error write moved to the common tail.** Master wrote it inside the block guarded by `BadHttpRequestException` / `ConnectionResetException` / `JsonException`; the merged classification returns the entry and the loop writes it after that block closes. So if the envelope decode fails and the client then vanishes, master caught the `ConnectionResetException` and returned normally where head lets it reach the transport. Unreachable today: production HTTP uses the `ReadOnlyMemory` overload, whose fallback cannot get here because the re-decode is deterministic, and the only in-repo callers of pipe + `SingleDocument` are the tests. Left as is.
4. **`AdvanceTo` shape on the pipe error paths.** Master wrapped the single-request dispatch in `finally { AdvanceTo(buffer.End) }`; head reported examined-only when dispatch threw. No response byte, status or metric changes - `ShouldExit` is set and `CompleteAsync()` follows - but it was an undisclosed difference. Restored below, and the batch shape (which master already left examined-only) now matches it.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

One new test dimension. My earlier claim that #13251's cases "cover both sources" was wrong on the point that matters: every case in `JsonRpcProcessorTests` runs over a `PipeReader`, and an HTTP context takes the complete-body fast path, so the HTTP cases all land on `MemoryBatchItemSource` and only the WS ones reach `DocumentBatchItemSource`. That is fine for the batch *shape* cases - the `[null]` / `[1]` / `["x"]` / `[[]]` items and the response-body-limit cases still pin what they always pinned - but not for `MaxBatchSize`, which this PR moves from two enforcement sites to one.

`Batch_size_limit_respects_authentication` was the only test reaching that guard and it sent over HTTP, so adding `source.KnownCount is null` to the guard - dropping the limit for every WS/IPC batch - left the whole suite green. The endpoint is now a dimension on that test; the WS arm fails on exactly that mutation (verified by applying it).

- `Nethermind.JsonRpc.Test` - 2057 passed, 22 skipped. Ran it 6 times; **the first run failed one test that passed on all five subsequent runs and whose name I did not capture.** Flagging it rather than hiding it. The suite has known timing-sensitive socket cases and nothing here touches socket timing, but I have not bisected it against master.
- `Nethermind.Runner.Test` - 776 passed, 3 skipped. This is the one that drives real HTTP through the processor: batches, malformed bodies, the chunk-size overflow from #13195.
- `Nethermind.Sockets.Test` - 17 passed.
- Build: 0 warnings, 0 errors. `dotnet format whitespace`: clean. Code-lint command reproduced locally with `EnforceCodeStyleInBuild` + `GenerateDocumentationFile`: 0 IDE/CA warnings.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

Internal restructuring only. Both log-level differences are below the threshold for release notes.

## Remarks

- **Public API unchanged.** `JsonRpcProcessor`'s surface is identical and all three new types are `internal`, so no plugin surface moves.
- **Two commits.** The second addresses review round 1 - see below. If you would rather review the refactor in stages, the natural split is R3 -> R4 -> R1 -> R2+R5+R6, each of which builds on its own; that needs a force-push, which would detach the existing inline review threads, so I have not done it unasked.
- **Known residual (Low, not addressed):** `TryProcessCompleteBodyAsync` adds one `async` frame to the single-object memory fast path, so a suspending RPC boxes one extra state machine per request. Sub-noise next to `SendRequestAsync`, and removing it would mean giving up the deduplication that is the point of R2.

### Review round 2

[Review](https://github.com/NethermindEth/nethermind/pull/13290#pullrequestreview-5156259295). Three commits:

- `b608272` - **the `JsonRpcDiagnostics` remark was false on arrival.** It said every member is a no-op or pass-through unless the diagnostic is on, so callers may invoke unconditionally; in fact both `RecordRequest` overloads dereferenced `_recorder` with no gate and both `TraceResult` overloads serialized regardless of the Trace level. The check is now folded into each member the way `RecordResponse` already did it, which removes the call-site guards, the `!` and the NRE, and puts `IsRecordingRequest` back to private.
- `0ec1d0d` - **`AdvanceTo` shape** restored, per difference 4 above. Also builds the `ReadOnlySequence` for the two parse-error returns inside those branches rather than once up front, where it was hoisted into every successful request's state machine.
- `fb7a48d` - **`MaxBatchSize` on the document source**, per the testing note above.

Not taken: splitting `TryProcessCompleteBodyAsync` into a synchronous `TryClassifyCompleteBody` plus per-caller dispatch. It would remove the extra async frame and shrink the guarded try, but it duplicates the dispatch policy back into both callers, which is the deduplication R2 exists for. Happy to do it as a follow-up if the frame matters more.

### Review round 1

[Review](https://github.com/NethermindEth/nethermind/pull/13290#issuecomment-5592198099): no Critical/High/Medium, three Lows. Addressed in `0b74899`:

- **Undocumented Debug-line difference** - now documented above, behaviour kept.
- **`<remarks>` narrating the refactor rather than the code** - a real AGENTS.md violation. Four of them rewritten to state the invariant without the history: why the batch source is `struct`-constrained, why the recorder is tested for rather than inferred from the flags, and that the batch `JsonException` scope is a client-visible contract.
- **Extra `async` frame** - acknowledged, not changed; recorded under Remarks above.

Also fixed the CI red in the same commit: `IDE0005` on an unused `using Nethermind.Core.Extensions` in `JsonRpcDiagnostics`. `GetApplicationResourcePath` comes from `Nethermind.Logging`'s `PathUtils`, so that using never resolved anything; only the lint job sees it, because `IDE0005` requires `GenerateDocumentationFile=true`, which a plain `dotnet build` does not set.

