### PR TITLE
fix(pruning): measure the full-pruning snapshot trigger from the pruning boundary (#13199)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/PruningTriggerPruningStrategyTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/PruningTriggerPruningStrategyTests.cs
@@ -15,6 +15,8 @@ namespace Nethermind.Blockchain.Test.FullPruning
     [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
     public class PruningTriggerPruningStrategyTests
     {
+        private const ulong PruningBoundary = 128; // Pruning.PruningBoundary with snap serving (SnapServingMaxDepth); minimum enforced is 64
+
         private IFullPruningDb _fullPruningDb;
         private IPruningStrategy _basePruningStrategy;
         private PruningTriggerPruningStrategy _strategy;
@@ -24,7 +26,7 @@ namespace Nethermind.Blockchain.Test.FullPruning
         {
             _fullPruningDb = Substitute.For<IFullPruningDb>();
             _basePruningStrategy = Substitute.For<IPruningStrategy>();
-            _strategy = new PruningTriggerPruningStrategy(_fullPruningDb, _basePruningStrategy);
+            _strategy = new PruningTriggerPruningStrategy(_fullPruningDb, _basePruningStrategy, PruningBoundary);
         }
 
         [TearDown]
@@ -47,13 +49,75 @@ namespace Nethermind.Blockchain.Test.FullPruning
             Assert.That(_strategy.DeleteObsoleteKeys, Is.True);
         }
 
-        [Test]
-        public void ShouldPruneDirtyNode_should_return_true_when_in_pruning_and_difference_greater_than_32()
+        // The highest-risk surface of the #13199 fix is the path it must NOT change: a node that never runs full
+        // pruning has to keep deferring to the base strategy exactly as before, whatever the block distances are.
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShouldPruneDirtyNode_defers_to_the_base_strategy_when_not_pruning(bool baseSaysPrune)
         {
-            TrieStoreState state = new(100, 200, 300, 250); // LatestCommittedBlock - LastPersistedBlock = 50 > 32
+            // Distances that WOULD trip the in-pruning forced branch, to prove the branch is not consulted here.
+            TrieStoreState state = new(100, 200, 500, 300);
+            _basePruningStrategy.ShouldPruneDirtyNode(state).Returns(baseSaysPrune);
+            Assert.That(_strategy.ShouldPruneDirtyNode(state), Is.EqualTo(baseSaysPrune));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void ShouldPruneDirtyNode_returns_to_the_base_strategy_after_pruning_finished(bool baseSaysPrune)
+        {
+            TrieStoreState state = new(100, 200, 500, 300);
+            _basePruningStrategy.ShouldPruneDirtyNode(state).Returns(baseSaysPrune);
+            _fullPruningDb.PruningStarted += Raise.Event<EventHandler<PruningEventArgs>>(null, new PruningEventArgs(Substitute.For<IPruningContext>(), true));
+            _fullPruningDb.PruningFinished += Raise.Event<EventHandler<PruningEventArgs>>(null, new PruningEventArgs(Substitute.For<IPruningContext>(), true));
+            Assert.That(_strategy.ShouldPruneDirtyNode(state), Is.EqualTo(baseSaysPrune),
+                "the forced branch must not outlive the prune that justified it");
+        }
+
+        [Test]
+        public void ShouldPruneDirtyNode_should_return_true_when_in_pruning_and_difference_reaches_32()
+        {
+            TrieStoreState state = new(100, 200, 500, 300); // (LatestCommittedBlock - PruningBoundary) - LastPersistedBlock = 72 >= 32
             _basePruningStrategy.ShouldPruneDirtyNode(state).Returns(false);
             _fullPruningDb.PruningStarted += Raise.Event<EventHandler<PruningEventArgs>>(null, new PruningEventArgs(Substitute.For<IPruningContext>(), true));
             Assert.That(_strategy.ShouldPruneDirtyNode(state), Is.True);
+        }
+
+        [Test]
+        public void ShouldPruneDirtyNode_should_not_fire_when_in_pruning_and_only_the_pruning_boundary_separates_head_from_persisted()
+        {
+            // A snapshot can only persist blocks older than the pruning boundary, so right after a snapshot
+            // LastPersistedBlock == LatestCommittedBlock - PruningBoundary. Nothing new is persistable here,
+            // so the full-pruning trigger must defer to the base strategy instead of forcing a prune.
+            TrieStoreState state = new(100, 200, 1000, 1000 - PruningBoundary);
+            _basePruningStrategy.ShouldPruneDirtyNode(Arg.Any<TrieStoreState>()).Returns(false);
+            _fullPruningDb.PruningStarted += Raise.Event<EventHandler<PruningEventArgs>>(null, new PruningEventArgs(Substitute.For<IPruningContext>(), true));
+            Assert.That(_strategy.ShouldPruneDirtyNode(state), Is.False);
+        }
+
+        [Test]
+        public void ShouldPruneDirtyNode_should_fire_once_per_32_blocks_not_once_per_block_when_in_pruning()
+        {
+            // Simulate a node at head during full pruning: each block commit evaluates the strategy and,
+            // when it fires, a snapshot persists everything up to LatestCommittedBlock - PruningBoundary.
+            _basePruningStrategy.ShouldPruneDirtyNode(Arg.Any<TrieStoreState>()).Returns(false);
+            _fullPruningDb.PruningStarted += Raise.Event<EventHandler<PruningEventArgs>>(null, new PruningEventArgs(Substitute.For<IPruningContext>(), true));
+
+            const ulong startBlock = 1000;
+            const int blocks = 256;
+            ulong lastPersisted = startBlock - PruningBoundary;
+            int prunes = 0;
+            for (ulong block = startBlock + 1; block <= startBlock + blocks; block++)
+            {
+                if (_strategy.ShouldPruneDirtyNode(new TrieStoreState(100, 200, block, lastPersisted)))
+                {
+                    prunes++;
+                    lastPersisted = block - PruningBoundary;
+                }
+            }
+
+            // Every 32nd block (1032, 1064, ..., 1256) has 32 persistable blocks behind the boundary: 8 snapshots.
+            // A head-relative trigger fires on all 256 blocks, each persisting a single block.
+            Assert.That(prunes, Is.EqualTo(8));
         }
     }
 }

--- a/src/Nethermind/Nethermind.Blockchain/FullPruning/PruningTriggerPruningStrategy.cs
+++ b/src/Nethermind/Nethermind.Blockchain/FullPruning/PruningTriggerPruningStrategy.cs
@@ -10,16 +10,30 @@ namespace Nethermind.Blockchain.FullPruning;
 
 public class PruningTriggerPruningStrategy : IPruningStrategy, IDisposable
 {
+    // While full pruning runs, force a snapshot once this many persistable blocks have accumulated
+    // behind the pruning boundary, so the best persisted state keeps advancing.
+    private const ulong SnapshotIntervalDuringFullPruning = 32;
+
     private readonly IFullPruningDb _fullPruningDb;
     private readonly IPruningStrategy _basePruningStrategy;
+    private readonly IPruningStrategy _duringFullPruningStrategy;
     private int _inPruning = 0;
 
     public PruningTriggerPruningStrategy(
         IFullPruningDb fullPruningDb,
-        IPruningStrategy basePruningStrategy)
+        IPruningStrategy basePruningStrategy,
+        ulong pruningBoundary)
     {
         _fullPruningDb = fullPruningDb;
         _basePruningStrategy = basePruningStrategy;
+        // Full pruning needs the best persisted state to keep changing, so while it runs the base strategy is
+        // wrapped in the same "last persisted block is too old" trigger the dirty-cache path already uses. Only
+        // blocks older than the pruning boundary can be persisted, and that helper measures from the boundary
+        // rather than from the head - a head-relative comparison is always true during a full prune, because the
+        // head is by construction at least `pruningBoundary` ahead of the last persisted block, so it forces a
+        // snapshot on every single block.
+        _duringFullPruningStrategy = basePruningStrategy.WhenLastPersistedBlockIsTooOld(
+            SnapshotIntervalDuringFullPruning, pruningBoundary);
         _fullPruningDb.PruningFinished += OnPruningFinished;
         _fullPruningDb.PruningStarted += OnPruningStarted;
     }
@@ -37,16 +51,8 @@ public class PruningTriggerPruningStrategy : IPruningStrategy, IDisposable
         }
     }
 
-    public bool ShouldPruneDirtyNode(TrieStoreState state)
-    {
-        bool inPruning = _inPruning != 0;
-        if (inPruning)
-        {
-            // Make it take snapshot regularly as full pruning need the best persisted state to change.
-            if (state.LatestCommittedBlock - state.LastPersistedBlock > 32) return true;
-        }
-        return _basePruningStrategy.ShouldPruneDirtyNode(state);
-    }
+    public bool ShouldPruneDirtyNode(TrieStoreState state) =>
+        (_inPruning != 0 ? _duringFullPruningStrategy : _basePruningStrategy).ShouldPruneDirtyNode(state);
 
     public bool ShouldPrunePersistedNode(TrieStoreState state) => _basePruningStrategy.ShouldPrunePersistedNode(state);
 

--- a/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
+++ b/src/Nethermind/Nethermind.Init/PruningTrieStateFactory.cs
@@ -154,7 +154,7 @@ public class MainPruningTrieStoreFactory
 
         if (stateDb is IFullPruningDb fullPruningDb)
         {
-            pruningStrategy = new PruningTriggerPruningStrategy(fullPruningDb, pruningStrategy);
+            pruningStrategy = new PruningTriggerPruningStrategy(fullPruningDb, pruningStrategy, pruningConfig.PruningBoundary);
         }
 
         // Interpose the barrier on the node storage flush so a block's deferred block-data is made durable


### PR DESCRIPTION
Fixes #13199

Split 1 of 3 out of #13252 at @asdacap's request. The other two are #13309 and #13310. Nothing in this PR is shared with either; the three are independent and can merge in any order.

## Changes

`PruningTriggerPruningStrategy` compared `LatestCommittedBlock - LastPersistedBlock > 32`. `LastPersistedBlock` does not move while a full prune runs, so that difference only grows: the comparison was tautologically true and a snapshot was forced on every block, for the whole prune.

While `_inPruning != 0` the strategy now composes `Prune.WhenLastPersistedBlockIsTooOld(32, pruningBoundary)` — measured from the pruning boundary, the only blocks a snapshot can persist — with `>=`, so the interval is exactly 32 blocks rather than 33. That is `MaxBlockInCachePruneStrategy`, which falls through to the base strategy on both paths, so the arithmetic has one home and both subtractions saturate: a `LastPersistedBlock` ahead of `LatestCommittedBlock` no longer underflows.

The boundary production passes is the normalised one — `PruningTrieStateFactory` raises `pruningConfig.PruningBoundary` to `SnapServingMaxDepth` and applies the 64 floor before constructing the strategy — so the trigger measures at the same boundary the store persists at. 32 > `MinUnpersistedBlockCount` (8), so the forced branch never fights the `UnlessLastPersistedBlockIsTooNew` floor.

## Behaviour change worth knowing

Full-pruning **start latency grows by up to 32 blocks** (~6.4 min on mainnet, ~64 s on 2 s chains). The old code forced a snapshot every block, so "Full Pruning Waiting for state" resolved within ~1 block of `Head >= blockToWaitFor + boundary`; it now resolves within ≤32. Not a stall — worth knowing so the extra log lines are not triaged as one.

## API surface

`PruningTriggerPruningStrategy`'s `public` constructor takes a required `ulong pruningBoundary`. No candidate default is safe — `Reorganization.MaxDepth` is a mutable static, not a `const` — so this is source-breaking for out-of-tree callers. Both in-tree call sites are updated here.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`PruningTriggerPruningStrategyTests` gains the boundary-relative cases and one existing test is retargeted to the boundary; the expected sequence (1032, 1064, …, 1256 = 8) is re-derived from the new arithmetic. An adversarial review pointed out that the not-in-pruning path — the one this must **not** change — had no coverage at all, so `ShouldPruneDirtyNode_defers_to_the_base_strategy_when_not_pruning` and `..._returns_to_the_base_strategy_after_pruning_finished` were added, both driven with distances that *would* trip the forced branch. 14/14 green, debug build 0 warnings / 0 errors.

One caveat on the cadence test: it models the snapshot as persisting to `Head - boundary`, while `TrieStore` actually uses `min(Head - boundary, finalized)`. When finality lags more than the boundary the real cadence is finalized-bounded and occasionally takes two steps; it cannot degenerate back to fire-every-block, so the test is best-case rather than wrong.

Validated on the 2.0.0-rc soak fleet before the split: a 4h28m full prune completed, and the `cache too low` line went from ~300/h to 0/h.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes

Full pruning no longer forces a state snapshot on every block.
