### PR TITLE
fix(erae): bound the slim receipt log array by the bytes that hold it

### DIFF
--- a/src/Nethermind/Nethermind.EraE.Test/Archive/EraSlimReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.EraE.Test/Archive/EraSlimReceiptDecoderTests.cs
@@ -4,6 +4,7 @@
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Encoding;
 using Nethermind.EraE.Archive;
 using Nethermind.Serialization.Rlp;
 using NUnit.Framework;
@@ -19,6 +20,12 @@ internal class EraSlimReceiptDecoderTests
     // go-ethereum 4-field format: outer_list { receipt_list { tx_type, status, gas, logs } }
     // Pre-Byzantium: the "status" field is a 32-byte PostTransactionState (state root), not a status code.
     // Post-Byzantium (EIP-658): the "status" field is 0x00 or 0x01 (1 byte).
+
+    // Comfortably under RlpLimit.ReceiptLogs, but far more logs than the bytes declaring them could hold.
+    private const int UnbackedLogCount = 1_000;
+
+    // Arbitrary - no test reads it back, it only has to be a well-formed cumulative gas item.
+    private const ulong GasUsedTotal = 21000;
 
     [Test]
     public void Decode_GethFormat_PreByzantium_SetsPostTransactionStateNotStatusCode()
@@ -119,6 +126,65 @@ internal class EraSlimReceiptDecoderTests
         Action act = () => sut.Decode(encoded.AsMemory());
 
         Assert.That(act, Throws.TypeOf<RlpException>());
+    }
+
+    [Test]
+    public void Decode_GethFormat_LogCountTheArchiveCannotHold_Throws()
+    {
+        byte[] encoded = EncodeGethReceiptArchive(ReceiptRlpBuilder.Repeat(UnbackedLogCount));
+
+        Action act = () => new EraSlimReceiptDecoder().Decode(encoded.AsMemory());
+
+        Assert.That(act, Throws.TypeOf<RlpLimitException>());
+    }
+
+    [Test]
+    public void Decode_GethFormat_LogListOfSmallestPossibleEntries_Decodes()
+    {
+        byte[] encoded = EncodeGethReceiptArchive(ReceiptRlpBuilder.Repeat(UnbackedLogCount, ReceiptRlpBuilder.MinimalLog()));
+
+        TxReceipt[] receipts = new EraSlimReceiptDecoder().Decode(encoded.AsMemory());
+
+        Assert.That(receipts[0].Logs, Has.Length.EqualTo(UnbackedLogCount));
+    }
+
+    /// <summary>
+    /// Builds a one-receipt archive whose log count can be declared without materialising the logs.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="WrapAsGethReceipt"/> cannot serve here - it only emits one-byte sequence prefixes,
+    /// so it caps a receipt at 55 bytes. The slim body also differs from the eth/63 and eth/69 receipts
+    /// <see cref="ReceiptRlpBuilder"/> encodes, hence the local writer.
+    /// </remarks>
+    private static byte[] EncodeGethReceiptArchive(ReadOnlySpan<LogEntry?> logs)
+    {
+        LogEntryDecoder logEntryDecoder = LogEntryDecoder.Instance;
+        int logsLength = 0;
+        foreach (LogEntry? log in logs)
+        {
+            logsLength += logEntryDecoder.GetLength(log);
+        }
+
+        int receiptLength = Rlp.LengthOf((byte)TxType.Legacy)
+                            + Rlp.LengthOf((byte)1)
+                            + Rlp.LengthOf(GasUsedTotal)
+                            + Rlp.LengthOfSequence(logsLength);
+        int outerLength = Rlp.LengthOfSequence(receiptLength);
+
+        byte[] bytes = new byte[Rlp.LengthOfSequence(outerLength)];
+        RlpWriter writer = new(bytes);
+        writer.StartSequence(outerLength);
+        writer.StartSequence(receiptLength);
+        writer.Encode((byte)TxType.Legacy);
+        writer.Encode((byte)1);
+        writer.Encode(GasUsedTotal);
+        writer.StartSequence(logsLength);
+        foreach (LogEntry? log in logs)
+        {
+            logEntryDecoder.Encode(ref writer, log);
+        }
+
+        return bytes;
     }
 
     // go-ethereum receipt encoding: outer_list { receipt_list { content } }

--- a/src/Nethermind/Nethermind.EraE/Archive/EraSlimReceiptDecoder.cs
+++ b/src/Nethermind/Nethermind.EraE/Archive/EraSlimReceiptDecoder.cs
@@ -68,7 +68,9 @@ internal sealed class EraSlimReceiptDecoder
 
         int logsLength = ctx.ReadSequenceLength();
         int logsEnd = ctx.Position + logsLength;
-        int logCount = ctx.PeekNumberOfItemsRemaining(logsEnd);
+        RlpLimit logsRlpLimit = RlpLimit.ReceiptLogs;
+        int logCount = ctx.PeekNumberOfItemsRemaining(logsEnd, logsRlpLimit.Limit + 1);
+        Rlp.GuardLimit(logCount, (logsEnd - ctx.Position) / LogEntryDecoder.MinEncodedLength, logsRlpLimit);
 
         LogEntry[] logs = new LogEntry[logCount];
         for (int i = 0; i < logCount; i++)


### PR DESCRIPTION
## Changes

- `EraSlimReceiptDecoder` sized its `LogEntry[]` straight from a peeked item count, with no guard. Era archives are third-party downloads, so ~N bytes of one-byte `0xC0` placeholders bought an 8N-byte array before any entry was validated. Bound the count by the bytes that can hold it, using `RlpLimit.ReceiptLogs` and `LogEntryDecoder.MinEncodedLength`.
- Regression tests in `EraSlimReceiptDecoderTests`: 1,000 one-byte placeholders must fail with `RlpLimitException`, while 1,000 real minimum-size logs still decode. The slim body differs from the eth/63 and eth/69 receipts `ReceiptRlpBuilder` encodes, and the file's existing `WrapAsGethReceipt` only emits one-byte sequence prefixes (capping a receipt at 55 bytes), so the tests carry a local writer that reuses `ReceiptRlpBuilder.Repeat`/`MinimalLog`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Proven with a red/green pair reverting only the `Rlp.GuardLimit` line: without it the placeholder test fails (the array allocates, then the first `0xC0` throws a plain `RlpException`, not `RlpLimitException`) while the minimum-size-log test still passes. With the guard restored, the EraE suite is 161 passed / 0 failed / 3 skipped — the skips are the pre-existing tests that need network access to `data.ethpandaops.io`. Build is clean at 0 warnings, and `dotnet format whitespace src/Nethermind/ --folder --verify-no-changes` is clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

**Stacked on #13288** — `RlpLimit.ReceiptLogs` and `LogEntryDecoder.MinEncodedLength` are introduced there and do not exist on master, so this targets `fix/derive-receipt-log-rlp-limit`. Retarget to master once that merges, or fold this commit into it.

One same-shape case is deliberately left alone: `Decode` also sizes `new TxReceipt[count]` from an unguarded outer count. A `TxReceipt` reference is 8 bytes against a 5-byte minimum slim receipt, so the amplification is ~1.6x rather than 8x, and bounding it needs a receipts-per-block limit that `RlpLimit` does not yet carry. Happy to add it here if preferred.
