### PR TITLE
docs(eip8141): correct the frame-mode caller and document the public frame API

### DIFF
--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -32,8 +32,10 @@ public static class FrameTxValidation
     public const string FrameGasOverflow = "total frame gas must not exceed 2^64 - 1";
     /// <summary>The EIP-7825 gas-cap failure message, which names the offending amounts rather than being a
     /// fixed constant.</summary>
-    /// <remarks>The cap is spec-dependent, so the check itself lives in the release-spec-aware validator; only
-    /// its wording is kept here alongside the other messages.</remarks>
+    /// <remarks>The cap is the fixed <see cref="Eip7825Constants.DefaultTxGasLimitCap"/>, applied unconditionally
+    /// as EIP-8141 § Constraints specifies. The check sits in the release-spec-aware validator only because
+    /// <see cref="TryCalculateBlockGasReservations"/> needs an <see cref="IReleaseSpec"/> to price the reservation,
+    /// so just its wording is kept here alongside the other messages.</remarks>
     public static string FrameExecutionGasExceedsCap(ulong executionReservation, ulong gasLimitCap) =>
         $"frame intrinsic and execution gas ({executionReservation}) exceeds the transaction gas cap of {gasLimitCap}";
     public const string InvalidExpiryFrame = "expiry verifier frame must have zero flags, zero value, and 8-byte data";
@@ -57,9 +59,10 @@ public static class FrameTxValidation
     /// The decision is a pure function of <paramref name="transaction"/> and <paramref name="postTxEnabled"/>: it
     /// reads no state and no release spec, so both consensus (<c>BlockValidator</c>) and the pool can reach it, and
     /// the same transaction always yields the same verdict at a given fork. Structural RLP shape is already enforced
-    /// at decode time and is not rechecked. Checks needing the release spec — the EIP-7594 blob-count limit and the
-    /// versioned-hash version byte — are left to <c>FrameTxFieldsTxValidator</c>, so passing this is necessary but
-    /// not sufficient for validity.
+    /// at decode time and is not rechecked. Checks needing the release spec — the EIP-7594 blob limits and the
+    /// EIP-7825 gas cap among them — are left to the validators in <c>TxValidator</c>'s frame composite, which is
+    /// also the only place several of this type's own message constants are raised, so passing this is necessary
+    /// but not sufficient for validity.
     /// </remarks>
     /// <param name="transaction">The frame transaction to check. Must carry <see cref="Transaction.Frames"/> and a
     /// resolved <see cref="Transaction.SenderAddress"/>; both are reported as failures rather than thrown on.</param>

--- a/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
+++ b/src/Nethermind/Nethermind.Core/FrameTxValidation.cs
@@ -30,6 +30,10 @@ public static class FrameTxValidation
     public const string AtomicBatchFollowedByPostTxFrame = "an atomic batch frame must not be followed by a POST_TX frame";
     public const string ApprovalScopeInAtomicBatch = "frames belonging to an atomic batch must not carry approval scope";
     public const string FrameGasOverflow = "total frame gas must not exceed 2^64 - 1";
+    /// <summary>The EIP-7825 gas-cap failure message, which names the offending amounts rather than being a
+    /// fixed constant.</summary>
+    /// <remarks>The cap is spec-dependent, so the check itself lives in the release-spec-aware validator; only
+    /// its wording is kept here alongside the other messages.</remarks>
     public static string FrameExecutionGasExceedsCap(ulong executionReservation, ulong gasLimitCap) =>
         $"frame intrinsic and execution gas ({executionReservation}) exceeds the transaction gas cap of {gasLimitCap}";
     public const string InvalidExpiryFrame = "expiry verifier frame must have zero flags, zero value, and 8-byte data";
@@ -45,6 +49,25 @@ public static class FrameTxValidation
     public const string TooManyRecentRootReferences = "at most 16 recent root references are allowed";
     public const string RecentRootReferencesNotEnabled = "recent root references are not enabled";
 
+    /// <summary>
+    /// Runs the EIP-8141 §Constraints checks a frame transaction can be judged on without state, over its frame
+    /// list, its signature entries and the fields the frame envelope adds.
+    /// </summary>
+    /// <remarks>
+    /// The decision is a pure function of <paramref name="transaction"/> and <paramref name="postTxEnabled"/>: it
+    /// reads no state and no release spec, so both consensus (<c>BlockValidator</c>) and the pool can reach it, and
+    /// the same transaction always yields the same verdict at a given fork. Structural RLP shape is already enforced
+    /// at decode time and is not rechecked. Checks needing the release spec — the EIP-7594 blob-count limit and the
+    /// versioned-hash version byte — are left to <c>FrameTxFieldsTxValidator</c>, so passing this is necessary but
+    /// not sufficient for validity.
+    /// </remarks>
+    /// <param name="transaction">The frame transaction to check. Must carry <see cref="Transaction.Frames"/> and a
+    /// resolved <see cref="Transaction.SenderAddress"/>; both are reported as failures rather than thrown on.</param>
+    /// <param name="postTxEnabled">Whether EIP-7906 is active, which decides only whether
+    /// <see cref="TxFrame.ModePostTx"/> frames are admitted at all.</param>
+    /// <param name="error">On failure, the first violated constraint, always one of this type's message constants;
+    /// <see langword="null"/> on success.</param>
+    /// <returns><see langword="true"/> if every stateless constraint holds.</returns>
     public static bool IsWellFormed(Transaction transaction, bool postTxEnabled, out string? error)
     {
         error = null;
@@ -507,6 +530,8 @@ public static class FrameTxValidation
     /// field is priced before they are measured, and a memo keyed on the spec alone would then answer a later
     /// caller from the unmeasured reading.
     /// </remarks>
+    /// <param name="transaction">The frame transaction to price.</param>
+    /// <param name="spec">The release spec the pricing is taken at; it also keys the memo.</param>
     /// <param name="intrinsicGas">The intrinsic cost, charged before any frame runs.</param>
     /// <param name="floorGas">The minimum chargeable gas, or 0 when floor pricing is not active.</param>
     /// <param name="maxGas">The gas reserved against the payer's balance and the block gas limit.</param>

--- a/src/Nethermind/Nethermind.Core/TxFrame.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrame.cs
@@ -28,10 +28,11 @@ public class TxFrame(byte mode, byte flags, Address? target, ulong executionGasL
     /// instead of merely reverting.</summary>
     /// <remarks>
     /// Ordinarily the transaction's validation prefix, where <see cref="Flags"/> lets it approve execution or
-    /// payment; the approval scope comes from the flags, not from this mode. Consensus fixes no position for a
-    /// VERIFY frame and permits one behind the prefix. Confining them to the leading run is a public-mempool rule
-    /// (<see cref="FrameTxValidation.HasVerifyFrameAfterPrefix"/>): a later VERIFY frame can revert on state the
-    /// pool never simulated, invalidating an already-announced transaction.
+    /// payment; the approval scope comes from the flags, not from this mode. Consensus does not confine a VERIFY
+    /// frame to that prefix — one may sit behind a body frame — though it may neither follow a POST_TX frame nor
+    /// directly follow an atomic-batch one. The public mempool additionally refuses a VERIFY frame behind the
+    /// first frame flagged to approve payment (<see cref="FrameTxValidation.HasVerifyFrameAfterPrefix"/>): its
+    /// revert would invalidate an already-announced transaction on state the pool never simulated.
     /// </remarks>
     public const byte ModeVerify = 1;
 

--- a/src/Nethermind/Nethermind.Core/TxFrame.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrame.cs
@@ -21,16 +21,27 @@ namespace Nethermind.Core;
 /// <param name="data">The frame's calldata.</param>
 public class TxFrame(byte mode, byte flags, Address? target, ulong executionGasLimit, ulong stateGasLimit, UInt256 value, ReadOnlyMemory<byte> data)
 {
-    /// <summary>An ordinary frame, called by the transaction sender.</summary>
+    /// <summary>An ordinary frame, called by <c>ENTRY_POINT</c>.</summary>
     public const byte ModeDefault = 0;
 
-    /// <summary>A validation-prefix frame: it may approve execution or payment, and runs before any body frame.</summary>
+    /// <summary>A read-only frame, called by <c>ENTRY_POINT</c>, whose failure invalidates the whole transaction
+    /// instead of merely reverting.</summary>
+    /// <remarks>
+    /// Ordinarily the transaction's validation prefix, where <see cref="Flags"/> lets it approve execution or
+    /// payment; the approval scope comes from the flags, not from this mode. Consensus fixes no position for a
+    /// VERIFY frame and permits one behind the prefix. Confining them to the leading run is a public-mempool rule
+    /// (<see cref="FrameTxValidation.HasVerifyFrameAfterPrefix"/>): a later VERIFY frame can revert on state the
+    /// pool never simulated, invalidating an already-announced transaction.
+    /// </remarks>
     public const byte ModeVerify = 1;
 
-    /// <summary>A frame whose calls appear to come from the transaction sender rather than from the frame's caller.</summary>
+    /// <summary>The one mode called by the transaction sender rather than <c>ENTRY_POINT</c>, and so the only one
+    /// that may carry <see cref="Value"/>.</summary>
+    /// <remarks>Rejected at execution unless an earlier frame has already approved execution for the sender.</remarks>
     public const byte ModeSender = 2;
 
-    /// <summary>EIP-7906: a read-only trailing frame that asserts the transaction's outcome.</summary>
+    /// <summary>EIP-7906: a read-only trailing frame, called by <c>ENTRY_POINT</c>, that asserts the
+    /// transaction's outcome.</summary>
     public const byte ModePostTx = 3;
 
     /// <summary>The frame may approve nothing; an <c>APPROVE</c> from it always reverts.</summary>

--- a/src/Nethermind/Nethermind.Core/TxFrameSignature.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrameSignature.cs
@@ -13,8 +13,9 @@ public class TxFrameSignature(byte scheme, Address? signer, ReadOnlyMemory<byte>
 {
     /// <summary>An entry the protocol does not verify: opaque bytes whose meaning is left to the frame code
     /// that reads them.</summary>
-    /// <remarks>Only the structural rules apply — it must name no <see cref="Signer"/>, and nothing constrains
-    /// <see cref="Signature"/>. A frame relying on such an entry must verify the witness itself.</remarks>
+    /// <remarks>Only the structural rules apply — it must name no <see cref="Signer"/>, and <see cref="Msg"/> is
+    /// still held to the empty-or-non-zero-32-byte rule though nothing reads it; <see cref="Signature"/> alone is
+    /// unconstrained. A frame relying on such an entry must verify the witness itself.</remarks>
     public const byte SchemeArbitrary = 0x0;
 
     /// <summary>An ECDSA signature over secp256k1, verified against the recovered address.</summary>
@@ -48,10 +49,13 @@ public class TxFrameSignature(byte scheme, Address? signer, ReadOnlyMemory<byte>
     /// <summary>The raw signature bytes, whose layout and required length are fixed by <see cref="Scheme"/>.</summary>
     public ReadOnlyMemory<byte> Signature { get; } = signature;
 
-    /// <summary>Whether this entry signs the transaction's canonical signature hash rather than a digest of
-    /// its own.</summary>
+    /// <summary>Whether this entry leaves <see cref="Msg"/> empty, so a protocol-verified scheme signs the
+    /// transaction's canonical signature hash rather than a digest of its own.</summary>
     /// <remarks>Every such entry of one transaction shares a digest, so it is computed once; entries carrying an
     /// explicit <see cref="Msg"/> never need it at all. The canonical hash elides these entries' own
-    /// <see cref="Signature"/> bytes, which is what lets them sign a transaction that contains them.</remarks>
+    /// <see cref="Signature"/> bytes, which is what lets them sign a transaction that contains them. EIP-8141
+    /// § Signature Hash keys that elision on the empty <c>msg</c> alone, so a <see cref="SchemeArbitrary"/> entry
+    /// — which signs nothing the protocol checks — is elided too, and its bytes stay rewritable without
+    /// disturbing any canonical-hash signature.</remarks>
     public bool SignsCanonicalHash => Msg.IsEmpty;
 }

--- a/src/Nethermind/Nethermind.Core/TxFrameSignature.cs
+++ b/src/Nethermind/Nethermind.Core/TxFrameSignature.cs
@@ -11,13 +11,32 @@ namespace Nethermind.Core;
 /// </summary>
 public class TxFrameSignature(byte scheme, Address? signer, ReadOnlyMemory<byte> msg, ReadOnlyMemory<byte> signature)
 {
+    /// <summary>An entry the protocol does not verify: opaque bytes whose meaning is left to the frame code
+    /// that reads them.</summary>
+    /// <remarks>Only the structural rules apply — it must name no <see cref="Signer"/>, and nothing constrains
+    /// <see cref="Signature"/>. A frame relying on such an entry must verify the witness itself.</remarks>
     public const byte SchemeArbitrary = 0x0;
+
+    /// <summary>An ECDSA signature over secp256k1, verified against the recovered address.</summary>
+    /// <remarks><see cref="Signature"/> is <see cref="Secp256k1SignatureLength"/> bytes laid out as
+    /// <c>v || r || s</c>, with <c>v</c> a single 0 or 1 byte and <c>s</c> required to be low.</remarks>
     public const byte SchemeSecp256k1 = 0x1;
+
+    /// <summary>An ECDSA signature over secp256r1 (P-256), verified through the EIP-7951 precompile.</summary>
+    /// <remarks><see cref="Signature"/> is <see cref="P256SignatureLength"/> bytes laid out as
+    /// <c>r || s || qx || qy</c>, with <c>s</c> required to be low. The public key must hash to
+    /// <see cref="Signer"/> under the usual <c>keccak(qx || qy)[12:]</c> derivation. An entry of this scheme is
+    /// rejected on a chain where the precompile is not yet active.</remarks>
     public const byte SchemeP256 = 0x2;
 
+    /// <summary>Exact length in bytes a <see cref="SchemeSecp256k1"/> <see cref="Signature"/> must have.</summary>
     public const int Secp256k1SignatureLength = 65;
+
+    /// <summary>Exact length in bytes a <see cref="SchemeP256"/> <see cref="Signature"/> must have; it carries the
+    /// public key as well as <c>r</c> and <c>s</c>.</summary>
     public const int P256SignatureLength = 128;
 
+    /// <summary>Which of the <c>Scheme*</c> constants governs how <see cref="Signature"/> is read and verified.</summary>
     public byte Scheme { get; } = scheme;
 
     /// <summary>Null resolves to the transaction sender. Must be null for <see cref="SchemeArbitrary"/>.</summary>
@@ -26,7 +45,13 @@ public class TxFrameSignature(byte scheme, Address? signer, ReadOnlyMemory<byte>
     /// <summary>Empty means the canonical transaction signature hash; otherwise an explicit 32-byte digest.</summary>
     public ReadOnlyMemory<byte> Msg { get; } = msg;
 
+    /// <summary>The raw signature bytes, whose layout and required length are fixed by <see cref="Scheme"/>.</summary>
     public ReadOnlyMemory<byte> Signature { get; } = signature;
 
+    /// <summary>Whether this entry signs the transaction's canonical signature hash rather than a digest of
+    /// its own.</summary>
+    /// <remarks>Every such entry of one transaction shares a digest, so it is computed once; entries carrying an
+    /// explicit <see cref="Msg"/> never need it at all. The canonical hash elides these entries' own
+    /// <see cref="Signature"/> bytes, which is what lets them sign a transaction that contains them.</remarks>
     public bool SignsCanonicalHash => Msg.IsEmpty;
 }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/FrameTxSigHash.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/FrameTxSigHash.cs
@@ -20,9 +20,10 @@ public static class FrameTxSigHash
 
     /// <summary>The digest a canonical-hash signature entry of <paramref name="transaction"/> signs.</summary>
     /// <remarks>
-    /// Independent of the signature bytes themselves, so every canonical-hash entry of one transaction shares a
-    /// digest and it need be computed only once per transaction. An entry carrying an explicit
-    /// <see cref="TxFrameSignature.Msg"/> signs that digest instead and does not consult this.
+    /// The preimage elides the <see cref="TxFrameSignature.Signature"/> bytes of canonical-hash entries alone, so
+    /// every such entry of one transaction shares this digest and it is computed only once. An entry carrying an
+    /// explicit <see cref="TxFrameSignature.Msg"/> signs that digest instead, and its own signature bytes stay in
+    /// the preimage (EIP-8141 § Signature Hash), so they must be final before this is computed.
     /// </remarks>
     public static ValueHash256 ComputeValue(Transaction transaction)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/FrameTxSigHash.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/FrameTxSigHash.cs
@@ -14,8 +14,16 @@ public static class FrameTxSigHash
 {
     private static readonly FrameTxDecoder<Transaction> Decoder = new();
 
+    /// <summary>The digest a canonical-hash signature entry of <paramref name="transaction"/> signs.</summary>
+    /// <remarks>Allocates; prefer <see cref="ComputeValue"/> on the verification path, which this wraps.</remarks>
     public static Hash256 Compute(Transaction transaction) => new(ComputeValue(transaction));
 
+    /// <summary>The digest a canonical-hash signature entry of <paramref name="transaction"/> signs.</summary>
+    /// <remarks>
+    /// Independent of the signature bytes themselves, so every canonical-hash entry of one transaction shares a
+    /// digest and it need be computed only once per transaction. An entry carrying an explicit
+    /// <see cref="TxFrameSignature.Msg"/> signs that digest instead and does not consult this.
+    /// </remarks>
     public static ValueHash256 ComputeValue(Transaction transaction)
     {
         KeccakRlpWriter writer = new();


### PR DESCRIPTION
## Changes

Addresses two P3 documentation threads from @benaadams on #12526. Documentation only — no behaviour change; the diff is comment lines plus three blank separators.

**1. The frame-mode documentation was wrong about the caller.** `TxFrame.ModeDefault` said "called by the transaction sender". The processor resolves the caller as `caller = isSender ? sender : Eip8141Constants.EntryPointAddress` (`TransactionProcessorBase.FrameTx.cs:276`, and unconditionally `ENTRY_POINT` in the validation-prefix loop at :613). So `SENDER` is the one mode called by the sender — which is also why it is the only mode permitted to carry `value` — and `DEFAULT`, `VERIFY` and `POST_TX` all run with `ENTRY_POINT` as caller. Each mode constant now names its caller.

**2. The VERIFY description presented a pool rule as an execution rule.** It said a VERIFY frame "runs before any body frame". `FrameTxValidation.IsWellFormed` imposes no positional rule on `VERIFY`, and the processor's main loop runs one at any index (static, with a revert invalidating the transaction). Confining the approving run to the head of the frame list is the public-mempool rule already stated on `HasVerifyFrameAfterPrefix`, enforced by `FrameTxVerifyAfterPrefixFilter`. The remark now says so and cross-references it.

While correcting that, the approval scope is attributed to `Flags` rather than to the mode: `InstructionApprove` gates on `AllowedApproveScope` and bars only `POST_TX` by mode, so an approving `DEFAULT` frame is possible — as `HasVerifyFrameAfterPrefix`'s own remark already notes.

**3. Missing XML on the new public entry points:** `FrameTxValidation.IsWellFormed` (scope, purity, what it deliberately leaves to the spec-aware validator, and the `out` contract), `FrameExecutionGasExceedsCap`, `FrameTxSigHash.Compute`/`ComputeValue`, and the undocumented public members of `TxFrameSignature` (the three schemes with their signature layouts and lengths, `Scheme`, `Signature`, `SignsCanonicalHash`).

Also completed the two `<param>` tags missing from `FrameTxValidation.TryCalculateGasBudget`, which documented its outputs but not `transaction` or `spec` (CS1573).

Not resolving the review threads — they are @benaadams' to close.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring
- [ ] Configuration change
- [ ] Other (please describe)

## Testing

Documentation only, so no tests were added.

- `Nethermind.Core.Test`: 6418 total, 0 failed (6282 passed, 136 skipped)
- `Nethermind.Evm.Test`: 10869 total, 0 failed (10850 passed, 19 skipped)
- Lint gate (`code-lint.yml`'s exact invocation): build succeeded, 0 warnings, 0 errors, no `IDE`/`CA` warnings. Positive-controlled — an injected unused `using` was caught as `IDE0005`, then reverted.
- Because that gate suppresses `CS1570`/`CS1572`/`CS1573`/`CS1574`/`CS1584`, a second build was run with `GenerateDocumentationFile=true` and those left enabled to confirm the new crefs resolve and the XML is well formed. No new doc warnings in the four touched files.

## Documentation

Requires documentation update

- [ ] Yes
- [x] No
