### PR TITLE
ci: point the sync-validation Slack alert at the webhook secret that exists

### DIFF
--- a/.github/workflows/sync-master-validation.yml
+++ b/.github/workflows/sync-master-validation.yml
@@ -1,5 +1,4 @@
-# NOTE: Requires repository secret SLACK_SYNC_WEBHOOK_URL for failure notifications.
-# Create a Slack incoming webhook and add it as a repo secret.
+# NOTE: Requires repository secret SLACK_WEBHOOK_URL for failure notifications.
 
 name: Sync Master Validation
 
@@ -206,7 +205,7 @@ jobs:
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
-          webhook: ${{ secrets.SLACK_SYNC_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {


### PR DESCRIPTION
## Changes

- Point the `notify-on-failure` job in `sync-master-validation.yml` at `SLACK_WEBHOOK_URL` instead of `SLACK_SYNC_WEBHOOK_URL`, which does not exist as a repository or organization secret
- Drop the now-stale header line instructing to create the webhook secret

An unset secret interpolates to an empty string, and `slackapi/slack-github-action@v2` drops empty inputs — the `with:` block reaching the action carried no `webhook` at all, so its config validator threw before any request was made:

```
##[error]Missing input! Either a method or webhook is required to take action.
    at Config.validate (.../src/config.js:193)
```

The consequence is that no sync failure on master has ever paged Slack since the notify job was added. The most recent one — `Sync gnosis (Flat) / sync`, failed after 2h0m42s on `014462b` in [run 34166477350](https://github.com/NethermindEth/nethermind/actions/runs/34166477350) — went unreported.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

The alert path cannot be exercised without a genuine sync failure on master, and firing a test webhook would page the channel. Verified statically instead: `gh secret list` and the organization-secrets API confirm `SLACK_WEBHOOK_URL` is the only Slack incoming webhook available to this repository, and the workflow YAML still parses.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

