### PR TITLE
fix(network): stop the connect workers dialling past MaxActivePeers

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -213,16 +213,23 @@ namespace Nethermind.Network.Test
         [Test]
         public async Task Will_only_connect_up_to_max_peers()
         {
+            const int candidateCount = 50;
+            const int expectedConnectCount = 25;
+
             await using Context ctx = new(1);
-            ctx.SetupPersistedPeers(50);
+            ctx.SetupPersistedPeers(candidateCount);
             ctx.PeerPool.Start();
+
+            // Feed the pool before the manager subscribes to PeerAdded: the quick-connect fast path claims
+            // its slot only after an await, so a candidate arriving mid-saturation can dial past the cap.
+            Assert.That(() => ctx.PeerPool.PeerCount, Is.EqualTo(candidateCount).After(_delayLonger, 10));
+
             ctx.PeerManager.Start();
 
-            const int expectedConnectCount = 25;
             await ctx.RlpxPeer.WaitForConnectCallsAsync(expectedConnectCount, TimeSpan.FromSeconds(30));
             await Task.Delay(_delayLong);
 
-            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.InRange(expectedConnectCount, expectedConnectCount + 1));
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(expectedConnectCount));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -210,20 +210,20 @@ namespace Nethermind.Network.Test
             Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1));
         }
 
-        [Test]
-        public async Task Will_only_connect_up_to_max_peers()
+        [TestCase(1, 1_000_000)]
+        [TestCase(8, 200)]
+        public async Task Will_only_connect_up_to_max_peers(int outgoingConnectParallelism, int maxOutgoingConnectPerSec)
         {
             const int candidateCount = 50;
             const int expectedConnectCount = 25;
 
-            await using Context ctx = new(1);
+            await using Context ctx = new(outgoingConnectParallelism);
+            // A throttled connect suspends in the rate limiter with its slot claimed but not yet active,
+            // which is where the workers used to lose count of each other.
+            ctx.NetworkConfig.MaxOutgoingConnectPerSec = maxOutgoingConnectPerSec;
+            ctx.CreatePeerManager();
             ctx.SetupPersistedPeers(candidateCount);
             ctx.PeerPool.Start();
-
-            // Feed the pool before the manager subscribes to PeerAdded: the quick-connect fast path claims
-            // its slot only after an await, so a candidate arriving mid-saturation can dial past the cap.
-            Assert.That(() => ctx.PeerPool.PeerCount, Is.EqualTo(candidateCount).After(_delayLonger, 10));
-
             ctx.PeerManager.Start();
 
             await ctx.RlpxPeer.WaitForConnectCallsAsync(expectedConnectCount, TimeSpan.FromSeconds(30));

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -246,48 +246,63 @@ namespace Nethermind.Network.Test
             Node contested = new(new PrivateKeyGenerator().Generate().PublicKey, "1.2.3.4", 30303);
             ctx.PeerPool.ActivePeers[contested.Id] = new Peer(contested);
             ctx.PeerPool.GetOrAdd(contested);
-            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.Zero, "an already active node was dialled again");
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.Zero, "an already active node was dialed again");
 
             ctx.PeerPool.GetOrAdd(new Node(new PrivateKeyGenerator().Generate().PublicKey, "1.2.3.5", 30303));
 
             Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1), "the claim was not released, so the freed slot is unusable");
         }
 
+        /// <remarks>
+        /// Contacting a candidate spends an entry in the production recent-IP filter, which then suppresses
+        /// it for five minutes. A candidate that loses the last slot before it can claim one was never
+        /// dialed, so it must not pay that price - it is offered again as soon as capacity returns, and that
+        /// offer has to reach the dial.
+        /// </remarks>
         [Test]
-        public async Task Will_not_dial_when_the_slots_fill_between_the_check_and_the_claim()
+        public async Task Will_not_consume_the_contact_filter_when_the_slot_is_lost_before_the_claim()
         {
             const int maxActivePeers = 3;
 
             await using Context ctx = new(maxActivePeers: maxActivePeers);
-            ctx.PeerManager.Start();
+            ctx.RlpxPeer.UseRecentIpFilter();
 
-            Node first = new(new PrivateKeyGenerator().Generate().PublicKey, "1.2.3.4", 30303);
-            Node refused = new(new PrivateKeyGenerator().Generate().PublicKey, "1.2.3.5", 30303);
+            // Port 0 keeps the candidate out of the update loop's selection, leaving the peer-added fast
+            // path as the only way it is dialed - which is what makes the interleaving below reproducible.
+            Node refused = new(new PrivateKeyGenerator().Generate().PublicKey, "203.0.113.1", 0);
 
-            // Both dial paths check for a free slot before ShouldContact and claim one after it, so
-            // filling the slots from here lands inside the window the claim has to close.
+            // CanConnectToPeer is the only step between the free-slot check and the claim, so taking the
+            // slots from its stats lookup lands the candidate inside the window the claim has to close.
             bool filled = false;
-            ctx.RlpxPeer.OnShouldContact = ip =>
+            ctx.Stats = ForwardingStats(ctx.Stats, node =>
             {
-                if (!ip.Equals(refused.Address.Address)) return;
+                if (filled || node.Id != refused.Id) return;
 
                 PrivateKeyGenerator keyGenerator = new();
                 while (ctx.PeerPool.ActivePeers.Count < maxActivePeers)
                 {
                     PublicKey key = keyGenerator.Generate().PublicKey;
-                    ctx.PeerPool.ActivePeers[key] = new Peer(new Node(key, "1.2.3.6", 30303));
+                    ctx.PeerPool.ActivePeers[key] = new Peer(new Node(key, "203.0.113.2", 30303));
                 }
 
                 filled = true;
-            };
-
-            ctx.PeerPool.GetOrAdd(first);
-            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1));
+            });
+            ctx.CreatePeerManager();
+            ctx.PeerManager.Start();
 
             ctx.PeerPool.GetOrAdd(refused);
 
             Assert.That(filled, Is.True, "the candidate never reached the claim");
-            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1), "dialled with no slot left");
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.Zero, "dialed with no slot left");
+            Assert.That(ctx.RlpxPeer.ContactedIps, Is.Empty, "a filter entry was spent on a dial that never happened");
+
+            // Capacity is back, so the retry has to get through - a spent entry would hold it off for the
+            // next five minutes.
+            ctx.PeerPool.ActivePeers.Clear();
+            ctx.PeerPool.TryRemove(refused.Id, out _);
+            ctx.PeerPool.GetOrAdd(refused);
+
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1), "the refused candidate stayed suppressed");
         }
 
         [Test]
@@ -901,6 +916,27 @@ namespace Nethermind.Network.Test
             Assert.That(() => ctx.PeerPool.TryRemove(node.NodeId, out _), Is.False.After(_delay, 10));
         }
 
+        /// <summary>
+        /// A stats manager that answers from <paramref name="inner"/> and runs <paramref name="onNodeChecked"/>
+        /// on every compatibility lookup, the one the dial fast path makes per candidate.
+        /// </summary>
+        private static INodeStatsManager ForwardingStats(INodeStatsManager inner, Action<Node> onNodeChecked)
+        {
+            INodeStatsManager stats = Substitute.For<INodeStatsManager>();
+            stats.GetOrAdd(Arg.Any<Node>()).Returns(call => inner.GetOrAdd(call.Arg<Node>()));
+            stats.GetCurrentReputation(Arg.Any<Node>()).Returns(call => inner.GetCurrentReputation(call.Arg<Node>()));
+            stats.IsConnectionDelayed(Arg.Any<Node>()).Returns(call => inner.IsConnectionDelayed(call.Arg<Node>()));
+            stats.HasFailedValidation(Arg.Any<Node>()).Returns(call => inner.HasFailedValidation(call.Arg<Node>()));
+            stats.FindCompatibilityValidationResult(Arg.Any<Node>()).Returns(call =>
+            {
+                Node node = call.Arg<Node>();
+                onNodeChecked(node);
+                return inner.FindCompatibilityValidationResult(node);
+            });
+
+            return stats;
+        }
+
         private class Context : IAsyncDisposable
         {
             public RlpxMock RlpxPeer { get; }
@@ -1055,6 +1091,7 @@ namespace Nethermind.Network.Test
         private class RlpxMock(List<Session> sessions) : IRlpxHost
         {
             private readonly List<Session> _sessions = sessions;
+            private NodeFilter _nodeFilter = NodeFilter.AcceptAll;
             private int _connectAsyncCallsCount;
 
             public ISessionMonitor SessionMonitor { get; }
@@ -1158,11 +1195,17 @@ namespace Nethermind.Network.Test
 
             public void MakeItFail() => _isFailing = true;
 
-            public Action<IPAddress>? OnShouldContact { get; set; }
+            /// <summary>Addresses accepted for contact, that is, the ones that spent a filter entry.</summary>
+            public ConcurrentBag<IPAddress> ContactedIps { get; } = [];
+
+            /// <summary>Replaces the accept-everything default with the production recent-IP filter.</summary>
+            public void UseRecentIpFilter() => _nodeFilter = NodeFilter.CreateExact(size: 256, timeout: TimeSpan.FromMinutes(5));
 
             public bool ShouldContact(IPAddress ip, bool exactOnly = false)
             {
-                OnShouldContact?.Invoke(ip);
+                if (!_nodeFilter.TryAccept(ip, exactOnly)) return false;
+
+                ContactedIps.Add(ip);
                 return true;
             }
 

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -210,26 +210,29 @@ namespace Nethermind.Network.Test
             Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1));
         }
 
-        [TestCase(1, 1_000_000)]
-        [TestCase(8, 200)]
-        public async Task Will_only_connect_up_to_max_peers(int outgoingConnectParallelism, int maxOutgoingConnectPerSec)
+        /// <remarks>
+        /// The numbers are the point of the case: eight workers against two slots, throttled to four dials a
+        /// second, so every worker dequeues a candidate and suspends in the rate limiter with its slot claimed
+        /// but not yet active. That is the window a plain capacity check cannot see - reverting the claim dials
+        /// five or six against a cap of two, on every run.
+        /// </remarks>
+        [Test]
+        public async Task Will_only_connect_up_to_max_peers()
         {
             const int candidateCount = 50;
-            const int expectedConnectCount = 25;
+            const int maxActivePeers = 2;
 
-            await using Context ctx = new(outgoingConnectParallelism);
-            // A throttled connect suspends in the rate limiter with its slot claimed but not yet active,
-            // which is where the workers used to lose count of each other.
-            ctx.NetworkConfig.MaxOutgoingConnectPerSec = maxOutgoingConnectPerSec;
+            await using Context ctx = new(parallelism: 8, maxActivePeers: maxActivePeers);
+            ctx.NetworkConfig.MaxOutgoingConnectPerSec = 4;
             ctx.CreatePeerManager();
             ctx.SetupPersistedPeers(candidateCount);
             ctx.PeerPool.Start();
             ctx.PeerManager.Start();
 
-            await ctx.RlpxPeer.WaitForConnectCallsAsync(expectedConnectCount, TimeSpan.FromSeconds(30));
+            await ctx.RlpxPeer.WaitForConnectCallsAsync(maxActivePeers, TimeSpan.FromSeconds(30));
             await Task.Delay(_delayLong);
 
-            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(expectedConnectCount));
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(maxActivePeers));
         }
 
         [Test]
@@ -997,6 +1000,8 @@ namespace Nethermind.Network.Test
         private class RlpxMock(List<Session> sessions) : IRlpxHost
         {
             private readonly List<Session> _sessions = sessions;
+            private int _connectAsyncCallsCount;
+
             public ISessionMonitor SessionMonitor { get; }
 
             public event Action? ConnectCalled;
@@ -1005,10 +1010,7 @@ namespace Nethermind.Network.Test
 
             public Task<bool> ConnectAsync(Node node)
             {
-                lock (this)
-                {
-                    ConnectAsyncCallsCount++;
-                }
+                Interlocked.Increment(ref _connectAsyncCallsCount);
 
                 if (_isFailing)
                 {
@@ -1069,7 +1071,7 @@ namespace Nethermind.Network.Test
                 session.Handshake(new PrivateKeyGenerator().Generate().PublicKey);
             }
 
-            public int ConnectAsyncCallsCount { get; set; }
+            public int ConnectAsyncCallsCount => Volatile.Read(ref _connectAsyncCallsCount);
 
             public Task Shutdown() => Task.CompletedTask;
 

--- a/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/PeerManagerTests.cs
@@ -236,6 +236,61 @@ namespace Nethermind.Network.Test
         }
 
         [Test]
+        public async Task Will_release_the_claimed_slot_when_the_candidate_is_already_active()
+        {
+            await using Context ctx = new(maxActivePeers: 2);
+            ctx.PeerManager.Start();
+
+            // An IN session for the same node can be initialized while the OUT attempt is in the rate
+            // limiter, so AddActivePeer refuses it - and the slot it claimed has to go back.
+            Node contested = new(new PrivateKeyGenerator().Generate().PublicKey, "1.2.3.4", 30303);
+            ctx.PeerPool.ActivePeers[contested.Id] = new Peer(contested);
+            ctx.PeerPool.GetOrAdd(contested);
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.Zero, "an already active node was dialled again");
+
+            ctx.PeerPool.GetOrAdd(new Node(new PrivateKeyGenerator().Generate().PublicKey, "1.2.3.5", 30303));
+
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1), "the claim was not released, so the freed slot is unusable");
+        }
+
+        [Test]
+        public async Task Will_not_dial_when_the_slots_fill_between_the_check_and_the_claim()
+        {
+            const int maxActivePeers = 3;
+
+            await using Context ctx = new(maxActivePeers: maxActivePeers);
+            ctx.PeerManager.Start();
+
+            Node first = new(new PrivateKeyGenerator().Generate().PublicKey, "1.2.3.4", 30303);
+            Node refused = new(new PrivateKeyGenerator().Generate().PublicKey, "1.2.3.5", 30303);
+
+            // Both dial paths check for a free slot before ShouldContact and claim one after it, so
+            // filling the slots from here lands inside the window the claim has to close.
+            bool filled = false;
+            ctx.RlpxPeer.OnShouldContact = ip =>
+            {
+                if (!ip.Equals(refused.Address.Address)) return;
+
+                PrivateKeyGenerator keyGenerator = new();
+                while (ctx.PeerPool.ActivePeers.Count < maxActivePeers)
+                {
+                    PublicKey key = keyGenerator.Generate().PublicKey;
+                    ctx.PeerPool.ActivePeers[key] = new Peer(new Node(key, "1.2.3.6", 30303));
+                }
+
+                filled = true;
+            };
+
+            ctx.PeerPool.GetOrAdd(first);
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1));
+
+            ctx.PeerPool.GetOrAdd(refused);
+
+            Assert.That(filled, Is.True, "the candidate never reached the claim");
+            Assert.That(ctx.RlpxPeer.ConnectAsyncCallsCount, Is.EqualTo(1), "dialled with no slot left");
+        }
+
+        [Test]
         public async Task Will_discard_a_duplicate_incoming_session()
         {
             await using Context ctx = new();
@@ -1103,7 +1158,13 @@ namespace Nethermind.Network.Test
 
             public void MakeItFail() => _isFailing = true;
 
-            public bool ShouldContact(IPAddress ip, bool exactOnly = false) => true;
+            public Action<IPAddress>? OnShouldContact { get; set; }
+
+            public bool ShouldContact(IPAddress ip, bool exactOnly = false)
+            {
+                OnShouldContact?.Invoke(ip);
+                return true;
+            }
 
             private void Track(Session session) => session.Disconnected += OnSessionDisconnected;
 

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -274,9 +274,7 @@ namespace Nethermind.Network
                 {
                     try
                     {
-                        // The queueing side checked capacity before this hand-off, and the hand-off blocks
-                        // while the workers are busy, so the slot it saw may be gone by now.
-                        if (HasAvailableActivePeerSlot() && ShouldContactPeer(peer))
+                        if (ShouldContactPeer(peer))
                         {
                             await SetupOutgoingPeerConnection(peer);
                         }
@@ -502,6 +500,22 @@ namespace Nethermind.Network
         }
 
         private bool HasAvailableActivePeerSlot() => AvailableActivePeersCount - _pending > 0;
+
+        /// <summary>
+        /// Reserves one of the <see cref="MaxActivePeers"/> slots for an outgoing connection attempt.
+        /// </summary>
+        /// <remarks>
+        /// Claims first and gives the claim back when there turns out to be no room, so that concurrent
+        /// callers cannot all pass <see cref="HasAvailableActivePeerSlot"/> for the same slot and then
+        /// dial once they resume. The claim is released in <see cref="SetupOutgoingPeerConnection"/>.
+        /// </remarks>
+        private bool TryClaimActivePeerSlot()
+        {
+            if (Interlocked.Increment(ref _pending) <= AvailableActivePeersCount) return true;
+
+            Interlocked.Decrement(ref _pending);
+            return false;
+        }
 
         private async Task<bool> EnsureAvailableActivePeerSlotAsync()
         {
@@ -771,23 +785,33 @@ namespace Nethermind.Network
         {
             if (cancelIfThrottled && _outgoingConnectionRateLimiter.IsThrottled()) return;
 
-            await _outgoingConnectionRateLimiter.WaitAsync(_cancellationTokenSource.Token);
+            // Claim the slot before the first await: a caller suspended in the rate limiter is invisible
+            // to a plain capacity check, so without the claim all of them dial past MaxActivePeers.
+            if (!TryClaimActivePeerSlot()) return;
 
-            // Can happen when In connection is received from the same peer and is initialized before we get here
-            // In this case we do not initialize OUT connection
-            if (!AddActivePeer(peer.Node.Id, peer, "upgrading candidate"))
+            bool result = false;
+            try
             {
-                if (_logger.IsTrace) TraceActivePeerAlreadyAddedToCollection();
-                return;
+                await _outgoingConnectionRateLimiter.WaitAsync(_cancellationTokenSource.Token);
+
+                // Can happen when In connection is received from the same peer and is initialized before we get here
+                // In this case we do not initialize OUT connection
+                if (!AddActivePeer(peer.Node.Id, peer, "upgrading candidate"))
+                {
+                    if (_logger.IsTrace) TraceActivePeerAlreadyAddedToCollection();
+                    return;
+                }
+
+                Interlocked.Increment(ref _tryCount);
+                result = await InitializeOutgoingPeerConnection(peer);
+                // for some time we will have a peer in active that has no session assigned - analyze this?
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _pending);
+                SignalPeerUpdateNeeded();
             }
 
-            Interlocked.Increment(ref _tryCount);
-            Interlocked.Increment(ref _pending);
-            bool result = await InitializeOutgoingPeerConnection(peer);
-            // for some time we will have a peer in active that has no session assigned - analyze this?
-
-            Interlocked.Decrement(ref _pending);
-            SignalPeerUpdateNeeded();
             if (_logger.IsTrace) TraceOutgoingConnectionResult();
 
             if (!result)

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -140,7 +140,7 @@ namespace Nethermind.Network
             }
 
             _stats.ReportEvent(peer.Node, NodeStatsEventType.NodeDiscovered);
-            if (_pending < AvailableActivePeersCount && CanConnectToPeer(peer))
+            if (HasAvailableActivePeerSlot() && CanConnectToPeer(peer))
             {
 #pragma warning disable 4014
 
@@ -507,11 +507,19 @@ namespace Nethermind.Network
         /// <remarks>
         /// Claims first and gives the claim back when there turns out to be no room, so that concurrent
         /// callers cannot all pass <see cref="HasAvailableActivePeerSlot"/> for the same slot and then
-        /// dial once they resume. The claim is released in <see cref="SetupOutgoingPeerConnection"/>.
+        /// dial once they resume. Static and trusted peers keep their claim either way: they are must-keep
+        /// and exempt from the cap everywhere else, and once the cap is full nothing re-selects them, so a
+        /// refusal here would drop them for good. The claim is released in
+        /// <see cref="SetupOutgoingPeerConnection"/>.
         /// </remarks>
-        private bool TryClaimActivePeerSlot()
+        private bool TryClaimActivePeerSlot(Peer peer)
         {
-            if (Interlocked.Increment(ref _pending) <= AvailableActivePeersCount) return true;
+            if (Interlocked.Increment(ref _pending) <= AvailableActivePeersCount
+                || peer.Node.IsStatic
+                || peer.Node.IsTrusted)
+            {
+                return true;
+            }
 
             Interlocked.Decrement(ref _pending);
             return false;
@@ -787,7 +795,13 @@ namespace Nethermind.Network
 
             // Claim the slot before the first await: a caller suspended in the rate limiter is invisible
             // to a plain capacity check, so without the claim all of them dial past MaxActivePeers.
-            if (!TryClaimActivePeerSlot()) return;
+            if (!TryClaimActivePeerSlot(peer))
+            {
+                // The candidate was selected and queued, so say it went nowhere - otherwise a slot freed
+                // in the meantime idles until the next PeersUpdateInterval.
+                SignalPeerUpdateNeeded();
+                return;
+            }
 
             bool result = false;
             try

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -274,7 +274,9 @@ namespace Nethermind.Network
                 {
                     try
                     {
-                        if (ShouldContactPeer(peer))
+                        // The queueing side checked capacity before this hand-off, and the hand-off blocks
+                        // while the workers are busy, so the slot it saw may be gone by now.
+                        if (HasAvailableActivePeerSlot() && ShouldContactPeer(peer))
                         {
                             await SetupOutgoingPeerConnection(peer);
                         }
@@ -499,9 +501,11 @@ namespace Nethermind.Network
             }
         }
 
+        private bool HasAvailableActivePeerSlot() => AvailableActivePeersCount - _pending > 0;
+
         private async Task<bool> EnsureAvailableActivePeerSlotAsync()
         {
-            if (AvailableActivePeersCount - _pending > 0)
+            if (HasAvailableActivePeerSlot())
             {
                 return true;
             }
@@ -511,13 +515,13 @@ namespace Nethermind.Network
             // the active peer count to go down within this time window.
             DateTimeOffset deadline = DateTimeOffset.UtcNow + Timeouts.Handshake +
                                       TimeSpan.FromMilliseconds(_networkConfig.ConnectTimeoutMs);
-            while (DateTimeOffset.UtcNow < deadline && (AvailableActivePeersCount - _pending) <= 0)
+            while (DateTimeOffset.UtcNow < deadline && !HasAvailableActivePeerSlot())
             {
                 // Wait for a signal or poll every 100ms.
                 await _peerUpdateRequested.WaitAsync(TimeSpan.FromMilliseconds(100), _cancellationTokenSource.Token);
             }
 
-            return AvailableActivePeersCount - _pending > 0;
+            return HasAvailableActivePeerSlot();
         }
 
         private void SelectAndRankCandidates()

--- a/src/Nethermind/Nethermind.Network/PeerManager.cs
+++ b/src/Nethermind/Nethermind.Network/PeerManager.cs
@@ -145,7 +145,7 @@ namespace Nethermind.Network
 #pragma warning disable 4014
 
                 // TODO: hack related to not clearly separated peer pool and peer manager
-                if (CanQuickConnect(peer))
+                if (!_nodesBeingAdded.ContainsKey(peer.Node.Id))
                 {
                     // fire and forget - all the surrounding logic will be executed
                     // exceptions can be lost here without issues
@@ -274,10 +274,7 @@ namespace Nethermind.Network
                 {
                     try
                     {
-                        if (ShouldContactPeer(peer))
-                        {
-                            await SetupOutgoingPeerConnection(peer);
-                        }
+                        await SetupOutgoingPeerConnection(peer);
                     }
                     catch (TaskCanceledException)
                     {
@@ -806,6 +803,11 @@ namespace Nethermind.Network
             bool result = false;
             try
             {
+                // Records the address in the recent-contact filter, so it has to run under the claim:
+                // a candidate refused a slot would otherwise stay suppressed for the whole filter
+                // window without ever having been dialed.
+                if (!ShouldContactPeer(peer)) return;
+
                 await _outgoingConnectionRateLimiter.WaitAsync(_cancellationTokenSource.Token);
 
                 // Can happen when In connection is received from the same peer and is initialized before we get here
@@ -977,15 +979,6 @@ namespace Nethermind.Network
                && _rlpxHost.ShouldContact(peer.Node.Address.Address, exactOnly: peer.Node.IsStatic || peer.Node.IsBootnode);
 
         private bool IsSelf(Peer peer) => peer.Node.Id == _enode.PublicKey;
-
-        /// <summary>
-        /// Fast-path guard for the peer-added event: checks throttle before the IP filter
-        /// so a throttled no-op does not consume a filter entry and block the peer for the full timeout window.
-        /// </summary>
-        private bool CanQuickConnect(Peer peer)
-            => !_nodesBeingAdded.ContainsKey(peer.Node.Id)
-               && !_outgoingConnectionRateLimiter.IsThrottled()
-               && ShouldContactPeer(peer);
 
         private bool CanConnectToPeer(Peer peer)
         {


### PR DESCRIPTION
## Changes

`Will_only_connect_up_to_max_peers` failed in CI with **27 connects for a cap of 25** ([run](https://github.com/NethermindEth/nethermind/actions/runs/34325392684/job/102435282216)). The cause is in `PeerManager`, not in the test's timing: the capacity check is separated from the dial by an `await`, so every caller that passes it and then suspends is invisible to the next one.

Two places do that. `QueueRemainingCandidates` checks for a free slot and then writes the candidate into a `Channel.CreateBounded<Peer>(1)` whose write *blocks* while the workers are busy, and nothing re-checks when it finally lands. And `SetupOutgoingPeerConnection` only claims the slot (`AddActivePeer` / `_pending++`) after awaiting the outgoing-connect rate limiter, so every worker suspended in there is uncounted. Measured against master: one worker with an unthrottled limiter dials up to 27, eight workers with `MaxOutgoingConnectPerSec=200` dial **31**.

- Claim the slot atomically in `SetupOutgoingPeerConnection`, before the first `await`, via `TryClaimActivePeerSlot()` — an `Interlocked.Increment` on `_pending` that is given back when it turns out there was no room. `AddActivePeer` happens inside that window, so an attempt is never in neither `_pending` nor `ActivePeers`.
- Release the claim in a `finally`. Besides the early returns, this fixes a pre-existing leak: an exception between the old `_pending++` and its decrement permanently shrank the effective cap.
- Extract `HasAvailableActivePeerSlot()` from the three places in `EnsureAvailableActivePeerSlotAsync` that spelled the predicate out.
- Turn the flaky test into a deterministic regression test: eight workers against a cap of two at four dials a second, asserting the exact connect count instead of a `±1` range.

Both dial paths — the update loop and the quick-connect fast path in `PeerPoolOnPeerAdded` — go through `SetupOutgoingPeerConnection`, so both are now capped by the same claim. This is a cap on **outgoing dials**: incoming connections reach `AddActivePeer` through `AddSession` without a claim, so the overall active-peer count is still `MaxActivePeers + MaxActivePeerMargin` by design and is shed in `OnP2PProtocolInitialized`.

Static and trusted peers are exempt from the claim, not merely re-checked by it. They are must-keep and exempt from the cap in `OnP2PProtocolInitialized` and `ProcessIncomingConnection`, and once the cap is genuinely full `SelectAndRankCandidates` returns early, so a static peer refused a slot here would never be offered again rather than being re-selected next loop.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Will_only_connect_up_to_max_peers` is now a deterministic regression test rather than a tolerance: eight workers (`NumConcurrentOutgoingConnects = 8`) against `MaxActivePeers = 2`, throttled to `MaxOutgoingConnectPerSec = 4`, so every worker suspends in the rate limiter with its slot claimed and not yet active.

- With `PeerManager.cs` reverted to the merge base it fails on every run: 5, 5 and 6 connects against a cap of 2.
- With the fix it lands on exactly 2 on every run.
- The earlier `[TestCase(1, 1_000_000)]` arm was dropped: at 1e6/s the limiter's delay is 1 µs, so no worker ever suspends in it and the arm only covered the bounded-channel overshoot.
- Full `PeerManagerTests` green across three consecutive runs. `dotnet format whitespace` clean.

Both of the remaining paths are covered now, and neither needs a race staged: `PeerPool.GetOrAdd` raises `PeerAdded` inline and the quick-connect path runs to the rate limiter synchronously, so the capacity check and the claim straddle a window the test writes into directly.

- `Will_release_the_claimed_slot_when_the_candidate_is_already_active` seeds `ActivePeers` with the candidate's own id, so `AddActivePeer` returns false deterministically, then asserts the freed slot is still dialable. It has to go through the quick-connect path — `SelectAndRankCandidates` skips a peer that is already active, so the update loop would never offer it. Turning the `finally` into a plain block fails the test.
- `Will_not_dial_when_the_slots_fill_between_the_check_and_the_claim` fills the cap from a hook on the mock's `ShouldContact`, the last thing both dial paths do between the check and the claim, so the fill lands inside the window by construction and the hook firing is asserted as a precondition. Making `TryClaimActivePeerSlot` never refuse fails the test with two dials against a cap of three.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
