### PR TITLE
EIP-8250: read keyed sequences as their own nonce domain in the pool

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/DelegatedAccountFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/DelegatedAccountFilterTest.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
@@ -130,6 +131,40 @@ internal class DelegatedAccountFilterTest
 
         Assert.That(result, Is.EqualTo(expected));
     }
+
+    private static IEnumerable<TestCaseData> KeyedNonceDelegationBoundCases()
+    {
+        yield return new TestCaseData(new UInt256[] { 0xbeef }, AcceptTxResult.Accepted).SetName("a replacement of the pending entry");
+        yield return new TestCaseData(new UInt256[] { 0xf00d }, AcceptTxResult.NotCurrentNonceForDelegation).SetName("a second domain alongside it");
+    }
+
+    /// <remarks>Every fresh key is current at sequence 0, so nothing in the keyed path holds a delegated sender
+    /// to the one pending transaction the account-nonce gate allowed, and one authorization would invalidate a
+    /// bucketful at once.</remarks>
+    [TestCaseSource(nameof(KeyedNonceDelegationBoundCases))]
+    public void Accept_SenderIsDelegated_BoundsKeyedDomainsToOnePendingTransaction(UInt256[] nonceKeys, AcceptTxResult expected)
+    {
+        (TxDistinctSortedPool standardPool, TxDistinctSortedPool blobPool) = CreatePools();
+        Transaction pending = KeyedFrameTx([0xbeef], TestItem.KeccakA);
+        standardPool.TryInsert(pending.Hash, pending);
+        TestReadOnlyStateProvider stateProvider = CreateDelegatedStateProvider();
+        DelegatedAccountFilter filter = CreateFilter(standardPool, blobPool, stateProvider);
+        Transaction transaction = KeyedFrameTx(nonceKeys, TestItem.KeccakB);
+        TxFilteringState state = new(transaction, stateProvider, Prague.Instance);
+
+        AcceptTxResult result = filter.Accept(transaction, ref state, TxHandlingOptions.None);
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    private static Transaction KeyedFrameTx(UInt256[] nonceKeys, Hash256 hash) =>
+        Build.A.Transaction
+            .WithType(TxType.FrameTx)
+            .WithNonce(0)
+            .WithNonceKeys(nonceKeys)
+            .WithSenderAddress(TestItem.AddressA)
+            .WithHash(hash)
+            .TestObject;
 
     private static readonly object[] Eip7702ActivationCases =
     {

--- a/src/Nethermind/Nethermind.TxPool.Test/DelegatedAccountFilterTest.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/DelegatedAccountFilterTest.cs
@@ -15,6 +15,7 @@ using NSubstitute;
 using NUnit.Framework;
 using System.Collections.Generic;
 using Nethermind.Core.Test;
+using Nethermind.Int256;
 
 namespace Nethermind.TxPool.Test;
 
@@ -42,10 +43,10 @@ internal class DelegatedAccountFilterTest
             stateProvider ?? Substitute.For<IReadOnlyStateProvider>(),
             delegationCache ?? new DelegationCache());
 
-    private static TestReadOnlyStateProvider CreateDelegatedStateProvider()
+    private static TestReadOnlyStateProvider CreateDelegatedStateProvider(ulong accountNonce = 0)
     {
         TestReadOnlyStateProvider stateProvider = new();
-        stateProvider.CreateAccount(TestItem.AddressA, 0);
+        stateProvider.CreateAccount(TestItem.AddressA, 0, accountNonce);
         byte[] code = [.. Eip7702Constants.DelegationHeader, .. TestItem.PrivateKeyA.Address.Bytes];
         stateProvider.InsertCode(code, TestItem.AddressA);
         return stateProvider;
@@ -93,6 +94,36 @@ internal class DelegatedAccountFilterTest
         TestReadOnlyStateProvider stateProvider = CreateDelegatedStateProvider();
         DelegatedAccountFilter filter = CreateFilter(standardPool, blobPool, stateProvider);
         Transaction transaction = Build.A.Transaction.WithNonce(txNonce).SignedAndResolved(Ecdsa, TestItem.PrivateKeyA).TestObject;
+        TxFilteringState state = new(transaction, stateProvider, Prague.Instance);
+
+        AcceptTxResult result = filter.Accept(transaction, ref state, TxHandlingOptions.None);
+
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    private static IEnumerable<TestCaseData> KeyedNonceDelegationCases()
+    {
+        yield return new TestCaseData((UInt256[])null, AcceptTxResult.NotCurrentNonceForDelegation).SetName("the account nonce domain");
+        yield return new TestCaseData(new UInt256[] { UInt256.Zero }, AcceptTxResult.NotCurrentNonceForDelegation).SetName("the [0] set, which aliases the account nonce");
+        yield return new TestCaseData(new UInt256[] { 0xbeef }, AcceptTxResult.Accepted).SetName("a fresh keyed domain");
+    }
+
+    /// <remarks>An EIP-8250 keyed transaction carries its domain's sequence, not an account nonce, so gating it on
+    /// the account nonce rejects a sender's every fresh key as a delegation nonce gap.</remarks>
+    [TestCaseSource(nameof(KeyedNonceDelegationCases))]
+    public void Accept_SenderIsDelegated_AppliesTheAccountNonceGateToTheAccountDomainOnly(UInt256[] nonceKeys, AcceptTxResult expected)
+    {
+        const ulong accountNonce = 7;
+        (TxDistinctSortedPool standardPool, TxDistinctSortedPool blobPool) = CreatePools();
+        TestReadOnlyStateProvider stateProvider = CreateDelegatedStateProvider(accountNonce);
+        DelegatedAccountFilter filter = CreateFilter(standardPool, blobPool, stateProvider);
+        // Sequence 0 against account nonce 7: only in a keyed domain is that the next one to execute.
+        Transaction transaction = Build.A.Transaction
+            .WithType(TxType.FrameTx)
+            .WithNonce(0)
+            .WithNonceKeys(nonceKeys)
+            .WithSenderAddress(TestItem.AddressA)
+            .TestObject;
         TxFilteringState state = new(transaction, stateProvider, Prague.Instance);
 
         AcceptTxResult result = filter.Accept(transaction, ref state, TxHandlingOptions.None);

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
@@ -354,22 +354,29 @@ public class FrameTxPayerExposureFilterTests
     }
 
     // The exposure ledger holds frame reservations only, so a plain transaction pooled first is invisible to
-    // it and the sender's balance would be booked twice.
-    [TestCase(TestCost + OrdinaryCost, false, TestName = "the sender covers both")]
-    [TestCase(TestCost + OrdinaryCost - 1, true, TestName = "the sender covers only one")]
-    public void Accept_SelfPayingFrameTx_SumsTheSendersOrdinaryPending(int senderBalance, bool rejected)
+    // it and the sender's balance would be booked twice. An EIP-8250 sequence does not order against the
+    // account nonce, so that ordinary liability is not the walk's to skip however the two compare numerically.
+    [TestCase(TestCost + OrdinaryCost, false, false, TestName = "the sender covers both")]
+    [TestCase(TestCost + OrdinaryCost - 1, true, false, TestName = "the sender covers only one")]
+    [TestCase(TestCost + OrdinaryCost, false, true, TestName = "a keyed sequence and the sender covers both")]
+    [TestCase(TestCost + OrdinaryCost - 1, true, true, TestName = "a keyed sequence and the sender covers only one")]
+    public void Accept_SelfPayingFrameTx_SumsTheSendersOrdinaryPending(int senderBalance, bool rejected, bool keyed)
     {
+        // A fresh key is current at sequence 0, below the account nonce the ordinary transaction sits at.
+        const ulong accountNonce = 7;
+
         // A legacy transaction, so its cost is exactly gas_limit * gas_price.
         Transaction ordinary = Build.A.Transaction.WithSenderAddress(TestItem.AddressA)
-            .WithNonce(0).WithGasLimit(OrdinaryCost).WithGasPrice(1).WithValue(0).TestObject;
+            .WithNonce(keyed ? accountNonce : 0).WithGasLimit(OrdinaryCost).WithGasPrice(1).WithValue(0).TestObject;
         ordinary.Hash = TestItem.KeccakA;
 
         Transaction tx = FrameTxCostingExactly(TestCost, payer: TestItem.AddressA);
-        tx.Nonce = 1;
+        tx.Nonce = keyed ? 0ul : 1ul;
+        if (keyed) tx.NonceKeys = [(UInt256)0xbeef];
         tx.Hash = TestItem.KeccakB;
 
         TestReadOnlyStateProvider senderAccounts = new();
-        senderAccounts.CreateAccount(TestItem.AddressA, (UInt256)senderBalance);
+        senderAccounts.CreateAccount(TestItem.AddressA, (UInt256)senderBalance, keyed ? accountNonce : 0);
 
         AcceptTxResult result = Accept(new TestReadOnlyStateProvider(), new PayerExposureCache(), tx, senderAccounts, Pool(blobs: false, ordinary));
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TransactionExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TransactionExtensionsTests.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using NUnit.Framework;
 
@@ -25,6 +27,75 @@ namespace Nethermind.TxPool.Test
 
             UInt256 payableGasPrice = tx.CalculateAffordableGasPrice(test.IsEip1559Enabled, test.BaseFee, test.AccountBalance);
             Assert.That(payableGasPrice, Is.EqualTo(test.ExpectedPayableGasPriceResult));
+        }
+
+        private const long DisplacedCost = 7_000;
+        private const long KeyedCost = 5_000;
+
+        /// <remarks>Ascending nonce order lets the walk stop at the entry the incoming transaction displaces, but
+        /// an EIP-8250 domain past that cut is an independent liability, so the exit only holds before activation.</remarks>
+        [TestCase(false, 0L, TestName = "before activation the walk stops at the transaction it displaces")]
+        [TestCase(true, KeyedCost, TestName = "after activation the keyed liability past it is still summed")]
+        public void IsOverflowWhenSummingSenderBucket_walks_past_the_displaced_transaction_only_after_activation(bool keyedNoncesEnabled, long expected)
+        {
+            Transaction displaced = OrdinaryTx(nonce: 1, DisplacedCost, TestItem.KeccakA);
+            Transaction incoming = OrdinaryTx(nonce: 1, DisplacedCost, TestItem.KeccakC);
+
+            bool overflow = incoming.IsOverflowWhenSummingSenderBucket(
+                FrameTxFilterTestPools.Pool(blobs: false, displaced, KeyedTx(nonce: 2, KeyedCost, TestItem.KeccakB)),
+                accountNonce: 1, unreservedOnly: false, keyedNoncesEnabled, out UInt256 cumulativeCost);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(overflow, Is.False);
+                Assert.That(cumulativeCost, Is.EqualTo((UInt256)expected));
+            }
+        }
+
+        /// <remarks>The control: with no keyed domain in the bucket the two readings must agree, so the guard
+        /// above changes only what it is meant to.</remarks>
+        [Test]
+        public void IsOverflowWhenSummingSenderBucket_is_unchanged_by_activation_over_an_account_domain_bucket([Values] bool keyedNoncesEnabled)
+        {
+            const long aheadCost = 3_000;
+            Transaction ahead = OrdinaryTx(nonce: 0, aheadCost, TestItem.KeccakA);
+            Transaction displaced = OrdinaryTx(nonce: 1, DisplacedCost, TestItem.KeccakB);
+            Transaction later = OrdinaryTx(nonce: 2, DisplacedCost, TestItem.KeccakD);
+            Transaction incoming = OrdinaryTx(nonce: 1, DisplacedCost, TestItem.KeccakC);
+
+            bool overflow = incoming.IsOverflowWhenSummingSenderBucket(
+                FrameTxFilterTestPools.Pool(blobs: false, ahead, displaced, later),
+                accountNonce: 0, unreservedOnly: false, keyedNoncesEnabled, out UInt256 cumulativeCost);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(overflow, Is.False);
+                Assert.That(cumulativeCost, Is.EqualTo((UInt256)aheadCost));
+            }
+        }
+
+        private static Transaction OrdinaryTx(ulong nonce, long cost, Hash256 hash) =>
+            Build.A.Transaction
+                .WithSenderAddress(TestItem.AddressA)
+                .WithNonce(nonce)
+                .WithGasLimit(1)
+                .WithGasPrice((UInt256)cost)
+                .WithValue(0)
+                .WithHash(hash)
+                .TestObject;
+
+        /// <summary>A frame transaction in its own EIP-8250 domain, priced at what admission recorded.</summary>
+        private static Transaction KeyedTx(ulong nonce, long cost, Hash256 hash)
+        {
+            Transaction tx = Build.A.Transaction
+                .WithType(TxType.FrameTx)
+                .WithSenderAddress(TestItem.AddressA)
+                .WithNonce(nonce)
+                .WithNonceKeys([(UInt256)1])
+                .WithHash(hash)
+                .TestObject;
+            tx.PayerExposure = (UInt256)cost;
+            return tx;
         }
 
         public class TransactionPayableGasPrice

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -495,6 +495,24 @@ public class TxBroadcasterTests
         Assert.That(_broadcaster.GetSnapshot(), Is.EquivalentTo(new[] { later }));
     }
 
+    /// <remarks>Inclusion consumes every key the transaction names, so a persistent entry that shares one is
+    /// permanently unmineable however the two key sets differ; a disjoint one is untouched.</remarks>
+    [Test]
+    public void EnsureStopBroadcastUpToNonce_supersedes_a_persistent_transaction_sharing_a_nonce_key()
+    {
+        _broadcaster = new TxBroadcaster(_comparer, TimerFactory.Default, _txPoolConfig, _headInfo, _logManager);
+        Transaction overlapping = PersistentTx(TestItem.KeccakA, 5, [(UInt256)1]);
+        Transaction disjoint = PersistentTx(TestItem.KeccakB, 5, [(UInt256)3]);
+        foreach (Transaction tx in new[] { overlapping, disjoint })
+        {
+            _broadcaster.Broadcast(tx, true);
+        }
+
+        _broadcaster.EnsureStopBroadcastUpToNonce(PersistentTx(TestItem.KeccakC, 5, [(UInt256)1, (UInt256)2]));
+
+        Assert.That(_broadcaster.GetSnapshot(), Is.EquivalentTo(new[] { disjoint }));
+    }
+
     /// <summary>A locally submitted transaction of one sender, distinguished from its siblings by hash and by
     /// which nonce domain <paramref name="nonceKeys"/> selects.</summary>
     private static Transaction PersistentTx(Hash256 hash, ulong nonce, UInt256[] nonceKeys) =>

--- a/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxBroadcasterTests.cs
@@ -456,6 +456,56 @@ public class TxBroadcasterTests
         Assert.That(pickedTxs, Is.EquivalentTo(expectedTxs).UsingTransactionComparer());
     }
 
+    /// <remarks>EIP-8250 sequences advance per domain, so a persistent transaction whose sequence is numerically
+    /// at or below the included one is superseded only when the two share a domain.</remarks>
+    [Test]
+    public void EnsureStopBroadcastUpToNonce_supersedes_only_the_included_transactions_nonce_domain([Values] bool includeKeyed)
+    {
+        _broadcaster = new TxBroadcaster(_comparer, TimerFactory.Default, _txPoolConfig, _headInfo, _logManager);
+        Transaction keyOne = PersistentTx(TestItem.KeccakA, 0, [(UInt256)1]);
+        Transaction keyTwo = PersistentTx(TestItem.KeccakB, 0, [(UInt256)2]);
+        Transaction accountDomain = PersistentTx(TestItem.KeccakC, 0, null);
+        foreach (Transaction tx in new[] { keyOne, keyTwo, accountDomain })
+        {
+            _broadcaster.Broadcast(tx, true);
+        }
+
+        _broadcaster.EnsureStopBroadcastUpToNonce(includeKeyed ? keyOne : accountDomain);
+
+        Assert.That(_broadcaster.GetSnapshot(),
+            Is.EquivalentTo(includeKeyed ? new[] { keyTwo, accountDomain } : new[] { keyOne, keyTwo }));
+    }
+
+    /// <remarks>The control for the case above: inside one domain every sequence at or below the included one
+    /// is still superseded.</remarks>
+    [Test]
+    public void EnsureStopBroadcastUpToNonce_stops_the_account_domain_up_to_the_included_nonce()
+    {
+        _broadcaster = new TxBroadcaster(_comparer, TimerFactory.Default, _txPoolConfig, _headInfo, _logManager);
+        Transaction first = PersistentTx(TestItem.KeccakA, 0, null);
+        Transaction included = PersistentTx(TestItem.KeccakB, 1, null);
+        Transaction later = PersistentTx(TestItem.KeccakC, 2, null);
+        foreach (Transaction tx in new[] { first, included, later })
+        {
+            _broadcaster.Broadcast(tx, true);
+        }
+
+        _broadcaster.EnsureStopBroadcastUpToNonce(included);
+
+        Assert.That(_broadcaster.GetSnapshot(), Is.EquivalentTo(new[] { later }));
+    }
+
+    /// <summary>A locally submitted transaction of one sender, distinguished from its siblings by hash and by
+    /// which nonce domain <paramref name="nonceKeys"/> selects.</summary>
+    private static Transaction PersistentTx(Hash256 hash, ulong nonce, UInt256[] nonceKeys) =>
+        Build.A.Transaction
+            .WithType(nonceKeys is null ? TxType.EIP1559 : TxType.FrameTx)
+            .WithNonce(nonce)
+            .WithNonceKeys(nonceKeys)
+            .WithSenderAddress(TestItem.AddressA)
+            .WithHash(hash)
+            .TestObject;
+
     [Test]
     public void should_broadcast_local_tx_immediately_after_receiving_it()
     {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -4916,6 +4916,38 @@ namespace Nethermind.TxPool.Test
                 "a valid plain transaction must survive an over-value keyed transaction sharing its sender bucket");
         }
 
+        /// <remarks>Admission sums a sender's keyed and account-domain liabilities against one balance; the
+        /// per-head sweep has to price them the same way, or a balance drop leaves both pending and announced.</remarks>
+        [TestCase(true, 1, TestName = "the balance covers each alone but not both")]
+        [TestCase(false, 2, TestName = "the balance covers both")]
+        public async Task Retention_sums_a_senders_keyed_and_account_domain_costs_against_one_balance(bool underfunded, int expectedPending)
+        {
+            _txPool = CreatePool(null, KeyedNonceSpecProvider());
+            Address sender = TestItem.PrivateKeyA.Address;
+            EnsureSenderBalance(sender, 100.Ether);
+
+            Transaction plain = Build.A.Transaction
+                .WithNonce(0)
+                .WithValue(1.Ether)
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .WithGasLimit(21_000)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+            Assert.That(_txPool.SubmitTx(plain, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Transaction keyed = BuildKeyedFrameTx(sender, nonceKey: 0xbeef, seq: 0, value: 1.Ether, maxFee: 1.GWei);
+            Assert.That(_txPool.SubmitTx(keyed, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Assert.That(keyed.PayerExposure, Is.Not.Null, "admission must have recorded the price the sweep reads");
+            UInt256 keyedCost = keyed.PayerExposure.Value;
+            UInt256 plainCost = 1.Ether + 21_000 * 1.GWei;
+            EnsureSenderBalance(sender, underfunded ? UInt256.Max(keyedCost, plainCost) : keyedCost + plainCost);
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).TestObject);
+
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(expectedPending));
+        }
+
         [Test]
         public async Task Keyed_tx_that_can_no_longer_fund_its_gas_is_evicted_and_may_re_enter()
         {

--- a/src/Nethermind/Nethermind.TxPool/Comparison/CompetingTransactionEqualityComparer.cs
+++ b/src/Nethermind/Nethermind.TxPool/Comparison/CompetingTransactionEqualityComparer.cs
@@ -47,6 +47,13 @@ namespace Nethermind.TxPool.Comparison
             return hash.ToHashCode();
         }
 
+        /// <summary>Whether two of a sender's transactions consume the same nonce domain, so their sequences
+        /// order against each other.</summary>
+        /// <remarks>Sequences in different domains advance independently, so comparing them numerically —
+        /// to order, supersede or exclude — treats unrelated transactions as one another's.</remarks>
+        internal static bool SameNonceDomain(Transaction newTx, Transaction oldTx) =>
+            SameNonceDomain(KeyedDomain(newTx), KeyedDomain(oldTx));
+
         /// <summary>The keys whose sequences <paramref name="tx"/> consumes, or an empty span when it consumes the account nonce.</summary>
         /// <remarks>The set <c>[0]</c> aliases the account nonce, so it must compare as the account-nonce domain or it stops competing with plain transactions.</remarks>
         private static ReadOnlySpan<UInt256> KeyedDomain(Transaction tx) =>

--- a/src/Nethermind/Nethermind.TxPool/Comparison/CompetingTransactionEqualityComparer.cs
+++ b/src/Nethermind/Nethermind.TxPool/Comparison/CompetingTransactionEqualityComparer.cs
@@ -61,5 +61,30 @@ namespace Nethermind.TxPool.Comparison
 
         private static bool SameNonceDomain(ReadOnlySpan<UInt256> newKeys, ReadOnlySpan<UInt256> oldKeys) =>
             newKeys.SequenceEqual(oldKeys);
+
+        /// <summary>Whether consuming one of a sender's transactions advances a sequence the other selects.</summary>
+        /// <remarks>EIP-8250 consumes every key a transaction names, so two unequal key sets sharing a key
+        /// invalidate one another; pending identity is the equal-set relation, being superseded is this one.</remarks>
+        internal static bool OverlapsNonceDomain(Transaction newTx, Transaction oldTx) =>
+            OverlapsNonceDomain(KeyedDomain(newTx), KeyedDomain(oldTx));
+
+        private static bool OverlapsNonceDomain(ReadOnlySpan<UInt256> newKeys, ReadOnlySpan<UInt256> oldKeys)
+        {
+            // The account domain is one domain, shared with nothing keyed.
+            if (newKeys.IsEmpty || oldKeys.IsEmpty) return newKeys.IsEmpty && oldKeys.IsEmpty;
+
+            // Both sets are strictly increasing (EIP-8250 well-formedness), so one merge pass finds a shared key.
+            int newIndex = 0;
+            int oldIndex = 0;
+            while (newIndex < newKeys.Length && oldIndex < oldKeys.Length)
+            {
+                int comparison = newKeys[newIndex].CompareTo(oldKeys[oldIndex]);
+                if (comparison == 0) return true;
+                if (comparison < 0) newIndex++;
+                else oldIndex++;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/BalanceTooLowFilter.cs
@@ -29,7 +29,7 @@ namespace Nethermind.TxPool.Filters
             UInt256 balance = account.Balance;
 
             TxDistinctSortedPool pool = tx.CarriesBlobs ? _blobTxs : _txs;
-            bool overflow = tx.IsOverflowWhenSummingSenderBucket(pool, account.Nonce, unreservedOnly: false, out UInt256 cumulativeCost);
+            bool overflow = tx.IsOverflowWhenSummingSenderBucket(pool, account.Nonce, unreservedOnly: false, state.HeadSpec.IsEip8250Enabled, out UInt256 cumulativeCost);
             overflow |= tx.IsOverflowWhenAddingTxCostToCumulative(cumulativeCost, out cumulativeCost);
 
             if (overflow)

--- a/src/Nethermind/Nethermind.TxPool/Filters/DelegatedAccountFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DelegatedAccountFilter.cs
@@ -1,5 +1,6 @@
 using Nethermind.Core;
 using Nethermind.Evm.State;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.TxPool.Collections;
 
 namespace Nethermind.TxPool.Filters
@@ -22,7 +23,9 @@ namespace Nethermind.TxPool.Filters
                 && !pendingDelegations.HasPending(tx.SenderAddress!))
                 return AcceptTxResult.Accepted;
             //If the account is delegated or has pending delegation we only accept the next transaction nonce
-            if (state.SenderAccount.Nonce != tx.Nonce)
+            // An EIP-8250 keyed sequence is not the account nonce; KeyedNonceFilter pins it to its own domain's
+            // current value, which is the same immediately-executable property this gate holds for.
+            if (!KeyedNonceManager.UsesKeyedNonce(tx) && state.SenderAccount.Nonce != tx.Nonce)
             {
                 return AcceptTxResult.NotCurrentNonceForDelegation;
             }

--- a/src/Nethermind/Nethermind.TxPool/Filters/DelegatedAccountFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/DelegatedAccountFilter.cs
@@ -22,15 +22,27 @@ namespace Nethermind.TxPool.Filters
             if ((!state.SenderAccount.HasCode || !worldState.IsDelegatedCode(state.SenderAccount.CodeHash))
                 && !pendingDelegations.HasPending(tx.SenderAddress!))
                 return AcceptTxResult.Accepted;
+            // Every fresh EIP-8250 key is current at sequence 0, so the count bound the account-nonce gate gave
+            // this sender is taken directly: one authorization must not invalidate a bucketful at once.
+            if (KeyedNonceManager.UsesKeyedNonce(tx))
+            {
+                return SenderHasOtherPendingTx(tx)
+                    ? AcceptTxResult.NotCurrentNonceForDelegation.WithMessage("delegated sender already has a pending transaction")
+                    : AcceptTxResult.Accepted;
+            }
+
             //If the account is delegated or has pending delegation we only accept the next transaction nonce
-            // An EIP-8250 keyed sequence is not the account nonce; KeyedNonceFilter pins it to its own domain's
-            // current value, which is the same immediately-executable property this gate holds for.
-            if (!KeyedNonceManager.UsesKeyedNonce(tx) && state.SenderAccount.Nonce != tx.Nonce)
+            if (state.SenderAccount.Nonce != tx.Nonce)
             {
                 return AcceptTxResult.NotCurrentNonceForDelegation;
             }
             return AcceptTxResult.Accepted;
         }
+
+        /// <summary>Whether the sender already has a pending transaction <paramref name="tx"/> would not displace.</summary>
+        private bool SenderHasOtherPendingTx(Transaction tx) =>
+            (standardPool.ContainsBucket(tx.SenderAddress!) || blobPool.ContainsBucket(tx.SenderAddress!))
+            && PendingReplacement.Find(tx, standardPool, blobPool) is null;
 
         private bool AuthorityHasPendingTx(AuthorizationTuple[] authorizations)
         {

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
@@ -51,7 +51,7 @@ internal sealed class FrameTxPayerExposureFilter(
             // The sender-balance filters defer to this one, so their cumulative bound is taken here. Only what
             // the payer ledger does not already sum is counted, or a self-paid reservation would count twice.
             TxDistinctSortedPool pool = tx.CarriesBlobs ? blobPool : standardPool;
-            if (tx.IsOverflowWhenSummingSenderBucket(pool, sender.Nonce, unreservedOnly: true, out UInt256 pending)
+            if (tx.IsOverflowWhenSummingSenderBucket(pool, sender.Nonce, unreservedOnly: true, spec.IsEip8250Enabled, out UInt256 pending)
                 // Reserving nothing, a payer-less transaction is the only one that has to read the other
                 // half of that split itself; TryReserve sums it for the rest.
                 || (payer is null && UInt256.AddOverflow(pending, SenderReservedAsPayer(tx), out pending)))

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -85,12 +85,13 @@ namespace Nethermind.TxPool
         internal static bool CheckForNotEnoughBalance(this Transaction tx, UInt256 currentCost, UInt256 balance, out UInt256 cumulativeCost)
             => tx.IsOverflowWhenAddingPricedCostToCumulative(currentCost, out cumulativeCost) || balance < cumulativeCost;
 
-        private struct SenderBucketState(Transaction tx, UInt256 accountNonce, bool unreservedOnly)
+        private struct SenderBucketState(Transaction tx, UInt256 accountNonce, bool unreservedOnly, bool keyedNoncesEnabled)
         {
             public readonly Transaction Tx = tx;
             public readonly UInt256 AccountNonce = accountNonce;
             public readonly UInt256 TxNonce = tx.Nonce;
             public readonly bool UnreservedOnly = unreservedOnly;
+            public readonly bool KeyedNoncesEnabled = keyedNoncesEnabled;
             public UInt256 CumulativeCost = UInt256.Zero;
             public bool Overflow = false;
         }
@@ -101,11 +102,14 @@ namespace Nethermind.TxPool
         /// payer's. <paramref name="unreservedOnly"/> additionally drops the self-paid ones, for a caller that
         /// measures against <see cref="PayerExposureCache"/>, which already sums them. EIP-8250 sequences order
         /// only within one nonce domain, so a pending transaction in another domain is an independent liability
-        /// however its sequence compares: the whole bucket is walked rather than stopped at a numeric match.</remarks>
+        /// however its sequence compares: with <paramref name="keyedNoncesEnabled"/> the whole bucket is walked
+        /// rather than stopped at a numeric match. Buckets are unbounded by default, so before activation — where
+        /// admission rejects a keyed transaction outright — the walk keeps the early exit ascending nonce order
+        /// allows.</remarks>
         /// <returns><c>true</c> when the sum overflows, leaving <paramref name="cumulativeCost"/> unusable.</returns>
-        internal static bool IsOverflowWhenSummingSenderBucket(this Transaction tx, TxDistinctSortedPool pool, in UInt256 accountNonce, bool unreservedOnly, out UInt256 cumulativeCost)
+        internal static bool IsOverflowWhenSummingSenderBucket(this Transaction tx, TxDistinctSortedPool pool, in UInt256 accountNonce, bool unreservedOnly, bool keyedNoncesEnabled, out UInt256 cumulativeCost)
         {
-            SenderBucketState bucket = new(tx, accountNonce, unreservedOnly);
+            SenderBucketState bucket = new(tx, accountNonce, unreservedOnly, keyedNoncesEnabled);
             // tx.SenderAddress! as unknownSenderFilter will run before either caller
             pool.VisitBucket(tx.SenderAddress!, ref bucket, static (Transaction otherTx, ref SenderBucketState bucketState) =>
             {
@@ -117,10 +121,11 @@ namespace Nethermind.TxPool
                 }
 
                 // Within one domain, at or past the incoming sequence is the transaction it displaces, or one
-                // that only executes after it. Another domain runs independently, so its cost is owed either way.
+                // that only executes after it. Another domain runs independently, so its cost is owed either way —
+                // and where none can exist, ascending nonce order means nothing past this entry is owed.
                 if (otherTx.Nonce >= bucketState.TxNonce && CompetingTransactionEqualityComparer.SameNonceDomain(bucketState.Tx, otherTx))
                 {
-                    return true;
+                    return bucketState.KeyedNoncesEnabled;
                 }
 
                 bool chargedElsewhere = bucketState.UnreservedOnly

--- a/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
+++ b/src/Nethermind/Nethermind.TxPool/TransactionExtensions.cs
@@ -4,9 +4,11 @@
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Extensions;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.Serialization.Rlp;
 using Nethermind.TxPool.Collections;
+using Nethermind.TxPool.Comparison;
 
 [assembly: InternalsVisibleTo("Nethermind.TxPool.Test")]
 
@@ -83,35 +85,42 @@ namespace Nethermind.TxPool
         internal static bool CheckForNotEnoughBalance(this Transaction tx, UInt256 currentCost, UInt256 balance, out UInt256 cumulativeCost)
             => tx.IsOverflowWhenAddingPricedCostToCumulative(currentCost, out cumulativeCost) || balance < cumulativeCost;
 
-        private struct SenderBucketState(UInt256 accountNonce, UInt256 txNonce, bool unreservedOnly)
+        private struct SenderBucketState(Transaction tx, UInt256 accountNonce, bool unreservedOnly)
         {
+            public readonly Transaction Tx = tx;
             public readonly UInt256 AccountNonce = accountNonce;
-            public readonly UInt256 TxNonce = txNonce;
+            public readonly UInt256 TxNonce = tx.Nonce;
             public readonly bool UnreservedOnly = unreservedOnly;
             public UInt256 CumulativeCost = UInt256.Zero;
             public bool Overflow = false;
         }
 
         /// <summary>Sums what the sender of <paramref name="tx"/> already owes across the pending transactions
-        /// ahead of it, so one balance cannot fund a whole bucket.</summary>
+        /// it does not displace, so one balance cannot fund a whole bucket.</summary>
         /// <remarks>An EIP-8141 frame transaction a third-party payer covers is never counted — its cost is that
         /// payer's. <paramref name="unreservedOnly"/> additionally drops the self-paid ones, for a caller that
-        /// measures against <see cref="PayerExposureCache"/>, which already sums them.</remarks>
+        /// measures against <see cref="PayerExposureCache"/>, which already sums them. EIP-8250 sequences order
+        /// only within one nonce domain, so a pending transaction in another domain is an independent liability
+        /// however its sequence compares: the whole bucket is walked rather than stopped at a numeric match.</remarks>
         /// <returns><c>true</c> when the sum overflows, leaving <paramref name="cumulativeCost"/> unusable.</returns>
         internal static bool IsOverflowWhenSummingSenderBucket(this Transaction tx, TxDistinctSortedPool pool, in UInt256 accountNonce, bool unreservedOnly, out UInt256 cumulativeCost)
         {
-            SenderBucketState bucket = new(accountNonce, tx.Nonce, unreservedOnly);
+            SenderBucketState bucket = new(tx, accountNonce, unreservedOnly);
             // tx.SenderAddress! as unknownSenderFilter will run before either caller
             pool.VisitBucket(tx.SenderAddress!, ref bucket, static (Transaction otherTx, ref SenderBucketState bucketState) =>
             {
-                if (otherTx.Nonce < bucketState.AccountNonce)
+                // An account nonce below the account's own is already mined; a keyed sequence is not
+                // comparable to it, and its domain's floor is not readable here.
+                if (!KeyedNonceManager.UsesKeyedNonce(otherTx) && otherTx.Nonce < bucketState.AccountNonce)
                 {
                     return true;
                 }
 
-                if (otherTx.Nonce >= bucketState.TxNonce)
+                // Within one domain, at or past the incoming sequence is the transaction it displaces, or one
+                // that only executes after it. Another domain runs independently, so its cost is owed either way.
+                if (otherTx.Nonce >= bucketState.TxNonce && CompetingTransactionEqualityComparer.SameNonceDomain(bucketState.Tx, otherTx))
                 {
-                    return false;
+                    return true;
                 }
 
                 bool chargedElsewhere = bucketState.UnreservedOnly

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -342,8 +342,9 @@ namespace Nethermind.TxPool
 
         /// <summary>Stops announcing the sender's persistent transactions that <paramref name="includedTx"/>
         /// has made unmineable.</summary>
-        /// <remarks>Only the included transaction's own EIP-8250 nonce domain is superseded: sequences in the
-        /// sender's other domains advance independently and stay announceable at the same numeric value.</remarks>
+        /// <remarks>Inclusion consumes every EIP-8250 key the transaction names, so a persistent entry is
+        /// superseded when it shares any of them: sequences in the sender's disjoint domains advance
+        /// independently and stay announceable at the same numeric value.</remarks>
         public void EnsureStopBroadcastUpToNonce(Transaction includedTx)
         {
             if (_persistentTxs.Count != 0)
@@ -352,7 +353,7 @@ namespace Nethermind.TxPool
                 // Ascending nonce order bounds the scan; the domain decides which of those entries is superseded.
                 foreach (Transaction tx in _persistentTxs.TakeWhile(includedTx.SenderAddress!, t => t.Nonce <= nonce))
                 {
-                    if (CompetingTransactionEqualityComparer.SameNonceDomain(includedTx, tx))
+                    if (CompetingTransactionEqualityComparer.OverlapsNonceDomain(includedTx, tx))
                     {
                         StopBroadcast(tx.Hash!);
                     }

--- a/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxBroadcaster.cs
@@ -15,6 +15,7 @@ using Nethermind.Core.Timers;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.TxPool.Collections;
+using Nethermind.TxPool.Comparison;
 using ITimer = Nethermind.Core.Timers.ITimer;
 
 namespace Nethermind.TxPool
@@ -339,13 +340,22 @@ namespace Nethermind.TxPool
             }
         }
 
-        public void EnsureStopBroadcastUpToNonce(Address address, ulong nonce)
+        /// <summary>Stops announcing the sender's persistent transactions that <paramref name="includedTx"/>
+        /// has made unmineable.</summary>
+        /// <remarks>Only the included transaction's own EIP-8250 nonce domain is superseded: sequences in the
+        /// sender's other domains advance independently and stay announceable at the same numeric value.</remarks>
+        public void EnsureStopBroadcastUpToNonce(Transaction includedTx)
         {
             if (_persistentTxs.Count != 0)
             {
-                foreach (Transaction tx in _persistentTxs.TakeWhile(address, t => t.Nonce <= nonce))
+                ulong nonce = includedTx.Nonce;
+                // Ascending nonce order bounds the scan; the domain decides which of those entries is superseded.
+                foreach (Transaction tx in _persistentTxs.TakeWhile(includedTx.SenderAddress!, t => t.Nonce <= nonce))
                 {
-                    StopBroadcast(tx.Hash!);
+                    if (CompetingTransactionEqualityComparer.SameNonceDomain(includedTx, tx))
+                    {
+                        StopBroadcast(tx.Hash!);
+                    }
                 }
             }
         }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1668,12 +1668,17 @@ namespace Nethermind.TxPool
                             }
                         }
 
-                        if (tx.FeeChargedToSender() && tx.CheckForNotEnoughBalance(UInt256.Zero, balance, out _))
+                        // Measured against the same running total as the account domain: the sender funds both
+                        // out of one balance, so retention prices the two together as admission does.
+                        UInt256 keyedCumulativeCost = cumulativeCost;
+                        if (tx.FeeChargedToSender() && tx.CheckForNotEnoughBalance(cumulativeCost, balance, out keyedCumulativeCost))
                         {
                             MarkForEviction(tx, allowLaterPoolReentrance: true);
                         }
                         else
                         {
+                            // Only what is retained stays a liability for the sender's other transactions.
+                            cumulativeCost = keyedCumulativeCost;
                             UInt256 keyedBottleneck = tx.CalculateEffectiveGasPrice(isEip1559, _headInfo.CurrentBaseFee);
                             if (tx.GasBottleneck != keyedBottleneck)
                             {

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -953,7 +953,7 @@ namespace Nethermind.TxPool
         private bool RemoveIncludedTransaction(Transaction tx)
         {
             bool removed = RemoveTransaction(tx.Hash);
-            _broadcaster.EnsureStopBroadcastUpToNonce(tx.SenderAddress!, tx.Nonce);
+            _broadcaster.EnsureStopBroadcastUpToNonce(tx);
             return removed;
         }
 


### PR DESCRIPTION
## Changes

Three transaction-pool paths on this branch still read an EIP-8250 `nonce_seq` as if it were the sender's account nonce. Each predates keyed domains and assumes one sequence per sender. From the [#12526](https://github.com/NethermindEth/nethermind/pull/12526) review by `benaadams`.

- **`DelegatedAccountFilter` compared `tx.Nonce` with the account nonce for every transaction.** A delegated sender at account nonce 7 with a valid fresh key at sequence 0 was rejected as `delegation nonce gap`. The gate now applies to the account domain only; `KeyedNonceFilter` already pins a keyed sequence to its own domain's current value, which is the same immediately-executable property this gate holds for.
- **`IsOverflowWhenSummingSenderBucket` stopped the bucket walk at the first entry whose nonce reached the incoming one**, which across nonce domains is an unrelated sequence. With account nonce 7, a sender's ordinary pending transaction and an incoming self-paid keyed transaction at sequence 0 were both admitted even when the balance covered only one; the exposure ledger holds frame reservations only, so it does not repair the omitted ordinary liability. The walk now visits the whole bucket and excludes only same-domain entries at or past the incoming sequence — the transaction it actually displaces — while the account-nonce floor is applied only where it means something.
- **`EnsureStopBroadcastUpToNonce` removed every persistent entry with a numerically lower or equal nonce.** Including key 1 at sequence 0 stopped announcing key 2 at sequence 0, and an account-domain transaction at nonce 0 with it. Cleanup now supersedes only the included transaction's own domain; ascending nonce order still bounds the scan.

The domain predicate is one `internal static CompetingTransactionEqualityComparer.SameNonceDomain`, so the pool's competing key and these three paths cannot drift apart.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

One regression per fix, each verified as a red/green pair against a revert of that change alone, and each paired with an account-domain control that stays green in both states:

| fix | regression | control |
| --- | --- | --- |
| delegation gate | `DelegatedAccountFilterTest.Accept_SenderIsDelegated_AppliesTheAccountNonceGateToTheAccountDomainOnly` — a fresh keyed domain (red: `delegation nonce gap`) | the same case for the account domain and for the `[0]` set that aliases it |
| bucket sum | `FrameTxPayerExposureFilterTests.Accept_SelfPayingFrameTx_SumsTheSendersOrdinaryPending` — a keyed sequence and the sender covers only one (red: `Accepted`) | the two pre-existing account-domain cases, which pin that the walk's arithmetic is unchanged there |
| broadcast cleanup | `TxBroadcasterTests.EnsureStopBroadcastUpToNonce_supersedes_only_the_included_transactions_nonce_domain` (red: the broadcaster is emptied) | `EnsureStopBroadcastUpToNonce_stops_the_account_domain_up_to_the_included_nonce` |

`Nethermind.TxPool.Test` and `Nethermind.Blockchain.Test` pass in release and in a checked build.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
