### PR TITLE
fix(sync): drain in-flight sync dispatch before database teardown (#13154)

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SimpleDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SimpleDispatcherTests.cs
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Blockchain.Synchronization;
+using Nethermind.Logging;
+using Nethermind.Synchronization.ParallelSync;
+using Nethermind.Synchronization.Peers;
+using Nethermind.Synchronization.Peers.AllocationStrategies;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Synchronization.Test.ParallelSync;
+
+[Parallelizable(ParallelScope.All)]
+public class SimpleDispatcherTests
+{
+    public class TestRequest;
+
+    /// <summary>
+    /// Hands out one request, then idles on the token like a real feed waiting for more work.
+    /// HandleResponse blocks on a gate to model a worker that is inside a DB write.
+    /// </summary>
+    private class GatedFeed : ISimpleSyncFeed<TestRequest>
+    {
+        private int _prepared;
+
+        public TaskCompletionSource HandleResponseEntered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Released to let the blocked worker finish. A TCS so it needs no disposal while a worker is inside it.</summary>
+        public TaskCompletionSource ReleaseHandleResponse { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        /// <summary>Set once the loop has observed cancellation and left <see cref="PrepareRequest"/>.</summary>
+        public TaskCompletionSource PrepareRequestCancelled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int HandleResponseCompleted => Volatile.Read(ref _completed);
+        private int _completed;
+
+        public async Task<TestRequest?> PrepareRequest(CancellationToken token)
+        {
+            if (Interlocked.Increment(ref _prepared) == 1) return new TestRequest();
+
+            try
+            {
+                await Task.Delay(Timeout.Infinite, token);
+            }
+            catch (OperationCanceledException)
+            {
+                PrepareRequestCancelled.TrySetResult();
+                throw;
+            }
+
+            return null;
+        }
+
+        public SyncResponseHandlingResult HandleResponse(TestRequest response, PeerInfo? peer = null)
+        {
+            HandleResponseEntered.TrySetResult();
+            ReleaseHandleResponse.Task.GetAwaiter().GetResult();
+            Interlocked.Increment(ref _completed);
+            return SyncResponseHandlingResult.OK;
+        }
+    }
+
+    private static SimpleDispatcher<TestRequest> CreateDispatcher(GatedFeed feed)
+    {
+        ISyncPeerPool peerPool = Substitute.For<ISyncPeerPool>();
+        peerPool.Allocate(Arg.Any<IPeerAllocationStrategy>(), Arg.Any<AllocationContexts>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                SyncPeerAllocation allocation = new(AllocationContexts.State);
+                allocation.AllocatePeer(new PeerInfo(Substitute.For<ISyncPeer>()));
+                return Task.FromResult(allocation);
+            });
+
+        return new SimpleDispatcher<TestRequest>(
+            feed,
+            Substitute.For<ISyncDownloader<TestRequest>>(),
+            Substitute.For<IPeerAllocationStrategyFactory<TestRequest>>(),
+            AllocationContexts.State,
+            peerPool,
+            new TestSyncConfig(),
+            LimboLogs.Instance);
+    }
+
+    [Test, CancelAfter(30_000)]
+    public async Task Cancelled_run_waits_for_in_flight_handle_response(CancellationToken cancellationToken)
+    {
+        GatedFeed feed = new();
+        SimpleDispatcher<TestRequest> dispatcher = CreateDispatcher(feed);
+        using CancellationTokenSource cts = new();
+
+        Task runTask = dispatcher.Run(cts.Token);
+
+        // Production invariant: the caller (Synchronizer -> Autofac) disposes the databases the moment Run returns,
+        // so no worker may still be inside HandleResponse at that instant. Sampling the counter in a synchronous
+        // continuation states that as an ordering fact rather than as a deadline the runner has to beat.
+        Task<int> completedWhenRunReturned = runTask.ContinueWith(
+            _ => feed.HandleResponseCompleted,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        try
+        {
+            await feed.HandleResponseEntered.Task.WaitAsync(cancellationToken);
+
+            // Shutdown: the loop is cancelled while a dispatched worker is still inside HandleResponse
+            // (in production: writing state-sync nodes into RocksDB).
+            cts.Cancel();
+
+            // The loop has left PrepareRequest with the cancellation, so everything Run does from here is its drain
+            // path and releasing the gate below cannot be mistaken for a normal second lap.
+            await feed.PrepareRequestCancelled.Task.WaitAsync(cancellationToken);
+
+            Assert.That(feed.HandleResponseCompleted, Is.EqualTo(0));
+        }
+        finally
+        {
+            // Unconditional: a failed assertion above must not leave the worker blocked on a gate nobody will open.
+            feed.ReleaseHandleResponse.TrySetResult();
+        }
+
+        Assert.ThrowsAsync<TaskCanceledException>(() => runTask.WaitAsync(CancellationToken.None));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(await completedWhenRunReturned, Is.EqualTo(1), "Run must wait for in-flight HandleResponse");
+            Assert.That(feed.HandleResponseCompleted, Is.EqualTo(1));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SimpleDispatcherTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/ParallelSync/SimpleDispatcherTests.cs
@@ -85,6 +85,12 @@ public class SimpleDispatcherTests
             LimboLogs.Instance);
     }
 
+    /// <summary>
+    /// How long the gated worker is held after the cancellation, i.e. how long Run is given to prove it does not
+    /// return. Paid only when the assertion fails.
+    /// </summary>
+    private static readonly TimeSpan WorkerHold = TimeSpan.FromMilliseconds(500);
+
     [Test, CancelAfter(30_000)]
     public async Task Cancelled_run_waits_for_in_flight_handle_response(CancellationToken cancellationToken)
     {
@@ -111,11 +117,18 @@ public class SimpleDispatcherTests
             // (in production: writing state-sync nodes into RocksDB).
             cts.Cancel();
 
-            // The loop has left PrepareRequest with the cancellation, so everything Run does from here is its drain
-            // path and releasing the gate below cannot be mistaken for a normal second lap.
+            // PrepareRequest has thrown the cancellation, so everything Run does from here is its exit path.
             await feed.PrepareRequestCancelled.Task.WaitAsync(cancellationToken);
 
-            Assert.That(feed.HandleResponseCompleted, Is.EqualTo(0));
+            // The worker holds the permit Run's drain has to reclaim, so Run cannot get back to its caller: the
+            // whole point of #13154. Hold the gate over the window instead of opening it here - if the drain sits
+            // after the loop rather than in the finally, the OperationCanceledException carries straight out of
+            // Run and this is what catches it. Only the failing path pays the wait, and the unwind it is racing
+            // is a handful of continuations with no IO, so the margin is four orders of magnitude.
+            Assert.That(await Task.WhenAny(runTask, Task.Delay(WorkerHold, cancellationToken)), Is.Not.SameAs(runTask),
+                "Run returned while a worker was still inside HandleResponse");
+
+            Assert.That(feed.HandleResponseCompleted, Is.EqualTo(0), "the gate is still closed");
         }
         finally
         {

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerModuleTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerModuleTests.cs
@@ -1,19 +1,14 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Blockchain;
-using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
-using Nethermind.Consensus.Processing;
-using Nethermind.Consensus.Validators;
 using Nethermind.Core;
-using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Modules;
 using Nethermind.Logging;
@@ -21,6 +16,7 @@ using Nethermind.Network.Config;
 using Nethermind.State;
 using Nethermind.Stats;
 using Nethermind.Synchronization.Blocks;
+using Nethermind.Synchronization.DbTuner;
 using Nethermind.Synchronization.FastBlocks;
 using Nethermind.Synchronization.FastSync;
 using Nethermind.Synchronization.ParallelSync;
@@ -75,26 +71,15 @@ public class SynchronizerModuleTests
     [Test]
     public async Task Synchronizer_dispose_is_idempotent()
     {
-        // The class under test is constructed directly: the assert needs a substituted feed, and the
-        // module registers the feed components in their own keyed lifetime scopes, which an outer
-        // override cannot reach.
         ISyncFeed<BlocksRequest> fullSyncFeed = Substitute.For<ISyncFeed<BlocksRequest>>();
-        static SyncFeedComponent<T> FeedOnly<T>(ISyncFeed<T> feed) => new(feed, null!, null!, null!, null!);
-        Synchronizer synchronizer = BuildSynchronizer(
-            Substitute.For<ISyncConfig>(),
-            Substitute.For<IBlockTree>(),
-            Substitute.For<IStateSyncRunner>(),
-            FeedOnly(fullSyncFeed),
-            FeedOnly(Substitute.For<ISyncFeed<BlocksRequest>>()),
-            FeedOnly(Substitute.For<ISyncFeed<HeadersSyncBatch>>()),
-            FeedOnly(Substitute.For<ISyncFeed<BodiesSyncBatch>>()),
-            FeedOnly(Substitute.For<ISyncFeed<ReceiptsSyncBatch>>()),
-            FeedOnly(Substitute.For<ISyncFeed<BlockAccessListsSyncBatch>>()));
+        await using IContainer container = BuildSyncContainer(fullSyncFeed: fullSyncFeed);
+
+        ISynchronizer synchronizer = container.Resolve<ISynchronizer>();
 
         await synchronizer.DisposeAsync();
         await synchronizer.DisposeAsync();
 
-        // Container teardown disposes twice (dispose tracking); the second run must not wait on
+        // Container teardown can dispose this more than once, and a repeat run would wait on
         // the feed tasks again - with a stuck feed it would pay the full termination timeout twice.
         _ = fullSyncFeed.Received(1).FeedTask;
     }
@@ -114,7 +99,11 @@ public class SynchronizerModuleTests
             return runnerGate.Task;
         });
 
-        Synchronizer synchronizer = BuildStartableSynchronizer(stateSyncRunner);
+        await using IContainer container = BuildSyncContainer(stateSyncRunner);
+
+        // Resolved rather than constructed: the join only runs on a real node because Autofac owns the concrete
+        // Synchronizer and disposes it in reverse activation order, ahead of the databases.
+        ISynchronizer synchronizer = container.Resolve<ISynchronizer>();
 
         synchronizer.Start();
         _ = stateSyncRunner.Received(1).Run(Arg.Any<CancellationToken>());
@@ -159,10 +148,12 @@ public class SynchronizerModuleTests
 
         TestLogger logger = new() { IsInfo = false, IsDebug = false, IsTrace = false };
         const int budgetMs = 50;
-        Synchronizer synchronizer = BuildStartableSynchronizer(
-            stateSyncRunner,
-            new OneLoggerLogManager(new(logger)),
-            budgetMs);
+
+        await using IContainer container = BuildSyncContainer(stateSyncRunner, logManager: new OneLoggerLogManager(new(logger)));
+
+        // The budget is an internal test knob with no DI surface, so this one Synchronizer is constructed rather than
+        // resolved - out of the container's own components, so the graph under test is still the production one.
+        await using Synchronizer synchronizer = ResolveSynchronizer(container, budgetMs);
 
         synchronizer.Start();
 
@@ -183,54 +174,61 @@ public class SynchronizerModuleTests
         }
     }
 
-    // The full rig, as opposed to BuildSynchronizer's bare construction: Start() drives the feed components, so
-    // these tests need real dispatchers behind the substituted feeds rather than the null! placeholders.
-    private static Synchronizer BuildStartableSynchronizer(
-        IStateSyncRunner stateSyncRunner,
-        ILogManager? logManager = null,
-        int stateSyncTerminationTimeout = Synchronizer.DefaultStateSyncTerminationTimeout)
+    /// <summary>
+    /// A production container: SynchronizerModule wires the feeds, their dispatchers and the lifetime scopes that own
+    /// them, and the join added for #13154 relies on Autofac owning the concrete <see cref="Synchronizer"/>. Only the
+    /// collaborators a test drives are substituted, and a feed override is applied inside the keyed scope that owns it
+    /// rather than on the outer container, which cannot reach in.
+    /// </summary>
+    private static IContainer BuildSyncContainer(
+        IStateSyncRunner? stateSyncRunner = null,
+        ISyncFeed<BlocksRequest>? fullSyncFeed = null,
+        ILogManager? logManager = null)
     {
-        logManager ??= LimboLogs.Instance;
-        TestSyncConfig syncConfig = new() { FastSync = true };
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.CanAcceptNewBlocks.Returns(true);
-        ISyncPeerPool peerPool = Substitute.For<ISyncPeerPool>();
-        BlockDownloader blockDownloader = new(
-            blockTree,
-            Substitute.For<IBlockValidator>(),
-            Substitute.For<ISyncReport>(),
-            Substitute.For<IReceiptStorage>(),
-            Substitute.For<ISpecProvider>(),
-            Substitute.For<IBetterPeerStrategy>(),
-            Substitute.For<IFullStateFinder>(),
-            Substitute.For<IForwardHeaderProvider>(),
-            peerPool,
-            Substitute.For<IReceiptsRecovery>(),
-            Substitute.For<IBlockProcessingQueue>(),
-            syncConfig,
-            LimboLogs.Instance);
+        SyncConfig syncConfig = new() { FastSync = true };
 
-        SyncFeedComponent<T> Component<T>()
+        ContainerBuilder builder = new ContainerBuilder()
+            .AddModule(new TestNethermindModule(new ConfigProvider(syncConfig)))
+            .AddModule(new SynchronizerModule(syncConfig))
+            .AddSingleton(stateSyncRunner ?? Substitute.For<IStateSyncRunner>())
+            .AddSingleton(Substitute.For<IWorldStateManager>());
+
+        if (fullSyncFeed is not null)
         {
-            ISyncFeed<T> feed = Substitute.For<ISyncFeed<T>>();
-            ISyncDownloader<T> downloader = Substitute.For<ISyncDownloader<T>>();
-            SyncDispatcher<T> dispatcher = new(syncConfig, feed, downloader, peerPool, Substitute.For<IPeerAllocationStrategyFactory<T>>(), LimboLogs.Instance);
-            return new SyncFeedComponent<T>(feed, dispatcher, downloader, new Lazy<BlockDownloader>(() => blockDownloader), Substitute.For<ILifetimeScope>());
+            builder.RegisterNamedComponentInItsOwnLifetime<SyncFeedComponent<BlocksRequest>>(
+                nameof(FullSyncFeed), cfg => cfg.AddSingleton(fullSyncFeed));
         }
 
-        return BuildSynchronizer(
-            syncConfig,
-            blockTree,
-            stateSyncRunner,
-            Component<BlocksRequest>(),
-            Component<BlocksRequest>(),
-            Component<HeadersSyncBatch>(),
-            Component<BodiesSyncBatch>(),
-            Component<ReceiptsSyncBatch>(),
-            Component<BlockAccessListsSyncBatch>(),
-            logManager,
-            stateSyncTerminationTimeout);
+        if (logManager is not null) builder.AddSingleton(logManager);
+
+        return builder.Build();
     }
+
+    /// <summary>
+    /// <see cref="Synchronizer"/> out of the container's own components, for the one test that has to set
+    /// <see cref="Synchronizer.StateSyncTerminationTimeout"/> - an <c>init</c> member with no registration to override.
+    /// </summary>
+    private static Synchronizer ResolveSynchronizer(IContainer container, int stateSyncTerminationTimeout) =>
+        new(container.Resolve<ISyncModeSelector>(),
+            container.Resolve<ISyncReport>(),
+            container.Resolve<ISyncConfig>(),
+            container.Resolve<IBlockTree>(),
+            container.Resolve<ISyncPivotResolver>(),
+            container.Resolve<ILogManager>(),
+            container.Resolve<INodeStatsManager>(),
+            container.ResolveNamed<SyncFeedComponent<BlocksRequest>>(nameof(FullSyncFeed)),
+            container.ResolveNamed<SyncFeedComponent<BlocksRequest>>(nameof(FastSyncFeed)),
+            container.Resolve<IStateSyncRunner>(),
+            container.ResolveNamed<SyncFeedComponent<HeadersSyncBatch>>(nameof(HeadersSyncFeed)),
+            container.Resolve<SyncFeedComponent<BodiesSyncBatch>>(),
+            container.Resolve<SyncFeedComponent<ReceiptsSyncBatch>>(),
+            container.Resolve<SyncFeedComponent<BlockAccessListsSyncBatch>>(),
+            container.Resolve<SyncDbTuner>(),
+            container.Resolve<MallocTrimmer>(),
+            container.Resolve<IProcessExitSource>())
+        {
+            StateSyncTerminationTimeout = stateSyncTerminationTimeout,
+        };
 
     private static async Task WaitForCancellation(CancellationToken watched, CancellationToken cancellationToken)
     {
@@ -240,41 +238,4 @@ public class SynchronizerModuleTests
             await cancelled.Task.WaitAsync(cancellationToken);
         }
     }
-
-    // Both dispose tests construct the class under test directly: the asserts need substituted feeds, and
-    // SynchronizerModule registers the feed components in their own keyed lifetime scopes, which an outer override
-    // cannot reach. Only the collaborators the tests actually drive are parameters here, so the constructor's other
-    // arguments live in one place instead of being repeated per test.
-    private static Synchronizer BuildSynchronizer(
-        ISyncConfig syncConfig,
-        IBlockTree blockTree,
-        IStateSyncRunner stateSyncRunner,
-        SyncFeedComponent<BlocksRequest> fullSync,
-        SyncFeedComponent<BlocksRequest> fastSync,
-        SyncFeedComponent<HeadersSyncBatch> fastHeaders,
-        SyncFeedComponent<BodiesSyncBatch> oldBodies,
-        SyncFeedComponent<ReceiptsSyncBatch> oldReceipts,
-        SyncFeedComponent<BlockAccessListsSyncBatch> oldBlockAccessLists,
-        ILogManager? logManager = null,
-        int stateSyncTerminationTimeout = Synchronizer.DefaultStateSyncTerminationTimeout) =>
-        new(Substitute.For<ISyncModeSelector>(),
-            Substitute.For<ISyncReport>(),
-            syncConfig,
-            blockTree,
-            Substitute.For<ISyncPivotResolver>(),
-            logManager ?? LimboLogs.Instance,
-            Substitute.For<INodeStatsManager>(),
-            fullSync,
-            fastSync,
-            stateSyncRunner,
-            fastHeaders,
-            oldBodies,
-            oldReceipts,
-            oldBlockAccessLists,
-            null!,
-            null!,
-            Substitute.For<IProcessExitSource>())
-        {
-            StateSyncTerminationTimeout = stateSyncTerminationTimeout,
-        };
 }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerModuleTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SynchronizerModuleTests.cs
@@ -1,12 +1,20 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Autofac;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Receipts;
 using Nethermind.Blockchain.Synchronization;
 using Nethermind.Config;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Validators;
 using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
 using Nethermind.Core.Test.Modules;
 using Nethermind.Logging;
 using Nethermind.Network.Config;
@@ -71,24 +79,17 @@ public class SynchronizerModuleTests
         // module registers the feed components in their own keyed lifetime scopes, which an outer
         // override cannot reach.
         ISyncFeed<BlocksRequest> fullSyncFeed = Substitute.For<ISyncFeed<BlocksRequest>>();
-        Synchronizer synchronizer = new(
-            Substitute.For<ISyncModeSelector>(),
-            Substitute.For<ISyncReport>(),
+        static SyncFeedComponent<T> FeedOnly<T>(ISyncFeed<T> feed) => new(feed, null!, null!, null!, null!);
+        Synchronizer synchronizer = BuildSynchronizer(
             Substitute.For<ISyncConfig>(),
             Substitute.For<IBlockTree>(),
-            Substitute.For<ISyncPivotResolver>(),
-            LimboLogs.Instance,
-            Substitute.For<INodeStatsManager>(),
-            new SyncFeedComponent<BlocksRequest>(fullSyncFeed, null!, null!, null!, null!),
-            new SyncFeedComponent<BlocksRequest>(Substitute.For<ISyncFeed<BlocksRequest>>(), null!, null!, null!, null!),
             Substitute.For<IStateSyncRunner>(),
-            new SyncFeedComponent<HeadersSyncBatch>(Substitute.For<ISyncFeed<HeadersSyncBatch>>(), null!, null!, null!, null!),
-            new SyncFeedComponent<BodiesSyncBatch>(Substitute.For<ISyncFeed<BodiesSyncBatch>>(), null!, null!, null!, null!),
-            new SyncFeedComponent<ReceiptsSyncBatch>(Substitute.For<ISyncFeed<ReceiptsSyncBatch>>(), null!, null!, null!, null!),
-            new SyncFeedComponent<BlockAccessListsSyncBatch>(Substitute.For<ISyncFeed<BlockAccessListsSyncBatch>>(), null!, null!, null!, null!),
-            null!,
-            null!,
-            Substitute.For<IProcessExitSource>());
+            FeedOnly(fullSyncFeed),
+            FeedOnly(Substitute.For<ISyncFeed<BlocksRequest>>()),
+            FeedOnly(Substitute.For<ISyncFeed<HeadersSyncBatch>>()),
+            FeedOnly(Substitute.For<ISyncFeed<BodiesSyncBatch>>()),
+            FeedOnly(Substitute.For<ISyncFeed<ReceiptsSyncBatch>>()),
+            FeedOnly(Substitute.For<ISyncFeed<BlockAccessListsSyncBatch>>()));
 
         await synchronizer.DisposeAsync();
         await synchronizer.DisposeAsync();
@@ -97,4 +98,183 @@ public class SynchronizerModuleTests
         // the feed tasks again - with a stuck feed it would pay the full termination timeout twice.
         _ = fullSyncFeed.Received(1).FeedTask;
     }
+
+    [Test, CancelAfter(30_000)]
+    public async Task Synchronizer_dispose_waits_for_state_sync_runner(CancellationToken cancellationToken)
+    {
+        // Start launches the state sync runner fire-and-forget; container teardown disposes the
+        // databases right after DisposeAsync returns, so DisposeAsync must join that task the same way
+        // it joins the feed tasks. The runner is gated to model in-flight snap/state sync work.
+        TaskCompletionSource runnerGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken runnerToken = default;
+        IStateSyncRunner stateSyncRunner = Substitute.For<IStateSyncRunner>();
+        stateSyncRunner.Run(Arg.Any<CancellationToken>()).Returns(ci =>
+        {
+            runnerToken = ci.Arg<CancellationToken>();
+            return runnerGate.Task;
+        });
+
+        Synchronizer synchronizer = BuildStartableSynchronizer(stateSyncRunner);
+
+        synchronizer.Start();
+        _ = stateSyncRunner.Received(1).Run(Arg.Any<CancellationToken>());
+
+        Task disposeTask = synchronizer.DisposeAsync().AsTask();
+
+        // Production invariant: container teardown disposes the databases the moment DisposeAsync returns, so the
+        // runner must have finished by then. Sampling in a synchronous continuation states that as an ordering fact
+        // rather than as a deadline the test runner has to beat.
+        Task<bool> runnerDoneWhenDisposeReturned = disposeTask.ContinueWith(
+            _ => runnerGate.Task.IsCompleted,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+
+        try
+        {
+            // DisposeAsync cancels the sync token before it joins anything, so once the runner has seen the
+            // cancellation, everything left is the join itself.
+            await WaitForCancellation(runnerToken, cancellationToken);
+            Assert.That(disposeTask.IsCompleted, Is.False, "DisposeAsync must wait for the state sync runner");
+        }
+        finally
+        {
+            // Unconditional: a failed assertion above must not leave DisposeAsync blocked on a gate nobody will open.
+            runnerGate.TrySetResult();
+        }
+
+        await disposeTask.WaitAsync(cancellationToken);
+        Assert.That(await runnerDoneWhenDisposeReturned, Is.True);
+    }
+
+    [Test, CancelAfter(30_000)]
+    public async Task Synchronizer_dispose_gives_up_on_a_state_sync_runner_that_outlives_its_budget(CancellationToken cancellationToken)
+    {
+        // The join is bounded on purpose: the runner sets ProcessTerminationTimeout to infinite, so a wait with no
+        // ceiling here is a node that hangs on SIGTERM instead of one that crashes. What the operator gets instead is
+        // a line naming the consequence, because the databases are disposed the moment DisposeAsync returns.
+        TaskCompletionSource runnerGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        IStateSyncRunner stateSyncRunner = Substitute.For<IStateSyncRunner>();
+        stateSyncRunner.Run(Arg.Any<CancellationToken>()).Returns(runnerGate.Task);
+
+        TestLogger logger = new() { IsInfo = false, IsDebug = false, IsTrace = false };
+        const int budgetMs = 50;
+        Synchronizer synchronizer = BuildStartableSynchronizer(
+            stateSyncRunner,
+            new OneLoggerLogManager(new(logger)),
+            budgetMs);
+
+        synchronizer.Start();
+
+        try
+        {
+            // The runner never completes, so this returning at all is the assertion: DisposeAsync gave up.
+            await synchronizer.DisposeAsync().AsTask().WaitAsync(cancellationToken);
+
+            Assert.That(
+                logger.LogList.Where(static l => l.Contains($"State sync did not stop within {budgetMs}ms")),
+                Is.Not.Empty,
+                $"WARN/ERROR lines: {string.Join(" | ", logger.LogList)}");
+        }
+        finally
+        {
+            // Unconditional: nothing else will ever release a runner substituted as a gate.
+            runnerGate.TrySetResult();
+        }
+    }
+
+    // The full rig, as opposed to BuildSynchronizer's bare construction: Start() drives the feed components, so
+    // these tests need real dispatchers behind the substituted feeds rather than the null! placeholders.
+    private static Synchronizer BuildStartableSynchronizer(
+        IStateSyncRunner stateSyncRunner,
+        ILogManager? logManager = null,
+        int stateSyncTerminationTimeout = Synchronizer.DefaultStateSyncTerminationTimeout)
+    {
+        logManager ??= LimboLogs.Instance;
+        TestSyncConfig syncConfig = new() { FastSync = true };
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.CanAcceptNewBlocks.Returns(true);
+        ISyncPeerPool peerPool = Substitute.For<ISyncPeerPool>();
+        BlockDownloader blockDownloader = new(
+            blockTree,
+            Substitute.For<IBlockValidator>(),
+            Substitute.For<ISyncReport>(),
+            Substitute.For<IReceiptStorage>(),
+            Substitute.For<ISpecProvider>(),
+            Substitute.For<IBetterPeerStrategy>(),
+            Substitute.For<IFullStateFinder>(),
+            Substitute.For<IForwardHeaderProvider>(),
+            peerPool,
+            Substitute.For<IReceiptsRecovery>(),
+            Substitute.For<IBlockProcessingQueue>(),
+            syncConfig,
+            LimboLogs.Instance);
+
+        SyncFeedComponent<T> Component<T>()
+        {
+            ISyncFeed<T> feed = Substitute.For<ISyncFeed<T>>();
+            ISyncDownloader<T> downloader = Substitute.For<ISyncDownloader<T>>();
+            SyncDispatcher<T> dispatcher = new(syncConfig, feed, downloader, peerPool, Substitute.For<IPeerAllocationStrategyFactory<T>>(), LimboLogs.Instance);
+            return new SyncFeedComponent<T>(feed, dispatcher, downloader, new Lazy<BlockDownloader>(() => blockDownloader), Substitute.For<ILifetimeScope>());
+        }
+
+        return BuildSynchronizer(
+            syncConfig,
+            blockTree,
+            stateSyncRunner,
+            Component<BlocksRequest>(),
+            Component<BlocksRequest>(),
+            Component<HeadersSyncBatch>(),
+            Component<BodiesSyncBatch>(),
+            Component<ReceiptsSyncBatch>(),
+            Component<BlockAccessListsSyncBatch>(),
+            logManager,
+            stateSyncTerminationTimeout);
+    }
+
+    private static async Task WaitForCancellation(CancellationToken watched, CancellationToken cancellationToken)
+    {
+        TaskCompletionSource cancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        await using (watched.Register(() => cancelled.TrySetResult()))
+        {
+            await cancelled.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    // Both dispose tests construct the class under test directly: the asserts need substituted feeds, and
+    // SynchronizerModule registers the feed components in their own keyed lifetime scopes, which an outer override
+    // cannot reach. Only the collaborators the tests actually drive are parameters here, so the constructor's other
+    // arguments live in one place instead of being repeated per test.
+    private static Synchronizer BuildSynchronizer(
+        ISyncConfig syncConfig,
+        IBlockTree blockTree,
+        IStateSyncRunner stateSyncRunner,
+        SyncFeedComponent<BlocksRequest> fullSync,
+        SyncFeedComponent<BlocksRequest> fastSync,
+        SyncFeedComponent<HeadersSyncBatch> fastHeaders,
+        SyncFeedComponent<BodiesSyncBatch> oldBodies,
+        SyncFeedComponent<ReceiptsSyncBatch> oldReceipts,
+        SyncFeedComponent<BlockAccessListsSyncBatch> oldBlockAccessLists,
+        ILogManager? logManager = null,
+        int stateSyncTerminationTimeout = Synchronizer.DefaultStateSyncTerminationTimeout) =>
+        new(Substitute.For<ISyncModeSelector>(),
+            Substitute.For<ISyncReport>(),
+            syncConfig,
+            blockTree,
+            Substitute.For<ISyncPivotResolver>(),
+            logManager ?? LimboLogs.Instance,
+            Substitute.For<INodeStatsManager>(),
+            fullSync,
+            fastSync,
+            stateSyncRunner,
+            fastHeaders,
+            oldBodies,
+            oldReceipts,
+            oldBlockAccessLists,
+            null!,
+            null!,
+            Substitute.For<IProcessExitSource>())
+        {
+            StateSyncTerminationTimeout = stateSyncTerminationTimeout,
+        };
 }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
@@ -91,13 +91,10 @@ public class SimpleDispatcher<T>(
         }
         finally
         {
-            // Wait for in-flight tasks to complete, also when the loop exits by cancellation: the caller
-            // tears down the databases right after this returns, and a worker still inside HandleResponse
-            // would then write to a disposed RocksDB. This has to be a finally rather than a statement after
-            // the loop - PrepareRequest throws OperationCanceledException on cancellation, which is precisely
-            // the shutdown path #13154 is about, and that would carry straight past a trailing drain. The throw
-            // out of the wait above lands here too, so a cancelled dispatch still joins its workers.
-            // CancellationToken.None so peer allocations are always freed in DoDispatch even when the caller cancels.
+            // The caller tears down the databases right after this returns, so no worker may still be inside
+            // HandleResponse by then. A finally rather than a statement after the loop: PrepareRequest and the
+            // semaphore wait both throw OperationCanceledException on shutdown, and that would carry straight
+            // past a trailing drain. CancellationToken.None so the join itself cannot be cancelled.
             for (int i = 0; i < maxThreads; i++)
                 await semaphore.WaitAsync(CancellationToken.None);
         }

--- a/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
+++ b/src/Nethermind/Nethermind.Synchronization/ParallelSync/SimpleDispatcher.cs
@@ -41,53 +41,66 @@ public class SimpleDispatcher<T>(
             : syncConfig.MaxProcessingThreads;
         SemaphoreSlim semaphore = new(maxThreads, maxThreads);
 
-        while (!token.IsCancellationRequested)
+        try
         {
-            long prepareTime = Stopwatch.GetTimestamp();
-            T? request = await feed.PrepareRequest(token);
-            Metrics.SyncDispatcherPrepareRequestTimeMicros.Observe(
-                Stopwatch.GetElapsedTime(prepareTime).TotalMicroseconds, new StringLabel(_feedName));
-
-            if (request is null)
-                break;
-
-            SyncPeerAllocation allocation = await peerPool.Allocate(
-                strategyFactory.Create(request), contexts, _allocateTimeoutMs, token);
-            PeerInfo? peer = allocation.Current;
-
-            if (peer is null)
+            while (!token.IsCancellationRequested)
             {
-                allocation.Dispose();
-                HandleResponse(request, null);
-                continue;
-            }
+                long prepareTime = Stopwatch.GetTimestamp();
+                T? request = await feed.PrepareRequest(token);
+                Metrics.SyncDispatcherPrepareRequestTimeMicros.Observe(
+                    Stopwatch.GetElapsedTime(prepareTime).TotalMicroseconds, new StringLabel(_feedName));
 
-            try
-            {
-                await semaphore.WaitAsync(token);
-            }
-            catch
-            {
-                allocation.Dispose();
-                throw;
-            }
+                if (request is null)
+                    break;
 
-            _ = Task.Run(async () =>
-            {
+                SyncPeerAllocation allocation = await peerPool.Allocate(
+                    strategyFactory.Create(request), contexts, _allocateTimeoutMs, token);
+                PeerInfo? peer = allocation.Current;
+
+                if (peer is null)
+                {
+                    // DoDispatch owns the allocation everywhere else; this path never reaches it.
+                    allocation.Dispose();
+                    HandleResponse(request, null);
+                    continue;
+                }
+
                 try
                 {
-                    await DoDispatch(request, peer, allocation, token);
+                    await semaphore.WaitAsync(token);
                 }
-                finally
+                catch
                 {
-                    semaphore.Release();
+                    // DoDispatch is what frees the allocation, and cancelling here means it never runs.
+                    allocation.Dispose();
+                    throw;
                 }
-            });
-        }
 
-        // Drain with CancellationToken.None so cancellation does not abandon in-flight tasks.
-        for (int i = 0; i < maxThreads; i++)
-            await semaphore.WaitAsync(CancellationToken.None);
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await DoDispatch(request, peer, allocation, token);
+                    }
+                    finally
+                    {
+                        semaphore.Release();
+                    }
+                });
+            }
+        }
+        finally
+        {
+            // Wait for in-flight tasks to complete, also when the loop exits by cancellation: the caller
+            // tears down the databases right after this returns, and a worker still inside HandleResponse
+            // would then write to a disposed RocksDB. This has to be a finally rather than a statement after
+            // the loop - PrepareRequest throws OperationCanceledException on cancellation, which is precisely
+            // the shutdown path #13154 is about, and that would carry straight past a trailing drain. The throw
+            // out of the wait above lands here too, so a cancelled dispatch still joins its workers.
+            // CancellationToken.None so peer allocations are always freed in DoDispatch even when the caller cancels.
+            for (int i = 0; i < maxThreads; i++)
+                await semaphore.WaitAsync(CancellationToken.None);
+        }
     }
 
     private async Task DoDispatch(

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -54,17 +54,12 @@ namespace Nethermind.Synchronization
         private const int FeedsTerminationTimeout = 5_000;
 
         /// <remarks>
-        /// The state sync drain is a memory-safety barrier, not a tidy-shutdown courtesy like the feed tasks: the
-        /// databases are disposed the moment this returns, and a dispatcher worker still inside HandleResponse then
-        /// writes to a freed native handle (#13154). It gets a budget of its own rather than the feeds' advisory one,
-        /// and it stays bounded because the runner sets ProcessTerminationTimeout to infinite - a wait with no ceiling
-        /// here is a node that never exits.
-        /// <para>
-        /// The budget therefore bounds the race rather than closing it: a runner that outlives it is warned about and
-        /// then left running while the databases go away, so #13154 remains reachable under an IO stall. Closing it
-        /// properly means making this an <c>IStoppableService</c> so teardown is ordered after sync, which is a
-        /// larger change than this fix.
-        /// </para>
+        /// The state sync join is a memory-safety barrier, not a tidy-shutdown courtesy like the feed tasks: the
+        /// databases are disposed the moment <see cref="DisposeAsync"/> returns, and a dispatcher worker still inside
+        /// HandleResponse then writes to a freed native handle (#13154). It is bounded because the runner sets
+        /// ProcessTerminationTimeout to infinite - a wait with no ceiling here is a node that never exits - so the
+        /// budget bounds the race rather than closing it. Ordering teardown after sync (making this an
+        /// <c>IStoppableService</c>) is what closes it, and is out of scope here.
         /// </remarks>
         internal const int DefaultStateSyncTerminationTimeout = 60_000;
 

--- a/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Synchronizer.cs
@@ -53,9 +53,42 @@ namespace Nethermind.Synchronization
     {
         private const int FeedsTerminationTimeout = 5_000;
 
+        /// <remarks>
+        /// The state sync drain is a memory-safety barrier, not a tidy-shutdown courtesy like the feed tasks: the
+        /// databases are disposed the moment this returns, and a dispatcher worker still inside HandleResponse then
+        /// writes to a freed native handle (#13154). It gets a budget of its own rather than the feeds' advisory one,
+        /// and it stays bounded because the runner sets ProcessTerminationTimeout to infinite - a wait with no ceiling
+        /// here is a node that never exits.
+        /// <para>
+        /// The budget therefore bounds the race rather than closing it: a runner that outlives it is warned about and
+        /// then left running while the databases go away, so #13154 remains reachable under an IO stall. Closing it
+        /// properly means making this an <c>IStoppableService</c> so teardown is ordered after sync, which is a
+        /// larger change than this fix.
+        /// </para>
+        /// </remarks>
+        internal const int DefaultStateSyncTerminationTimeout = 60_000;
+
+        /// <summary>How long <see cref="DisposeAsync"/> waits for the state sync runner before giving up on it.</summary>
+        /// <remarks>
+        /// Settable rather than a <c>const</c> so the give-up branch can be exercised in milliseconds; nothing outside
+        /// the tests sets it. See <see cref="DefaultStateSyncTerminationTimeout"/> for why this wait exists and why it
+        /// is bounded at all.
+        /// </remarks>
+        internal int StateSyncTerminationTimeout { get; init; } = DefaultStateSyncTerminationTimeout;
+
         private readonly ILogger _logger = logManager.GetClassLogger<Synchronizer>();
 
         private CancellationTokenSource? _syncCancellation = new();
+
+        /// <remarks>
+        /// <see cref="Start"/> publishes <see cref="_stateSyncTask"/> and <see cref="DisposeAsync"/> joins it, from
+        /// different threads and with no ordering between them. Guarding both with one lock also makes a dispose that
+        /// wins the race safe, by refusing to start after it. It orders those two fields and the cancellation token
+        /// read alongside them - not the whole of <see cref="Start"/>, whose remaining wiring runs outside it.
+        /// </remarks>
+        private readonly Lock _startStopLock = new();
+
+        private Task _stateSyncTask = Task.CompletedTask;
 
         private bool _disposed;
 
@@ -71,15 +104,28 @@ namespace Nethermind.Synchronization
                 return;
             }
 
-            StartFullSyncComponents();
-
-            if (syncConfig.FastSync)
+            CancellationToken gateToken;
+            lock (_startStopLock)
             {
-                StartFastBlocksComponents();
+                if (_disposed)
+                {
+                    return;
+                }
 
-                StartFastSyncComponents();
+                // Read under the lock: a DisposeAsync that wins the race nulls the field, and this method
+                // goes on to use the token after leaving the lock.
+                gateToken = _syncCancellation!.Token;
 
-                StartSnapAndStateSyncComponents();
+                StartFullSyncComponents();
+
+                if (syncConfig.FastSync)
+                {
+                    StartFastBlocksComponents();
+
+                    StartFastSyncComponents();
+
+                    StartSnapAndStateSyncComponents();
+                }
             }
 
             if (syncConfig.ExitOnSynced)
@@ -98,7 +144,7 @@ namespace Nethermind.Synchronization
 
             // Mode selection only begins once startup prerequisites are met: the DB block load has finished
             // and the starting sync pivot has been resolved. Until then the feeds wired above stay dormant.
-            _ = StartModeSelectorAfterGates(_syncCancellation!.Token);
+            _ = StartModeSelectorAfterGates(gateToken);
         }
 
         private async Task StartModeSelectorAfterGates(CancellationToken cancellationToken)
@@ -174,9 +220,8 @@ namespace Nethermind.Synchronization
             });
         }
 
-        private void StartSnapAndStateSyncComponents()
-        {
-            Task _ = stateSyncRunner.Run(_syncCancellation!.Token).ContinueWith(t =>
+        private void StartSnapAndStateSyncComponents() =>
+            _stateSyncTask = stateSyncRunner.Run(_syncCancellation!.Token).ContinueWith(t =>
             {
                 if (t.IsFaulted)
                 {
@@ -187,7 +232,6 @@ namespace Nethermind.Synchronization
                     if (_logger.IsInfo) _logger.Info("State sync task completed.");
                 }
             });
-        }
 
         private void StartFastBlocksComponents()
         {
@@ -269,17 +313,27 @@ namespace Nethermind.Synchronization
 
         public async ValueTask DisposeAsync()
         {
-            // Container teardown can dispose this more than once, and a repeat run would wait on
-            // the feed tasks again - the full termination timeout when any feed failed to finish.
-            if (Interlocked.CompareExchange(ref _disposed, true, false))
+            Task stateSyncTask;
+            lock (_startStopLock)
             {
-                return;
+                // Container teardown can dispose this more than once, and a repeat run would wait on
+                // the feed tasks again - the full termination timeout when any feed failed to finish.
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                stateSyncTask = _stateSyncTask;
             }
 
             _syncCancellation?.Cancel();
 
             using CancellationTokenSource timeoutCts = new();
-            Task timeout = Task.Delay(FeedsTerminationTimeout, timeoutCts.Token);
+            // Both budgets start here so they run concurrently rather than back to back.
+            Task feedsTimeout = Task.Delay(FeedsTerminationTimeout, timeoutCts.Token);
+            Task stateSyncTimeout = Task.Delay(StateSyncTerminationTimeout, timeoutCts.Token);
+
             Task feedsTask = Task.WhenAll(
                 fullSyncComponent.Feed.FeedTask,
                 fastSyncComponent.Feed.FeedTask,
@@ -287,16 +341,20 @@ namespace Nethermind.Synchronization
                 oldBodiesComponent.Feed.FeedTask,
                 oldReceiptsComponent.Feed.FeedTask,
                 oldBlockAccessListsComponent.Feed.FeedTask);
-            Task completedFirst = await Task.WhenAny(timeout, feedsTask);
 
-            if (completedFirst == timeout)
+            if (await Task.WhenAny(feedsTimeout, feedsTask) == feedsTimeout && _logger.IsWarn)
             {
-                if (_logger.IsWarn) _logger.Warn("Sync feeds dispose timeout");
+                _logger.Warn("Sync feeds dispose timeout");
             }
-            else
+
+            // The state sync runner is joined separately: the databases are disposed right after this returns, so
+            // its dispatcher must have drained its in-flight workers by then.
+            if (await Task.WhenAny(stateSyncTimeout, stateSyncTask) == stateSyncTimeout && _logger.IsWarn)
             {
-                timeoutCts.Cancel();
+                _logger.Warn($"State sync did not stop within {StateSyncTerminationTimeout}ms, databases are disposed under in-flight sync work");
             }
+
+            timeoutCts.Cancel();
 
             CancellationTokenExtensions.CancelDisposeAndClear(ref _syncCancellation);
         }


### PR DESCRIPTION
Fixes #13154

Split 2 of 3 out of #13252 at @asdacap's request. The other two are #13308 and #13310. Nothing in this PR is shared with either; the three are independent and can merge in any order.

## Changes

A node stopped while state-syncing segfaulted in librocksdb. `SimpleDispatcher.Run` drained its in-flight workers *after* the dispatch loop, so the `OperationCanceledException` path skipped the drain entirely and left a worker writing to RocksDB as the databases were disposed.

- The drain moves into a `finally`, where it acquires all `maxThreads` permits. That is exact: the loop takes one permit and each worker releases one, so holding all of them means every worker has returned. The loop holds a permit only between the wait and the `Task.Run`, and `Task.Run(Func<Task>)` does not throw, so every other exit path — `request is null`, a cancelled `PrepareRequest`, a throwing `Allocate`, the `peer is null` continue — holds none.
- The pre-dispatch `semaphore.WaitAsync` keeps the token and the base `catch { allocation.Dispose(); throw; }`. An earlier revision made it uncancellable; review showed that bought nothing (the base already disposed the allocation, and `DoDispatch` returns early on a cancelled token so `HandleResponse` is skipped either way) and cost one extra request dispatched on an already-cancelled token. The `finally` alone is the fix.
- Both consumers benefit: `SnapSyncRunner.Run`'s `finally { snapTrieFactory.FinalizeSync(); }` now runs *after* the workers are joined instead of racing them.
- `Synchronizer` keeps the runner task and `DisposeAsync` joins it under one `Lock`, on a 60 s `StateSyncTerminationTimeout` started alongside the feeds' 5 s rather than after it — worst case 60 s, not 65 s. Nothing else bounds this: the host sets `ProcessTerminationTimeout` to infinite (`Runner/Program.cs`). `Start` refuses after a dispose that won the race, and reads the cancellation token inside the lock so the lock actually orders it; giving up warns that the databases are about to be disposed under in-flight sync work, and `timeoutCts.Cancel()` is unconditional.

**The budget bounds the race, it does not close it.** A runner that outlives 60 s is warned about and then left running while Autofac disposes the databases, so #13154 stays reachable under an IO stall — which is the condition the issue was found in. Closing it properly means making `Synchronizer` an `IStoppableService` so teardown is ordered after sync; that is a larger change with its own soak, and is deliberately not in this PR. On PoS nodes the join works because Autofac owns the concrete `Synchronizer` — `MergeSynchronizer.DisposeAsync` does not dispose it.

`StateSyncRunner.Run` awaits both `snapSyncRunner.Run` and `stateSyncDispatcher.Run`, so joining `_stateSyncTask` genuinely covers the drain.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`SimpleDispatcherTests` is new. Both it and the `Synchronizer` shutdown tests assert the production invariant — the call must **not** return while work is in flight — rather than the implementation. Gates are `TaskCompletionSource` released in `finally`, and the invariant is sampled in a synchronous continuation on the task under test rather than after a sleep, so a failure to inline can only produce a false pass, never a false failure. The double-dispose test moves onto a shared builder.

`Nethermind.Synchronization.Test`: **2621 total / 0 failed / 393 skipped**, debug build 0 warnings / 0 errors.

Untested, and stated rather than claimed: `Start` refusing after a dispose, and the peer-allocation leak the uncancellable `WaitAsync` prevents — the new dispatcher test never contends the semaphore.

Fleet-validated before the split: a clean 13.3 s stop at 60 % state sync, with no new `dmesg` entry.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes

Shutdown SIGSEGV while state-syncing.

## Remarks

Not taken here, and worth its own PR: making `Synchronizer` an `IStoppableService` so database teardown is a hard happens-before edge rather than a 60 s budget. That needs its own soak.
