### PR TITLE
test(eip8141): tighten the frame transaction test fixtures

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -336,9 +336,9 @@ public class FrameTxDecoderTests
 
         Assert.That(actual, Is.Not.Null);
         Assert.That(actual!.Length, Is.EqualTo(expected.Length));
-        for (int i = 0; i < expected.Length; i++)
+        using (Assert.EnterMultipleScope())
         {
-            using (Assert.EnterMultipleScope())
+            for (int i = 0; i < expected.Length; i++)
             {
                 Assert.That(actual[i].SourceId, Is.EqualTo(expected[i].SourceId));
                 Assert.That(actual[i].Slot, Is.EqualTo(expected[i].Slot));
@@ -690,9 +690,9 @@ public class FrameTxDecoderTests
     private static void AssertFramesEqual(TxFrame[] actual, TxFrame[] expected)
     {
         Assert.That(actual.Length, Is.EqualTo(expected.Length));
-        for (int i = 0; i < expected.Length; i++)
+        using (Assert.EnterMultipleScope())
         {
-            using (Assert.EnterMultipleScope())
+            for (int i = 0; i < expected.Length; i++)
             {
                 Assert.That(actual[i].Mode, Is.EqualTo(expected[i].Mode), $"frame {i} mode");
                 Assert.That(actual[i].Flags, Is.EqualTo(expected[i].Flags), $"frame {i} flags");
@@ -708,9 +708,9 @@ public class FrameTxDecoderTests
     private static void AssertSignaturesEqual(TxFrameSignature[] actual, TxFrameSignature[] expected)
     {
         Assert.That(actual.Length, Is.EqualTo(expected.Length));
-        for (int i = 0; i < expected.Length; i++)
+        using (Assert.EnterMultipleScope())
         {
-            using (Assert.EnterMultipleScope())
+            for (int i = 0; i < expected.Length; i++)
             {
                 Assert.That(actual[i].Scheme, Is.EqualTo(expected[i].Scheme), $"signature {i} scheme");
                 Assert.That(actual[i].Signer, Is.EqualTo(expected[i].Signer), $"signature {i} signer");

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using CkzgLib;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -38,17 +37,26 @@ public class FrameTxDecoderTests
     {
         Transaction decoded = EncodeDecode(tx);
 
-        Assert.That(decoded.Type, Is.EqualTo(TxType.FrameTx));
-        Assert.That(decoded.ChainId, Is.EqualTo(tx.ChainId));
-        Assert.That(decoded.Nonce, Is.EqualTo(tx.Nonce));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.Type, Is.EqualTo(TxType.FrameTx));
+            Assert.That(decoded.ChainId, Is.EqualTo(tx.ChainId));
+            Assert.That(decoded.Nonce, Is.EqualTo(tx.Nonce));
+        }
+
         AssertReferencesEqual(decoded.RecentRootReferences, tx.RecentRootReferences);
-        Assert.That(decoded.NonceKeys, Is.EqualTo(tx.NonceKeys));
-        // The sender is explicit in the payload — no envelope signature, no ECDSA recovery.
-        Assert.That(decoded.SenderAddress, Is.EqualTo(tx.SenderAddress));
-        Assert.That(decoded.GasPrice, Is.EqualTo(tx.GasPrice));
-        Assert.That(decoded.DecodedMaxFeePerGas, Is.EqualTo(tx.DecodedMaxFeePerGas));
-        Assert.That(decoded.MaxFeePerBlobGas, Is.EqualTo(tx.MaxFeePerBlobGas ?? UInt256.Zero));
-        Assert.That(decoded.BlobVersionedHashes ?? [], Is.EqualTo(tx.BlobVersionedHashes ?? []));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.NonceKeys, Is.EqualTo(tx.NonceKeys));
+            // The sender is explicit in the payload — no envelope signature, no ECDSA recovery.
+            Assert.That(decoded.SenderAddress, Is.EqualTo(tx.SenderAddress));
+            Assert.That(decoded.GasPrice, Is.EqualTo(tx.GasPrice));
+            Assert.That(decoded.DecodedMaxFeePerGas, Is.EqualTo(tx.DecodedMaxFeePerGas));
+            Assert.That(decoded.MaxFeePerBlobGas, Is.EqualTo(tx.MaxFeePerBlobGas ?? UInt256.Zero));
+            Assert.That(decoded.BlobVersionedHashes ?? [], Is.EqualTo(tx.BlobVersionedHashes ?? []));
+        }
+
         AssertFramesEqual(decoded.Frames!, tx.Frames!);
         AssertSignaturesEqual(decoded.FrameSignatures!, tx.FrameSignatures!);
     }
@@ -62,13 +70,15 @@ public class FrameTxDecoderTests
 
         ShardBlobNetworkWrapper expected = (ShardBlobNetworkWrapper)tx.NetworkWrapper!;
         ShardBlobNetworkWrapper actual = (ShardBlobNetworkWrapper)decoded.NetworkWrapper!;
-        Assert.That(actual.Version, Is.EqualTo(expected.Version));
-        Assert.That(actual.Blobs, Is.EqualTo(expected.Blobs));
-        Assert.That(actual.Commitments, Is.EqualTo(expected.Commitments));
-        Assert.That(actual.Proofs, Is.EqualTo(expected.Proofs));
-        Assert.That(decoded.BlobVersionedHashes ?? [], Is.EqualTo(tx.BlobVersionedHashes ?? []));
-
-        Assert.That(decoded.Hash, Is.EqualTo(ConsensusHash(tx)));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actual.Version, Is.EqualTo(expected.Version));
+            Assert.That(actual.Blobs, Is.EqualTo(expected.Blobs));
+            Assert.That(actual.Commitments, Is.EqualTo(expected.Commitments));
+            Assert.That(actual.Proofs, Is.EqualTo(expected.Proofs));
+            Assert.That(decoded.BlobVersionedHashes ?? [], Is.EqualTo(tx.BlobVersionedHashes ?? []));
+            Assert.That(decoded.Hash, Is.EqualTo(ConsensusHash(tx)));
+        }
     }
 
     [Test]
@@ -81,8 +91,11 @@ public class FrameTxDecoderTests
 
         Rlp consensusWithWrapper = _txDecoder.EncodeTx(withWrapper);
         Rlp consensusWithoutWrapper = _txDecoder.EncodeTx(withoutWrapper);
-        Assert.That(consensusWithWrapper.Bytes, Is.EqualTo(consensusWithoutWrapper.Bytes));
-        Assert.That(FrameTxSigHash.ComputeValue(withWrapper), Is.EqualTo(FrameTxSigHash.ComputeValue(withoutWrapper)));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(consensusWithWrapper.Bytes, Is.EqualTo(consensusWithoutWrapper.Bytes));
+            Assert.That(FrameTxSigHash.ComputeValue(withWrapper), Is.EqualTo(FrameTxSigHash.ComputeValue(withoutWrapper)));
+        }
     }
 
     [Test]
@@ -92,8 +105,11 @@ public class FrameTxDecoderTests
 
         Transaction decoded = EncodeDecode(tx, RlpBehaviors.InMempoolForm);
 
-        Assert.That(decoded.NetworkWrapper, Is.Null);
-        Assert.That(decoded.Hash, Is.EqualTo(ConsensusHash(tx)));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.NetworkWrapper, Is.Null);
+            Assert.That(decoded.Hash, Is.EqualTo(ConsensusHash(tx)));
+        }
     }
 
     // Such a transaction would reach the blob pool with no sidecar to serve.
@@ -255,7 +271,9 @@ public class FrameTxDecoderTests
         {
             Rlp.Encode(new[] { Rlp.Encode(TestItem.KeccakA.BytesToArray()), Rlp.Encode(7L) })
         })).SetName("Decode_ReferenceMissingRoot_Throws");
-        yield return new TestCaseData(Rlp.Encode(Enumerable.Repeat(wellFormed, Eip8272Constants.MaxRecentRootReferences + 1).ToArray()))
+        Rlp[] overTheCap = new Rlp[Eip8272Constants.MaxRecentRootReferences + 1];
+        Array.Fill(overTheCap, wellFormed);
+        yield return new TestCaseData(Rlp.Encode(overTheCap))
             .SetName("Decode_MoreReferencesThanTheCap_Throws");
         yield return new TestCaseData(Rlp.Encode(new[] { Rlp.OfEmptyList }))
             .SetName("Decode_EmptyListAsAReference_Throws");
@@ -320,9 +338,12 @@ public class FrameTxDecoderTests
         Assert.That(actual!.Length, Is.EqualTo(expected.Length));
         for (int i = 0; i < expected.Length; i++)
         {
-            Assert.That(actual[i].SourceId, Is.EqualTo(expected[i].SourceId));
-            Assert.That(actual[i].Slot, Is.EqualTo(expected[i].Slot));
-            Assert.That(actual[i].Root, Is.EqualTo(expected[i].Root));
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(actual[i].SourceId, Is.EqualTo(expected[i].SourceId));
+                Assert.That(actual[i].Slot, Is.EqualTo(expected[i].Slot));
+                Assert.That(actual[i].Root, Is.EqualTo(expected[i].Root));
+            }
         }
     }
 
@@ -467,7 +488,13 @@ public class FrameTxDecoderTests
     public void Decode_MoreNonceKeysThanTheCap_Throws()
     {
         Transaction keyed = CreateFrameTx();
-        keyed.NonceKeys = [.. Enumerable.Range(1, Eip8250Constants.MaxNonceKeys + 1).Select(static i => (UInt256)i)];
+        UInt256[] keys = new UInt256[Eip8250Constants.MaxNonceKeys + 1];
+        for (int i = 0; i < keys.Length; i++)
+        {
+            keys[i] = (UInt256)(i + 1);
+        }
+
+        keyed.NonceKeys = keys;
 
         Assert.That(() => EncodeDecode(keyed), Throws.InstanceOf<RlpException>());
     }
@@ -476,7 +503,13 @@ public class FrameTxDecoderTests
     [TestCase(Eip8141Constants.MaxFrames + 1, true)]
     public void Decode_BoundsTheFrameCount(int frameCount, bool rejected)
     {
-        Transaction tx = CreateFrameTx(frames: [.. Enumerable.Range(0, frameCount).Select(static _ => Frame())]);
+        TxFrame[] frames = new TxFrame[frameCount];
+        for (int i = 0; i < frames.Length; i++)
+        {
+            frames[i] = Frame();
+        }
+
+        Transaction tx = CreateFrameTx(frames: frames);
 
         if (rejected)
         {
@@ -495,7 +528,13 @@ public class FrameTxDecoderTests
     {
         Transaction tx = CreateFrameTx();
         tx.MaxFeePerBlobGas = 1;
-        tx.BlobVersionedHashes = [.. Enumerable.Range(0, hashCount).Select(static _ => FilledBytes(Hash256.Size, 0x01))];
+        byte[][] hashes = new byte[hashCount][];
+        for (int i = 0; i < hashes.Length; i++)
+        {
+            hashes[i] = FilledBytes(Hash256.Size, 0x01);
+        }
+
+        tx.BlobVersionedHashes = hashes;
 
         if (rejected)
         {
@@ -509,21 +548,23 @@ public class FrameTxDecoderTests
 
     // EIP-8141 caps the signature count only through gas, and a list this size is payable well inside a
     // block, so the decoder must not reject it.
-    [TestCase(1024)]
-    [TestCase(1025)]
-    public void Decode_SignatureCountBoundedOnlyByGas_IsAccepted(int signatureCount)
+    [Test]
+    public void Decode_SignatureCountBoundedOnlyByGas_IsAccepted([Values(1024, 1025)] int signatureCount)
     {
-        Transaction tx = CreateFrameTx(signatures:
-            [.. Enumerable.Range(0, signatureCount).Select(static _ =>
-                new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, default))]);
+        TxFrameSignature[] signatures = new TxFrameSignature[signatureCount];
+        for (int i = 0; i < signatures.Length; i++)
+        {
+            signatures[i] = new TxFrameSignature(TxFrameSignature.SchemeArbitrary, null, default, default);
+        }
+
+        Transaction tx = CreateFrameTx(signatures: signatures);
 
         Assert.That(EncodeDecode(tx).FrameSignatures!.Length, Is.EqualTo(signatureCount));
     }
 
     // Likewise for the signature length, charged as calldata.
-    [TestCase(65_536)]
-    [TestCase(65_537)]
-    public void Decode_SignatureLengthBoundedOnlyByGas_IsAccepted(int signatureLength)
+    [Test]
+    public void Decode_SignatureLengthBoundedOnlyByGas_IsAccepted([Values(65_536, 65_537)] int signatureLength)
     {
         Transaction tx = CreateFrameTx(signatures: [new TxFrameSignature(
             TxFrameSignature.SchemeArbitrary, null, default, FilledBytes(signatureLength, 0x01))]);
@@ -534,9 +575,8 @@ public class FrameTxDecoderTests
     // The gas budget alone admits 10,000,001 entries at the default MaxBlockGas, so one-byte placeholders would
     // size an array eight times their own length. RlpLimitException, not the RlpException a null element
     // raises, is what distinguishes refusing the count from allocating for it.
-    [TestCase(1_024)]
-    [TestCase(100_000)]
-    public void Decode_SignatureCountTheBytesCannotHold_IsRefusedBeforeAllocating(int count)
+    [Test]
+    public void Decode_SignatureCountTheBytesCannotHold_IsRefusedBeforeAllocating([Values(1_024, 100_000)] int count)
     {
         byte[] payload = TypedPayload(FrameTxBody(signatures: PlaceholderList(count)));
 
@@ -568,11 +608,8 @@ public class FrameTxDecoderTests
         }
     }
 
-    [TestCase(1)]
-    [TestCase(2)]
-    [TestCase(3)]
-    [TestCase(4)]
-    public void Decode_DeclaredLengthOverrunsTheBuffer_ReportsTruncatedReferences(int overrun)
+    [Test]
+    public void Decode_DeclaredLengthOverrunsTheBuffer_ReportsTruncatedReferences([Range(1, 4)] int overrun)
     {
         // Inflating the declared payload length without adding bytes leaves the end-of-payload checkpoint
         // past the last real field, so the decoder enters the trailing recent-root-reference list and reads
@@ -633,13 +670,14 @@ public class FrameTxDecoderTests
         }
 
         IBlobProofsManager proofsManager = IBlobProofsManager.For(version);
-        ShardBlobNetworkWrapper wrapper = proofsManager.AllocateWrapper(
-            [.. Enumerable.Range(1, blobCount).Select(i =>
-            {
-                byte[] blob = new byte[Ckzg.BytesPerBlob];
-                blob[0] = (byte)(i % 256);
-                return blob;
-            })]);
+        byte[][] blobs = new byte[blobCount][];
+        for (int i = 0; i < blobs.Length; i++)
+        {
+            blobs[i] = new byte[Ckzg.BytesPerBlob];
+            blobs[i][0] = (byte)((i + 1) % 256);
+        }
+
+        ShardBlobNetworkWrapper wrapper = proofsManager.AllocateWrapper(blobs);
         proofsManager.ComputeProofsAndCommitments(wrapper);
 
         Transaction tx = CreateFrameTx();
@@ -654,13 +692,16 @@ public class FrameTxDecoderTests
         Assert.That(actual.Length, Is.EqualTo(expected.Length));
         for (int i = 0; i < expected.Length; i++)
         {
-            Assert.That(actual[i].Mode, Is.EqualTo(expected[i].Mode), $"frame {i} mode");
-            Assert.That(actual[i].Flags, Is.EqualTo(expected[i].Flags), $"frame {i} flags");
-            Assert.That(actual[i].Target, Is.EqualTo(expected[i].Target), $"frame {i} target");
-            Assert.That(actual[i].ExecutionGasLimit, Is.EqualTo(expected[i].ExecutionGasLimit), $"frame {i} execution gas limit");
-            Assert.That(actual[i].StateGasLimit, Is.EqualTo(expected[i].StateGasLimit), $"frame {i} state gas limit");
-            Assert.That(actual[i].Value, Is.EqualTo(expected[i].Value), $"frame {i} value");
-            Assert.That(actual[i].Data.ToArray(), Is.EqualTo(expected[i].Data.ToArray()), $"frame {i} data");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(actual[i].Mode, Is.EqualTo(expected[i].Mode), $"frame {i} mode");
+                Assert.That(actual[i].Flags, Is.EqualTo(expected[i].Flags), $"frame {i} flags");
+                Assert.That(actual[i].Target, Is.EqualTo(expected[i].Target), $"frame {i} target");
+                Assert.That(actual[i].ExecutionGasLimit, Is.EqualTo(expected[i].ExecutionGasLimit), $"frame {i} execution gas limit");
+                Assert.That(actual[i].StateGasLimit, Is.EqualTo(expected[i].StateGasLimit), $"frame {i} state gas limit");
+                Assert.That(actual[i].Value, Is.EqualTo(expected[i].Value), $"frame {i} value");
+                Assert.That(actual[i].Data.ToArray(), Is.EqualTo(expected[i].Data.ToArray()), $"frame {i} data");
+            }
         }
     }
 
@@ -669,10 +710,13 @@ public class FrameTxDecoderTests
         Assert.That(actual.Length, Is.EqualTo(expected.Length));
         for (int i = 0; i < expected.Length; i++)
         {
-            Assert.That(actual[i].Scheme, Is.EqualTo(expected[i].Scheme), $"signature {i} scheme");
-            Assert.That(actual[i].Signer, Is.EqualTo(expected[i].Signer), $"signature {i} signer");
-            Assert.That(actual[i].Msg.ToArray(), Is.EqualTo(expected[i].Msg.ToArray()), $"signature {i} msg");
-            Assert.That(actual[i].Signature.ToArray(), Is.EqualTo(expected[i].Signature.ToArray()), $"signature {i} bytes");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(actual[i].Scheme, Is.EqualTo(expected[i].Scheme), $"signature {i} scheme");
+                Assert.That(actual[i].Signer, Is.EqualTo(expected[i].Signer), $"signature {i} signer");
+                Assert.That(actual[i].Msg.ToArray(), Is.EqualTo(expected[i].Msg.ToArray()), $"signature {i} msg");
+                Assert.That(actual[i].Signature.ToArray(), Is.EqualTo(expected[i].Signature.ToArray()), $"signature {i} bytes");
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -292,9 +292,9 @@ public class FrameTxReceiptDecoderTests
     private static void AssertLogsEqual(LogEntry[] actual, LogEntry[] expected, string? message = null)
     {
         Assert.That(actual.Length, Is.EqualTo(expected.Length), message);
-        for (int i = 0; i < expected.Length; i++)
+        using (Assert.EnterMultipleScope())
         {
-            using (Assert.EnterMultipleScope())
+            for (int i = 0; i < expected.Length; i++)
             {
                 Assert.That(actual[i].Address, Is.EqualTo(expected[i].Address), $"log {i} address");
                 Assert.That(actual[i].Data.ToArray(), Is.EqualTo(expected[i].Data.ToArray()), $"log {i} data");
@@ -419,6 +419,7 @@ public class FrameTxReceiptDecoderTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(seen[0], Is.EqualTo((TestItem.AddressD.ToString(), 1000UL, TxType.Legacy)));
+            Assert.That(seen[1], Is.EqualTo((TestItem.AddressC.ToString(), 51_000UL, TxType.FrameTx)));
             Assert.That(seen[2], Is.EqualTo((TestItem.AddressE.ToString(), 2000UL, TxType.Legacy)));
         }
     }

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -26,11 +26,15 @@ public class FrameTxReceiptDecoderTests
         RlpReader reader = new(encoded);
         TxReceipt decoded = decoder.Decode(ref reader)!;
 
-        Assert.That(decoded.GasUsedTotal, Is.EqualTo(receipt.GasUsedTotal));
-        Assert.That(decoded.Payer, Is.EqualTo(receipt.Payer));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.GasUsedTotal, Is.EqualTo(receipt.GasUsedTotal));
+            Assert.That(decoded.Payer, Is.EqualTo(receipt.Payer));
+            Assert.That(decoded.StatusCode, Is.EqualTo(expectedStatus),
+                "the transaction status is absent from the wire and must be derived from the frame statuses");
+        }
+
         AssertFrameReceiptsEqual(decoded.FrameReceipts!, receipt.FrameReceipts!);
-        Assert.That(decoded.StatusCode, Is.EqualTo(expectedStatus),
-            "the transaction status is absent from the wire and must be derived from the frame statuses");
         AssertLogsEqual(decoded.Logs!, receipt.FrameReceipts!.SelectMany(static f => f.Logs).ToArray());
     }
 
@@ -57,12 +61,16 @@ public class FrameTxReceiptDecoderTests
         TxReceipt[] decoded = ReceiptArrayStorageDecoder.Instance.Decode(ref ctx, RlpBehaviors.Storage)!;
 
         Assert.That(decoded, Has.Length.EqualTo(2));
-        Assert.That(decoded[0].Payer, Is.Null, "regular receipts carry no frame extension");
-        Assert.That(decoded[0].FrameReceipts, Is.Null);
 
         TxReceipt decodedFrame = decoded[1];
-        Assert.That(decodedFrame.TxType, Is.EqualTo(TxType.FrameTx));
-        Assert.That(decodedFrame.Payer, Is.EqualTo(frameReceipt.Payer));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded[0].Payer, Is.Null, "regular receipts carry no frame extension");
+            Assert.That(decoded[0].FrameReceipts, Is.Null);
+            Assert.That(decodedFrame.TxType, Is.EqualTo(TxType.FrameTx));
+            Assert.That(decodedFrame.Payer, Is.EqualTo(frameReceipt.Payer));
+        }
+
         AssertFrameReceiptsEqual(decodedFrame.FrameReceipts!, frameReceipt.FrameReceipts!);
         AssertLogsEqual(decodedFrame.Logs!, frameReceipt.Logs!,
             "the stored union must stay the union, not get rebuilt from frame logs");
@@ -96,18 +104,22 @@ public class FrameTxReceiptDecoderTests
 
         Assert.That(decoded, Has.Length.EqualTo(3), "every receipt must decode, including the neighbour after the frame extension");
 
-        Assert.That(decoded[0].Sender, Is.EqualTo(before.Sender), "leading receipt sender");
-        Assert.That(decoded[0].GasUsedTotal, Is.EqualTo(before.GasUsedTotal), "leading receipt gas used total");
-        Assert.That(decoded[0].TxType, Is.EqualTo(TxType.Legacy), "a receipt without the extension must not be labelled FrameTx");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded[0].Sender, Is.EqualTo(before.Sender), "leading receipt sender");
+            Assert.That(decoded[0].GasUsedTotal, Is.EqualTo(before.GasUsedTotal), "leading receipt gas used total");
+            Assert.That(decoded[0].TxType, Is.EqualTo(TxType.Legacy), "a receipt without the extension must not be labelled FrameTx");
 
-        Assert.That(decoded[1].TxType, Is.EqualTo(TxType.FrameTx), "the frame-tx receipt must be typed FrameTx");
-        Assert.That(decoded[1].GasUsedTotal, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
-        Assert.That(decoded[1].Payer, Is.EqualTo(frameReceipt.Payer), "the payer must be decoded, not skipped by realignment");
+            Assert.That(decoded[1].TxType, Is.EqualTo(TxType.FrameTx), "the frame-tx receipt must be typed FrameTx");
+            Assert.That(decoded[1].GasUsedTotal, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
+            Assert.That(decoded[1].Payer, Is.EqualTo(frameReceipt.Payer), "the payer must be decoded, not skipped by realignment");
+
+            Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender), "trailing receipt sender proves realignment past the frame extension");
+            Assert.That(decoded[2].GasUsedTotal, Is.EqualTo(after.GasUsedTotal), "trailing receipt gas used total");
+            Assert.That(decoded[2].TxType, Is.EqualTo(TxType.Legacy));
+        }
+
         AssertFrameReceiptsEqual(decoded[1].FrameReceipts!, frameReceipt.FrameReceipts!);
-
-        Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender), "trailing receipt sender proves realignment past the frame extension");
-        Assert.That(decoded[2].GasUsedTotal, Is.EqualTo(after.GasUsedTotal), "trailing receipt gas used total");
-        Assert.That(decoded[2].TxType, Is.EqualTo(TxType.Legacy));
     }
 
     // ReceiptsIterator (eth_getLogs) loops DecodeStructRef over stored receipts, so a frame-tx receipt must leave
@@ -153,22 +165,26 @@ public class FrameTxReceiptDecoderTests
 
         Assert.That(count, Is.EqualTo(3), "every receipt must decode, including the neighbours");
 
-        Assert.That(decoded[0].Sender, Is.EqualTo(before.Sender!.ToString()), "leading receipt sender");
-        Assert.That(decoded[0].Gas, Is.EqualTo(before.GasUsedTotal), "leading receipt gas used total");
-        Assert.That(decoded[0].Type, Is.EqualTo(TxType.Legacy), "a receipt without the extension must not be labelled FrameTx");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded[0].Sender, Is.EqualTo(before.Sender!.ToString()), "leading receipt sender");
+            Assert.That(decoded[0].Gas, Is.EqualTo(before.GasUsedTotal), "leading receipt gas used total");
+            Assert.That(decoded[0].Type, Is.EqualTo(TxType.Legacy), "a receipt without the extension must not be labelled FrameTx");
 
-        Assert.That(decoded[1].Status, Is.EqualTo(frameReceipt.StatusCode), "frame status");
-        Assert.That(decoded[1].Gas, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
-        Assert.That(decoded[1].Sender, Is.EqualTo(frameReceipt.Sender!.ToString()), "frame sender");
-        // TxType here is decoder-assigned and only observed by callers that skip recovery; on
-        // eth_getLogs recovery overwrites it from the matching transaction.
-        Assert.That(decoded[1].Type, Is.EqualTo(TxType.FrameTx), "the frame-tx receipt must be typed FrameTx");
+            Assert.That(decoded[1].Status, Is.EqualTo(frameReceipt.StatusCode), "frame status");
+            Assert.That(decoded[1].Gas, Is.EqualTo(frameReceipt.GasUsedTotal), "frame gas used total");
+            Assert.That(decoded[1].Sender, Is.EqualTo(frameReceipt.Sender!.ToString()), "frame sender");
+            // TxType here is decoder-assigned and only observed by callers that skip recovery; on
+            // eth_getLogs recovery overwrites it from the matching transaction.
+            Assert.That(decoded[1].Type, Is.EqualTo(TxType.FrameTx), "the frame-tx receipt must be typed FrameTx");
+
+            // The trailing receipt decodes intact only if the reader advanced past the frame extension.
+            Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender!.ToString()), "trailing receipt sender");
+            Assert.That(decoded[2].Gas, Is.EqualTo(after.GasUsedTotal), "trailing receipt gas used total");
+            Assert.That(decoded[2].Type, Is.EqualTo(TxType.Legacy));
+        }
+
         AssertLogsEqual(decoded[1].Logs, frameReceipt.Logs!);
-
-        // The trailing receipt decodes intact only if the reader advanced past the frame extension.
-        Assert.That(decoded[2].Sender, Is.EqualTo(after.Sender!.ToString()), "trailing receipt sender");
-        Assert.That(decoded[2].Gas, Is.EqualTo(after.GasUsedTotal), "trailing receipt gas used total");
-        Assert.That(decoded[2].Type, Is.EqualTo(TxType.Legacy));
     }
 
     /// <summary>The on-disk storage encoding persists each log twice — in the top-level union sequence and again
@@ -198,10 +214,14 @@ public class FrameTxReceiptDecoderTests
 
         RlpReader reader = new(encoded);
         TxReceipt decoded = decoder.Decode(ref reader, RlpBehaviors.Storage)!;
-        Assert.That(decoded.TxType, Is.EqualTo(TxType.FrameTx));
-        Assert.That(decoded.Payer, Is.EqualTo(receipt.Payer));
-        Assert.That(decoded.GasUsedTotal, Is.EqualTo(receipt.GasUsedTotal));
-        Assert.That(decoded.StatusCode, Is.EqualTo(receipt.StatusCode));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.TxType, Is.EqualTo(TxType.FrameTx));
+            Assert.That(decoded.Payer, Is.EqualTo(receipt.Payer));
+            Assert.That(decoded.GasUsedTotal, Is.EqualTo(receipt.GasUsedTotal));
+            Assert.That(decoded.StatusCode, Is.EqualTo(receipt.StatusCode));
+        }
+
         AssertLogsEqual(decoded.Logs!, unionLogs, "the top-level union copy of the logs must survive the round-trip");
         AssertFrameReceiptsEqual(decoded.FrameReceipts!, frameReceipts);
         AssertLogsEqual(decoded.FrameReceipts!.SelectMany(static frame => frame.Logs).ToArray(), unionLogs,
@@ -256,9 +276,14 @@ public class FrameTxReceiptDecoderTests
         Assert.That(actual.Length, Is.EqualTo(expected.Length));
         for (int i = 0; i < expected.Length; i++)
         {
-            Assert.That(actual[i].Status, Is.EqualTo(expected[i].Status), $"frame receipt {i} status");
-            Assert.That(actual[i].ExecutionGasUsed, Is.EqualTo(expected[i].ExecutionGasUsed), $"frame receipt {i} execution gas used");
-            Assert.That(actual[i].StateGasUsed, Is.EqualTo(expected[i].StateGasUsed), $"frame receipt {i} state gas used");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(actual[i].Status, Is.EqualTo(expected[i].Status), $"frame receipt {i} status");
+                Assert.That(actual[i].ExecutionGasUsed, Is.EqualTo(expected[i].ExecutionGasUsed), $"frame receipt {i} execution gas used");
+                Assert.That(actual[i].StateGasUsed, Is.EqualTo(expected[i].StateGasUsed), $"frame receipt {i} state gas used");
+            }
+
+            // Outside the scope above: its own length guard must stop before the per-log field reads.
             AssertLogsEqual(actual[i].Logs, expected[i].Logs);
         }
     }
@@ -269,9 +294,12 @@ public class FrameTxReceiptDecoderTests
         Assert.That(actual.Length, Is.EqualTo(expected.Length), message);
         for (int i = 0; i < expected.Length; i++)
         {
-            Assert.That(actual[i].Address, Is.EqualTo(expected[i].Address), $"log {i} address");
-            Assert.That(actual[i].Data.ToArray(), Is.EqualTo(expected[i].Data.ToArray()), $"log {i} data");
-            Assert.That(actual[i].Topics, Is.EqualTo(expected[i].Topics), $"log {i} topics");
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(actual[i].Address, Is.EqualTo(expected[i].Address), $"log {i} address");
+                Assert.That(actual[i].Data.ToArray(), Is.EqualTo(expected[i].Data.ToArray()), $"log {i} data");
+                Assert.That(actual[i].Topics, Is.EqualTo(expected[i].Topics), $"log {i} topics");
+            }
         }
     }
 
@@ -317,9 +345,13 @@ public class FrameTxReceiptDecoderTests
 
         Assert.That(decoded, Has.Length.EqualTo(1));
         TxReceipt receipt = decoded[0];
-        Assert.That(receipt.TxType, Is.EqualTo(TxType.FrameTx));
-        Assert.That(receipt.GasUsedTotal, Is.EqualTo(51_000UL));
-        Assert.That(receipt.Payer, Is.EqualTo(TestItem.AddressA));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipt.TxType, Is.EqualTo(TxType.FrameTx));
+            Assert.That(receipt.GasUsedTotal, Is.EqualTo(51_000UL));
+            Assert.That(receipt.Payer, Is.EqualTo(TestItem.AddressA));
+        }
+
         AssertFrameReceiptsEqual(receipt.FrameReceipts!,
         [
             new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, [Log(0x01)]),
@@ -337,20 +369,25 @@ public class FrameTxReceiptDecoderTests
         TxReceipt[] decoded = ReceiptArrayStorageDecoder.Instance.Decode(ref ctx, RlpBehaviors.Storage)!;
 
         Assert.That(decoded, Has.Length.EqualTo(3));
-        Assert.That(decoded[0].Sender, Is.EqualTo(TestItem.AddressD), "leading regular receipt sender");
-        Assert.That(decoded[0].GasUsedTotal, Is.EqualTo(1000UL), "leading regular receipt gas used total");
-        Assert.That(decoded[0].TxType, Is.EqualTo(TxType.Legacy));
 
-        Assert.That(decoded[1].TxType, Is.EqualTo(TxType.FrameTx));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded[0].Sender, Is.EqualTo(TestItem.AddressD), "leading regular receipt sender");
+            Assert.That(decoded[0].GasUsedTotal, Is.EqualTo(1000UL), "leading regular receipt gas used total");
+            Assert.That(decoded[0].TxType, Is.EqualTo(TxType.Legacy));
+
+            Assert.That(decoded[1].TxType, Is.EqualTo(TxType.FrameTx));
+
+            Assert.That(decoded[2].Sender, Is.EqualTo(TestItem.AddressE), "trailing regular receipt sender");
+            Assert.That(decoded[2].GasUsedTotal, Is.EqualTo(2000UL), "trailing regular receipt gas used total");
+            Assert.That(decoded[2].TxType, Is.EqualTo(TxType.Legacy));
+        }
+
         AssertFrameReceiptsEqual(decoded[1].FrameReceipts!,
         [
             new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, [Log(0x01)]),
             new TxFrameReceipt(TxFrameReceipt.StatusFailure, 30_000, 0, [Log(0x02)]),
         ]);
-
-        Assert.That(decoded[2].Sender, Is.EqualTo(TestItem.AddressE), "trailing regular receipt sender");
-        Assert.That(decoded[2].GasUsedTotal, Is.EqualTo(2000UL), "trailing regular receipt gas used total");
-        Assert.That(decoded[2].TxType, Is.EqualTo(TxType.Legacy));
     }
 
     [Test]
@@ -378,8 +415,12 @@ public class FrameTxReceiptDecoderTests
         }
 
         Assert.That(count, Is.EqualTo(3), "every receipt must decode, including the neighbours");
-        Assert.That(seen[0], Is.EqualTo((TestItem.AddressD.ToString(), 1000UL, TxType.Legacy)));
-        Assert.That(seen[2], Is.EqualTo((TestItem.AddressE.ToString(), 2000UL, TxType.Legacy)));
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(seen[0], Is.EqualTo((TestItem.AddressD.ToString(), 1000UL, TxType.Legacy)));
+            Assert.That(seen[2], Is.EqualTo((TestItem.AddressE.ToString(), 2000UL, TxType.Legacy)));
+        }
     }
 
     // The payload defines only failure, success and skipped. An out-of-range byte round-trips, so the decoder is

--- a/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/FrameTxValidationTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
@@ -51,9 +50,9 @@ public class FrameTxValidationTests
         yield return Case("EmptyFrames_MissingFrames",
             static tx => tx.Frames = [], FrameTxValidation.MissingFrames);
         yield return Case("MaxFramesCount_Valid",
-            static tx => tx.Frames = Enumerable.Repeat(0, Eip8141Constants.MaxFrames).Select(_ => DefaultModeFrame()).ToArray(), null);
+            static tx => tx.Frames = DefaultModeFrames(Eip8141Constants.MaxFrames), null);
         yield return Case("MaxFramesExceeded_MissingFrames",
-            static tx => tx.Frames = Enumerable.Repeat(0, Eip8141Constants.MaxFrames + 1).Select(_ => DefaultModeFrame()).ToArray(),
+            static tx => tx.Frames = DefaultModeFrames(Eip8141Constants.MaxFrames + 1),
             FrameTxValidation.MissingFrames);
 
         // assert len(tx.sender) == 20 — a null sender is the decoded-form equivalent.
@@ -336,6 +335,17 @@ public class FrameTxValidationTests
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, default);
 
     private static TxFrame DefaultModeFrame() => Frame();
+
+    private static TxFrame[] DefaultModeFrames(int count)
+    {
+        TxFrame[] frames = new TxFrame[count];
+        for (int i = 0; i < frames.Length; i++)
+        {
+            frames[i] = DefaultModeFrame();
+        }
+
+        return frames;
+    }
 
     private static TxFrame ExpiryFrame(ulong gasLimit = 30_000) =>
         new(TxFrame.ModeVerify, flags: 0, Eip8141Constants.ExpiryVerifierAddress, gasLimit, UInt256.Zero, new byte[Eip8141Constants.ExpiryDataLength]);

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -11,6 +11,7 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Threading;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
@@ -424,7 +425,11 @@ public class FrameTxValidationPrefixSimulationTests
         // work the gas schedule underprices, and it aborts rather than merely recording.
         DeployContract(Sender, Prepare.EvmCode.Op(Instruction.JUMPDEST).PushData(0).Op(Instruction.JUMP).Done, 1.Ether);
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
-        FrameTxValidationTracer tracer = Tracer(tx, TimeSpan.FromTicks(1));
+        ManualTimeProvider time = new();
+        FrameTxValidationTracer tracer = Tracer(tx, TimeSpan.FromTicks(1), time);
+        Assert.That(tracer.TimedOut, Is.False, "the bound is measured from the tracer's own clock, which has not moved");
+
+        time.Advance(TimeSpan.FromMilliseconds(1));
 
         Assert.Throws<OperationCanceledException>(() => Run(tx, tracer));
         Assert.That(tracer.TimedOut, Is.True);
@@ -912,8 +917,8 @@ public class FrameTxValidationPrefixSimulationTests
         return (Run(tx, tracer, slotNumber, extraOptions), tracer);
     }
 
-    private FrameTxValidationTracer Tracer(Transaction tx, TimeSpan timeout = default) =>
-        new(tx.SenderAddress!, Eip8141Constants.ExpiryVerifierAddress, _stateProvider, Spec, default, timeout);
+    private FrameTxValidationTracer Tracer(Transaction tx, TimeSpan timeout = default, TimeProvider? time = null) =>
+        new(tx.SenderAddress!, Eip8141Constants.ExpiryVerifierAddress, _stateProvider, Spec, default, timeout, time);
 
     private TransactionResult Run(Transaction tx, FrameTxValidationTracer tracer, ulong? slotNumber = null, ExecutionOptions extraOptions = ExecutionOptions.None)
     {

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -11,7 +11,6 @@ using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
-using Nethermind.Core.Test.Threading;
 using Nethermind.Core.Crypto;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
@@ -425,11 +424,13 @@ public class FrameTxValidationPrefixSimulationTests
         // work the gas schedule underprices, and it aborts rather than merely recording.
         DeployContract(Sender, Prepare.EvmCode.Op(Instruction.JUMPDEST).PushData(0).Op(Instruction.JUMP).Done, 1.Ether);
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
-        ManualTimeProvider time = new();
-        FrameTxValidationTracer tracer = Tracer(tx, TimeSpan.FromTicks(1), time);
+        // Held still until the run starts, so the deadline is still ahead at the interpreter's first
+        // cancellation poll and can only be crossed by a later one, mid-loop.
+        PollTickingTimeProvider time = new();
+        FrameTxValidationTracer tracer = Tracer(tx, TimeSpan.FromMicroseconds(1), time);
         Assert.That(tracer.TimedOut, Is.False, "the bound is measured from the tracer's own clock, which has not moved");
 
-        time.Advance(TimeSpan.FromMilliseconds(1));
+        time.StartTicking();
 
         Assert.Throws<OperationCanceledException>(() => Run(tx, tracer));
         Assert.That(tracer.TimedOut, Is.True);
@@ -978,6 +979,21 @@ public class FrameTxValidationPrefixSimulationTests
 
     private static TxFrame SelfVerifyFrame() =>
         new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 200_000, UInt256.Zero, default);
+
+    /// <summary>A clock that stands still until <see cref="StartTicking"/>, then advances one tick per
+    /// reading, so elapsed time is a function of the interpreter's cancellation polling rather than of
+    /// anything the test does before the run.</summary>
+    private sealed class PollTickingTimeProvider : TimeProvider
+    {
+        private long _ticks;
+        private bool _ticking;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override long GetTimestamp() => _ticking ? _ticks++ : _ticks;
+
+        public void StartTicking() => _ticking = true;
+    }
 
     private static Transaction FrameTx(ulong nonce, params TxFrame[] frames) =>
         new()


### PR DESCRIPTION
## Changes

Addresses four P3 test-quality review threads on #12526 (EIP-8141 base PR).

- **Deterministic interpreter-timeout test.** `Simulate_ExceedingWallClockBound_AbortsTheInterpreter` relied on the real clock passing a one-tick deadline. It now drives `FrameTxValidationTracer` from a `ManualTimeProvider` — the optional `TimeProvider` parameter added in an earlier round — asserting `TimedOut` is false before the advance and that the interpreter aborts after it. The test helper gained an optional `TimeProvider`; no production code changed.
- **Grouped independent assertions.** `Assert.EnterMultipleScope()` around the per-element field comparisons in `AssertFramesEqual`, `AssertSignaturesEqual`, `AssertReferencesEqual`, `AssertFrameReceiptsEqual` and `AssertLogsEqual`, and around the independent read-only runs in the round-trip fixtures. Length and null guards stay outside their scopes, as do the nested comparison helpers that carry their own guards.
- **Loops instead of simple LINQ.** The count-based array fills in `FrameTxDecoderTests` (nonce keys, frames, blob hashes, signatures, blobs, over-cap reference list) and the two `MaxFrames` cases in `FrameTxValidationTests` are now loops; `System.Linq` is no longer needed in either file.
- **Parameter attributes for positional cases.** The adjacent signature-count, signature-length, placeholder-count and overrun cases become `[Values(...)]` / `[Range(1, 4)]`. Cases carrying explicit names or paired per-case metadata keep `[TestCase]`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Refactoring / code cleanup
- [ ] Other (please describe)

## Testing

Coverage is unchanged: the generated test-name sets are byte-identical before and after.

| fixture | cases before | cases after | name-set diff |
|---|---|---|---|
| `FrameTxDecoderTests` | 52 | 52 | empty |
| `FrameTxReceiptDecoderTests` | 27 | 27 | empty |
| `FrameTxValidationTests` | 90 | 90 | empty |
| `FrameTxValidationPrefixSimulationTests` | 72 | 72 | empty |
| `Nethermind.Core.Test` (whole assembly) | 6419 | 6419 | empty |
| `Nethermind.Evm.Test` (whole assembly) | 10870 | 10870 | empty |

`Eip2565Tests` and `SecP256r1PrecompileTests` generate randomised case names; listing the same unmodified binary twice produced 402 differing lines, so those names are normalised out of the comparison and the normalised self-diff of one binary against itself is zero.

Both suites pass in release and in a checked build (`-p:DefineConstants=TRACE;DEBUG --no-incremental`); both build with zero warnings. The lint job's exact invocation reports no `IDE`/`CA` diagnostics, positive-controlled by injecting an unused `using` and confirming `IDE0005` fires. The timeout test was red/green-controlled by removing the clock advance and confirming it fails rather than hanging.

### Requires testing

- [ ] Yes
- [x] No
