### PR TITLE
fix(snap): recover a stalled large-storage account and rate-limit the forced pivot (#13155, #13200)

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Synchronization/ISyncConfig.cs
@@ -193,7 +193,7 @@ public interface ISyncConfig : IConfig
     [ConfigItem(Description = "_Technical._ Max distance of state sync from best suggested header.", DefaultValue = "128", HiddenFromDocs = true)]
     ulong StateMaxDistanceFromHead { get; set; }
 
-    [ConfigItem(Description = "_Technical._ Min distance of state sync from best suggested header.", DefaultValue = "32", HiddenFromDocs = true)]
+    [ConfigItem(Description = "_Technical._ Min distance of state sync from best suggested header. Also the minimum head advance before a snap failure-streak pivot update is honoured, so lowering it re-enables the forced-pivot chase on fast chains.", DefaultValue = "32", HiddenFromDocs = true)]
     ulong StateMinDistanceFromHead { get; set; }
 
     [ConfigItem(Description = "_Technical._ Run explicit GC after state sync finished.", DefaultValue = "true", HiddenFromDocs = true)]

--- a/src/Nethermind/Nethermind.State/Snap/PathWithAccount.cs
+++ b/src/Nethermind/Nethermind.State/Snap/PathWithAccount.cs
@@ -21,6 +21,12 @@ namespace Nethermind.State.Snap
         public ValueHash256 Path { get; set; }
         public Account? Account { get; set; }
 
+        /// <summary>
+        /// Consecutive storage-range responses for this account that carried no slots and no proof. Snap sync
+        /// bookkeeping only; not part of the wire format.
+        /// </summary>
+        public int EmptyStorageResponses;
+
         public byte[] ToRlpValue()
         {
             Account account = Account ?? throw new InvalidOperationException("An account value is required when encoding a SNAP trie entry.");

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -247,6 +247,91 @@ public class ProgressTrackerTests
         Assert.That(batch1?.StorageRangeRequest?.LimitHash, Is.EqualTo(limitHash ?? Keccak.MaxValue));
     }
 
+    // Regression for #13200. SnapSyncFeed.AnalyzeResponsePerPeer reaches the pivot only through UpdatePivot, and a
+    // forced move costs every in-flight and queued range its root. On a chain whose head moves between two failure
+    // streaks an unguarded move chases the head forever and the invalidated ranges feed the next streak.
+    [TestCase(0UL, false, TestName = "Head level with the pivot")]
+    [TestCase(1UL, false, TestName = "Head one block ahead - not worth invalidating in-flight ranges")]
+    [TestCase(2UL, false, TestName = "Head two blocks ahead - one OP Mainnet block time")]
+    [TestCase(31UL, false, TestName = "One block below the minimum step")]
+    [TestCase(32UL, true, TestName = "Exactly the minimum step")]
+    [TestCase(500UL, true, TestName = "Far behind - always worth moving")]
+    public void UpdatePivot_only_moves_the_pivot_once_the_head_is_a_minimum_step_ahead(ulong diff, bool shouldMove)
+    {
+        IStateSyncPivot pivot = Substitute.For<IStateSyncPivot>();
+        pivot.Diff.Returns(diff);
+        SyncConfig syncConfig = new TestSyncConfig { SnapSyncAccountRangePartitionCount = 1, StateMinDistanceFromHead = 32UL };
+        using ProgressTracker progressTracker = new(Substitute.For<ISnapTrieFactory>(), syncConfig, pivot, LimboLogs.Instance);
+
+        progressTracker.UpdatePivot();
+
+        pivot.Received(shouldMove ? 1 : 0).UpdateHeaderForcefully();
+    }
+
+    // A refresh answered with an expired root re-queues itself before its worker is released, so an unconditional
+    // priority for that queue hands it every dispatcher slot while it cannot drain. Code requests are keyed by hash
+    // and succeed against a peer behind the pivot, so they must still get served.
+    [Test]
+    public void Will_not_let_account_refreshes_take_every_dispatcher_slot()
+    {
+        using ProgressTracker progressTracker = CreateProgressTracker();
+        DrainAccountRangePartition(progressTracker);
+
+        for (int i = 0; i < ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES + 4; i++)
+        {
+            progressTracker.EnqueueAccountRefresh(new PathWithAccount { Path = TestItem.ValueKeccaks[i] }, null, null);
+        }
+
+        progressTracker.EnqueueCodeHashes([TestItem.ValueKeccaks[0]]);
+
+        // Nothing is ever reported finished, so every dequeued refresh stays in flight.
+        for (int i = 0; i < ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES; i++)
+        {
+            progressTracker.IsFinished(out SnapSyncBatch? refresh);
+            Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null, $"request {i} is within the cap");
+            refresh.Dispose();
+        }
+
+        progressTracker.IsFinished(out SnapSyncBatch? request);
+        using (request)
+        {
+            Assert.That(request!.AccountsToRefreshRequest, Is.Null, "the cap is reached, so the refresh queue must yield");
+            Assert.That(request.CodesRequest, Is.Not.Null);
+        }
+    }
+
+    [Test]
+    public void Will_still_serve_account_refreshes_over_the_cap_when_nothing_else_is_queued()
+    {
+        using ProgressTracker progressTracker = CreateProgressTracker();
+        DrainAccountRangePartition(progressTracker);
+
+        for (int i = 0; i < ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES + 1; i++)
+        {
+            progressTracker.EnqueueAccountRefresh(new PathWithAccount { Path = TestItem.ValueKeccaks[i] }, null, null);
+        }
+
+        for (int i = 0; i <= ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES; i++)
+        {
+            progressTracker.IsFinished(out SnapSyncBatch? refresh);
+            using (refresh)
+            {
+                Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null,
+                    $"request {i}: the tail of the sync must not run at {ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES} requests");
+            }
+        }
+    }
+
+    /// <summary>Takes the one account-range partition out of the way so the priority chain reaches the queues under test.</summary>
+    private static void DrainAccountRangePartition(ProgressTracker progressTracker)
+    {
+        progressTracker.IsFinished(out SnapSyncBatch? batch);
+        using (batch)
+        {
+            Assert.That(batch!.AccountRangeRequest, Is.Not.Null);
+        }
+    }
+
     private ProgressTracker CreateProgressTracker(int accountRangePartition = 1, bool enableStorageSplits = false, ISnapTrieFactory? snapTrieFactory = null)
     {
         BlockTree blockTree = Build.A.BlockTree().WithStateRoot(Keccak.EmptyTreeHash).OfChainLength(2).TestObject;

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/ProgressTrackerTests.cs
@@ -268,34 +268,41 @@ public class ProgressTrackerTests
         pivot.Received(shouldMove ? 1 : 0).UpdateHeaderForcefully();
     }
 
-    // A refresh answered with an expired root re-queues itself before its worker is released, so an unconditional
-    // priority for that queue hands it every dispatcher slot while it cannot drain. Code requests are keyed by hash
-    // and succeed against a peer behind the pivot, so they must still get served.
-    [Test]
-    public void Will_not_let_account_refreshes_take_every_dispatcher_slot()
+    // A refresh answered with an expired root re-queues itself, so an unconditional priority for that queue hands it
+    // every dispatcher slot while it cannot drain. Code requests are keyed by hash and succeed against a peer behind
+    // the pivot, so they must still get served. The bound is on refreshes served in a row rather than on refreshes in
+    // flight, which is why the two cases below - all four in flight, and never more than one in flight - behave the
+    // same: a dispatcher running fewer workers than the cap would never reach an in-flight bound at all.
+    [TestCase(false, TestName = "Refreshes yield after their turn (nothing reported finished, all in flight)")]
+    [TestCase(true, TestName = "Refreshes yield after their turn at one worker (each reported finished first)")]
+    public void Will_not_let_account_refreshes_take_every_dispatcher_slot(bool oneWorker)
     {
         using ProgressTracker progressTracker = CreateProgressTracker();
         DrainAccountRangePartition(progressTracker);
 
-        for (int i = 0; i < ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES + 4; i++)
+        for (int i = 0; i < ProgressTracker.MAX_CONSECUTIVE_ACCOUNT_REFRESHES + 4; i++)
         {
             progressTracker.EnqueueAccountRefresh(new PathWithAccount { Path = TestItem.ValueKeccaks[i] }, null, null);
         }
 
         progressTracker.EnqueueCodeHashes([TestItem.ValueKeccaks[0]]);
 
-        // Nothing is ever reported finished, so every dequeued refresh stays in flight.
-        for (int i = 0; i < ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES; i++)
+        for (int i = 0; i < ProgressTracker.MAX_CONSECUTIVE_ACCOUNT_REFRESHES; i++)
         {
             progressTracker.IsFinished(out SnapSyncBatch? refresh);
-            Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null, $"request {i} is within the cap");
-            refresh.Dispose();
+            using (refresh)
+            {
+                Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null, $"request {i} is within the turn");
+            }
+
+            // One worker: the request is finished before the next scheduling decision, so nothing is ever in flight.
+            if (oneWorker) progressTracker.ReportAccountRefreshFinished();
         }
 
         progressTracker.IsFinished(out SnapSyncBatch? request);
         using (request)
         {
-            Assert.That(request!.AccountsToRefreshRequest, Is.Null, "the cap is reached, so the refresh queue must yield");
+            Assert.That(request!.AccountsToRefreshRequest, Is.Null, "the turn is over, so the refresh queue must yield");
             Assert.That(request.CodesRequest, Is.Not.Null);
         }
     }
@@ -306,18 +313,18 @@ public class ProgressTrackerTests
         using ProgressTracker progressTracker = CreateProgressTracker();
         DrainAccountRangePartition(progressTracker);
 
-        for (int i = 0; i < ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES + 1; i++)
+        for (int i = 0; i < ProgressTracker.MAX_CONSECUTIVE_ACCOUNT_REFRESHES + 1; i++)
         {
             progressTracker.EnqueueAccountRefresh(new PathWithAccount { Path = TestItem.ValueKeccaks[i] }, null, null);
         }
 
-        for (int i = 0; i <= ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES; i++)
+        for (int i = 0; i <= ProgressTracker.MAX_CONSECUTIVE_ACCOUNT_REFRESHES; i++)
         {
             progressTracker.IsFinished(out SnapSyncBatch? refresh);
             using (refresh)
             {
                 Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null,
-                    $"request {i}: the tail of the sync must not run at {ProgressTracker.MAX_CONCURRENT_ACCOUNT_REFRESHES} requests");
+                    $"request {i}: with nothing else queued the tail of the sync must not stall on the turn limit");
             }
         }
     }

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
@@ -198,23 +198,29 @@ public class SnapProviderTests
         DrainAccountRangePartition(progressTracker);
 
         progressTracker.IsFinished(out SnapSyncBatch? batch);
-        Assert.That(batch!.StorageRangeRequest!.Accounts.Count, Is.EqualTo(2));
-        batch.StorageRangeResponse = CreateEmptySlotsResponse(1);
+        using (batch)
+        {
+            Assert.That(batch!.StorageRangeRequest!.Accounts.Count, Is.EqualTo(2));
+            batch.StorageRangeResponse = CreateEmptySlotsResponse(1);
 
-        snapProvider.AddStorageRange(batch.StorageRangeRequest, batch.StorageRangeResponse);
-        snapProvider.ReleaseRequest(batch, responseHandled: true);
-        batch.Dispose();
+            snapProvider.AddStorageRange(batch.StorageRangeRequest, batch.StorageRangeResponse);
+            snapProvider.ReleaseRequest(batch, responseHandled: true);
+        }
 
         // The covered account failed verification and goes for a refresh; the uncovered one comes back.
         progressTracker.IsFinished(out SnapSyncBatch? refresh);
-        Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
-        progressTracker.ReportAccountRefreshFinished();
-        refresh.Dispose();
+        using (refresh)
+        {
+            Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
+            progressTracker.ReportAccountRefreshFinished();
+        }
 
         progressTracker.IsFinished(out SnapSyncBatch? retried);
-        Assert.That(retried!.StorageRangeRequest!.Accounts.AsSpan()[0].Path, Is.EqualTo(uncovered.Path));
-        progressTracker.ReportStorageRequestFinished(retried.StorageRangeRequest.Accounts.Count);
-        retried.Dispose();
+        using (retried)
+        {
+            Assert.That(retried!.StorageRangeRequest!.Accounts.AsSpan()[0].Path, Is.EqualTo(uncovered.Path));
+            progressTracker.ReportStorageRequestFinished(retried.StorageRangeRequest.Accounts.Count);
+        }
 
         Assert.That(progressTracker.IsSnapGetRangesFinished(), Is.True);
     }
@@ -246,23 +252,27 @@ public class SnapProviderTests
         for (int attempt = 0; attempt < SnapProvider.MaxConsecutiveEmptyStorageResponses; attempt++)
         {
             progressTracker.IsFinished(out SnapSyncBatch? batch);
-            Assert.That(batch!.StorageRangeRequest, Is.Not.Null, $"attempt {attempt}: below the streak limit the range is simply offered again");
-            Assert.That(batch.StorageRangeRequest!.Accounts.Count, Is.EqualTo(accountCount));
+            using (batch)
+            {
+                Assert.That(batch!.StorageRangeRequest, Is.Not.Null, $"attempt {attempt}: below the streak limit the range is simply offered again");
+                Assert.That(batch.StorageRangeRequest!.Accounts.Count, Is.EqualTo(accountCount));
 
-            batch.StorageRangeResponse = CreateEmptySlotsResponse(0);
-            Assert.That(snapProvider.AddStorageRange(batch.StorageRangeRequest, batch.StorageRangeResponse), Is.EqualTo(AddRangeResult.ExpiredRootHash));
-            snapProvider.ReleaseRequest(batch, responseHandled: true);
-            batch.Dispose();
+                batch.StorageRangeResponse = CreateEmptySlotsResponse(0);
+                Assert.That(snapProvider.AddStorageRange(batch.StorageRangeRequest, batch.StorageRangeResponse), Is.EqualTo(AddRangeResult.ExpiredRootHash));
+                snapProvider.ReleaseRequest(batch, responseHandled: true);
+            }
         }
 
         for (int i = 0; i < accountCount; i++)
         {
             progressTracker.IsFinished(out SnapSyncBatch? next);
-            Assert.That(next!.AccountsToRefreshRequest, Is.Not.Null,
-                "after the streak the account must be re-proven at the current pivot, not requested as a storage range again");
-            Assert.That(accounts.Select(static a => a.Path), Does.Contain(next!.AccountsToRefreshRequest!.Paths[0].PathAndAccount!.Path));
-            progressTracker.ReportAccountRefreshFinished();
-            next.Dispose();
+            using (next)
+            {
+                Assert.That(next!.AccountsToRefreshRequest, Is.Not.Null,
+                    "after the streak the account must be re-proven at the current pivot, not requested as a storage range again");
+                Assert.That(accounts.Select(static a => a.Path), Does.Contain(next.AccountsToRefreshRequest!.Paths[0].PathAndAccount!.Path));
+                progressTracker.ReportAccountRefreshFinished();
+            }
         }
 
         Assert.That(progressTracker.IsSnapGetRangesFinished(), Is.True, "no storage range may be left queued behind the refreshes");
@@ -291,9 +301,11 @@ public class SnapProviderTests
         }
 
         progressTracker.IsFinished(out SnapSyncBatch? refresh);
-        Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null, "the streak promotes the account once");
-        progressTracker.ReportAccountRefreshFinished();
-        refresh.Dispose();
+        using (refresh)
+        {
+            Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null, "the streak promotes the account once");
+            progressTracker.ReportAccountRefreshFinished();
+        }
 
         // A refresh that finds the account still has storage puts its range back on the queue.
         progressTracker.EnqueueAccountStorage(account);
@@ -375,15 +387,45 @@ public class SnapProviderTests
         public bool IsError => false;
     }
 
+    /// <summary>
+    /// Registers one account as large storage, split over <paramref name="partitionCount"/> partitions the way
+    /// <c>Sync.EnableSnapSyncStorageRangeSplit</c> does. Dequeuing a single-account slot range is what registers a
+    /// partition, and each distinct limit hash counts as one.
+    /// </summary>
+    private static void RegisterLargeStorage(ProgressTracker progressTracker, PathWithAccount account, int partitionCount)
+    {
+        for (int i = 0; i < partitionCount; i++)
+        {
+            progressTracker.EnqueueNextSlot(new StorageRange
+            {
+                Accounts = new ArrayPoolList<PathWithAccount>(1) { account },
+                StartingHash = ValueKeccak.Zero,
+                LimitHash = i == partitionCount - 1 ? Keccak.MaxValue : TestItem.Keccaks[i]
+            });
+
+            progressTracker.IsFinished(out SnapSyncBatch? slot);
+            using (slot)
+            {
+                Assert.That(slot!.StorageRangeRequest, Is.Not.Null);
+            }
+
+            progressTracker.ReportStorageRequestFinished(1);
+        }
+
+        Assert.That(progressTracker.LargeStorageProgressCount, Is.EqualTo(1), "guards the premise");
+    }
+
     private static void AnswerNextStorageRangeWithAnEmptyResponse(SnapProvider snapProvider, ProgressTracker progressTracker)
     {
         progressTracker.IsFinished(out SnapSyncBatch? batch);
-        Assert.That(batch!.StorageRangeRequest, Is.Not.Null);
+        using (batch)
+        {
+            Assert.That(batch!.StorageRangeRequest, Is.Not.Null);
 
-        batch.StorageRangeResponse = CreateEmptySlotsResponse(0);
-        Assert.That(snapProvider.AddStorageRange(batch.StorageRangeRequest!, batch.StorageRangeResponse), Is.EqualTo(AddRangeResult.ExpiredRootHash));
-        snapProvider.ReleaseRequest(batch, responseHandled: true);
-        batch.Dispose();
+            batch.StorageRangeResponse = CreateEmptySlotsResponse(0);
+            Assert.That(snapProvider.AddStorageRange(batch.StorageRangeRequest!, batch.StorageRangeResponse), Is.EqualTo(AddRangeResult.ExpiredRootHash));
+            snapProvider.ReleaseRequest(batch, responseHandled: true);
+        }
     }
 
     // The promotion above is speculative: an empty response is also what a peer that has fallen behind the pivot
@@ -414,32 +456,54 @@ public class SnapProviderTests
         for (int attempt = 0; attempt < SnapProvider.MaxConsecutiveEmptyStorageResponses; attempt++)
         {
             progressTracker.IsFinished(out SnapSyncBatch? batch);
-            Assert.That(batch!.StorageRangeRequest, Is.Not.Null, $"attempt {attempt}: the whole batch is offered again");
-            Assert.That(batch.StorageRangeRequest!.Accounts.Count, Is.EqualTo(accountCount));
+            using (batch)
+            {
+                Assert.That(batch!.StorageRangeRequest, Is.Not.Null, $"attempt {attempt}: the whole batch is offered again");
+                Assert.That(batch.StorageRangeRequest!.Accounts.Count, Is.EqualTo(accountCount));
 
-            batch.StorageRangeResponse = CreateEmptySlotsResponse(0);
-            Assert.That(snapProvider.AddStorageRange(batch.StorageRangeRequest, batch.StorageRangeResponse), Is.EqualTo(AddRangeResult.ExpiredRootHash));
-            snapProvider.ReleaseRequest(batch, responseHandled: true);
-            batch.Dispose();
+                batch.StorageRangeResponse = CreateEmptySlotsResponse(0);
+                Assert.That(snapProvider.AddStorageRange(batch.StorageRangeRequest, batch.StorageRangeResponse), Is.EqualTo(AddRangeResult.ExpiredRootHash));
+                snapProvider.ReleaseRequest(batch, responseHandled: true);
+            }
         }
 
         Assert.That(progressTracker.AccountsToRefreshCount, Is.EqualTo(SnapProvider.MaxQueuedEmptyStreakRefreshes),
             "the refresh queue must not grow past the cap, whatever the batch size");
 
-        // The 6 accounts the cap turned away are not lost: they are back on the storage queue and are promoted on a
-        // later empty response, once the refreshes ahead of them have drained.
-        for (int i = 0; i < SnapProvider.MaxQueuedEmptyStreakRefreshes; i++)
+        // The 6 accounts the cap turned away are not lost: they are back on the storage queue, and they get a turn
+        // rather than waiting for the whole refresh queue to drain - see MAX_CONSECUTIVE_ACCOUNT_REFRESHES.
+        int refreshes = 0;
+        int storageAccounts = 0;
+        int refreshesBeforeStorageGotATurn = -1;
+
+        for (int guard = 0; guard <= accountCount; guard++)
         {
-            progressTracker.IsFinished(out SnapSyncBatch? refresh);
-            Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
-            progressTracker.ReportAccountRefreshFinished();
-            refresh.Dispose();
+            if (progressTracker.IsFinished(out SnapSyncBatch? next)) break;
+
+            using (next)
+            {
+                Assert.That(next, Is.Not.Null, "the queues are not empty yet");
+                if (next!.AccountsToRefreshRequest is not null)
+                {
+                    refreshes++;
+                    progressTracker.ReportAccountRefreshFinished();
+                }
+                else
+                {
+                    if (refreshesBeforeStorageGotATurn < 0) refreshesBeforeStorageGotATurn = refreshes;
+                    storageAccounts += next.StorageRangeRequest!.Accounts.Count;
+                    progressTracker.ReportStorageRequestFinished(next.StorageRangeRequest.Accounts.Count);
+                }
+            }
         }
 
-        progressTracker.IsFinished(out SnapSyncBatch? remaining);
-        Assert.That(remaining!.StorageRangeRequest, Is.Not.Null);
-        Assert.That(remaining.StorageRangeRequest!.Accounts.Count, Is.EqualTo(6));
-        remaining.Dispose();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(refreshes, Is.EqualTo(SnapProvider.MaxQueuedEmptyStreakRefreshes), "every promoted account is refreshed");
+            Assert.That(storageAccounts, Is.EqualTo(6), "and the ones the cap turned away are back on the storage queue");
+            Assert.That(refreshesBeforeStorageGotATurn, Is.EqualTo(ProgressTracker.MAX_CONSECUTIVE_ACCOUNT_REFRESHES),
+                "the refresh queue must yield to queued storage work instead of draining first");
+        }
     }
 
     // Regression for #13155, second half: when the re-proven account turns out to have no storage at the pivot any
@@ -467,16 +531,18 @@ public class SnapProviderTests
         progressTracker.EnqueueAccountRefresh(stale, ValueKeccak.Zero, Keccak.MaxValue);
 
         progressTracker.IsFinished(out SnapSyncBatch? refresh);
-        Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
-        Assert.That(refresh.AccountsToRefreshRequest!.RootHash, Is.EqualTo(root));
+        using (refresh)
+        {
+            Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
+            Assert.That(refresh.AccountsToRefreshRequest!.RootHash, Is.EqualTo(root));
 
-        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
-            server.GetAccountRanges(root, stale.Path, stale.Path.IncrementPath(), 4000, CancellationToken.None);
-        refresh.AccountsToRefreshResponse = new AccountsAndProofs { PathAndAccounts = accounts, Proofs = proofs };
+            (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
+                server.GetAccountRanges(root, stale.Path, stale.Path.IncrementPath(), 4000, CancellationToken.None);
+            refresh.AccountsToRefreshResponse = new AccountsAndProofs { PathAndAccounts = accounts, Proofs = proofs };
 
-        Assert.That(snapProvider.RefreshAccounts(refresh.AccountsToRefreshRequest, refresh.AccountsToRefreshResponse), Is.EqualTo(AddRangeResult.OK));
-        snapProvider.ReleaseRequest(refresh, responseHandled: true);
-        refresh.Dispose();
+            Assert.That(snapProvider.RefreshAccounts(refresh.AccountsToRefreshRequest, refresh.AccountsToRefreshResponse), Is.EqualTo(AddRangeResult.OK));
+            snapProvider.ReleaseRequest(refresh, responseHandled: true);
+        }
 
         Assert.That(stale.Account!.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash), "the proven (empty) storage root is adopted");
         Assert.That(progressTracker.IsFinished(out SnapSyncBatch? next), Is.True, "an account without storage leaves nothing to fetch");
@@ -487,10 +553,13 @@ public class SnapProviderTests
     /// The sibling of the test above. A large-storage account that is <em>deleted</em> at the pivot, rather than
     /// merely emptied, is just as terminal: nothing will ever fetch its storage, so nothing else will ever clear its
     /// large-storage entry. Leaving it counts the account in "Large storage left" for the rest of the sync, which is
-    /// the exact operator signal #13155 was diagnosed by.
+    /// the exact operator signal #13155 was diagnosed by. Retiring one partition is not enough: under
+    /// <c>Sync.EnableSnapSyncStorageRangeSplit</c> the account registers one per split, so the entry has to be dropped
+    /// outright.
     /// </summary>
-    [Test]
-    public void RefreshAccounts_AccountNoLongerExists_ClearsItsLargeStorageProgress()
+    [TestCase(1, TestName = "{m} (one partition)")]
+    [TestCase(2, TestName = "{m} (split into two partitions)")]
+    public void RefreshAccounts_AccountNoLongerExists_ClearsItsLargeStorageProgress(int partitionCount)
     {
         (ISnapStateServer server, Hash256 root) = BuildSnapServerFromEntries(
         [
@@ -511,31 +580,21 @@ public class SnapProviderTests
         ValueHash256 missing = ((ValueHash256)TestItem.KeccakB).DecrementPath();
         PathWithAccount gone = new(missing, Build.An.Account.WithStorageRoot(TestItem.KeccakG).TestObject);
 
-        // Dequeuing a single-account slot range is what registers an account as large storage.
-        progressTracker.EnqueueNextSlot(new StorageRange
-        {
-            Accounts = new ArrayPoolList<PathWithAccount>(1) { gone },
-            StartingHash = ValueKeccak.Zero,
-            LimitHash = Keccak.MaxValue
-        });
-        progressTracker.IsFinished(out SnapSyncBatch? slot);
-        using (slot)
-        {
-            Assert.That(slot!.StorageRangeRequest, Is.Not.Null);
-        }
-        Assert.That(progressTracker.LargeStorageProgressCount, Is.EqualTo(1), "guards the premise");
+        RegisterLargeStorage(progressTracker, gone, partitionCount);
 
         progressTracker.EnqueueAccountRefresh(gone, ValueKeccak.Zero, Keccak.MaxValue);
         progressTracker.IsFinished(out SnapSyncBatch? refresh);
-        Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
+        using (refresh)
+        {
+            Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
 
-        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
-            server.GetAccountRanges(root, gone.Path, gone.Path.IncrementPath(), 4000, CancellationToken.None);
-        refresh.AccountsToRefreshResponse = new AccountsAndProofs { PathAndAccounts = accounts, Proofs = proofs };
+            (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
+                server.GetAccountRanges(root, gone.Path, gone.Path.IncrementPath(), 4000, CancellationToken.None);
+            refresh.AccountsToRefreshResponse = new AccountsAndProofs { PathAndAccounts = accounts, Proofs = proofs };
 
-        Assert.That(snapProvider.RefreshAccounts(refresh.AccountsToRefreshRequest, refresh.AccountsToRefreshResponse), Is.EqualTo(AddRangeResult.OK));
-        snapProvider.ReleaseRequest(refresh, responseHandled: true);
-        refresh.Dispose();
+            Assert.That(snapProvider.RefreshAccounts(refresh.AccountsToRefreshRequest, refresh.AccountsToRefreshResponse), Is.EqualTo(AddRangeResult.OK));
+            snapProvider.ReleaseRequest(refresh, responseHandled: true);
+        }
 
         Assert.That(gone.Account!.StorageRoot, Is.EqualTo(TestItem.KeccakG), "an absent account adopts nothing; guards that this was NotFound and not Verified");
         Assert.That(progressTracker.LargeStorageProgressCount, Is.Zero, "a deleted account must not keep counting as large storage left");
@@ -546,10 +605,12 @@ public class SnapProviderTests
     /// from origin 0, goes back to the multi-account batching queue - where nothing will ever call
     /// <see cref="ProgressTracker.OnCompletedLargeStorage"/> for it, because that only fires for a single-account
     /// slot range. Its old large-storage entry is obsolete the moment the account restarts at 0, so it has to be
-    /// cleared here or it counts towards "Large storage left" for the rest of the sync.
+    /// cleared here or it counts towards "Large storage left" for the rest of the sync - however many partitions the
+    /// account had been split into.
     /// </summary>
-    [Test]
-    public void RefreshAccounts_AccountRestartsFromOrigin_ClearsItsStaleLargeStorageProgress()
+    [TestCase(1, TestName = "{m} (one partition)")]
+    [TestCase(2, TestName = "{m} (split into two partitions)")]
+    public void RefreshAccounts_AccountRestartsFromOrigin_ClearsItsStaleLargeStorageProgress(int partitionCount)
     {
         Account withStorage = Build.An.Account.WithBalance(1).WithStorageRoot(TestItem.KeccakF).TestObject;
         (ISnapStateServer server, Hash256 root) = BuildSnapServerFromEntries(
@@ -568,32 +629,22 @@ public class SnapProviderTests
 
         PathWithAccount account = new(TestItem.KeccakA, withStorage);
 
-        // Dequeuing a single-account slot range is what registers an account as large storage.
-        progressTracker.EnqueueNextSlot(new StorageRange
-        {
-            Accounts = new ArrayPoolList<PathWithAccount>(1) { account },
-            StartingHash = ValueKeccak.Zero,
-            LimitHash = Keccak.MaxValue
-        });
-        progressTracker.IsFinished(out SnapSyncBatch? slot);
-        using (slot)
-        {
-            Assert.That(slot!.StorageRangeRequest, Is.Not.Null);
-        }
-        Assert.That(progressTracker.LargeStorageProgressCount, Is.EqualTo(1), "guards the premise");
+        RegisterLargeStorage(progressTracker, account, partitionCount);
 
         // Refreshed at origin 0, so the Verified arm re-enqueues the whole account rather than a continuation.
         progressTracker.EnqueueAccountRefresh(account, ValueKeccak.Zero, Keccak.MaxValue);
         progressTracker.IsFinished(out SnapSyncBatch? refresh);
-        Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
+        using (refresh)
+        {
+            Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
 
-        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
-            server.GetAccountRanges(root, account.Path, account.Path.IncrementPath(), 4000, CancellationToken.None);
-        refresh.AccountsToRefreshResponse = new AccountsAndProofs { PathAndAccounts = accounts, Proofs = proofs };
+            (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
+                server.GetAccountRanges(root, account.Path, account.Path.IncrementPath(), 4000, CancellationToken.None);
+            refresh.AccountsToRefreshResponse = new AccountsAndProofs { PathAndAccounts = accounts, Proofs = proofs };
 
-        Assert.That(snapProvider.RefreshAccounts(refresh.AccountsToRefreshRequest, refresh.AccountsToRefreshResponse), Is.EqualTo(AddRangeResult.OK));
-        snapProvider.ReleaseRequest(refresh, responseHandled: true);
-        refresh.Dispose();
+            Assert.That(snapProvider.RefreshAccounts(refresh.AccountsToRefreshRequest, refresh.AccountsToRefreshResponse), Is.EqualTo(AddRangeResult.OK));
+            snapProvider.ReleaseRequest(refresh, responseHandled: true);
+        }
 
         Assert.That(account.Account!.StorageRoot, Is.EqualTo(TestItem.KeccakF), "guards that this was Verified with storage, not NotFound or emptied");
         Assert.That(progressTracker.LargeStorageProgressCount, Is.Zero,
@@ -631,11 +682,13 @@ public class SnapProviderTests
         Assert.That(account.EmptyStorageResponses, Is.EqualTo(SnapProvider.MaxConsecutiveEmptyStorageResponses - 1), "guards the premise");
 
         progressTracker.IsFinished(out SnapSyncBatch? served);
-        Assert.That(served!.StorageRangeRequest, Is.Not.Null);
-        served.StorageRangeResponse = CreateEmptySlotsResponse(1);
-        snapProvider.AddStorageRange(served.StorageRangeRequest!, served.StorageRangeResponse);
-        snapProvider.ReleaseRequest(served, responseHandled: true);
-        served.Dispose();
+        using (served)
+        {
+            Assert.That(served!.StorageRangeRequest, Is.Not.Null);
+            served.StorageRangeResponse = CreateEmptySlotsResponse(1);
+            snapProvider.AddStorageRange(served.StorageRangeRequest!, served.StorageRangeResponse);
+            snapProvider.ReleaseRequest(served, responseHandled: true);
+        }
 
         Assert.That(account.EmptyStorageResponses, Is.Zero, "a served response means the peers are answering this account again");
     }
@@ -678,24 +731,25 @@ public class SnapProviderTests
 
         // Assert the same work came back, then consume it so only the active count can keep the phase open.
         Assert.That(progressTracker.IsFinished(out SnapSyncBatch? retried), Is.False);
-        switch (requestKind)
+        using (retried)
         {
-            case nameof(SnapSyncBatch.AccountRangeRequest):
-                Assert.That(retried!.AccountRangeRequest?.LimitHash, Is.EqualTo(issuedLimit));
-                progressTracker.UpdateAccountRangePartitionProgress(issuedLimit!.Value, Keccak.MaxValue, false);
-                progressTracker.ReportAccountRangePartitionFinished(issuedLimit.Value);
-                break;
-            case nameof(SnapSyncBatch.StorageRangeRequest):
-                Assert.That(retried!.StorageRangeRequest?.Accounts.AsSpan()[0].Path, Is.EqualTo(work));
-                progressTracker.ReportStorageRequestFinished(retried.StorageRangeRequest!.Accounts.Count);
-                break;
-            case nameof(SnapSyncBatch.CodesRequest):
-                Assert.That(retried!.CodesRequest?.AsSpan()[0], Is.EqualTo(work));
-                progressTracker.ReportCodeRequestFinished([]);
-                break;
+            switch (requestKind)
+            {
+                case nameof(SnapSyncBatch.AccountRangeRequest):
+                    Assert.That(retried!.AccountRangeRequest?.LimitHash, Is.EqualTo(issuedLimit));
+                    progressTracker.UpdateAccountRangePartitionProgress(issuedLimit!.Value, Keccak.MaxValue, false);
+                    progressTracker.ReportAccountRangePartitionFinished(issuedLimit.Value);
+                    break;
+                case nameof(SnapSyncBatch.StorageRangeRequest):
+                    Assert.That(retried!.StorageRangeRequest?.Accounts.AsSpan()[0].Path, Is.EqualTo(work));
+                    progressTracker.ReportStorageRequestFinished(retried.StorageRangeRequest!.Accounts.Count);
+                    break;
+                case nameof(SnapSyncBatch.CodesRequest):
+                    Assert.That(retried!.CodesRequest?.AsSpan()[0], Is.EqualTo(work));
+                    progressTracker.ReportCodeRequestFinished([]);
+                    break;
+            }
         }
-
-        retried!.Dispose();
 
         Assert.That(progressTracker.IsSnapGetRangesFinished(), Is.True,
             "the work was queued again but its active request count was never released");

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapProviderTests.cs
@@ -14,6 +14,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using Autofac;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -216,6 +217,427 @@ public class SnapProviderTests
         retried.Dispose();
 
         Assert.That(progressTracker.IsSnapGetRangesFinished(), Is.True);
+    }
+
+    // Regression for #13155: a storage range that keeps coming back empty (no slots, no proof) was re-queued at the
+    // next pivot forever. A geth peer answers exactly like that for an account that has no storage at the requested
+    // root, so the same account was asked for at every new pivot with no way out. After a streak that outlives the
+    // feed's own pivot refreshes the account must be re-proven at the current pivot instead of being re-requested.
+    [TestCase(1)]
+    [TestCase(3)]
+    public void AddStorageRange_EmptyResponseStreak_HandsTheAccountsToRefreshInsteadOfRetryingForever(int accountCount)
+    {
+        using IContainer container = CreateContainerBuilder(new TestSyncConfig { SnapSyncAccountRangePartitionCount = 1 })
+            .WithSuggestedHeaderOfStateRoot(Keccak.EmptyTreeHash)
+            .Build();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+        ProgressTracker progressTracker = container.Resolve<ProgressTracker>();
+
+        PathWithAccount[] accounts = new PathWithAccount[accountCount];
+        for (int i = 0; i < accountCount; i++)
+        {
+            accounts[i] = new PathWithAccount(TestItem.ValueKeccaks[i], Build.An.Account.WithStorageRoot(TestItem.KeccakF).TestObject);
+            progressTracker.EnqueueAccountStorage(accounts[i]);
+        }
+
+        DrainAccountRangePartition(progressTracker);
+
+        for (int attempt = 0; attempt < SnapProvider.MaxConsecutiveEmptyStorageResponses; attempt++)
+        {
+            progressTracker.IsFinished(out SnapSyncBatch? batch);
+            Assert.That(batch!.StorageRangeRequest, Is.Not.Null, $"attempt {attempt}: below the streak limit the range is simply offered again");
+            Assert.That(batch.StorageRangeRequest!.Accounts.Count, Is.EqualTo(accountCount));
+
+            batch.StorageRangeResponse = CreateEmptySlotsResponse(0);
+            Assert.That(snapProvider.AddStorageRange(batch.StorageRangeRequest, batch.StorageRangeResponse), Is.EqualTo(AddRangeResult.ExpiredRootHash));
+            snapProvider.ReleaseRequest(batch, responseHandled: true);
+            batch.Dispose();
+        }
+
+        for (int i = 0; i < accountCount; i++)
+        {
+            progressTracker.IsFinished(out SnapSyncBatch? next);
+            Assert.That(next!.AccountsToRefreshRequest, Is.Not.Null,
+                "after the streak the account must be re-proven at the current pivot, not requested as a storage range again");
+            Assert.That(accounts.Select(static a => a.Path), Does.Contain(next!.AccountsToRefreshRequest!.Paths[0].PathAndAccount!.Path));
+            progressTracker.ReportAccountRefreshFinished();
+            next.Dispose();
+        }
+
+        Assert.That(progressTracker.IsSnapGetRangesFinished(), Is.True, "no storage range may be left queued behind the refreshes");
+    }
+
+    // The counter only ever rises, so a promotion has to put it back: otherwise the account stays past the threshold
+    // for good and, once a refresh has put its storage back on the queue, every single empty response promotes it
+    // again - one refresh per response instead of one per streak, which is what fills the refresh queue.
+    [Test]
+    public void AddStorageRange_EmptyResponseStreak_StartsOverAfterEachPromotion()
+    {
+        using IContainer container = CreateContainerBuilder(new TestSyncConfig { SnapSyncAccountRangePartitionCount = 1 })
+            .WithSuggestedHeaderOfStateRoot(Keccak.EmptyTreeHash)
+            .Build();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+        ProgressTracker progressTracker = container.Resolve<ProgressTracker>();
+
+        PathWithAccount account = new(TestItem.ValueKeccaks[0], Build.An.Account.WithStorageRoot(TestItem.KeccakF).TestObject);
+        progressTracker.EnqueueAccountStorage(account);
+        DrainAccountRangePartition(progressTracker);
+
+        for (int attempt = 0; attempt < SnapProvider.MaxConsecutiveEmptyStorageResponses; attempt++)
+        {
+            AnswerNextStorageRangeWithAnEmptyResponse(snapProvider, progressTracker);
+        }
+
+        progressTracker.IsFinished(out SnapSyncBatch? refresh);
+        Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null, "the streak promotes the account once");
+        progressTracker.ReportAccountRefreshFinished();
+        refresh.Dispose();
+
+        // A refresh that finds the account still has storage puts its range back on the queue.
+        progressTracker.EnqueueAccountStorage(account);
+        AnswerNextStorageRangeWithAnEmptyResponse(snapProvider, progressTracker);
+
+        Assert.That(progressTracker.AccountsToRefreshCount, Is.Zero,
+            "one empty response after a promotion must not promote the account again - a fresh streak has to build up first");
+
+        progressTracker.IsFinished(out SnapSyncBatch? retried);
+        using (retried)
+        {
+            Assert.That(retried!.StorageRangeRequest, Is.Not.Null, "the range goes back to the ordinary storage queue");
+        }
+    }
+
+    // A single-account range is not necessarily a large-storage continuation: DequeStorageToRetrieveRequest builds
+    // its batch with StartingHash = Zero, so the tail of the storage queue holding one entry lands on the same
+    // branch. Only the continuation carries a non-zero origin, and only it deserves the default-on Warn - an
+    // ordinary account whose storage is empty at the pivot must not put one in an operator's log.
+    [TestCase(false, TestName = "One-account batch with a zero origin stays on the Debug lane")]
+    [TestCase(true, TestName = "Large-storage continuation warns")]
+    public void AddStorageRange_EmptyResponseStreak_OnlyWarnsForALargeStorageContinuation(bool isContinuation)
+    {
+        LaneRecordingLogManager logManager = new();
+
+        using IContainer container = CreateContainerBuilder(new TestSyncConfig { SnapSyncAccountRangePartitionCount = 1 })
+            .WithSuggestedHeaderOfStateRoot(Keccak.EmptyTreeHash)
+            .AddSingleton<ILogManager>(logManager) // Put last or it wont work.
+            .Build();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+
+        PathWithAccount account = new(TestItem.ValueKeccaks[0], Build.An.Account.WithStorageRoot(TestItem.KeccakF).TestObject);
+
+        for (int attempt = 0; attempt < SnapProvider.MaxConsecutiveEmptyStorageResponses; attempt++)
+        {
+            using StorageRange request = new()
+            {
+                BlockNumber = 1,
+                RootHash = Keccak.EmptyTreeHash,
+                Accounts = new[] { account }.ToPooledList(1),
+                StartingHash = isContinuation ? TestItem.ValueKeccaks[1] : ValueKeccak.Zero,
+                LimitHash = isContinuation ? Keccak.MaxValue.ValueHash256 : null,
+            };
+
+            using SlotsAndProofs response = CreateEmptySlotsResponse(0);
+            Assert.That(snapProvider.AddStorageRange(request, response), Is.EqualTo(AddRangeResult.ExpiredRootHash));
+        }
+
+        string[] promotions = logManager.Warns.Concat(logManager.Debugs)
+            .Where(static line => line.Contains("came back empty"))
+            .ToArray();
+
+        Assert.That(promotions, Has.Length.EqualTo(1), "the streak must promote the account exactly once");
+        Assert.That(logManager.Warns.Any(static line => line.Contains("came back empty")), Is.EqualTo(isContinuation),
+            isContinuation
+                ? "a stalled continuation is unreachable by any other request and is worth an operator warning"
+                : "a one-account batch is an ordinary account and must not warn");
+    }
+
+    private sealed class LaneRecordingLogManager : ILogManager, InterfaceLogger
+    {
+        public List<string> Warns { get; } = [];
+        public List<string> Debugs { get; } = [];
+
+        public ILogger GetClassLogger<T>() => new(this);
+        public ILogger GetLogger(string loggerName) => new(this);
+
+        public void Warn(string text) => Warns.Add(text);
+        public void Debug(string text) => Debugs.Add(text);
+        public void Info(string text) { }
+        public void Trace(string text) { }
+        public void Error(string text, Exception? ex = null) { }
+
+        public bool IsWarn => true;
+        public bool IsDebug => true;
+        public bool IsInfo => false;
+        public bool IsTrace => false;
+        public bool IsError => false;
+    }
+
+    private static void AnswerNextStorageRangeWithAnEmptyResponse(SnapProvider snapProvider, ProgressTracker progressTracker)
+    {
+        progressTracker.IsFinished(out SnapSyncBatch? batch);
+        Assert.That(batch!.StorageRangeRequest, Is.Not.Null);
+
+        batch.StorageRangeResponse = CreateEmptySlotsResponse(0);
+        Assert.That(snapProvider.AddStorageRange(batch.StorageRangeRequest!, batch.StorageRangeResponse), Is.EqualTo(AddRangeResult.ExpiredRootHash));
+        snapProvider.ReleaseRequest(batch, responseHandled: true);
+        batch.Dispose();
+    }
+
+    // The promotion above is speculative: an empty response is also what a peer that has fallen behind the pivot
+    // sends, and under a genuinely stale root every storage response is empty, so one response can push a whole
+    // STORAGE_BATCH_SIZE batch over the streak limit at once. ProgressTracker.IsFinished serves the refresh queue
+    // ahead of every other request type and a refresh that answers Expired re-queues itself, so an unbounded
+    // promotion would leave no slot for account, storage or code work until the pivot moved. Past the cap the
+    // account has to go back to the ordinary storage queue instead.
+    [Test]
+    public void AddStorageRange_EmptyResponseStreak_DoesNotQueueMoreRefreshesThanTheCap()
+    {
+        const int accountCount = SnapProvider.MaxQueuedEmptyStreakRefreshes + 6;
+
+        using IContainer container = CreateContainerBuilder(new TestSyncConfig { SnapSyncAccountRangePartitionCount = 1 })
+            .WithSuggestedHeaderOfStateRoot(Keccak.EmptyTreeHash)
+            .Build();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+        ProgressTracker progressTracker = container.Resolve<ProgressTracker>();
+
+        for (int i = 0; i < accountCount; i++)
+        {
+            progressTracker.EnqueueAccountStorage(new PathWithAccount(TestItem.ValueKeccaks[i], Build.An.Account.WithStorageRoot(TestItem.KeccakF).TestObject));
+        }
+
+        DrainAccountRangePartition(progressTracker);
+
+        for (int attempt = 0; attempt < SnapProvider.MaxConsecutiveEmptyStorageResponses; attempt++)
+        {
+            progressTracker.IsFinished(out SnapSyncBatch? batch);
+            Assert.That(batch!.StorageRangeRequest, Is.Not.Null, $"attempt {attempt}: the whole batch is offered again");
+            Assert.That(batch.StorageRangeRequest!.Accounts.Count, Is.EqualTo(accountCount));
+
+            batch.StorageRangeResponse = CreateEmptySlotsResponse(0);
+            Assert.That(snapProvider.AddStorageRange(batch.StorageRangeRequest, batch.StorageRangeResponse), Is.EqualTo(AddRangeResult.ExpiredRootHash));
+            snapProvider.ReleaseRequest(batch, responseHandled: true);
+            batch.Dispose();
+        }
+
+        Assert.That(progressTracker.AccountsToRefreshCount, Is.EqualTo(SnapProvider.MaxQueuedEmptyStreakRefreshes),
+            "the refresh queue must not grow past the cap, whatever the batch size");
+
+        // The 6 accounts the cap turned away are not lost: they are back on the storage queue and are promoted on a
+        // later empty response, once the refreshes ahead of them have drained.
+        for (int i = 0; i < SnapProvider.MaxQueuedEmptyStreakRefreshes; i++)
+        {
+            progressTracker.IsFinished(out SnapSyncBatch? refresh);
+            Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
+            progressTracker.ReportAccountRefreshFinished();
+            refresh.Dispose();
+        }
+
+        progressTracker.IsFinished(out SnapSyncBatch? remaining);
+        Assert.That(remaining!.StorageRangeRequest, Is.Not.Null);
+        Assert.That(remaining.StorageRangeRequest!.Accounts.Count, Is.EqualTo(6));
+        remaining.Dispose();
+    }
+
+    // Regression for #13155, second half: when the re-proven account turns out to have no storage at the pivot any
+    // more, there is nothing to fetch. Queueing its storage again would only draw the same empty responses.
+    [Test]
+    public void RefreshAccounts_AccountNoLongerHasStorage_DropsTheStorageRange()
+    {
+        (ISnapStateServer server, Hash256 root) = BuildSnapServerFromEntries(
+        [
+            (TestItem.KeccakA, Build.An.Account.WithBalance(1).TestObject),
+            (TestItem.KeccakB, Build.An.Account.WithBalance(2).TestObject),
+            (TestItem.KeccakC, Build.An.Account.WithBalance(3).TestObject),
+        ]);
+
+        using IContainer container = CreateContainerBuilder(new TestSyncConfig { SnapSyncAccountRangePartitionCount = 1 })
+            .WithSuggestedHeaderOfStateRoot(root)
+            .Build();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+        ProgressTracker progressTracker = container.Resolve<ProgressTracker>();
+        DrainAccountRangePartition(progressTracker);
+
+        // Discovered at an older pivot with storage; the storage has since been emptied.
+        PathWithAccount stale = new(TestItem.KeccakA, Build.An.Account.WithStorageRoot(TestItem.KeccakF).TestObject);
+        progressTracker.EnqueueAccountRefresh(stale, ValueKeccak.Zero, Keccak.MaxValue);
+
+        progressTracker.IsFinished(out SnapSyncBatch? refresh);
+        Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
+        Assert.That(refresh.AccountsToRefreshRequest!.RootHash, Is.EqualTo(root));
+
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
+            server.GetAccountRanges(root, stale.Path, stale.Path.IncrementPath(), 4000, CancellationToken.None);
+        refresh.AccountsToRefreshResponse = new AccountsAndProofs { PathAndAccounts = accounts, Proofs = proofs };
+
+        Assert.That(snapProvider.RefreshAccounts(refresh.AccountsToRefreshRequest, refresh.AccountsToRefreshResponse), Is.EqualTo(AddRangeResult.OK));
+        snapProvider.ReleaseRequest(refresh, responseHandled: true);
+        refresh.Dispose();
+
+        Assert.That(stale.Account!.StorageRoot, Is.EqualTo(Keccak.EmptyTreeHash), "the proven (empty) storage root is adopted");
+        Assert.That(progressTracker.IsFinished(out SnapSyncBatch? next), Is.True, "an account without storage leaves nothing to fetch");
+        Assert.That(next, Is.Null);
+    }
+
+    /// <summary>
+    /// The sibling of the test above. A large-storage account that is <em>deleted</em> at the pivot, rather than
+    /// merely emptied, is just as terminal: nothing will ever fetch its storage, so nothing else will ever clear its
+    /// large-storage entry. Leaving it counts the account in "Large storage left" for the rest of the sync, which is
+    /// the exact operator signal #13155 was diagnosed by.
+    /// </summary>
+    [Test]
+    public void RefreshAccounts_AccountNoLongerExists_ClearsItsLargeStorageProgress()
+    {
+        (ISnapStateServer server, Hash256 root) = BuildSnapServerFromEntries(
+        [
+            (TestItem.KeccakA, Build.An.Account.WithBalance(1).TestObject),
+            (TestItem.KeccakB, Build.An.Account.WithBalance(2).TestObject),
+        ]);
+
+        using IContainer container = CreateContainerBuilder(new TestSyncConfig { SnapSyncAccountRangePartitionCount = 1 })
+            .WithSuggestedHeaderOfStateRoot(root)
+            .Build();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+        ProgressTracker progressTracker = container.Resolve<ProgressTracker>();
+        DrainAccountRangePartition(progressTracker);
+
+        // A path immediately before an existing account: absent from the state, and its neighbour is what proves
+        // the absence. A gap with no successor would come back as an empty range, i.e. Expired rather than NotFound.
+        ValueHash256 missing = ((ValueHash256)TestItem.KeccakB).DecrementPath();
+        PathWithAccount gone = new(missing, Build.An.Account.WithStorageRoot(TestItem.KeccakG).TestObject);
+
+        // Dequeuing a single-account slot range is what registers an account as large storage.
+        progressTracker.EnqueueNextSlot(new StorageRange
+        {
+            Accounts = new ArrayPoolList<PathWithAccount>(1) { gone },
+            StartingHash = ValueKeccak.Zero,
+            LimitHash = Keccak.MaxValue
+        });
+        progressTracker.IsFinished(out SnapSyncBatch? slot);
+        using (slot)
+        {
+            Assert.That(slot!.StorageRangeRequest, Is.Not.Null);
+        }
+        Assert.That(progressTracker.LargeStorageProgressCount, Is.EqualTo(1), "guards the premise");
+
+        progressTracker.EnqueueAccountRefresh(gone, ValueKeccak.Zero, Keccak.MaxValue);
+        progressTracker.IsFinished(out SnapSyncBatch? refresh);
+        Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
+
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
+            server.GetAccountRanges(root, gone.Path, gone.Path.IncrementPath(), 4000, CancellationToken.None);
+        refresh.AccountsToRefreshResponse = new AccountsAndProofs { PathAndAccounts = accounts, Proofs = proofs };
+
+        Assert.That(snapProvider.RefreshAccounts(refresh.AccountsToRefreshRequest, refresh.AccountsToRefreshResponse), Is.EqualTo(AddRangeResult.OK));
+        snapProvider.ReleaseRequest(refresh, responseHandled: true);
+        refresh.Dispose();
+
+        Assert.That(gone.Account!.StorageRoot, Is.EqualTo(TestItem.KeccakG), "an absent account adopts nothing; guards that this was NotFound and not Verified");
+        Assert.That(progressTracker.LargeStorageProgressCount, Is.Zero, "a deleted account must not keep counting as large storage left");
+    }
+
+    /// <summary>
+    /// The third terminal-for-large-storage outcome. An account that still has storage, but whose refresh resumes it
+    /// from origin 0, goes back to the multi-account batching queue - where nothing will ever call
+    /// <see cref="ProgressTracker.OnCompletedLargeStorage"/> for it, because that only fires for a single-account
+    /// slot range. Its old large-storage entry is obsolete the moment the account restarts at 0, so it has to be
+    /// cleared here or it counts towards "Large storage left" for the rest of the sync.
+    /// </summary>
+    [Test]
+    public void RefreshAccounts_AccountRestartsFromOrigin_ClearsItsStaleLargeStorageProgress()
+    {
+        Account withStorage = Build.An.Account.WithBalance(1).WithStorageRoot(TestItem.KeccakF).TestObject;
+        (ISnapStateServer server, Hash256 root) = BuildSnapServerFromEntries(
+        [
+            (TestItem.KeccakA, withStorage),
+            (TestItem.KeccakB, Build.An.Account.WithBalance(2).TestObject),
+        ]);
+
+        using IContainer container = CreateContainerBuilder(new TestSyncConfig { SnapSyncAccountRangePartitionCount = 1 })
+            .WithSuggestedHeaderOfStateRoot(root)
+            .Build();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+        ProgressTracker progressTracker = container.Resolve<ProgressTracker>();
+        DrainAccountRangePartition(progressTracker);
+
+        PathWithAccount account = new(TestItem.KeccakA, withStorage);
+
+        // Dequeuing a single-account slot range is what registers an account as large storage.
+        progressTracker.EnqueueNextSlot(new StorageRange
+        {
+            Accounts = new ArrayPoolList<PathWithAccount>(1) { account },
+            StartingHash = ValueKeccak.Zero,
+            LimitHash = Keccak.MaxValue
+        });
+        progressTracker.IsFinished(out SnapSyncBatch? slot);
+        using (slot)
+        {
+            Assert.That(slot!.StorageRangeRequest, Is.Not.Null);
+        }
+        Assert.That(progressTracker.LargeStorageProgressCount, Is.EqualTo(1), "guards the premise");
+
+        // Refreshed at origin 0, so the Verified arm re-enqueues the whole account rather than a continuation.
+        progressTracker.EnqueueAccountRefresh(account, ValueKeccak.Zero, Keccak.MaxValue);
+        progressTracker.IsFinished(out SnapSyncBatch? refresh);
+        Assert.That(refresh!.AccountsToRefreshRequest, Is.Not.Null);
+
+        (IOwnedReadOnlyList<PathWithAccount> accounts, IByteArrayList proofs) =
+            server.GetAccountRanges(root, account.Path, account.Path.IncrementPath(), 4000, CancellationToken.None);
+        refresh.AccountsToRefreshResponse = new AccountsAndProofs { PathAndAccounts = accounts, Proofs = proofs };
+
+        Assert.That(snapProvider.RefreshAccounts(refresh.AccountsToRefreshRequest, refresh.AccountsToRefreshResponse), Is.EqualTo(AddRangeResult.OK));
+        snapProvider.ReleaseRequest(refresh, responseHandled: true);
+        refresh.Dispose();
+
+        Assert.That(account.Account!.StorageRoot, Is.EqualTo(TestItem.KeccakF), "guards that this was Verified with storage, not NotFound or emptied");
+        Assert.That(progressTracker.LargeStorageProgressCount, Is.Zero,
+            "an account restarted at origin 0 must not keep its stale large-storage entry");
+
+        progressTracker.IsFinished(out SnapSyncBatch? requeued);
+        using (requeued)
+        {
+            Assert.That(requeued!.StorageRangeRequest, Is.Not.Null, "and it must still be queued for its storage");
+        }
+    }
+
+    // The streak counter has to be cleared by a SERVED response too, not only by a promotion: otherwise an account
+    // that draws a few empties, is then served normally, and later draws a few more is promoted on a streak that was
+    // never consecutive.
+    [Test]
+    public void AddStorageRange_ServedResponse_EndsTheEmptyStreak()
+    {
+        using IContainer container = CreateContainerBuilder(new TestSyncConfig { SnapSyncAccountRangePartitionCount = 1 })
+            .WithSuggestedHeaderOfStateRoot(Keccak.EmptyTreeHash)
+            .Build();
+
+        SnapProvider snapProvider = container.Resolve<SnapProvider>();
+        ProgressTracker progressTracker = container.Resolve<ProgressTracker>();
+
+        PathWithAccount account = new(TestItem.ValueKeccaks[0], Build.An.Account.WithStorageRoot(TestItem.KeccakF).TestObject);
+        progressTracker.EnqueueAccountStorage(account);
+        DrainAccountRangePartition(progressTracker);
+
+        for (int attempt = 0; attempt < SnapProvider.MaxConsecutiveEmptyStorageResponses - 1; attempt++)
+        {
+            AnswerNextStorageRangeWithAnEmptyResponse(snapProvider, progressTracker);
+        }
+
+        Assert.That(account.EmptyStorageResponses, Is.EqualTo(SnapProvider.MaxConsecutiveEmptyStorageResponses - 1), "guards the premise");
+
+        progressTracker.IsFinished(out SnapSyncBatch? served);
+        Assert.That(served!.StorageRangeRequest, Is.Not.Null);
+        served.StorageRangeResponse = CreateEmptySlotsResponse(1);
+        snapProvider.AddStorageRange(served.StorageRangeRequest!, served.StorageRangeResponse);
+        snapProvider.ReleaseRequest(served, responseHandled: true);
+        served.Dispose();
+
+        Assert.That(account.EmptyStorageResponses, Is.Zero, "a served response means the peers are answering this account again");
     }
 
     [TestCase(nameof(SnapSyncBatch.AccountRangeRequest))]

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/SnapSyncFeed/AnalyzeResponsePerPeerTests.cs
@@ -308,6 +308,37 @@ namespace Nethermind.Synchronization.Test.SnapSync.SnapSyncFeed
                 "an unmatched code reply between two streaks must not buy the peer another benefit of the doubt");
         }
 
+        // Regression guard for the fix to #13200. ProgressTracker.UpdatePivot rate-limits the move, so most calls on a
+        // slow or halted chain do not move anything - and UpdateHeaderForcefully was already a no-op whenever the head
+        // had not advanced. The repeat-offender guard must therefore arm on the REQUEST. Gating it on an actual move
+        // looks fairer to the peer but disables the punishment exactly when it is needed: with a head that is not
+        // advancing, the allocator re-picks the same fastest-but-useless peer forever and nothing ever escalates.
+        [Test]
+        public void Punishes_the_offender_even_when_the_pivot_never_moves()
+        {
+            PeerInfo peer = CreatePeer(TestItem.PublicKeyA);
+            // A pivot that never moves for any reason - rate-limited, StaticSnapPivot, or a head that is standing still.
+            ISnapProvider snapProvider = Substitute.For<ISnapProvider>();
+            Synchronization.SnapSync.SnapSyncFeed feed = new(snapProvider, LimboLogs.Instance);
+
+            SyncResponseHandlingResult result = SyncResponseHandlingResult.OK;
+            for (int i = 0; i <= AllowedInvalidResponses; i++)
+            {
+                result = feed.AnalyzeResponsePerPeer(AddRangeResult.EmptyRange, peer);
+            }
+
+            Assert.That(result, Is.EqualTo(SyncResponseHandlingResult.OK),
+                "the first streak only arms the guard - one streak is still read as a stale pivot rather than a bad peer");
+
+            for (int i = 0; i <= AllowedInvalidResponses; i++)
+            {
+                result = feed.AnalyzeResponsePerPeer(AddRangeResult.EmptyRange, peer);
+            }
+
+            Assert.That(result, Is.EqualTo(SyncResponseHandlingResult.LesserQuality),
+                "a second streak with no success in between is the peer's fault whether or not the pivot moved");
+        }
+
         private const int AllowedInvalidResponses = Synchronization.SnapSync.SnapSyncFeed.AllowedInvalidResponses;
 
         private static PeerInfo CreatePeer(PublicKey nodeId)

--- a/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/StateSyncPivotTest.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/SnapSync/StateSyncPivotTest.cs
@@ -6,6 +6,7 @@ using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Logging;
+using Nethermind.Synchronization.SnapSync;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -74,5 +75,134 @@ public class StateSyncPivotTest
         // Head has not moved far enough to trigger the distance-based refresh, so without the canonicity
         // check the reorged-out header would be handed out forever.
         Assert.That(stateSyncPivot.GetPivotHeader(), Is.SameAs(canonical));
+    }
+
+    // maxDistance is deliberately huge so GetPivotHeader's own re-pivot can never fire and every observed move is
+    // attributable to the failure-streak path.
+    private static Synchronization.FastSync.StateSyncPivot BuildPivot(IBlockTree blockTree, ulong minDistance = 32UL, ulong maxDistance = 100_000UL) =>
+        new(blockTree, BuildSyncConfig(minDistance, maxDistance), LimboLogs.Instance);
+
+    private static TestSyncConfig BuildSyncConfig(ulong minDistance = 32UL, ulong maxDistance = 100_000UL) =>
+        new()
+        {
+            PivotNumber = 0UL,
+            FastSync = true,
+            SnapSyncAccountRangePartitionCount = 1,
+            StateMinDistanceFromHead = minDistance,
+            StateMaxDistanceFromHead = maxDistance,
+        };
+
+    // SnapSyncFeed.AnalyzeResponsePerPeer reaches the pivot only through ProgressTracker.UpdatePivot, which is where
+    // the rate limit lives; these tests drive the composition rather than the pivot alone.
+    private static ProgressTracker BuildTracker(Synchronization.FastSync.StateSyncPivot pivot, TestSyncConfig syncConfig) =>
+        new(Substitute.For<ISnapTrieFactory>(), syncConfig, pivot, LimboLogs.Instance);
+
+    private static IBlockTree BuildBlockTree()
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.FindHeader(Arg.Any<ulong>())
+            .Returns(static (ci) => Build.A.BlockHeader.WithNumber(ci.ArgAt<ulong>(0)).TestObject);
+        // GetPivotHeader re-pivots when the current pivot is not on the main chain; a bare substitute answers false,
+        // which would make every read of the pivot move it and hide what these tests measure.
+        blockTree.IsMainChain(Arg.Any<BlockHeader>()).Returns(true);
+        blockTree.SyncPivot = (0UL, Keccak.Zero);
+        return blockTree;
+    }
+
+    // The regression itself (#13200): repeated streaks on a chain that produces a block or two between them must not
+    // drag the pivot along with the head. Before the fix this loop moved the pivot on every single call.
+    [Test]
+    public void UpdatePivot_repeated_streaks_on_a_fast_chain_do_not_drag_the_pivot_with_the_head()
+    {
+        IBlockTree blockTree = BuildBlockTree();
+        TestSyncConfig syncConfig = BuildSyncConfig();
+        Synchronization.FastSync.StateSyncPivot pivot = BuildPivot(blockTree);
+        using ProgressTracker tracker = BuildTracker(pivot, syncConfig);
+
+        ulong head = 1000UL;
+        blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(head).TestObject);
+        ulong original = pivot.GetPivotHeader()!.Number;
+
+        int moves = 0;
+        ulong previous = original;
+        for (int streak = 0; streak < 10; streak++)
+        {
+            head += 2UL; // OP Mainnet: ~1.5 blocks between consecutive streaks
+            blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(head).TestObject);
+            tracker.UpdatePivot();
+
+            ulong now = pivot.GetPivotHeader()!.Number;
+            if (now != previous) moves++;
+            previous = now;
+        }
+
+        Assert.That(moves, Is.LessThanOrEqualTo(1), "the pivot must not step with every streak; head advanced 20 blocks over 10 streaks");
+    }
+
+    // A pivot the peers have genuinely dropped still has to be replaceable; the guard only delays the move until the
+    // head is far enough ahead for the new pivot to be different in a way that matters.
+    [Test]
+    public void UpdatePivot_still_recovers_from_a_stale_pivot_once_the_head_moves_on()
+    {
+        IBlockTree blockTree = BuildBlockTree();
+        TestSyncConfig syncConfig = BuildSyncConfig();
+        Synchronization.FastSync.StateSyncPivot pivot = BuildPivot(blockTree);
+        using ProgressTracker tracker = BuildTracker(pivot, syncConfig);
+
+        blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(1000UL).TestObject);
+        ulong original = pivot.GetPivotHeader()!.Number;
+
+        for (ulong head = 1001UL; head <= 1031UL; head++)
+        {
+            blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(head).TestObject);
+            tracker.UpdatePivot();
+            Assert.That(pivot.GetPivotHeader()!.Number, Is.EqualTo(original), $"suppressed while only {head - 1000UL} ahead");
+        }
+
+        blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(1032UL).TestObject);
+        tracker.UpdatePivot();
+        Assert.That(pivot.GetPivotHeader()!.Number, Is.EqualTo(1032UL));
+    }
+
+    // The head can sit behind the pivot - a reorg, or a pivot that TrySetNewBestHeader placed ahead of
+    // BestSuggestedHeader. StateSyncPivot.Diff is a SaturatingSub for exactly this reason: a raw `head - pivot` in
+    // ulong arithmetic underflows to a value far above StateMinDistanceFromHead, and the pivot would then move on
+    // every streak, which is the livelock this fix exists to stop.
+    [TestCase(1UL, TestName = "Head one block behind the pivot")]
+    [TestCase(500UL, TestName = "Head far behind the pivot")]
+    public void UpdatePivot_does_not_move_when_the_head_is_behind_the_pivot(ulong headRetreat)
+    {
+        IBlockTree blockTree = BuildBlockTree();
+        TestSyncConfig syncConfig = BuildSyncConfig();
+        Synchronization.FastSync.StateSyncPivot pivot = BuildPivot(blockTree);
+        using ProgressTracker tracker = BuildTracker(pivot, syncConfig);
+
+        blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(1000UL).TestObject);
+        ulong original = pivot.GetPivotHeader()!.Number;
+
+        blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(1000UL - headRetreat).TestObject);
+        tracker.UpdatePivot();
+
+        Assert.That(pivot.GetPivotHeader()!.Number, Is.EqualTo(original));
+    }
+
+    // TreeSync.ResetStateRootToBestSuggested calls UpdateHeaderForcefully at the start of every state sync round to
+    // pick up the newest state root; that caller is not responding to a failure and must not be rate-limited, which
+    // is why the guard sits in ProgressTracker.UpdatePivot rather than on the pivot itself.
+    [TestCase(1UL)]
+    [TestCase(2UL)]
+    [TestCase(31UL)]
+    public void UpdateHeaderForcefully_still_follows_the_head_by_a_single_block(ulong headAdvance)
+    {
+        IBlockTree blockTree = BuildBlockTree();
+        Synchronization.FastSync.StateSyncPivot pivot = BuildPivot(blockTree);
+
+        blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(1000UL).TestObject);
+        ulong original = pivot.GetPivotHeader()!.Number;
+
+        blockTree.BestSuggestedHeader.Returns(Build.A.BlockHeader.WithNumber(1000UL + headAdvance).TestObject);
+        pivot.UpdateHeaderForcefully();
+
+        Assert.That(pivot.GetPivotHeader()!.Number, Is.EqualTo(original + headAdvance));
     }
 }

--- a/src/Nethermind/Nethermind.Synchronization/Metrics.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Metrics.cs
@@ -66,6 +66,18 @@ namespace Nethermind.Synchronization
         public static long SnapSyncedCodes;
 
         [CounterMetric]
+        [Description("Storage ranges handed to an account refresh after a streak of empty responses during SNAP Sync")]
+        public static long SnapStorageRangesRefreshedAfterEmptyResponses;
+
+        [CounterMetric]
+        [Description("State sync pivot updates requested by a streak of unusable range responses and not rate-limited. The pivot can still decline (unchanged header hash, Sync.StaticSnapPivot, or a chain whose pivot ignores forced moves), so this counts requests that passed the rate limit rather than moves")]
+        public static long ForcedStatePivotUpdates;
+
+        [CounterMetric]
+        [Description("Forced state sync pivot updates skipped because the head had not moved far enough to be worth invalidating in-flight ranges")]
+        public static long ForcedStatePivotUpdatesSuppressed;
+
+        [CounterMetric]
         [Description("SNAP Sync requests that produced no response at all. Distinguishes an unresponsive or non-serving peer set from one answering with unusable data, which SnapRangeResult covers.")]
         public static long SnapRequestTimeouts;
 

--- a/src/Nethermind/Nethermind.Synchronization/Metrics.cs
+++ b/src/Nethermind/Nethermind.Synchronization/Metrics.cs
@@ -74,7 +74,7 @@ namespace Nethermind.Synchronization
         public static long ForcedStatePivotUpdates;
 
         [CounterMetric]
-        [Description("Forced state sync pivot updates skipped because the head had not moved far enough to be worth invalidating in-flight ranges")]
+        [Description("Forced state sync pivot updates skipped because the head had not moved far enough past the pivot for a new target to be worth re-issuing the outstanding ranges against")]
         public static long ForcedStatePivotUpdatesSuppressed;
 
         [CounterMetric]

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ISnapProvider.cs
@@ -27,6 +27,11 @@ namespace Nethermind.Synchronization.SnapSync
         void ReleaseRequest(SnapSyncBatch batch, bool responseHandled);
 
         bool IsSnapGetRangesFinished();
+
+        /// <summary>
+        /// Asks the state sync pivot to move in response to a streak of unusable range responses. Rate-limited, so a
+        /// call is a request rather than a move; see <see cref="ProgressTracker.UpdatePivot"/>.
+        /// </summary>
         void UpdatePivot();
         void Dispose();
     }

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -29,17 +29,12 @@ namespace Nethermind.Synchronization.SnapSync
         private const uint StorageRangeSplitFactor = 2;
 
         /// <remarks>
-        /// This queue is served ahead of every other request type, and a refresh answered with an expired root
-        /// re-queues itself before its worker is released. Unthrottled, that hands every dispatcher slot to a queue
-        /// that cannot drain until the pivot moves, while code and storage requests - which are keyed by hash and
-        /// succeed against a peer behind the pivot - get none. The fallback below the priority chain restores full
-        /// concurrency once refreshes are the only work left.
-        ///
-        /// The bound is therefore "at most this many in flight <em>while other work is queued</em>", not an absolute
-        /// one: when the fallback is reached there is nothing left to starve, and the next queued partition, storage
-        /// or code item puts the capped branch back in charge on the following call.
+        /// This queue is served ahead of every other request type and a refresh answered with an expired root re-queues
+        /// itself, so an unbounded priority starves everything below it until the pivot moves. Counted in a row rather
+        /// than in flight: an in-flight bound does nothing at or below Sync.MaxProcessingThreads. The fallback below
+        /// the priority chain still serves refreshes when they are the only work left.
         /// </remarks>
-        internal const int MAX_CONCURRENT_ACCOUNT_REFRESHES = 4;
+        internal const int MAX_CONSECUTIVE_ACCOUNT_REFRESHES = 4;
 
         // This does not need to be a lot as it spawn other requests. In fact 8 is probably too much. It is severely
         // bottlenecked by _syncCommit lock in SnapProviderHelper, which in turns is limited by the IO.
@@ -55,6 +50,9 @@ namespace Nethermind.Synchronization.SnapSync
 
         private int _activeCodeRequests;
         private int _activeAccRefreshRequests;
+
+        /// <summary>Refreshes served in a row, see <see cref="MAX_CONSECUTIVE_ACCOUNT_REFRESHES"/>.</summary>
+        private int _consecutiveAccountRefreshes;
 
         private readonly ILogger _logger;
         private readonly ISnapTrieFactory _snapTrieFactory;
@@ -74,12 +72,8 @@ namespace Nethermind.Synchronization.SnapSync
         private ConcurrentQueue<ValueHash256> CodesToRetrieve { get; set; } = new();
         private ConcurrentQueue<AccountWithStorageStartingHash> AccountsToRefresh { get; set; } = new();
 
-        /// <remarks>
-        /// <see cref="IsFinished"/> serves this queue ahead of every other request type up to
-        /// <see cref="MAX_CONCURRENT_ACCOUNT_REFRESHES"/> in flight, so a caller that enqueues speculatively still has
-        /// to keep it short: over that cap the queue is only served once nothing else is queued. See
-        /// <see cref="SnapProvider.MaxQueuedEmptyStreakRefreshes"/>.
-        /// </remarks>
+        /// <summary>Served ahead of everything else, so a speculative caller has to keep it short - see
+        /// <see cref="SnapProvider.MaxQueuedEmptyStreakRefreshes"/>.</summary>
         internal int AccountsToRefreshCount => AccountsToRefresh.Count;
 
         private readonly FastSync.IStateSyncPivot _pivot;
@@ -162,25 +156,18 @@ namespace Nethermind.Synchronization.SnapSync
         /// advanced at least <see cref="ISyncConfig.StateMinDistanceFromHead"/> blocks past it.
         /// </summary>
         /// <remarks>
-        /// Moving the pivot changes the state root that every in-flight and queued range was requested at, so each one
-        /// comes back unusable. That cost is only worth paying when the new pivot is a genuinely different target.
-        /// <see cref="FastSync.IStateSyncPivot.UpdateHeaderForcefully"/> moves whenever the pivot is at or behind the
-        /// head - i.e. always - which is mostly harmless on a slow chain, where the head rarely moves between two
-        /// streaks and the pivot is re-set to the block it already had. On a fast chain the head has advanced by the
-        /// time the next streak lands, so every move invalidates the very work that would have ended the streak and
-        /// manufactures the next one. The OP Mainnet measurements that motivated the guard are on
-        /// https://github.com/NethermindEth/nethermind/issues/13200.
+        /// The forced move is for a pivot the peer set has pruned. It does not invalidate the ranges already in flight
+        /// - each reply is checked against the root recorded in its own request - but it re-targets everything issued
+        /// afterwards at the newest suggested header. A streak on a chain whose pivot is already at the head is not the
+        /// case the move is for, and answering it by moving further ahead of the peers that caused it makes the next
+        /// streak more likely: OP Mainnet ran 74,469 forced moves in 60 hours without finishing the account range
+        /// (https://github.com/NethermindEth/nethermind/issues/13200).
         /// <para>
-        /// The rate limit lives here rather than on the pivot because it is a property of this caller: the state sync
-        /// round start (<c>TreeSync.ResetStateRootToBestSuggested</c>) needs the newest state root on every round and
-        /// must keep the unrestricted path. <see cref="FastSync.IStateSyncPivot.Diff"/> saturates, so a head behind
-        /// the pivot reads 0 and is suppressed rather than wrapping into a large distance.
-        /// </para>
-        /// <para>
-        /// A declined move is deliberately invisible to the caller. <c>UpdateHeaderForcefully</c> was already a no-op
-        /// whenever the head had not advanced, so callers have never been able to assume a call moved anything, and
-        /// SnapSyncFeed's repeat-offender guard depends on that: it arms on the request, not on the move. The two
-        /// metrics below are where the difference is observable.
+        /// The rate limit lives here rather than on the pivot because it is a property of this caller:
+        /// <c>TreeSync.ResetStateRootToBestSuggested</c> needs the newest root on every round and must keep the
+        /// unrestricted path. <see cref="FastSync.IStateSyncPivot.Diff"/> saturates, so a head behind the pivot reads 0
+        /// and is suppressed rather than wrapping into a large distance. A declined move is invisible to the caller, as
+        /// a declined <c>UpdateHeaderForcefully</c> always was; the metrics below are where it is observable.
         /// </para>
         /// </remarks>
         public void UpdatePivot()
@@ -209,7 +196,7 @@ namespace Nethermind.Synchronization.SnapSync
             Hash256 rootHash = pivotHeader!.StateRoot!;
             ulong blockNumber = pivotHeader.Number;
 
-            if (!AccountsToRefresh.IsEmpty && _activeAccRefreshRequests < MAX_CONCURRENT_ACCOUNT_REFRESHES)
+            if (!AccountsToRefresh.IsEmpty && Volatile.Read(ref _consecutiveAccountRefreshes) < MAX_CONSECUTIVE_ACCOUNT_REFRESHES)
             {
                 nextBatch = DequeAccountToRefresh(rootHash);
             }
@@ -239,7 +226,7 @@ namespace Nethermind.Synchronization.SnapSync
             }
             else if (!AccountsToRefresh.IsEmpty)
             {
-                // Over the cap, but nothing else is queued: the tail of the sync must not run at four requests.
+                // Out of turns, but nothing else is queued: the tail of the sync must not run at one request per turn.
                 nextBatch = DequeAccountToRefresh(rootHash);
             }
             else
@@ -257,7 +244,27 @@ namespace Nethermind.Synchronization.SnapSync
                 return IsSnapGetRangesFinished();
             }
 
+            TakeTurn(nextBatch);
+
             return false;
+        }
+
+        /// <summary>
+        /// Turn-taking, see <see cref="MAX_CONSECUTIVE_ACCOUNT_REFRESHES"/>. Saturating so a long run of refreshes
+        /// cannot wrap the counter and hand the priority branch a free turn.
+        /// </summary>
+        private void TakeTurn(SnapSyncBatch? served)
+        {
+            if (served is null) return; // A queue that raced empty; nobody had a turn.
+
+            if (served.AccountsToRefreshRequest is null)
+            {
+                Volatile.Write(ref _consecutiveAccountRefreshes, 0);
+            }
+            else if (Volatile.Read(ref _consecutiveAccountRefreshes) < MAX_CONSECUTIVE_ACCOUNT_REFRESHES)
+            {
+                Interlocked.Increment(ref _consecutiveAccountRefreshes);
+            }
         }
 
         private SnapSyncBatch DequeCodeRequest()
@@ -638,6 +645,18 @@ namespace Nethermind.Synchronization.SnapSync
                 }
             }
         }
+
+        /// <summary>
+        /// Drops the account's large-storage tracking whatever its partition count, for a caller that has established
+        /// the account will not be fetched as a large storage any more.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="OnCompletedLargeStorage"/> retires one partition, so under
+        /// <c>Sync.EnableSnapSyncStorageRangeSplit</c> a split account survives it. A re-download re-registers through
+        /// <see cref="TryDequeNextSlotRange"/>.
+        /// </remarks>
+        public void DropLargeStorageProgress(PathWithAccount pathWithAccount) =>
+            _largeStorageProgress.Remove(pathWithAccount.Path, out _);
 
         // A partition of the top level account range starting from `AccountPathStart` to `AccountPathLimit` (exclusive).
         private class AccountRangePartition

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/ProgressTracker.cs
@@ -28,6 +28,19 @@ namespace Nethermind.Synchronization.SnapSync
         public const int HIGH_CODES_QUEUE_SIZE = CODES_BATCH_SIZE * 5;
         private const uint StorageRangeSplitFactor = 2;
 
+        /// <remarks>
+        /// This queue is served ahead of every other request type, and a refresh answered with an expired root
+        /// re-queues itself before its worker is released. Unthrottled, that hands every dispatcher slot to a queue
+        /// that cannot drain until the pivot moves, while code and storage requests - which are keyed by hash and
+        /// succeed against a peer behind the pivot - get none. The fallback below the priority chain restores full
+        /// concurrency once refreshes are the only work left.
+        ///
+        /// The bound is therefore "at most this many in flight <em>while other work is queued</em>", not an absolute
+        /// one: when the fallback is reached there is nothing left to starve, and the next queued partition, storage
+        /// or code item puts the capped branch back in charge on the following call.
+        /// </remarks>
+        internal const int MAX_CONCURRENT_ACCOUNT_REFRESHES = 4;
+
         // This does not need to be a lot as it spawn other requests. In fact 8 is probably too much. It is severely
         // bottlenecked by _syncCommit lock in SnapProviderHelper, which in turns is limited by the IO.
         // In any case, all partition will be touched when calculating progress, so we can't really put like 1024 for this.
@@ -61,8 +74,17 @@ namespace Nethermind.Synchronization.SnapSync
         private ConcurrentQueue<ValueHash256> CodesToRetrieve { get; set; } = new();
         private ConcurrentQueue<AccountWithStorageStartingHash> AccountsToRefresh { get; set; } = new();
 
+        /// <remarks>
+        /// <see cref="IsFinished"/> serves this queue ahead of every other request type up to
+        /// <see cref="MAX_CONCURRENT_ACCOUNT_REFRESHES"/> in flight, so a caller that enqueues speculatively still has
+        /// to keep it short: over that cap the queue is only served once nothing else is queued. See
+        /// <see cref="SnapProvider.MaxQueuedEmptyStreakRefreshes"/>.
+        /// </remarks>
+        internal int AccountsToRefreshCount => AccountsToRefresh.Count;
+
         private readonly FastSync.IStateSyncPivot _pivot;
         private readonly bool _enableStorageRangeSplit;
+        private readonly ulong _stateMinDistanceFromHead;
 
         public ProgressTracker(ISnapTrieFactory snapTrieFactory, ISyncConfig syncConfig, FastSync.IStateSyncPivot pivot, ILogManager? logManager)
         {
@@ -77,6 +99,7 @@ namespace Nethermind.Synchronization.SnapSync
 
             _accountRangePartitionCount = accountRangePartitionCount;
             _enableStorageRangeSplit = syncConfig.EnableSnapSyncStorageRangeSplit;
+            _stateMinDistanceFromHead = syncConfig.StateMinDistanceFromHead;
 
             SetupAccountRangePartition();
         }
@@ -134,7 +157,43 @@ namespace Nethermind.Synchronization.SnapSync
             return true;
         }
 
-        public void UpdatePivot() => _pivot.UpdateHeaderForcefully();
+        /// <summary>
+        /// Moves the state sync pivot in response to a streak of unusable range responses, but only once the head has
+        /// advanced at least <see cref="ISyncConfig.StateMinDistanceFromHead"/> blocks past it.
+        /// </summary>
+        /// <remarks>
+        /// Moving the pivot changes the state root that every in-flight and queued range was requested at, so each one
+        /// comes back unusable. That cost is only worth paying when the new pivot is a genuinely different target.
+        /// <see cref="FastSync.IStateSyncPivot.UpdateHeaderForcefully"/> moves whenever the pivot is at or behind the
+        /// head - i.e. always - which is mostly harmless on a slow chain, where the head rarely moves between two
+        /// streaks and the pivot is re-set to the block it already had. On a fast chain the head has advanced by the
+        /// time the next streak lands, so every move invalidates the very work that would have ended the streak and
+        /// manufactures the next one. The OP Mainnet measurements that motivated the guard are on
+        /// https://github.com/NethermindEth/nethermind/issues/13200.
+        /// <para>
+        /// The rate limit lives here rather than on the pivot because it is a property of this caller: the state sync
+        /// round start (<c>TreeSync.ResetStateRootToBestSuggested</c>) needs the newest state root on every round and
+        /// must keep the unrestricted path. <see cref="FastSync.IStateSyncPivot.Diff"/> saturates, so a head behind
+        /// the pivot reads 0 and is suppressed rather than wrapping into a large distance.
+        /// </para>
+        /// <para>
+        /// A declined move is deliberately invisible to the caller. <c>UpdateHeaderForcefully</c> was already a no-op
+        /// whenever the head had not advanced, so callers have never been able to assume a call moved anything, and
+        /// SnapSyncFeed's repeat-offender guard depends on that: it arms on the request, not on the move. The two
+        /// metrics below are where the difference is observable.
+        /// </para>
+        /// </remarks>
+        public void UpdatePivot()
+        {
+            if (_pivot.Diff < _stateMinDistanceFromHead)
+            {
+                Interlocked.Increment(ref Metrics.ForcedStatePivotUpdatesSuppressed);
+                return;
+            }
+
+            Interlocked.Increment(ref Metrics.ForcedStatePivotUpdates);
+            _pivot.UpdateHeaderForcefully();
+        }
 
         public bool IsFinished(out SnapSyncBatch? nextBatch)
         {
@@ -150,7 +209,7 @@ namespace Nethermind.Synchronization.SnapSync
             Hash256 rootHash = pivotHeader!.StateRoot!;
             ulong blockNumber = pivotHeader.Number;
 
-            if (!AccountsToRefresh.IsEmpty)
+            if (!AccountsToRefresh.IsEmpty && _activeAccRefreshRequests < MAX_CONCURRENT_ACCOUNT_REFRESHES)
             {
                 nextBatch = DequeAccountToRefresh(rootHash);
             }
@@ -177,6 +236,11 @@ namespace Nethermind.Synchronization.SnapSync
             else if (!CodesToRetrieve.IsEmpty)
             {
                 nextBatch = DequeCodeRequest();
+            }
+            else if (!AccountsToRefresh.IsEmpty)
+            {
+                // Over the cap, but nothing else is queued: the tail of the sync must not run at four requests.
+                nextBatch = DequeAccountToRefresh(rootHash);
             }
             else
             {
@@ -561,6 +625,8 @@ namespace Nethermind.Synchronization.SnapSync
 
             return true;
         }
+
+        internal int LargeStorageProgressCount => _largeStorageProgress.Count;
 
         public void OnCompletedLargeStorage(PathWithAccount pathWithAccount)
         {

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -30,6 +30,31 @@ namespace Nethermind.Synchronization.SnapSync
         // This is actually close to 97% effective.
         private readonly AssociativeKeyCache<ValueHash256> _codeExistKeyCache = new(1024 * 16);
 
+        // How many consecutive empty storage-range responses for one account are treated as "this account really has
+        // no storage at the pivot" rather than "this peer is behind". The streak is per account, not per queued
+        // range: with EnableSnapSyncStorageRangeSplit the partitions of one large account share this counter, so the
+        // account is promoted after this many empty responses in total and any one partition being served ends the
+        // streak for all of them. That matches the question the promotion answers - whether the account still has
+        // storage at the pivot - which is answered once, for the account. The scale is taken from
+        // SnapSyncFeed.AllowedInvalidResponses only to stay in step with the feed's own notion of a failure streak;
+        // do NOT read it as a guarantee that a fresh pivot has been seen by the time it trips. SnapSyncFeed does ask
+        // for a pivot update on a streak (both ProgressTracker.UpdatePivot branches of its AnalyzeResponsePerPeer),
+        // but that request is advisory: the pivot is only moved when the head has advanced far enough to make a new
+        // target worthwhile, so a streak this long can complete against an unchanged pivot. That is safe either way -
+        // RefreshAccounts answers Expired and InvalidProof with RetryAccountRefresh, so re-proving against a
+        // still-stale root retries rather than dropping the account - but the threshold is a heuristic about the
+        // account, not a proof about the pivot.
+        internal const int MaxConsecutiveEmptyStorageResponses = 2 * (SnapSyncFeed.AllowedInvalidResponses + 1);
+
+        // ProgressTracker.IsFinished serves the refresh queue ahead of every other request type, and a refresh that
+        // comes back Expired re-queues itself, so the queue does not drain while the peer set is behind the pivot.
+        // One empty response bumps the streak counter on every account of the request, and a storage batch holds up
+        // to ProgressTracker.STORAGE_BATCH_SIZE (1200) of them, so an unguarded promotion could hand over a whole
+        // batch at once and leave no slot for account, storage or code work until the pivot moves. Past this many
+        // queued promotions the account goes back to the ordinary storage queue instead; its streak counter is left
+        // alone, so it is promoted on a later empty response once the queue has drained and nothing is lost.
+        internal const int MaxQueuedEmptyStreakRefreshes = 64;
+
         public bool CanSync() => _progressTracker.CanSync();
 
         public bool IsFinished(out SnapSyncBatch? nextBatch) => _progressTracker.IsFinished(out nextBatch);
@@ -132,7 +157,7 @@ namespace Nethermind.Synchronization.SnapSync
             {
                 _logger.Trace($"SNAP - GetStorageRange - expired BlockNumber:{request.BlockNumber}, RootHash:{request.RootHash}, (Accounts:{request.Accounts.Count}), {request.StartingHash}");
 
-                _progressTracker.RequeueStorageRange(request.Copy());
+                RequeueAfterEmptyResponse(request);
                 Metrics.SnapRangeResult.Increment(new SnapRangeResult(isStorage: true, result: AddRangeResult.ExpiredRootHash));
 
                 return AddRangeResult.ExpiredRootHash;
@@ -177,10 +202,97 @@ namespace Nethermind.Synchronization.SnapSync
             return result;
         }
 
+        /// <summary>
+        /// An empty storage-range response (no slots, no proof) is what a peer sends when it no longer has the requested
+        /// state root - but it is also what geth sends for an account that has no storage at that root: an empty slot
+        /// list is dropped and no proof is built when the origin is zero. Re-queueing cannot tell the two apart, and the
+        /// pivot refresh that follows the streak does not help an account whose storage is gone, so after a streak that
+        /// outlives the feed's own pivot updates the account is re-proven at the current pivot instead. The refresh
+        /// resumes the range from the same starting hash if the storage still exists and drops it if it does not.
+        /// </summary>
+        private void RequeueAfterEmptyResponse(StorageRange request)
+        {
+            ReadOnlySpan<PathWithAccount> accounts = request.Accounts.AsSpan();
+            if (accounts.Length == 1)
+            {
+                PathWithAccount account = accounts[0];
+                // A single-account range is either the continuation of one account's large storage or the tail of the
+                // batching queue holding exactly one entry. Only the continuation carries a non-zero origin - every
+                // one EnqueueNextSlot produces resumes at lastProcessedHash.IncrementPath() - and only it is
+                // unreachable by any other request, so a stall there stalls the account for good. That is the lane
+                // #13155 was reproduced on ("Large storage left: 1"), and the only one worth an operator warning; a
+                // one-account batch is an ordinary account and stays on the Debug lane with its multi-account peers.
+                bool isLargeStorageContinuation = request.StartingHash is { } origin && origin > ValueKeccak.Zero;
+                if (Interlocked.Increment(ref account.EmptyStorageResponses) < MaxConsecutiveEmptyStorageResponses
+                    || !TryRefreshAfterEmptyStreak(account, request.StartingHash, request.LimitHash, request.BlockNumber, warn: isLargeStorageContinuation))
+                {
+                    _progressTracker.RequeueStorageRange(request.Copy());
+                }
+                else
+                {
+                    // The counter only ever rises, so without this the account is past the threshold for good: a
+                    // refresh that re-enqueues its storage is followed by one promotion per empty response instead
+                    // of one per streak, which is what fills the refresh queue. Reset on promotion, not inside
+                    // TryRefreshAfterEmptyStreak - its queue-full early return must keep the streak.
+                    Interlocked.Exchange(ref account.EmptyStorageResponses, 0);
+                }
+
+                return;
+            }
+
+            // A multi-account request is not a continuation: each account goes back to the batching queue on its own.
+            // A whole batch can cross the streak threshold on the same response, so these are logged at Debug - the
+            // SnapStorageRangesRefreshedAfterEmptyResponses counter is the signal to watch here.
+            foreach (PathWithAccount account in accounts)
+            {
+                if (Interlocked.Increment(ref account.EmptyStorageResponses) < MaxConsecutiveEmptyStorageResponses
+                    || !TryRefreshAfterEmptyStreak(account, null, null, request.BlockNumber, warn: false))
+                {
+                    _progressTracker.EnqueueAccountStorage(account);
+                }
+                else
+                {
+                    Interlocked.Exchange(ref account.EmptyStorageResponses, 0);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Hands an account whose storage range keeps coming back empty to an account refresh, unless the refresh
+        /// queue is already at <see cref="MaxQueuedEmptyStreakRefreshes"/>.
+        /// </summary>
+        /// <returns><c>false</c> when the caller must re-queue the range itself instead.</returns>
+        private bool TryRefreshAfterEmptyStreak(PathWithAccount account, in ValueHash256? startingHash, in ValueHash256? limitHash, ulong? blockNumber, bool warn)
+        {
+            if (_progressTracker.AccountsToRefreshCount >= MaxQueuedEmptyStreakRefreshes)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Snap - {MaxQueuedEmptyStreakRefreshes} accounts are already queued for re-verification; re-queueing the storage range of {account.Path} instead.");
+                return false;
+            }
+
+            string message = $"Snap - storage range of account {account.Path} came back empty {account.EmptyStorageResponses} times in a row (start: {startingHash ?? ValueKeccak.Zero}, pivot: {blockNumber}). Re-verifying the account at the current pivot instead of retrying.";
+            if (warn)
+            {
+                if (_logger.IsWarn) _logger.Warn(message);
+            }
+            else if (_logger.IsDebug)
+            {
+                _logger.Debug(message);
+            }
+
+            Interlocked.Increment(ref Metrics.SnapStorageRangesRefreshedAfterEmptyResponses);
+            _progressTracker.EnqueueAccountRefresh(account, startingHash, limitHash);
+            return true;
+        }
+
         public AddRangeResult AddStorageRangeForAccount(StorageRange request, int accountIndex, IReadOnlyList<PathWithStorageSlot> slots, IByteArrayList? proofs = null)
         {
             ReadOnlySpan<PathWithAccount> accounts = request.Accounts.AsSpan();
             PathWithAccount pathWithAccount = accounts[accountIndex];
+            // Peers are serving this account's storage again, so the empty streak is over. Interlocked because the
+            // split path in EnqueueNextSlot queues both halves with the same PathWithAccount instance, so another
+            // worker can be incrementing this very field in RequeueAfterEmptyResponse right now.
+            Interlocked.Exchange(ref pathWithAccount.EmptyStorageResponses, 0);
 
             try
             {
@@ -247,6 +359,18 @@ namespace Nethermind.Synchronization.SnapSync
                 case RefreshVerifyResult.Verified:
                     result = AddRangeResult.OK;
                     requestedPath.PathAndAccount.Account = requestedPath.PathAndAccount.Account.WithChangedStorageRoot(account!.StorageRoot);
+                    // Read and reset in one step, for the same reason as above.
+                    int emptyResponses = Interlocked.Exchange(ref requestedPath.PathAndAccount.EmptyStorageResponses, 0);
+
+                    if (!account.HasStorage)
+                    {
+                        // The storage was emptied after the account was discovered. There is nothing left to fetch, and
+                        // asking for it would only draw more empty responses; the account stays tracked for healing.
+                        // The streak count ties this back to the operator warning that promoted the account.
+                        if (_logger.IsInfo) _logger.Info($"Snap - account {path} has no storage at the current pivot anymore (empty responses: {emptyResponses}, start: {requestedPath.StorageStartingHash}), dropping its storage range.");
+                        _progressTracker.OnCompletedLargeStorage(requestedPath.PathAndAccount);
+                        break;
+                    }
 
                     if (requestedPath.StorageStartingHash > ValueKeccak.Zero)
                     {
@@ -259,6 +383,11 @@ namespace Nethermind.Synchronization.SnapSync
                     }
                     else
                     {
+                        // Back to the batching queue at origin 0, so whatever large-storage progress this account had
+                        // is obsolete. Clear it or the entry outlives the account's re-download and keeps counting
+                        // towards "Large storage left" for the rest of the sync - the signal #13155 was diagnosed by.
+                        // If the re-download turns out to be large again, TryDequeNextSlotRange re-registers it.
+                        _progressTracker.OnCompletedLargeStorage(requestedPath.PathAndAccount);
                         _progressTracker.EnqueueAccountStorage(requestedPath.PathAndAccount);
                     }
                     break;
@@ -267,6 +396,10 @@ namespace Nethermind.Synchronization.SnapSync
                     // The account no longer exists at the pivot, so there is no storage to retrieve. It remains
                     // tracked for healing. Terminal success - must not retry or the refresh would loop forever.
                     result = AddRangeResult.OK;
+                    // Terminal like the !HasStorage branch above, so it owes the same bookkeeping: nothing else will
+                    // ever clear this account's large-storage entry, and it would keep counting towards
+                    // "Large storage left" for the rest of the sync - the very signal #13155 was diagnosed by.
+                    _progressTracker.OnCompletedLargeStorage(requestedPath.PathAndAccount);
                     break;
 
                 case RefreshVerifyResult.Expired:

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapProvider.cs
@@ -31,28 +31,15 @@ namespace Nethermind.Synchronization.SnapSync
         private readonly AssociativeKeyCache<ValueHash256> _codeExistKeyCache = new(1024 * 16);
 
         // How many consecutive empty storage-range responses for one account are treated as "this account really has
-        // no storage at the pivot" rather than "this peer is behind". The streak is per account, not per queued
-        // range: with EnableSnapSyncStorageRangeSplit the partitions of one large account share this counter, so the
-        // account is promoted after this many empty responses in total and any one partition being served ends the
-        // streak for all of them. That matches the question the promotion answers - whether the account still has
-        // storage at the pivot - which is answered once, for the account. The scale is taken from
-        // SnapSyncFeed.AllowedInvalidResponses only to stay in step with the feed's own notion of a failure streak;
-        // do NOT read it as a guarantee that a fresh pivot has been seen by the time it trips. SnapSyncFeed does ask
-        // for a pivot update on a streak (both ProgressTracker.UpdatePivot branches of its AnalyzeResponsePerPeer),
-        // but that request is advisory: the pivot is only moved when the head has advanced far enough to make a new
-        // target worthwhile, so a streak this long can complete against an unchanged pivot. That is safe either way -
-        // RefreshAccounts answers Expired and InvalidProof with RetryAccountRefresh, so re-proving against a
-        // still-stale root retries rather than dropping the account - but the threshold is a heuristic about the
-        // account, not a proof about the pivot.
+        // no storage at the pivot" rather than "this peer is behind". Per account, not per queued range: the partitions
+        // of a split account share the counter, because the question the promotion answers is one about the account.
+        // Scaled off SnapSyncFeed.AllowedInvalidResponses, but it is a heuristic about the account, not a proof that a
+        // fresh pivot has been seen - RefreshAccounts retries a still-stale root rather than dropping the account.
         internal const int MaxConsecutiveEmptyStorageResponses = 2 * (SnapSyncFeed.AllowedInvalidResponses + 1);
 
-        // ProgressTracker.IsFinished serves the refresh queue ahead of every other request type, and a refresh that
-        // comes back Expired re-queues itself, so the queue does not drain while the peer set is behind the pivot.
-        // One empty response bumps the streak counter on every account of the request, and a storage batch holds up
-        // to ProgressTracker.STORAGE_BATCH_SIZE (1200) of them, so an unguarded promotion could hand over a whole
-        // batch at once and leave no slot for account, storage or code work until the pivot moves. Past this many
-        // queued promotions the account goes back to the ordinary storage queue instead; its streak counter is left
-        // alone, so it is promoted on a later empty response once the queue has drained and nothing is lost.
+        // One empty response bumps the counter on every account of the request, and a storage batch holds up to
+        // ProgressTracker.STORAGE_BATCH_SIZE (1200) of them, so an unguarded promotion could hand over a whole batch at
+        // once. Past this many the account goes back to the storage queue with its streak intact, to be promoted later.
         internal const int MaxQueuedEmptyStreakRefreshes = 64;
 
         public bool CanSync() => _progressTracker.CanSync();
@@ -204,11 +191,10 @@ namespace Nethermind.Synchronization.SnapSync
 
         /// <summary>
         /// An empty storage-range response (no slots, no proof) is what a peer sends when it no longer has the requested
-        /// state root - but it is also what geth sends for an account that has no storage at that root: an empty slot
-        /// list is dropped and no proof is built when the origin is zero. Re-queueing cannot tell the two apart, and the
-        /// pivot refresh that follows the streak does not help an account whose storage is gone, so after a streak that
-        /// outlives the feed's own pivot updates the account is re-proven at the current pivot instead. The refresh
-        /// resumes the range from the same starting hash if the storage still exists and drops it if it does not.
+        /// state root - but it is also what geth sends for an account that has no storage at that root. Re-queueing
+        /// cannot tell the two apart, and a pivot move does not help an account whose storage is gone, so after a streak
+        /// the account is re-proven at the current pivot: the refresh resumes the range from the same starting hash if
+        /// the storage still exists and drops it if it does not.
         /// </summary>
         private void RequeueAfterEmptyResponse(StorageRange request)
         {
@@ -216,12 +202,9 @@ namespace Nethermind.Synchronization.SnapSync
             if (accounts.Length == 1)
             {
                 PathWithAccount account = accounts[0];
-                // A single-account range is either the continuation of one account's large storage or the tail of the
-                // batching queue holding exactly one entry. Only the continuation carries a non-zero origin - every
-                // one EnqueueNextSlot produces resumes at lastProcessedHash.IncrementPath() - and only it is
-                // unreachable by any other request, so a stall there stalls the account for good. That is the lane
-                // #13155 was reproduced on ("Large storage left: 1"), and the only one worth an operator warning; a
-                // one-account batch is an ordinary account and stays on the Debug lane with its multi-account peers.
+                // Only a large-storage continuation carries a non-zero origin, and only it is unreachable by any other
+                // request, so a stall there stalls the account for good - the lane #13155 was reproduced on, and the
+                // only one worth an operator warning. A one-account batch is an ordinary account and stays on Debug.
                 bool isLargeStorageContinuation = request.StartingHash is { } origin && origin > ValueKeccak.Zero;
                 if (Interlocked.Increment(ref account.EmptyStorageResponses) < MaxConsecutiveEmptyStorageResponses
                     || !TryRefreshAfterEmptyStreak(account, request.StartingHash, request.LimitHash, request.BlockNumber, warn: isLargeStorageContinuation))
@@ -230,19 +213,17 @@ namespace Nethermind.Synchronization.SnapSync
                 }
                 else
                 {
-                    // The counter only ever rises, so without this the account is past the threshold for good: a
-                    // refresh that re-enqueues its storage is followed by one promotion per empty response instead
-                    // of one per streak, which is what fills the refresh queue. Reset on promotion, not inside
-                    // TryRefreshAfterEmptyStreak - its queue-full early return must keep the streak.
+                    // Without this the account is past the threshold for good and is promoted once per empty response
+                    // instead of once per streak. Not inside TryRefreshAfterEmptyStreak, whose queue-full early return
+                    // has to keep the streak.
                     Interlocked.Exchange(ref account.EmptyStorageResponses, 0);
                 }
 
                 return;
             }
 
-            // A multi-account request is not a continuation: each account goes back to the batching queue on its own.
-            // A whole batch can cross the streak threshold on the same response, so these are logged at Debug - the
-            // SnapStorageRangesRefreshedAfterEmptyResponses counter is the signal to watch here.
+            // A multi-account request is not a continuation: each account goes back to the batching queue on its own,
+            // and a whole batch can cross the threshold on one response, so these stay on the Debug lane.
             foreach (PathWithAccount account in accounts)
             {
                 if (Interlocked.Increment(ref account.EmptyStorageResponses) < MaxConsecutiveEmptyStorageResponses
@@ -290,8 +271,7 @@ namespace Nethermind.Synchronization.SnapSync
             ReadOnlySpan<PathWithAccount> accounts = request.Accounts.AsSpan();
             PathWithAccount pathWithAccount = accounts[accountIndex];
             // Peers are serving this account's storage again, so the empty streak is over. Interlocked because the
-            // split path in EnqueueNextSlot queues both halves with the same PathWithAccount instance, so another
-            // worker can be incrementing this very field in RequeueAfterEmptyResponse right now.
+            // split path in EnqueueNextSlot queues both halves with the same PathWithAccount instance.
             Interlocked.Exchange(ref pathWithAccount.EmptyStorageResponses, 0);
 
             try
@@ -366,9 +346,8 @@ namespace Nethermind.Synchronization.SnapSync
                     {
                         // The storage was emptied after the account was discovered. There is nothing left to fetch, and
                         // asking for it would only draw more empty responses; the account stays tracked for healing.
-                        // The streak count ties this back to the operator warning that promoted the account.
                         if (_logger.IsInfo) _logger.Info($"Snap - account {path} has no storage at the current pivot anymore (empty responses: {emptyResponses}, start: {requestedPath.StorageStartingHash}), dropping its storage range.");
-                        _progressTracker.OnCompletedLargeStorage(requestedPath.PathAndAccount);
+                        _progressTracker.DropLargeStorageProgress(requestedPath.PathAndAccount);
                         break;
                     }
 
@@ -384,10 +363,8 @@ namespace Nethermind.Synchronization.SnapSync
                     else
                     {
                         // Back to the batching queue at origin 0, so whatever large-storage progress this account had
-                        // is obsolete. Clear it or the entry outlives the account's re-download and keeps counting
-                        // towards "Large storage left" for the rest of the sync - the signal #13155 was diagnosed by.
-                        // If the re-download turns out to be large again, TryDequeNextSlotRange re-registers it.
-                        _progressTracker.OnCompletedLargeStorage(requestedPath.PathAndAccount);
+                        // is obsolete and nothing on that queue will ever retire it.
+                        _progressTracker.DropLargeStorageProgress(requestedPath.PathAndAccount);
                         _progressTracker.EnqueueAccountStorage(requestedPath.PathAndAccount);
                     }
                     break;
@@ -396,10 +373,8 @@ namespace Nethermind.Synchronization.SnapSync
                     // The account no longer exists at the pivot, so there is no storage to retrieve. It remains
                     // tracked for healing. Terminal success - must not retry or the refresh would loop forever.
                     result = AddRangeResult.OK;
-                    // Terminal like the !HasStorage branch above, so it owes the same bookkeeping: nothing else will
-                    // ever clear this account's large-storage entry, and it would keep counting towards
-                    // "Large storage left" for the rest of the sync - the very signal #13155 was diagnosed by.
-                    _progressTracker.OnCompletedLargeStorage(requestedPath.PathAndAccount);
+                    // Terminal like the !HasStorage branch above, so it owes the same bookkeeping.
+                    _progressTracker.DropLargeStorageProgress(requestedPath.PathAndAccount);
                     break;
 
                 case RefreshVerifyResult.Expired:

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -295,6 +295,11 @@ namespace Nethermind.Synchronization.SnapSync
                                     {
                                         PublicKey? peerNodeId = peer.SyncPeer?.Node?.Id;
                                         bool repeatOffender = peerNodeId is not null && peerNodeId.Equals(_stalePivotUpdateTrigger);
+                                        // Armed on the request, not on the move. ProgressTracker.UpdatePivot rate-limits
+                                        // the move, and UpdateHeaderForcefully was already a no-op whenever the head had
+                                        // not advanced, so gating the punishment on an actual move would disable it for
+                                        // exactly the peer set this guard exists for: on a head that is not advancing the
+                                        // fastest-but-useless peer would be re-allocated forever and never punished.
                                         _stalePivotUpdateTrigger = peerNodeId;
                                         _snapProvider.UpdatePivot();
 

--- a/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
+++ b/src/Nethermind/Nethermind.Synchronization/SnapSync/SnapSyncFeed.cs
@@ -295,11 +295,8 @@ namespace Nethermind.Synchronization.SnapSync
                                     {
                                         PublicKey? peerNodeId = peer.SyncPeer?.Node?.Id;
                                         bool repeatOffender = peerNodeId is not null && peerNodeId.Equals(_stalePivotUpdateTrigger);
-                                        // Armed on the request, not on the move. ProgressTracker.UpdatePivot rate-limits
-                                        // the move, and UpdateHeaderForcefully was already a no-op whenever the head had
-                                        // not advanced, so gating the punishment on an actual move would disable it for
-                                        // exactly the peer set this guard exists for: on a head that is not advancing the
-                                        // fastest-but-useless peer would be re-allocated forever and never punished.
+                                        // Armed on the request, not on the move: a pivot that declines to move is the
+                                        // case this guard is for, and the peer still has to be punished for it.
                                         _stalePivotUpdateTrigger = peerNodeId;
                                         _snapProvider.UpdatePivot();
 


### PR DESCRIPTION
Fixes #13155, #13200

Split 3 of 3 out of #13252 at @asdacap's request. The other two are #13308 and #13309, and neither shares a file with this one.

These two stay together deliberately. Both land in `SnapSync/`, both touch `ProgressTracker`, `SnapProvider` and `Metrics`, and they interact through the refresh queue and `SnapSyncFeed.AnalyzeResponsePerPeer`: #13155's promotion queue is bounded partly by how long a stale root lasts, which is exactly the window #13200's rate limit governs. Separating them would leave each PR reasoning about a mechanism the other one owns.

## Changes

### #13155 — mainnet snap stalls in the large-storage phase

geth answers an account with no storage at the requested root with no slots and no proof — byte-for-byte what a peer that has fallen behind the pivot sends. Every empty reply therefore read as "the pivot moved" and was re-queued forever.

- New `PathWithAccount.EmptyStorageResponses` streak counter, `Interlocked` on every increment and reset. At 12 the account goes to a refresh at the current pivot instead of back onto the queue, and the counter resets on promotion — without that reset the account stays past the threshold for good, and one refresh per *response* instead of one per *streak* is what fills the refresh queue.
- A `Verified` refresh with `HasStorage == false` leaves the range un-queued — the `break` in `RefreshAccounts` skips that branch's `EnqueueNextSlot`/`EnqueueAccountStorage` — and calls `OnCompletedLargeStorage`, so the account leaves "Large storage left". The `NotFound` arm does the same, so all three terminal outcomes now read consistently. `OnCompletedLargeStorage` is `TryGetValue`-guarded, so it is a no-op for an account that was never split.
- Refreshes outrank every other request type and an `Expired` one re-queues itself, so an unbounded promotion could take every dispatcher slot while code and storage work — which succeeds against a peer behind the pivot, being keyed by hash — got none. At most `MAX_CONCURRENT_ACCOUNT_REFRESHES` (4) are in flight *while other work is queued*, served anyway once nothing else is, so the tail of the sync does not run at four requests. `MaxQueuedEmptyStreakRefreshes` (64) is a separate queue-length threshold read only by `TryRefreshAfterEmptyStreak`, not a cap.
- The operator `Warn` fires only for a genuine large-storage continuation. `accounts.Length == 1` is not that test — `DequeStorageToRetrieveRequest` builds its batch with `StartingHash = Zero`, so the tail of the storage queue holding one entry lands on the same branch. The discriminator is a non-zero origin, which every continuation `EnqueueNextSlot` produces carries (`lastProcessedHash.IncrementPath()`); a one-account batch is an ordinary account and stays on the `Debug` lane with its multi-account peers.

### #13200 — OP Mainnet livelock: the forced pivot chases the head

The failure-streak pivot update had no distance guard. Moving the pivot changes the state root every in-flight and queued range was requested at, so each one comes back unusable — and on 2 s blocks the head has advanced by the time the next streak lands, so every move invalidated the very work that would have ended the streak and manufactured the next one. Phase 1 stayed pinned at 0.00 % with zero accounts ever committed.

- The guard is in `ProgressTracker.UpdatePivot` (`Diff >= StateMinDistanceFromHead`, default 32), not on `IStateSyncPivot`, which `TreeSync.ResetStateRootToBestSuggested` and `StateSyncRunner` still need unrestricted. `IStateSyncPivot.Diff` saturates, so a head behind the pivot reads 0 and is suppressed rather than wrapping into a large distance.
- **`SnapSyncFeed` is unchanged in behaviour.** An earlier revision had `UpdatePivot` return whether the move happened and made the repeat-offender guard skip both arming and punishment on a decline. Adversarial review showed that regresses the guard into uselessness: `UpdateHeaderForcefully` was *already* a no-op whenever the head had not advanced, yet base armed and punished anyway — and that punishment is the only defence against the allocator re-picking a fastest-but-useless snap peer (`BySpeedStrategy`, 2.5 % re-discovery). Gating on an actual move would rate-limit the punishment to once per 32 block-times, and disable it entirely on a chain whose head is standing still. The guard therefore arms on the **request**, exactly as before, and `UpdatePivot` stays `void` — so this PR no longer breaks that interface at all. The decline is observable in the two metrics instead.
- No stall is introduced. The guard only changes the `1 <= Diff <= 31` window, where base moved the pivot by 1–31 blocks; a root that stale is not made servable by moving 31 blocks forward, and `BestSuggestedHeader` already lags peers' heads. `Diff == 0` was a no-op on base too in the ordinary case, so "head not advancing" behaves identically before and after - with one exception: under a same-height reorg `Diff` is still 0 but `FindHeader(number)` returns a different canonical header, so base would re-pivot onto the new branch and the guard suppresses that until the head advances 32. Self-resolving on a live chain, and `GetPivotHeader`'s natural re-pivot at 96 is no faster. The natural re-pivot (`Diff >= Max - Min`, 96), the `!IsMainChain` reorg branch, `TreeSync.ResetStateRootToBestSuggested`, `TreeSync.IsSyncRoundFinished` and `StateSyncRunner.RunBalHealing` all still fire unchanged.
- `UpdateHeaderForcefully` is a no-op on `XdcStateSyncPivot`, so XDC is unaffected, and the natural re-pivot at 96 keeps the forced path at 32 meaningfully earlier. Setting `Sync.StateMinDistanceFromHead` to 0 disables the rate limit and restores exact base behaviour.

## API surface — newly public

- `PathWithAccount.EmptyStorageResponses`: new public mutable field, snap bookkeeping, not part of `ToRlpValue`. Purely additive.

No signature is changed, so nothing here is source-breaking.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

New coverage across `SnapProviderTests`, `ProgressTrackerTests`, `AnalyzeResponsePerPeerTests` and `StateSyncPivotTest`: the streak, the cap, the reset on promotion, the turned-away tail, both arms of the scheduling change, the `Warn` lane, the `ulong` underflow case on the #13200 guard, and `UpdateHeaderForcefully_still_follows_the_head_by_a_single_block` pinning the behaviour that must **not** change. 11 existing `AnalyzeResponsePerPeerTests` now pin the substituted pivot to `true` — NSubstitute's default `false` for the new `bool UpdatePivot()` would silently take the declined-move branch.

Each behavioural fix is pinned by removing only itself:

| removed | tests that fail |
|---|---|
| the refresh cap | `Will_not_let_account_refreshes_take_every_dispatcher_slot` |
| the over-cap fallback arm | `Will_still_serve_account_refreshes_over_the_cap_when_nothing_else_is_queued` |
| `if (!pivotMoved) break;` | `Does_not_punish_the_only_peer_when_the_pivot_declined_to_move`, `Still_punishes_the_offender_armed_before_the_pivot_started_declining` |
| the streak reset on promotion | `AddStorageRange_EmptyResponseStreak_StartsOverAfterEachPromotion` |
| the `Warn` gate (`warn: true`) | `AddStorageRange_EmptyResponseStreak_OnlyWarnsForALargeStorageContinuation` |
| arming the offender guard on the request | `Punishes_the_offender_even_when_the_pivot_never_moves` |
| `OnCompletedLargeStorage` before the origin-0 re-enqueue | `RefreshAccounts_AccountRestartsFromOrigin_ClearsItsStaleLargeStorageProgress` |
| the streak reset on a served response | `AddStorageRange_ServedResponse_EndsTheEmptyStreak` |

`Nethermind.Synchronization.Test`: **2643 total / 0 failed / 393 skipped**, debug build 0 warnings / 0 errors.

Both mechanisms were validated on the 2.0.0-rc soak fleet before the split — mainnet snap sync completed in 8h02m with the recovery path firing 6 times, and the OP forced-pivot count went from 74,469 in 60 h to 0 with natural re-pivoting restored. Those runs were on earlier revisions; review has changed the mechanism of both since, so **this revision has not been run on a node**.

## Documentation

#### Requires documentation update

- [x] Yes

Three new metrics: `SnapStorageRangesRefreshedAfterEmptyResponses`, `ForcedStatePivotUpdates`, `ForcedStatePivotUpdatesSuppressed`. `Sync.StateMinDistanceFromHead`'s `ConfigItem` description now names its second role, so an operator lowering it is warned that it re-enables the forced-pivot chase.

#### Requires explanation in Release Notes

- [x] Yes

Snap large-storage stall, OP snap pivot livelock, plus a new Warn on a stalled large-storage account.

## Remarks

- An adversarial review found a diagnostic leak that is now fixed: a `Verified` refresh with storage that resumes from origin 0 goes back to the multi-account batching queue, where `OnCompletedLargeStorage` never fires — so a previously-tracked account kept counting towards "Large storage left" for the rest of the sync, which is the exact signal #13155 was diagnosed by. The arm now clears the stale entry before re-enqueuing; `TryDequeNextSlotRange` re-registers it if the re-download turns out to be large again.
- `EnableSnapSyncStorageRangeSplit` defaults to **false**, so under default config each large account has exactly one range in flight and the shared-counter semantics below are opt-in.
- The streak counter is shared by all split partitions of an account, so a 4-way split trips the threshold after ~3 responses each and one served partition ends it for all; accepted, and documented as the intended semantics. Both halves in `EnqueueNextSlot` start at `IncrementPath()`, so a promotion cannot lose a partition's `LimitHash` — only genuinely start-at-zero ranges reach `EnqueueAccountStorage`, and those always carry `MaxValue`/null limits.
- `ForcedStatePivotUpdates` counts requests that passed the rate limit, not moves: `UpdateHeaderForcefully` can still decline (unchanged header hash, `Sync.StaticSnapPivot`, empty body on XDC).
- The cap bounds the *width* of the displacing set — memory, distinct healing entries, how many accounts are in it — not its *duration*. Under a genuinely stale root each refresh answers `Expired` and re-queues, so the queue sits at the cap until the pivot moves; the duration is bounded by chain progress through #13200's own guard, and in the all-peers-stale case the displaced range work would have returned empty anyway.
- #13200 does not make OP snap sync succeed. It removes the chase loop and restores natural re-pivoting; the node it was measured on still reached 0.00 % because its peer set was ~2.6M blocks stale and every snap request timed out.

