### PR TITLE
EIP-8141: revalidate the fork-gated frame checks when the head specification changes

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/TxValidatorTests.cs
@@ -703,7 +703,13 @@ public class TxValidatorTests
             Type = TxType.FrameTx,
             ChainId = TestBlockchainIds.ChainId,
             SenderAddress = TestItem.AddressA,
-            Frames = [SelfVerify(Eip7825Constants.DefaultTxGasLimitCap + 1)],
+            // Split across the two budgets, so the envelope total clears the cap while the execution
+            // reservation that does bound a frame transaction stays well under it.
+            Frames =
+            [
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null,
+                    executionGasLimit: PrefixFrameGas, stateGasLimit: Eip7825Constants.DefaultTxGasLimitCap, UInt256.Zero, Array.Empty<byte>())
+            ],
             FrameSignatures = [],
         };
         // The decoder, not the caller, derives GasLimit from the frames; mirror it or the cap is never reached.

--- a/src/Nethermind/Nethermind.Consensus/Validators/HeadTxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/HeadTxValidator.cs
@@ -13,6 +13,8 @@ public sealed class HeadTxValidator() :
         MaxBlobCountBlobTxValidator.Instance,
         new ExceptFrameTxValidator(GasLimitCapTxValidator.Instance),
         MempoolBlobTxProofVersionValidator.Instance,
-        FrameTxNonceKeysTxValidator.Instance
+        FrameTxNonceKeysTxValidator.Instance,
+        FrameTxEnvelopeTxValidator.Instance,
+        FrameTxHeadFieldsTxValidator.Instance
     ];
 }

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -250,14 +250,10 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
             return error!;
         }
 
-        if (!FrameTxValidation.TryCalculateBlockGasReservations(transaction, releaseSpec, out ulong executionReservation, out _))
+        ValidationResult gasReservationResult = FrameTxHeadFieldsTxValidator.Instance.IsWellFormed(transaction, releaseSpec);
+        if (!gasReservationResult)
         {
-            return FrameTxValidation.FrameGasOverflow;
-        }
-
-        if (executionReservation > Eip7825Constants.DefaultTxGasLimitCap)
-        {
-            return FrameTxValidation.FrameExecutionGasExceedsCap(executionReservation, Eip7825Constants.DefaultTxGasLimitCap);
+            return gasReservationResult;
         }
 
         // EIP-7594: a blob-carrying frame tx is bound by the same per-tx blob-count limit and
@@ -275,6 +271,51 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
         }
 
         return ValidationResult.Success;
+    }
+}
+
+/// <summary>The frame-transaction rules of <see cref="FrameTxFieldsTxValidator"/> whose verdict a change of
+/// head specification can flip: the EIP-7906 POST_TX gate and the spec-priced execution-gas reservation.</summary>
+/// <remarks>
+/// Everything else that validator checks is fork-independent frame shape, so re-running it against a new head
+/// could not change the answer. These two can: a POST_TX frame admitted after EIP-7906 is invalid on a head
+/// below it, and a repricing of the intrinsic or floored gas moves the reservation across the EIP-7825 cap
+/// while <see cref="GasLimitCapTxValidator"/> skips frame transactions. This therefore also runs in
+/// <see cref="HeadTxValidator"/>. A transaction carrying no frames — every other type, and a reloaded light
+/// record — passes through; a light record is judged when its body is read back.
+/// </remarks>
+public sealed class FrameTxHeadFieldsTxValidator : ITxValidator
+{
+    public static readonly FrameTxHeadFieldsTxValidator Instance = new();
+    private FrameTxHeadFieldsTxValidator() { }
+
+    public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
+    {
+        TxFrame[]? frames = transaction.Frames;
+        if (frames is null)
+        {
+            return ValidationResult.Success;
+        }
+
+        if (!releaseSpec.IsEip7906Enabled)
+        {
+            foreach (TxFrame frame in frames)
+            {
+                if (frame.Mode == TxFrame.ModePostTx)
+                {
+                    return FrameTxValidation.PostTxNotEnabled;
+                }
+            }
+        }
+
+        if (!FrameTxValidation.TryCalculateBlockGasReservations(transaction, releaseSpec, out ulong executionReservation, out _))
+        {
+            return FrameTxValidation.FrameGasOverflow;
+        }
+
+        return executionReservation > Eip7825Constants.DefaultTxGasLimitCap
+            ? FrameTxValidation.FrameExecutionGasExceedsCap(executionReservation, Eip7825Constants.DefaultTxGasLimitCap)
+            : ValidationResult.Success;
     }
 }
 
@@ -323,7 +364,8 @@ public sealed class FrameTxNonceKeysTxValidator : ITxValidator
 /// <remarks>The RLP decoder tells the envelope shapes apart without fork context, so the fork gate lives here.
 /// The reference cap is not re-checked: <see cref="FrameTxFieldsTxValidator"/> also sits in the frame-transaction
 /// composite and enforces it through <see cref="FrameTxValidation.IsWellFormed"/>, on decoder-built and
-/// caller-built transactions alike.</remarks>
+/// caller-built transactions alike. A transaction admitted after EIP-8272 is invalid on a head below it, so this
+/// also runs in <see cref="HeadTxValidator"/> to evict it at the transition.</remarks>
 public sealed class FrameTxEnvelopeTxValidator : ITxValidator
 {
     public static readonly FrameTxEnvelopeTxValidator Instance = new();

--- a/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/TxValidator.cs
@@ -250,7 +250,8 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
             return error!;
         }
 
-        ValidationResult gasReservationResult = FrameTxHeadFieldsTxValidator.Instance.IsWellFormed(transaction, releaseSpec);
+        // The POST_TX gate the head validator also carries is already answered by the call above.
+        ValidationResult gasReservationResult = FrameTxHeadFieldsTxValidator.ValidateGasReservation(transaction, releaseSpec);
         if (!gasReservationResult)
         {
             return gasReservationResult;
@@ -277,12 +278,15 @@ public sealed class FrameTxFieldsTxValidator : ITxValidator
 /// <summary>The frame-transaction rules of <see cref="FrameTxFieldsTxValidator"/> whose verdict a change of
 /// head specification can flip: the EIP-7906 POST_TX gate and the spec-priced execution-gas reservation.</summary>
 /// <remarks>
-/// Everything else that validator checks is fork-independent frame shape, so re-running it against a new head
-/// could not change the answer. These two can: a POST_TX frame admitted after EIP-7906 is invalid on a head
-/// below it, and a repricing of the intrinsic or floored gas moves the reservation across the EIP-7825 cap
-/// while <see cref="GasLimitCapTxValidator"/> skips frame transactions. This therefore also runs in
-/// <see cref="HeadTxValidator"/>. A transaction carrying no frames — every other type, and a reloaded light
-/// record — passes through; a light record is judged when its body is read back.
+/// A POST_TX frame admitted after EIP-7906 is invalid on a head below it, and a repricing of the intrinsic or
+/// floored gas moves the reservation across the EIP-7825 cap while <see cref="GasLimitCapTxValidator"/> skips
+/// frame transactions. This therefore also runs in <see cref="HeadTxValidator"/>.
+/// What that validator checks and this one does not is either fork-independent frame shape, or the EIP-7594 blob
+/// leg, which is fork-priced but re-checked at the head by <see cref="MaxBlobCountBlobTxValidator"/> — a
+/// blob-carrying frame transaction falls through its type arm into the same bound. Out of scope here is
+/// <c>GasLimitTxFilter</c>'s admission bound, the head block gas limit: it is not a specification property, so a
+/// spec-change hook could not see it move. A transaction carrying no frames — every other type, and a reloaded
+/// light record — passes through; a light record is judged when its body is read back.
 /// </remarks>
 public sealed class FrameTxHeadFieldsTxValidator : ITxValidator
 {
@@ -291,13 +295,7 @@ public sealed class FrameTxHeadFieldsTxValidator : ITxValidator
 
     public ValidationResult IsWellFormed(Transaction transaction, IReleaseSpec releaseSpec)
     {
-        TxFrame[]? frames = transaction.Frames;
-        if (frames is null)
-        {
-            return ValidationResult.Success;
-        }
-
-        if (!releaseSpec.IsEip7906Enabled)
+        if (!releaseSpec.IsEip7906Enabled && transaction.Frames is { } frames)
         {
             foreach (TxFrame frame in frames)
             {
@@ -306,6 +304,17 @@ public sealed class FrameTxHeadFieldsTxValidator : ITxValidator
                     return FrameTxValidation.PostTxNotEnabled;
                 }
             }
+        }
+
+        return ValidateGasReservation(transaction, releaseSpec);
+    }
+
+    /// <summary>The reservation leg alone, for the caller that has already answered the POST_TX gate.</summary>
+    internal static ValidationResult ValidateGasReservation(Transaction transaction, IReleaseSpec releaseSpec)
+    {
+        if (transaction.Frames is null)
+        {
+            return ValidationResult.Success;
         }
 
         if (!FrameTxValidation.TryCalculateBlockGasReservations(transaction, releaseSpec, out ulong executionReservation, out _))

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -3182,7 +3182,7 @@ namespace Nethermind.TxPool.Test
 
             _txPool = CreatePool(new TxPoolConfig { GasLimit = long.MaxValue, FrameTxMaxVerifyGas = 0 }, provider);
             _headInfo.BlockGasLimit = long.MaxValue;
-            Transaction frameTx = ForkGatedFrameTx(gate, preForkSpec);
+            Transaction frameTx = ForkGatedFrameTx(gate, preForkSpec, postForkSpec, revokedAtFork);
 
             using (Assert.EnterMultipleScope())
             {
@@ -3196,7 +3196,7 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(revokedAtFork ? 0 : 1));
         }
 
-        private Transaction ForkGatedFrameTx(FrameForkGate gate, IReleaseSpec preForkSpec)
+        private Transaction ForkGatedFrameTx(FrameForkGate gate, IReleaseSpec preForkSpec, IReleaseSpec postForkSpec, bool revokedAtFork)
         {
             switch (gate)
             {
@@ -3212,9 +3212,18 @@ namespace Nethermind.TxPool.Test
                     // next head is the whole difference. The half also absorbs the few tokens by which a fresh
                     // signature's own byte pattern moves the reservation.
                     Transaction probe = ValueTransferFrameTx(executionGasLimit: 0);
-                    FrameTxValidation.TryCalculateBlockGasReservations(probe, preForkSpec, out ulong baseline, out _);
-                    return ValueTransferFrameTx(
+                    Assert.That(FrameTxValidation.TryCalculateBlockGasReservations(probe, preForkSpec, out ulong baseline, out _), Is.True);
+
+                    Transaction nearCap = ValueTransferFrameTx(
                         Eip7825Constants.DefaultTxGasLimitCap - baseline - GasCostOf.TxValueCostEip2780 / 2);
+                    // Pins the arithmetic here rather than through the pool sweep it feeds.
+                    using (Assert.EnterMultipleScope())
+                    {
+                        Assert.That(FrameTxHeadFieldsTxValidator.Instance.IsWellFormed(nearCap, preForkSpec).AsBool(), Is.True);
+                        Assert.That(FrameTxHeadFieldsTxValidator.Instance.IsWellFormed(nearCap, postForkSpec).AsBool(), Is.EqualTo(!revokedAtFork));
+                    }
+
+                    return nearCap;
             }
         }
 
@@ -3223,6 +3232,45 @@ namespace Nethermind.TxPool.Test
                 SelfVerifyPrefixFrame(),
                 new TxFrame(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, executionGasLimit, UInt256.One, Array.Empty<byte>())
             ]);
+
+        // A locally built frame tx skips the decoder that measures its EIP-8272 reference calldata, so admission
+        // has to measure before it prices: head revalidation prices the measured transaction, and anything
+        // admitted on the lighter reading is pooled, unselectable and evicted at the next transition.
+        [TestCase(true, TestName = "frame_tx_over_the_cap_once_its_reference_calldata_is_measured_is_refused")]
+        [TestCase(false, TestName = "frame_tx_under_the_cap_once_its_reference_calldata_is_measured_is_admitted")]
+        public void SubmitTx_LocallyBuiltFrameTx_IsPricedOnMeasuredReferenceCalldata(bool overCapOnceMeasured)
+        {
+            OverridableReleaseSpec spec = new(Eip8141Prototype.Instance) { IsEip8272Enabled = true };
+            _txPool = CreatePool(new TxPoolConfig { GasLimit = long.MaxValue, FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(spec));
+            _headInfo.BlockGasLimit = long.MaxValue;
+
+            RecentRootReference[] references = new RecentRootReference[Eip8272Constants.MaxRecentRootReferences];
+            for (int i = 0; i < references.Length; i++)
+            {
+                references[i] = new RecentRootReference(TestItem.KeccakA, (ulong)i + 1, TestItem.KeccakB);
+            }
+
+            Transaction probe = ReferenceFrameTx(0);
+            probe.ReferenceCalldataStats = RecentRootReferenceDecoder.Instance.Measure(references);
+            Assert.That(FrameTxValidation.TryCalculateBlockGasReservations(probe, spec, out ulong measured, out _), Is.True);
+
+            ulong headroom = Eip7825Constants.DefaultTxGasLimitCap - measured;
+            Transaction frameTx = ReferenceFrameTx(overCapOnceMeasured ? headroom + 1 : headroom);
+            AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result == AcceptTxResult.Accepted, Is.EqualTo(!overCapOnceMeasured), result.ToString());
+                Assert.That(FrameTxHeadFieldsTxValidator.Instance.IsWellFormed(frameTx, spec).AsBool(), Is.EqualTo(!overCapOnceMeasured));
+            }
+
+            Transaction ReferenceFrameTx(ulong executionGasLimit) => SignedFrameTx(
+                [
+                    SelfVerifyPrefixFrame(),
+                    new TxFrame(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, executionGasLimit, UInt256.Zero, Array.Empty<byte>())
+                ],
+                references);
+        }
 
         [TestCase(100_000UL, 0UL, 0, true)]
         [TestCase(118_000UL, 0UL, 0, false)]
@@ -5579,7 +5627,39 @@ namespace Nethermind.TxPool.Test
                 NonceKeys = [UInt256.One],
                 RecentRootReferences = [new RecentRootReference(TestItem.KeccakA, slot: 1, TestItem.KeccakB)],
             },
+            NearCapFrameTx(),
         ];
+
+        /// <summary>A frame transaction reserving execution gas just under the EIP-7825 cap, so a repricing flag
+        /// moves it across.</summary>
+        /// <remarks>The presence gates above are reached by every corpus entry, but the priced leg of the head
+        /// validator reads far more of the specification than they do and no other entry sits near enough to the
+        /// cap for a price to move its verdict. Sized half the EIP-2780 transfer charge below the cap, so
+        /// enabling that charge is the whole difference between valid and invalid.</remarks>
+        private static Transaction NearCapFrameTx()
+        {
+            ReleaseSpec baseline = SpecChangeMarkerBaseline();
+            if (!FrameTxValidation.TryCalculateBlockGasReservations(ValueTransferFrameTx(0), baseline, out ulong reserved, out _))
+            {
+                throw new InvalidOperationException("the near-cap corpus entry could not be priced");
+            }
+
+            return ValueTransferFrameTx(Eip7825Constants.DefaultTxGasLimitCap - reserved - GasCostOf.TxValueCostEip2780 / 2);
+
+            static Transaction ValueTransferFrameTx(ulong executionGasLimit) => new()
+            {
+                Type = TxType.FrameTx,
+                ChainId = TestBlockchainIds.ChainId,
+                SenderAddress = TestItem.AddressA,
+                Frames =
+                [
+                    FrameTxTestFrames.SelfVerify(FrameTxTestFrames.PrefixFrameGas),
+                    new TxFrame(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, executionGasLimit, UInt256.One, Array.Empty<byte>())
+                ],
+                FrameSignatures = [],
+                NonceKeys = [UInt256.One],
+            };
+        }
 
         /// <summary>A stable rendering of how <paramref name="validator"/> judges <paramref name="corpus"/>.</summary>
         private static string Verdicts(ITxValidator validator, IReleaseSpec spec, Transaction[] corpus)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -3124,7 +3124,7 @@ namespace Nethermind.TxPool.Test
         private static TxFrame SelfVerifyPrefixFrame() =>
             new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, Array.Empty<byte>());
 
-        private Transaction SignedFrameTx(TxFrame[] frames)
+        private Transaction SignedFrameTx(TxFrame[] frames, RecentRootReference[] recentRootReferences = null)
         {
             Transaction frameTx = new()
             {
@@ -3134,6 +3134,7 @@ namespace Nethermind.TxPool.Test
                 SenderAddress = TestItem.PrivateKeyA.Address,
                 Frames = frames,
                 FrameSignatures = [],
+                RecentRootReferences = recentRootReferences,
                 GasLimit = 1_000_000,
                 GasPrice = 1.GWei,
                 DecodedMaxFeePerGas = 1.GWei,
@@ -3143,6 +3144,85 @@ namespace Nethermind.TxPool.Test
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
             return frameTx;
         }
+
+        /// <summary>The frame-transaction properties a change of head specification can turn from valid to invalid.</summary>
+        public enum FrameForkGate { PostTx, RecentRoots, ExecutionGasCap }
+
+        // Each is admitted under a head that allows it, and the block that included it under the next head would
+        // be invalid, so the pool must drop it at the transition. The retained rows hold the same transaction
+        // across the same transition with the gate untouched, so the flipped flag is the only variable.
+        [TestCase(FrameForkGate.PostTx, true, TestName = "post_tx_frame_is_evicted_when_the_new_head_drops_eip7906")]
+        [TestCase(FrameForkGate.PostTx, false, TestName = "post_tx_frame_is_retained_while_eip7906_stays_active")]
+        [TestCase(FrameForkGate.RecentRoots, true, TestName = "recent_root_reference_is_evicted_when_the_new_head_drops_eip8272")]
+        [TestCase(FrameForkGate.RecentRoots, false, TestName = "recent_root_reference_is_retained_while_eip8272_stays_active")]
+        [TestCase(FrameForkGate.ExecutionGasCap, true, TestName = "frame_execution_reservation_is_evicted_when_repriced_over_the_cap")]
+        [TestCase(FrameForkGate.ExecutionGasCap, false, TestName = "frame_execution_reservation_is_retained_while_the_price_holds")]
+        public async Task Frame_transaction_invalidated_by_the_new_head_is_evicted(FrameForkGate gate, bool revokedAtFork)
+        {
+            Block head = _blockTree.Head;
+            _blockTree.BestSuggestedHeader = head.Header;
+
+            OverridableReleaseSpec preForkSpec = new(Eip8141Prototype.Instance)
+            {
+                IsEip7906Enabled = gate == FrameForkGate.PostTx,
+                IsEip8272Enabled = gate == FrameForkGate.RecentRoots,
+                IsEip2780Enabled = false
+            };
+            OverridableReleaseSpec postForkSpec = new(Eip8141Prototype.Instance)
+            {
+                IsEip7906Enabled = preForkSpec.IsEip7906Enabled && !(revokedAtFork && gate == FrameForkGate.PostTx),
+                IsEip8272Enabled = preForkSpec.IsEip8272Enabled && !(revokedAtFork && gate == FrameForkGate.RecentRoots),
+                IsEip2780Enabled = revokedAtFork && gate == FrameForkGate.ExecutionGasCap
+            };
+            TestSpecProvider provider = new(preForkSpec)
+            {
+                NextForkSpec = postForkSpec,
+                ForkOnBlockNumber = head.Number + 1
+            };
+
+            _txPool = CreatePool(new TxPoolConfig { GasLimit = long.MaxValue, FrameTxMaxVerifyGas = 0 }, provider);
+            _headInfo.BlockGasLimit = long.MaxValue;
+            Transaction frameTx = ForkGatedFrameTx(gate, preForkSpec);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(_txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
+            }
+
+            await AddEmptyBlock();
+            AssertRevalidatedForHead();
+
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(revokedAtFork ? 0 : 1));
+        }
+
+        private Transaction ForkGatedFrameTx(FrameForkGate gate, IReleaseSpec preForkSpec)
+        {
+            switch (gate)
+            {
+                case FrameForkGate.PostTx:
+                    return SelfVerifyFrameTx(
+                        new TxFrame(TxFrame.ModePostTx, TxFrame.ApproveScopeNone, TestItem.AddressB, gasLimit: 1_000, UInt256.Zero, Array.Empty<byte>()));
+                case FrameForkGate.RecentRoots:
+                    return SignedFrameTx(
+                        [SelfVerifyPrefixFrame()],
+                        [new RecentRootReference(TestItem.KeccakA, slot: 1, TestItem.KeccakB)]);
+                default:
+                    // Reserving half the EIP-2780 transfer charge below the cap, so pricing the transfer at the
+                    // next head is the whole difference. The half also absorbs the few tokens by which a fresh
+                    // signature's own byte pattern moves the reservation.
+                    Transaction probe = ValueTransferFrameTx(executionGasLimit: 0);
+                    FrameTxValidation.TryCalculateBlockGasReservations(probe, preForkSpec, out ulong baseline, out _);
+                    return ValueTransferFrameTx(
+                        Eip7825Constants.DefaultTxGasLimitCap - baseline - GasCostOf.TxValueCostEip2780 / 2);
+            }
+        }
+
+        private Transaction ValueTransferFrameTx(ulong executionGasLimit) =>
+            SignedFrameTx([
+                SelfVerifyPrefixFrame(),
+                new TxFrame(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressB, executionGasLimit, UInt256.One, Array.Empty<byte>())
+            ]);
 
         [TestCase(100_000UL, 0UL, 0, true)]
         [TestCase(118_000UL, 0UL, 0, false)]
@@ -5473,6 +5553,31 @@ namespace Nethermind.TxPool.Test
                 Frames = [FrameTxTestFrames.SelfVerify(FrameTxTestFrames.PrefixFrameGas)],
                 FrameSignatures = [],
                 NonceKeys = [UInt256.One],
+            },
+            // The optional frame extensions carry their own fork gates, and each needs a transaction that
+            // uses it before the sweep can see the gate move a verdict.
+            new Transaction
+            {
+                Type = TxType.FrameTx,
+                ChainId = TestBlockchainIds.ChainId,
+                SenderAddress = TestItem.AddressA,
+                Frames =
+                [
+                    FrameTxTestFrames.SelfVerify(FrameTxTestFrames.PrefixFrameGas),
+                    new TxFrame(TxFrame.ModePostTx, TxFrame.ApproveScopeNone, TestItem.AddressB, gasLimit: 1_000, UInt256.Zero, Array.Empty<byte>())
+                ],
+                FrameSignatures = [],
+                NonceKeys = [UInt256.One],
+            },
+            new Transaction
+            {
+                Type = TxType.FrameTx,
+                ChainId = TestBlockchainIds.ChainId,
+                SenderAddress = TestItem.AddressA,
+                Frames = [FrameTxTestFrames.SelfVerify(FrameTxTestFrames.PrefixFrameGas)],
+                FrameSignatures = [],
+                NonceKeys = [UInt256.One],
+                RecentRootReferences = [new RecentRootReference(TestItem.KeccakA, slot: 1, TestItem.KeccakB)],
             },
         ];
 

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxCalldataStatsFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxCalldataStatsFilter.cs
@@ -16,8 +16,10 @@ namespace Nethermind.TxPool.Filters;
 /// <c>eth_sendTransaction</c> never passes through it and would otherwise be priced as if those fields
 /// occupied no calldata — under-stating the intrinsic gas, and with it every bound derived from it. Rejects
 /// nothing; it exists so the pool prices the same transaction the processor does, which measures for itself
-/// before pricing. Must run after <see cref="MalformedTxFilter"/>: measuring encodes into a buffer sized for
-/// a well-formed reference list, and before any filter that prices the transaction.
+/// before pricing. Must run before every filter that prices a frame transaction, <see cref="GasLimitTxFilter"/>
+/// and <see cref="MalformedTxFilter"/> included, or admission and head revalidation price different transactions.
+/// An over-long set is left unmeasured rather than measured into an out-of-range buffer; <see cref="MalformedTxFilter"/>
+/// rejects it for the same bound further down the pipeline.
 /// </remarks>
 internal sealed class FrameTxCalldataStatsFilter : IIncomingTxFilter
 {
@@ -28,12 +30,16 @@ internal sealed class FrameTxCalldataStatsFilter : IIncomingTxFilter
             return AcceptTxResult.Accepted;
         }
 
-        if (tx.NonceKeys is not null)
+        if (tx.NonceKeys is { Length: <= Eip8250Constants.MaxNonceKeys })
         {
             tx.FrameCalldataStats = FrameTxNonceCalldata.Measure(tx);
         }
 
-        tx.ReferenceCalldataStats = RecentRootReferenceDecoder.Instance.Measure(tx.RecentRootReferences);
+        if (tx.RecentRootReferences is null or { Length: <= Eip8272Constants.MaxRecentRootReferences })
+        {
+            tx.ReferenceCalldataStats = RecentRootReferenceDecoder.Instance.Measure(tx.RecentRootReferences);
+        }
+
         return AcceptTxResult.Accepted;
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -2060,7 +2060,7 @@ namespace Nethermind.TxPool
                 + FormattableString.Invariant($"|{spec.IsEip2780Enabled}|{spec.IsEip2930Enabled}|{spec.MaxInitCodeSize}")
                 + FormattableString.Invariant($"|{spec.IsEip1559Enabled}|{spec.IsEip3860Enabled}|{spec.IsEip4844Enabled}|{spec.IsEip7623Enabled}")
                 + FormattableString.Invariant($"|{spec.IsEip7702Enabled}|{spec.IsEip7976Enabled}|{spec.IsEip7981Enabled}|{spec.IsEip8037Enabled}|{spec.IsEip8038Enabled}")
-                + FormattableString.Invariant($"|{spec.IsEip8141Enabled}|{spec.IsEip8250Enabled}")
+                + FormattableString.Invariant($"|{spec.IsEip8141Enabled}|{spec.IsEip8250Enabled}|{spec.IsEip7906Enabled}|{spec.IsEip8272Enabled}")
                 + FormattableString.Invariant($"|{gasCosts.TxDataNonZeroMultiplier}|{gasCosts.TotalCostFloorPerToken}|{gasCosts.MaxBlobGasPerBlock}|{gasCosts.MaxBlobGasPerTx}")
                 + FormattableString.Invariant($"|{spec.GetTxGasLimitCap()}|{spec.BlobProofVersion}");
         }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -255,6 +255,9 @@ namespace Nethermind.TxPool
             [
                 new NotSupportedTxFilter(txPoolConfig, _specProvider, _logger),
                 new SizeTxFilter(txPoolConfig, _logger),
+                // before GasLimitTxFilter, the first filter that prices a frame tx: a locally built one skips
+                // the decoder that measures these, and head revalidation would then price a different transaction
+                new FrameTxCalldataStatsFilter(),
                 new GasLimitTxFilter(_headInfo, txPoolConfig, logManager),
                 new PriorityFeeTooLowFilter(_headInfo, txPoolConfig, _logger),
                 new FeeTooLowFilter(_headInfo, _transactions, _blobTransactions, thereIsPriorityContract, _logger)
@@ -265,9 +268,6 @@ namespace Nethermind.TxPool
                 new NullHashTxFilter(), // needs to be first as it assigns the hash
                 new AlreadyKnownTxFilter(_hashCache, _logger),
                 new MalformedTxFilter(validator, _specChangeTxValidator, ecdsa, _logger),
-                // after MalformedTxFilter, before anything prices the transaction: a locally built frame tx
-                // skips the decoder that measures these, and would be priced as if the fields were free
-                new FrameTxCalldataStatsFilter(),
                 new FrameTxMisplacedExpiryFrameFilter(_logger), // before ExpiredFrameTxFilter: leaves the deadline readable from the leading frame alone
                 new ExpiredFrameTxFilter(chainHeadInfoProvider, _logger), // after MalformedTxFilter: reads the deadline from an already well-formed frame
                 new FrameTxVerifyGasFilter(txPoolConfig, _logger), // after MalformedTxFilter: reads gas limits from an already well-formed frame list


### PR DESCRIPTION
Addresses the P2 `SpecChangeTxValidator.cs:18` thread on #12526.

## Changes

`SpecChangeTxValidator` re-ran only the frame checks EIP-8250 gates, so a transaction relying on another optional frame extension survived a head that no longer defines it — the pool kept it while full validation and the block validator would reject it.

Three frame rules can change verdict across a specification change, and all three are now re-run at the head:

- **EIP-7906 POST_TX gate.** `FrameTxValidation.IsWellFormed` takes `postTxEnabled` from `spec.IsEip7906Enabled`, so a POST_TX frame admitted after the fork is invalid on a head below it.
- **EIP-8272 recent-root envelope gate.** `FrameTxEnvelopeTxValidator` admits `RecentRootReferences` only where `IsEip8272Enabled`; it is now in `HeadTxValidator.Validators` as well, the same treatment `FrameTxNonceKeysTxValidator` already had.
- **Frame execution-gas reservation (beyond the ask).** `GasLimitCapTxValidator` is wrapped in `ExceptFrameTxValidator`, and the frame equivalent — `executionReservation` against the EIP-7825 cap — lived only in `FrameTxFieldsTxValidator`, which head revalidation never ran. The reservation is priced from the spec (EIP-7623/7976 floor terms, the calldata token rates, EIP-2780 transfer cost, the EIP-8272 and EIP-8250 envelope calldata), so a repricing fork moves it across a fixed cap. This is the frame analogue of `should_evict_transactions_that_become_under_gassed_after_fork`.

The first and third are extracted into `FrameTxHeadFieldsTxValidator`, which `FrameTxFieldsTxValidator` now delegates its gas leg to rather than duplicating it. Transactions carrying no frames pass through, so the light-record path is unchanged and a light blob record is still judged when its body is read back.

Everything else in the frame composite is either fork-independent (frame modes, flags, atomic-batch shape, signature schemes, chain id, nonce cap, the versioned-hash version byte) or already re-checked at the head (`ReleaseSpecTxValidator` for the EIP-8141 type gate, `MaxBlobCountBlobTxValidator` for the per-tx blob limit, `MempoolBlobTxProofVersionValidator`).

`IsEip7906Enabled` and `IsEip8272Enabled` are added to the pool's persistence marker, so a restart across either cannot skip revalidation.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Frame_transaction_invalidated_by_the_new_head_is_evicted` submits a frame transaction under a head that allows the extension and asserts the count after the transition, with a retained row per gate holding the transaction across the same transition with the gate untouched — so the flipped flag is the only variable. Without the two `HeadTxValidator` entries the three eviction rows fail and the three retained rows still pass.

The marker sweep `Spec_change_marker_moves_with_every_spec_flag_the_validator_can_act_on` already guards every flag a validator acts on, but its corpus carried no transaction using either extension, so neither gate could move a verdict for it to notice. With the corpus extended and the marker left alone it reports `IsEip8272Enabled, IsEip7906Enabled`; with the marker fixed it passes.

`HeadValidation_FrameTx_IsNotJudgedByEnvelopeGasLimitCap` now splits its budget across execution and state gas: the envelope total still clears the cap the test is about, while the execution reservation the frame validators do bound stays under it.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
