### PR TITLE
perf(zkevm): keep resolved children resolved in the guest

### DIFF
--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -939,7 +939,7 @@ namespace Nethermind.Trie
             // Don't unresolve nodes with path length <= 4; there should be relatively few and they should fit
             // in RAM, but they are hit quite a lot, and don't have very good data locality.
             // That said, in practice, it does nothing notable, except for significantly improving benchmark score.
-            if (child?.IsPersisted == true && !keepChildRef && childPath.Length > 4 && childPath.Length % 2 == 0)
+            if (PruneTraversedChildren && child?.IsPersisted == true && !keepChildRef && childPath.Length > 4 && childPath.Length % 2 == 0)
             {
                 UnresolveChild(childIndex);
             }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.std.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.std.cs
@@ -79,10 +79,10 @@ namespace Nethermind.Trie
                 spin.SpinOnce(); // CAS failed — another writer raced; back off before retry
             }
         }
-    
+
         /// <summary>Whether a resolved, persisted child is dropped back to its hash once traversed.</summary>
         /// <remarks>Worth it for a long-lived process, whose node cache would otherwise retain every deep
         /// persisted path it has ever walked. See <c>TrieNode.zkevm.cs</c> for why the guest declines.</remarks>
         private const bool PruneTraversedChildren = true;
-}
+    }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.std.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.std.cs
@@ -79,5 +79,10 @@ namespace Nethermind.Trie
                 spin.SpinOnce(); // CAS failed — another writer raced; back off before retry
             }
         }
-    }
+    
+        /// <summary>Whether a resolved, persisted child is dropped back to its hash once traversed.</summary>
+        /// <remarks>Worth it for a long-lived process, whose node cache would otherwise retain every deep
+        /// persisted path it has ever walked. See <c>TrieNode.zkevm.cs</c> for why the guest declines.</remarks>
+        private const bool PruneTraversedChildren = true;
+}
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.zkevm.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.zkevm.cs
@@ -58,12 +58,12 @@ namespace Nethermind.Trie
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void WriteRlp(CappedArray<byte> value) => InitRlp(value);
-    
+
         /// <inheritdoc cref="PruneTraversedChildren"/>
         /// <remarks>The guest verifies one block and exits, so there is no cache to keep small and nothing
         /// to amortise a re-resolve against: dropping a child only guarantees decoding its RLP again the
         /// next time the path is walked. Over a mainnet block the witness holds 26,025 distinct nodes while
         /// the trie decodes 34,789 times, so 8,764 of those decodes are repeats.</remarks>
         private const bool PruneTraversedChildren = false;
-}
+    }
 }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.zkevm.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.zkevm.cs
@@ -58,5 +58,12 @@ namespace Nethermind.Trie
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void WriteRlp(CappedArray<byte> value) => InitRlp(value);
-    }
+    
+        /// <inheritdoc cref="PruneTraversedChildren"/>
+        /// <remarks>The guest verifies one block and exits, so there is no cache to keep small and nothing
+        /// to amortise a re-resolve against: dropping a child only guarantees decoding its RLP again the
+        /// next time the path is walked. Over a mainnet block the witness holds 26,025 distinct nodes while
+        /// the trie decodes 34,789 times, so 8,764 of those decodes are repeats.</remarks>
+        private const bool PruneTraversedChildren = false;
+}
 }


### PR DESCRIPTION
## Changes

`GetChildWithChildPath` drops a resolved, persisted child back to its bare `Hash256` once the path has been walked:

```csharp
// pruning trick so we never store long persisted paths
// ...
// That said, in practice, it does nothing notable, except for significantly improving benchmark score.
if (child?.IsPersisted == true && !keepChildRef && childPath.Length > 4 && childPath.Length % 2 == 0)
```

For a long-lived process that is the right trade: without it the node cache retains every deep persisted path it has ever traversed. The zkVM guest verifies one block and exits, so there is no cache to bound and nothing to amortise a re-resolve against — dropping the child only guarantees decoding the same RLP again the next time the path is walked.

- Gate the condition on a `private const bool PruneTraversedChildren`, added to the existing `TrieNode.std.cs` / `TrieNode.zkevm.cs` split. The host keeps `true`, where the compiler folds the conjunction away and emits exactly today's condition; the guest keeps `false`, which removes the block. Both builds stay one code path, which is why this is a constant rather than a deleted condition.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The host arm is unchanged by construction — `true &&` in front of the existing condition — so existing coverage applies unmodified: `Nethermind.Trie.Test` passes 565 / 0 failed / 12 skipped.

For the guest arm the end-to-end check is the run itself: it recomputes a mainnet block's state root over ~26k witness nodes and the output hash is byte-identical to master. Retaining a resolved child cannot change what the trie computes, only how often it decodes to get there — and a wrong child would change that root.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

**Guest measurement.** `ziskemu` is deterministic, so these are exact rather than sampled.

| | steps | prover cost |
|---|---:|---:|
| master | 455,076,097 | 51,622,906,058 |
| this PR | 442,257,382 | 50,369,107,861 |
| | **−2.816%** | **−2.429%** |

The mechanism is confirmed in the profile rather than inferred: `TrieNode.DecodeRlp` and `TrieNode.ResolveUnknownNode` both fall from **34,789 to 26,066 calls**, i.e. 8,723 decodes removed, against ~26k distinct nodes in the witness.

Worth recording that the saving per removed decode is ~1,470 steps, far more than `DecodeRlp`'s own ~135 steps per call: a re-resolve also re-runs `ResolveUnknownNode`, `FindCachedOrUnknown` and a node-store hash lookup before it reaches the RLP walk. I had sized this at ~0.5% from the decode cost alone and it came in at 2.8%.

**No host gate run.** The host arm folds to the identical condition at compile time, so there is nothing for a benchmark to detect; this is `Nethermind.Trie` rather than `Nethermind.Evm`, so the opcode-benchmark workflow does not apply either. If a reviewer wants it covered anyway, the trie encode/decode benchmarks are the place.
