### PR TITLE
perf(zkevm): mix hash keys 32 bits at a time

### DIFF
--- a/src/Nethermind/Nethermind.Core.ZkEvm.Test/Extensions/GuestMixerTests.cs
+++ b/src/Nethermind/Nethermind.Core.ZkEvm.Test/Extensions/GuestMixerTests.cs
@@ -245,29 +245,29 @@ public class GuestMixerTests
         }
     }
 
-    [TestCase(0, 829642253)]
-    [TestCase(1, -1995569106)]
-    [TestCase(2, 1769987572)]
-    [TestCase(3, -1616582951)]
-    [TestCase(4, 1452475728)]
-    [TestCase(5, -1073280757)]
-    [TestCase(6, 526470818)]
-    [TestCase(7, -333637061)]
-    [TestCase(8, 981384108)]
-    [TestCase(9, -1160461789)]
-    [TestCase(10, -1058923909)]
-    [TestCase(11, -631305068)]
-    [TestCase(12, -268664765)]
-    [TestCase(13, 1129042570)]
-    [TestCase(14, 887642953)]
-    [TestCase(15, -1833596490)]
-    [TestCase(16, -843876032)]
-    [TestCase(17, -1085161699)]
-    [TestCase(31, 2051868692)]
-    [TestCase(33, -1984651310)]
-    [TestCase(63, -1935689013)]
-    [TestCase(64, 466906938)]
-    [TestCase(65, 547616034)]
+    [TestCase(0, -1484263088)]
+    [TestCase(1, -1437334993)]
+    [TestCase(2, 546991680)]
+    [TestCase(3, 631479625)]
+    [TestCase(4, 2147352365)]
+    [TestCase(5, 1767956899)]
+    [TestCase(6, 1977685397)]
+    [TestCase(7, 80136087)]
+    [TestCase(8, 1837388150)]
+    [TestCase(9, 652902647)]
+    [TestCase(10, -1585083149)]
+    [TestCase(11, 724197958)]
+    [TestCase(12, 836101102)]
+    [TestCase(13, 558865327)]
+    [TestCase(14, 710723939)]
+    [TestCase(15, 1376555104)]
+    [TestCase(16, 703589929)]
+    [TestCase(17, -381711026)]
+    [TestCase(31, 686656626)]
+    [TestCase(33, -174859442)]
+    [TestCase(63, 2140830044)]
+    [TestCase(64, -1120339129)]
+    [TestCase(65, -499937045)]
     public void Scalar_hash_preserves_tail_and_block_boundary_vectors(int length, int expected)
     {
         SpanExtensions.SeedHashes(new UInt256(0x243F6A8885A308D3UL, 0x13198A2E03707344UL,
@@ -351,7 +351,8 @@ public class GuestMixerTests
         ulong sum = ReferenceLanes(value.u0, seed.u0) + ReferenceLanes(value.u1, seed.u1)
             + ReferenceLanes(value.u2, seed.u2) + ReferenceLanes(value.u3, seed.u3);
         ulong hash = sum ^ (sum >> 31);
-        hash = (ulong)((BigInteger)hash * (seed.u1 | 1UL) & ulong.MaxValue);
+        ulong finalizer = ReferenceFold(seed.u0 ^ 0x9E3779B97F4A7C15UL, seed.u3 ^ ~0x9E3779B97F4A7C15UL) | 1UL;
+        hash = (ulong)((BigInteger)hash * finalizer & ulong.MaxValue);
         return hash ^ (hash >> 29);
     }
 

--- a/src/Nethermind/Nethermind.Core.ZkEvm.Test/Extensions/GuestMixerTests.cs
+++ b/src/Nethermind/Nethermind.Core.ZkEvm.Test/Extensions/GuestMixerTests.cs
@@ -154,23 +154,32 @@ public class GuestMixerTests
     [Test]
     public void Guest_mixer_reseeding_breaks_a_collision_set()
     {
-        HashSet<long> before = [];
-        HashSet<long> after = [];
+        // The set is searched for rather than constructed: it is specific to the seed in force, which is
+        // the property under test, so it cannot be written down.
+        SpanExtensions.SeedHashes(SeedGuestHashes.Seed);
         byte[] key = new byte[32];
-        BinaryPrimitives.WriteUInt64LittleEndian(key, SeedGuestHashes.Seed.u0);
-        for (ulong value = 0; value < 4096; value++)
+        // The bucket a dictionary reads is the 32-bit hash code, so the set is searched for there.
+        Dictionary<int, ulong> seen = [];
+        List<ulong>? collisions = null;
+        for (ulong value = 0; value < 1 << 21 && collisions is null; value++)
         {
             BinaryPrimitives.WriteUInt64LittleEndian(key.AsSpan(8), value);
-            SpanExtensions.SeedHashes(SeedGuestHashes.Seed);
-            before.Add(Hash(key));
-            SpanExtensions.SeedHashes(SecondSeed);
-            after.Add(Hash(key));
+            int hash = SpanExtensions.FastHashFallback(key);
+            if (seen.TryGetValue(hash, out ulong first)) collisions = [first, value];
+            else seen[hash] = value;
         }
-        using (Assert.EnterMultipleScope())
+
+        Assert.That(collisions, Is.Not.Null, "no collision found under the first seed");
+
+        HashSet<int> after = [];
+        SpanExtensions.SeedHashes(SecondSeed);
+        foreach (ulong value in collisions!)
         {
-            Assert.That(before.Count, Is.EqualTo(1), "constructed collision set");
-            Assert.That(after.Count, Is.GreaterThan(4064), "replacement seed");
+            BinaryPrimitives.WriteUInt64LittleEndian(key.AsSpan(8), value);
+            after.Add(SpanExtensions.FastHashFallback(key));
         }
+
+        Assert.That(after, Has.Count.EqualTo(collisions.Count), "replacement seed");
     }
 
     /// <summary>Checks the 32-byte mixer against an independent widening-product reference.</summary>
@@ -181,9 +190,7 @@ public class GuestMixerTests
         SpanExtensions.SeedHashes(seed);
         foreach (UInt256 value in new[] { UInt256.Zero, UInt256.One, UInt256.MaxValue, SecondSeed })
         {
-            ulong a = ReferenceFold(value.u0 ^ seed.u0, value.u1 ^ seed.u1);
-            ulong b = ReferenceFold(value.u2 ^ seed.u2, value.u3 ^ seed.u3);
-            ulong expected = ReferenceFold(a ^ 0x9E3779B97F4A7C15UL, b ^ 0xBF58476D1CE4E5B9UL);
+            ulong expected = ReferenceMix(value, seed);
             byte[] bytes = value.ToLittleEndian();
             using (Assert.EnterMultipleScope())
             {
@@ -238,29 +245,29 @@ public class GuestMixerTests
         }
     }
 
-    [TestCase(0, -220954673)]
-    [TestCase(1, 1365513433)]
-    [TestCase(2, 1215851697)]
-    [TestCase(3, 1062475265)]
-    [TestCase(4, 1800791587)]
-    [TestCase(5, -1439988632)]
-    [TestCase(6, 211467597)]
-    [TestCase(7, 1321382043)]
-    [TestCase(8, -128984591)]
-    [TestCase(9, 1383455619)]
-    [TestCase(10, -1217756578)]
-    [TestCase(11, -2027848051)]
-    [TestCase(12, -1289996763)]
-    [TestCase(13, 751476928)]
-    [TestCase(14, -2043828144)]
-    [TestCase(15, -308078777)]
-    [TestCase(16, -1699459048)]
-    [TestCase(17, -1754749950)]
-    [TestCase(31, -1045709015)]
-    [TestCase(33, 1762330450)]
-    [TestCase(63, 1350296845)]
-    [TestCase(64, -1610973583)]
-    [TestCase(65, -1918792359)]
+    [TestCase(0, 829642253)]
+    [TestCase(1, -1995569106)]
+    [TestCase(2, 1769987572)]
+    [TestCase(3, -1616582951)]
+    [TestCase(4, 1452475728)]
+    [TestCase(5, -1073280757)]
+    [TestCase(6, 526470818)]
+    [TestCase(7, -333637061)]
+    [TestCase(8, 981384108)]
+    [TestCase(9, -1160461789)]
+    [TestCase(10, -1058923909)]
+    [TestCase(11, -631305068)]
+    [TestCase(12, -268664765)]
+    [TestCase(13, 1129042570)]
+    [TestCase(14, 887642953)]
+    [TestCase(15, -1833596490)]
+    [TestCase(16, -843876032)]
+    [TestCase(17, -1085161699)]
+    [TestCase(31, 2051868692)]
+    [TestCase(33, -1984651310)]
+    [TestCase(63, -1935689013)]
+    [TestCase(64, 466906938)]
+    [TestCase(65, 547616034)]
     public void Scalar_hash_preserves_tail_and_block_boundary_vectors(int length, int expected)
     {
         SpanExtensions.SeedHashes(new UInt256(0x243F6A8885A308D3UL, 0x13198A2E03707344UL,
@@ -336,6 +343,23 @@ public class GuestMixerTests
     {
         BigInteger product = (BigInteger)a * b;
         return (ulong)(product & ulong.MaxValue) ^ (ulong)(product >> 64);
+    }
+
+    /// <summary>Recomputes the 32-byte lane mixer in <see cref="BigInteger"/> arithmetic.</summary>
+    private static ulong ReferenceMix(in UInt256 value, in UInt256 seed)
+    {
+        ulong sum = ReferenceLanes(value.u0, seed.u0) + ReferenceLanes(value.u1, seed.u1)
+            + ReferenceLanes(value.u2, seed.u2) + ReferenceLanes(value.u3, seed.u3);
+        ulong hash = sum ^ (sum >> 31);
+        hash = (ulong)((BigInteger)hash * (seed.u1 | 1UL) & ulong.MaxValue);
+        return hash ^ (hash >> 29);
+    }
+
+    private static ulong ReferenceLanes(ulong word, ulong key)
+    {
+        BigInteger low = (word & uint.MaxValue) + (key & uint.MaxValue) & uint.MaxValue;
+        BigInteger high = (word >> 32) + (key >> 32) & uint.MaxValue;
+        return (ulong)(low * high);
     }
 
     private static void AssertWindowsAreDistributed(long[] hashes, string context)

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -704,65 +704,15 @@ namespace Nethermind.Core.Extensions
                 Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref b, 24)), ref seeds);
         }
 
-#if ZK_EVM
-        // Keep a call boundary: the RISC-V backend can omit the int truncation after an inlined multiply-fold.
-        [MethodImpl(MethodImplOptions.NoInlining)]
-#else
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-        private static ulong MixWords(ulong u0, ulong u1, ulong u2, ulong u3, ref ulong seeds)
-        {
-#if ZK_EVM
-            // NH (the UMAC/VMAC core) over 32-bit lanes: one product per key word. The guest's target has
-            // no reachable 64x64->128 multiply, so each MultiplyFold costs four muls and a shift chain,
-            // while a 32x32->64 product is a single mul.
-            ulong sum = MixLanes(u0, seeds)
-                + MixLanes(u1, Unsafe.Add(ref seeds, 1))
-                + MixLanes(u2, Unsafe.Add(ref seeds, 2))
-                + MixLanes(u3, Unsafe.Add(ref seeds, 3));
-            // NH's own output carries its entropy high, and a dictionary buckets on the low bits, so the
-            // sum needs a finalizer. Multiply-shift by a seed limb is one more mul. Installing the odd
-            // multiplier at seed time instead measured 215,127 steps worse: the limbs share one base
-            // pointer, so reading another one folds into an offset while a new static does not.
-            ulong hash = sum ^ (sum >> 31);
-            hash *= Unsafe.Add(ref seeds, 1) | 1UL;
-            return hash ^ (hash >> 29);
-#else
-            // Mix each seed limb into its key limb before any information is lost to folding.
-            ulong a = MultiplyFold(u0 ^ seeds, u1 ^ Unsafe.Add(ref seeds, 1));
-            ulong b = MultiplyFold(u2 ^ Unsafe.Add(ref seeds, 2), u3 ^ Unsafe.Add(ref seeds, 3));
-            return (ulong)MumFold(a, b);
-#endif
-        }
+        /// <summary>Mixes four key words with their seed limbs into one 64-bit hash.</summary>
+        /// <remarks>The construction differs by build: see the <c>std</c> and <c>zkevm</c> partials.</remarks>
+        private static partial ulong MixWords(ulong u0, ulong u1, ulong u2, ulong u3, ref ulong seeds);
 
-#if ZK_EVM
-        /// <summary>Keys both 32-bit lanes of a key word and multiplies them into one 64-bit product.</summary>
+        /// <summary>Multiplies two words to twice their width and folds the halves together.</summary>
         /// <remarks>
-        /// The lane keys must be independent per position: sharing one across words would leave the sum
-        /// invariant under permuting them.
+        /// The product is non-linear in both operands, so neither survives into the result on its own.
         /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong MixLanes(ulong word, ulong key)
-            => (ulong)(uint)((uint)word + (uint)key) * (uint)((uint)(word >> 32) + (uint)(key >> 32));
-#endif
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong MultiplyFold(ulong a, ulong b)
-        {
-#if ZK_EVM
-            uint al = (uint)a, ah = (uint)(a >> 32);
-            uint bl = (uint)b, bh = (uint)(b >> 32);
-            ulong lower = (ulong)al * bl;
-            ulong middle = (ulong)ah * bl + (lower >> 32);
-            ulong carry = (ulong)al * bh + (uint)middle;
-            ulong low = (carry << 32) | (uint)lower;
-            ulong high = (ulong)ah * bh + (middle >> 32) + (carry >> 32);
-            return low ^ high;
-#else
-            ulong high = Math.BigMul(a, b, out ulong low);
-            return low ^ high;
-#endif
-        }
+        private static partial ulong MultiplyFold(ulong a, ulong b);
 
         private static ulong[] CreateShortHashSeeds(in UInt256 seed)
         {

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.cs
@@ -712,11 +712,39 @@ namespace Nethermind.Core.Extensions
 #endif
         private static ulong MixWords(ulong u0, ulong u1, ulong u2, ulong u3, ref ulong seeds)
         {
+#if ZK_EVM
+            // NH (the UMAC/VMAC core) over 32-bit lanes: one product per key word. The guest's target has
+            // no reachable 64x64->128 multiply, so each MultiplyFold costs four muls and a shift chain,
+            // while a 32x32->64 product is a single mul.
+            ulong sum = MixLanes(u0, seeds)
+                + MixLanes(u1, Unsafe.Add(ref seeds, 1))
+                + MixLanes(u2, Unsafe.Add(ref seeds, 2))
+                + MixLanes(u3, Unsafe.Add(ref seeds, 3));
+            // NH's own output carries its entropy high, and a dictionary buckets on the low bits, so the
+            // sum needs a finalizer. Multiply-shift by a seed limb is one more mul. Installing the odd
+            // multiplier at seed time instead measured 215,127 steps worse: the limbs share one base
+            // pointer, so reading another one folds into an offset while a new static does not.
+            ulong hash = sum ^ (sum >> 31);
+            hash *= Unsafe.Add(ref seeds, 1) | 1UL;
+            return hash ^ (hash >> 29);
+#else
             // Mix each seed limb into its key limb before any information is lost to folding.
             ulong a = MultiplyFold(u0 ^ seeds, u1 ^ Unsafe.Add(ref seeds, 1));
             ulong b = MultiplyFold(u2 ^ Unsafe.Add(ref seeds, 2), u3 ^ Unsafe.Add(ref seeds, 3));
             return (ulong)MumFold(a, b);
+#endif
         }
+
+#if ZK_EVM
+        /// <summary>Keys both 32-bit lanes of a key word and multiplies them into one 64-bit product.</summary>
+        /// <remarks>
+        /// The lane keys must be independent per position: sharing one across words would leave the sum
+        /// invariant under permuting them.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong MixLanes(ulong word, ulong key)
+            => (ulong)(uint)((uint)word + (uint)key) * (uint)((uint)(word >> 32) + (uint)(key >> 32));
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ulong MultiplyFold(ulong a, ulong b)

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.std.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.std.cs
@@ -28,6 +28,24 @@ namespace Nethermind.Core.Extensions
         public static partial void SeedHashes(in Int256.UInt256 seed) { }
 
         /// <inheritdoc />
+        /// <remarks>Mixes each seed limb into its key limb before any information is lost to folding.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static partial ulong MixWords(ulong u0, ulong u1, ulong u2, ulong u3, ref ulong seeds)
+        {
+            ulong a = MultiplyFold(u0 ^ seeds, u1 ^ Unsafe.Add(ref seeds, 1));
+            ulong b = MultiplyFold(u2 ^ Unsafe.Add(ref seeds, 2), u3 ^ Unsafe.Add(ref seeds, 3));
+            return (ulong)MumFold(a, b);
+        }
+
+        /// <inheritdoc />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static partial ulong MultiplyFold(ulong a, ulong b)
+        {
+            ulong high = Math.BigMul(a, b, out ulong low);
+            return low ^ high;
+        }
+
+        /// <inheritdoc />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static partial int CombineHash(uint hash, ulong value) => (int)BitOperations.Crc32C(hash, value);
 

--- a/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/SpanExtensions.zkevm.cs
@@ -37,6 +37,8 @@ namespace Nethermind.Core.Extensions
 
         // No field initializers: the guest must not pay a class-constructor check on each hash call.
         internal static Int256.UInt256 InstanceRandom;
+        // Independent of the lane keys: NH's bound assumes the finalizer key is not one of them.
+        private static ulong HashFinalizerKey;
         private static ulong[]? AddressSeeds;
         private static ulong[]? ShortHashSeeds;
 
@@ -44,6 +46,8 @@ namespace Nethermind.Core.Extensions
         public static partial void SeedHashes(in Int256.UInt256 seed)
         {
             InstanceRandom = seed;
+            // Installed before anything mixes, which CreateShortHashSeeds below does.
+            HashFinalizerKey = MultiplyFold(seed.u0 ^ FinalizerDomain, seed.u3 ^ ~FinalizerDomain) | 1UL;
             ShortHashSeeds = CreateShortHashSeeds(in InstanceRandom);
             AddressSeeds = [DeriveAddressSeed(seed.u0), DeriveAddressSeed(seed.u1),
                 DeriveAddressSeed(seed.u2), DeriveAddressSeed(seed.u3)];
@@ -57,6 +61,53 @@ namespace Nethermind.Core.Extensions
             AesHash32Seed1 = seed.u1 ^ 0x5BE0CD19137E2179UL;
             AesHashFinalSeed0 = seed.u2 ^ 0x3C6EF372FE94F82BUL;
             AesHashFinalSeed1 = seed.u3 ^ 0xA54FF53A5F1D36F1UL;
+        }
+
+        private const ulong FinalizerDomain = 0x9E3779B97F4A7C15UL;
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// NH, the UMAC/VMAC core, over 32-bit lanes: one product per key word. The guest's target has no
+        /// widening multiply reachable from here, so <see cref="MultiplyFold"/> costs four muls and a
+        /// shift chain, while a 32x32-&gt;64 product is a single mul.
+        /// </remarks>
+        // Keep a call boundary: the RISC-V backend can omit the int truncation after an inlined mixer.
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static partial ulong MixWords(ulong u0, ulong u1, ulong u2, ulong u3, ref ulong seeds)
+        {
+            ulong sum = MixLanes(u0, seeds)
+                + MixLanes(u1, Unsafe.Add(ref seeds, 1))
+                + MixLanes(u2, Unsafe.Add(ref seeds, 2))
+                + MixLanes(u3, Unsafe.Add(ref seeds, 3));
+            // NH carries its entropy high and a dictionary buckets on the low bits, so the sum needs a
+            // finalizer. Each step is a bijection, so it moves bits without adding collisions of its own.
+            ulong hash = sum ^ (sum >> 31);
+            hash *= HashFinalizerKey;
+            return hash ^ (hash >> 29);
+        }
+
+        /// <summary>Keys both 32-bit lanes of a key word and multiplies them into one 64-bit product.</summary>
+        /// <remarks>
+        /// The lane keys have to stay independent per position: sharing one across words would leave the
+        /// sum invariant under permuting them.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong MixLanes(ulong word, ulong key)
+            => (ulong)(uint)((uint)word + (uint)key) * (uint)((uint)(word >> 32) + (uint)(key >> 32));
+
+        /// <inheritdoc />
+        /// <remarks>Hand-rolled from 32-bit products: ILC has no <c>mulhu</c> intrinsic on this target.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static partial ulong MultiplyFold(ulong a, ulong b)
+        {
+            uint al = (uint)a, ah = (uint)(a >> 32);
+            uint bl = (uint)b, bh = (uint)(b >> 32);
+            ulong lower = (ulong)al * bl;
+            ulong middle = (ulong)ah * bl + (lower >> 32);
+            ulong carry = (ulong)al * bh + (uint)middle;
+            ulong low = (carry << 32) | (uint)lower;
+            ulong high = (ulong)ah * bh + (middle >> 32) + (carry >> 32);
+            return low ^ high;
         }
     }
 }


### PR DESCRIPTION
## Changes

`Mix32` is the guest's hash for every 32-byte key — `ValueHash256`, storage slots, address/slot pairs and
the witness node store — and it runs three `MultiplyFold`s per key. `MultiplyFold` is a 64x64->128
widening product, which the guest's target cannot reach: `Math.BigMul` has no `mulhu` intrinsic on
riscv64 under ILC, so the `#if ZK_EVM` body hand-rolls the product from four 32-bit multiplies plus a
shift/mask chain. A 32x32->64 product, on the other hand, is a single `mul` there.

So the guest mixer becomes NH — the UMAC/VMAC core — keyed per 32-bit lane: one product per key word,
summed, then a multiply-shift finalizer.

- `MixWords` and `MultiplyFold` were the last `#if ZK_EVM` bodies in `SpanExtensions.cs`. They become
  partial declarations there and move into `SpanExtensions.std.cs` and `SpanExtensions.zkevm.cs` with
  the rest of the flavour seam, so each side carries its own construction, inlining choice and remarks
  without a preprocessor branch. The guest side gains `MixLanes`; the host keeps the widening fold,
  where `BigMul` is one instruction.
- Lane keys stay independent per position. Sharing one derived constant across words would leave the
  sum invariant under permuting them, and it would not pay anyway: on this target an aligned 8-byte
  load is 16 cost units against 56 for a shift, so re-deriving lane keys costs more than reading them.
- The finalizer's odd multiplier is installed with the seed, folded from two limbs behind a domain
  constant, so it is not one of the lane keys — NH's bound assumes the finalizer key is independent of
  them. Reading a lane key inline instead is 207,809 steps cheaper, because the limbs share a base
  pointer while a new static needs its own address, but that is 0.05% for a weaker argument.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.Core.ZkEvm.Test` 2372/0, `Nethermind.Evm.ZkEvm.Test` 578/0, `Nethermind.Trie.ZkEvm.Test`
105/0, host `Nethermind.Core.Test` 6121/0 (108 skipped).

Three existing tests move with the construction:

- `Guest_word_mixer_matches_reference` gets a `ReferenceMix`/`ReferenceLanes` pair that recomputes the
  lane mixer in `BigInteger` arithmetic, replacing the widening-product reference.
- The pinned vectors in `Scalar_hash_preserves_tail_and_block_boundary_vectors` are regenerated. They
  exist to catch accidental change, so a deliberate one has to re-pin all 23.
- `Guest_mixer_reseeding_breaks_a_collision_set` constructed its set by setting word 0 equal to the
  seed's word 0, which makes `MultiplyFold(u0 ^ s0, u1 ^ s1)` return zero and drop word 1 — a property
  of the widening fold that the lane mixer does not have. It now searches for a colliding pair on the
  32-bit hash code, the bucket a dictionary actually reads, and asserts the replacement seed separates
  it. Same shape #13166 used when it made the leading-bytes test search rather than assume.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

`ziskemu` for mainnet block 25532382, `bflat-riscv64` + `zisk:1.2.0-alpha`, `-Ot
--no-stacktrace-data --ldflags=--strip-all`, one worktree, output byte-identical at both rungs
(`d38ffa…a833` + `0101…0100`, `IsSuccess` checked, not just the root).

| | steps | cost |
|---|---:|---:|
| master `68ce888a8f` | 410,569,383 | 47,777,127,944 |
| this branch | 396,367,705 | 46,000,921,476 |
| | **−3.46%** | **−3.72%** |

`OP mul` 3,150,338 → 1,765,042, `srl` 18,860,913 → 13,380,843, `sll` 10,301,221 → 5,355,537.

On the construction: NH over uniform lane keys is 2^-32-almost-universal, and each finalizer step is a
bijection on 64 bits, so the finalizer redistributes bits into the window a dictionary reads without
adding collisions of its own. The fold it replaces carries no such bound, and it has a degenerate case
the lane mixer does not: `MultiplyFold(0, b)` is 0, so keys whose first limb equals the seed's first
limb drop the second limb entirely. Neither construction resists an attacker who knows the seed and
chooses keys freely; what makes that infeasible is where the seed comes from, which this does not
touch. No formal proof is written for the truncation to `int`.

Two things this does not do:

- `MixWords` keeps `NoInlining` on the guest. That annotation is a workaround tied to the widening
  fold, and with a body this cheap the call frame is worth revisiting — but a hash change cannot be
  validated by the block output, since it moves buckets and not results, so it wants its own pass.
- Keeping the finalizer key in a fifth word alongside the lane keys would fold its load into an offset
  and recover the 0.05%, but it means widening the seed blocks on both paths.
- `FastHashShort` and the variable-length path still call `MultiplyFold` directly. The same treatment
  likely applies; measured separately.

For context on where this sits: the mixer arrived with #13166, which measured +6.40% on the guest
(`4ff8346910` 385,885,868 → `b2461eccc5` 410,573,331). This recovers 58% of that. The remainder is
the witness node store's key hash, which #13166's own remarks point at a structural fix for —
bounding the witness or rejecting unreachable nodes — rather than a cheaper hash.
