### PR TITLE
perf(zkevm): drop the transaction-hash lock in the guest

### DIFF
--- a/src/Nethermind/Nethermind.Core/Transaction.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.cs
@@ -19,7 +19,7 @@ using Nethermind.Int256;
 namespace Nethermind.Core
 {
     [DebuggerDisplay("{Hash}, Value: {Value}, To: {To}, Gas: {GasLimit}")]
-    public class Transaction
+    public partial class Transaction
     {
         public const byte MaxTxType = 0x7F;
         public const uint BaseTxGasCost = 21000;
@@ -95,16 +95,23 @@ namespace Nethermind.Core
             Hash256? hash = _hash;
             if (hash is not null) return hash;
 
-            lock (this)
-            {
-                hash = _hash;
-                if (hash is not null) return hash;
+            return CalculateHashSynchronized();
+        }
 
-                if (_preHash.Length > 0)
-                {
-                    _hash = hash = Keccak.Compute(_preHash.Span);
-                    ClearPreHashInternal();
-                }
+        /// <summary>Computes and memoizes the hash, holding whatever exclusion the target needs.</summary>
+        /// <remarks>Split per target: see <c>Transaction.std.cs</c> and <c>Transaction.zkevm.cs</c>.</remarks>
+        private partial Hash256 CalculateHashSynchronized();
+
+        /// <summary>The memoizing computation itself, with no exclusion of its own.</summary>
+        private Hash256 ComputeAndMemoizeHash()
+        {
+            Hash256? hash = _hash;
+            if (hash is not null) return hash;
+
+            if (_preHash.Length > 0)
+            {
+                _hash = hash = Keccak.Compute(_preHash.Span);
+                ClearPreHashInternal();
             }
 
             return hash!;

--- a/src/Nethermind/Nethermind.Core/Transaction.std.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.std.cs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Core
+{
+    public partial class Transaction
+    {
+        /// <inheritdoc cref="CalculateHashSynchronized"/>
+        /// <remarks>Two threads can race to hash the same transaction, so the memoization is guarded.</remarks>
+        private partial Hash256 CalculateHashSynchronized()
+        {
+            lock (this)
+            {
+                return ComputeAndMemoizeHash();
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Transaction.zkevm.cs
+++ b/src/Nethermind/Nethermind.Core/Transaction.zkevm.cs
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Core
+{
+    public partial class Transaction
+    {
+        /// <inheritdoc cref="CalculateHashSynchronized"/>
+        /// <remarks>The guest is single-threaded, so there is no race to guard and the lock is pure
+        /// overhead - 1,231 acquisitions over one mainnet block.</remarks>
+        private partial Hash256 CalculateHashSynchronized() => ComputeAndMemoizeHash();
+    }
+}


### PR DESCRIPTION
## Changes

`Transaction.CalculateHashInternal` guards its memoization with `lock (this)`, which is right on the host: two threads can race to hash the same transaction. The zkVM guest is single-threaded, so the lock is pure overhead — **1,231 acquisitions over one mainnet block**, and `Monitor.Enter`/`Exit` together accounted for 0.10% of guest steps.

- Split the synchronized wrapper per target, `Transaction.std.cs` / `Transaction.zkevm.cs`: the host takes the lock, the guest calls straight through.
- Factor the memoization itself into a shared `ComputeAndMemoizeHash`, so neither arm duplicates the logic and the two cannot drift.
- `Transaction` becomes `partial`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The host arm keeps today's locking and the memoization body is shared verbatim, so existing coverage applies: `Nethermind.Core.Test` passes 6,229 / 0 failed. The guest run recomputes a mainnet block's state root and receipts root with the output hash byte-identical to master — a mis-memoized transaction hash would change the receipts root.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Measured on top of #13173 + #13291 + #13294 + #13295, in one worktree and toolchain:

| | steps |
|---|---:|
| before | 373,143,647 |
| this PR | 372,835,085 |
| | **−0.083%** |

Small, and worth saying why it is still worth having: it came out of a systematic sweep for host-motivated machinery that the guest cannot use, and it is the only thing that sweep found. For the record, the rest measured as follows, so nobody repeats the search:

- **Metrics: 197 steps** in the whole guest run, and **loggers: 375**. Both already compiled out; nothing to remove.
- **`ParallelUnbalancedWork`: 12,624 steps.** Already effectively inert.
- **The remaining lock traffic is `ClassConstructorRunner`** — 1,359 one-time type initializations, in runtime code rather than ours.
- **The bounded code cache must stay.** `CacheCodeInfoRepository.GetOrCacheCodeInfo` runs 3,687 times for 398 `CodeInfo` constructions, an 89% hit rate; replacing it with the plain repository would mean ~3,600 jump-destination analyses instead of 377. Swapping its set-associative cache for an unbounded dictionary measured **+75,610 steps**, i.e. the 398 misses are 398 genuinely distinct code hashes and there is no duplicate-code win to be had.
