### PR TITLE
fix(txpool): count a leading SENDER frame's value and pin the gas filter's spec

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
@@ -427,21 +427,41 @@ public class FrameTxPayerExposureFilterTests
         Assert.That(result, Is.EqualTo(rejected ? AcceptTxResult.InsufficientFunds : AcceptTxResult.Accepted));
     }
 
-    // TXPARAM(0x06) prices gas alone, so the wei a SENDER frame moves sits outside it. One in the leading static
-    // run needs the balance to already hold it; one behind a DEFAULT frame may be funded by what that frame does.
-    [TestCase(0, false, false, TestName = "the sender covers the fee and the leading frame's value")]
-    [TestCase(-1, true, false, TestName = "the sender falls one wei short of the leading frame's value")]
-    [TestCase(-1, false, true, TestName = "a SENDER frame an earlier DEFAULT frame could fund is not summed")]
-    public void Accept_SelfPayingSender_CountsTheValueOfALeadingSenderFrame(int balanceDelta, bool rejected, bool creditable)
+    /// <summary>Where the SENDER frame whose value is bounded sits, relative to the validation prefix.</summary>
+    public enum SenderFramePosition
+    {
+        /// <summary>[self_verify, user_op]: the basic self-relay layout.</summary>
+        BehindTheApprovingFrame,
+
+        /// <summary>[deploy, self_verify, user_op]: the deploy-new-account layout, EIP-8141's other self-relay prefix.</summary>
+        BehindThePrologueDeployFrame,
+
+        /// <summary>[expiry_verify, deploy, self_verify, user_op]: the same, behind the optional expiry frame.</summary>
+        BehindTheExpiryAndDeployFrames,
+
+        /// <summary>[self_verify, DEFAULT, user_op]: a DEFAULT frame past the prefix runs arbitrary code.</summary>
+        BehindAPostPrefixDefaultFrame,
+    }
+
+    // TXPARAM(0x06) prices gas alone, so the wei a SENDER frame moves sits outside it. One in the leading prologue
+    // needs the balance to already hold it; one behind a DEFAULT frame the prefix does not cover may be funded by
+    // what that frame does. Payer-less and self-paid alike: neither leg reserves the sender's value anywhere else.
+    [TestCase(0, false, SenderFramePosition.BehindTheApprovingFrame, false, TestName = "the sender covers the fee and the leading frame's value")]
+    [TestCase(-1, true, SenderFramePosition.BehindTheApprovingFrame, false, TestName = "the sender falls one wei short of the leading frame's value")]
+    [TestCase(0, false, SenderFramePosition.BehindTheApprovingFrame, true, TestName = "a payer-less sender covers the fee and the leading frame's value")]
+    [TestCase(-1, true, SenderFramePosition.BehindTheApprovingFrame, true, TestName = "a payer-less sender falls one wei short of the leading frame's value")]
+    [TestCase(-1, true, SenderFramePosition.BehindThePrologueDeployFrame, false, TestName = "a deploy frame opening the prefix moves no wei, so the value is still summed")]
+    [TestCase(-1, true, SenderFramePosition.BehindTheExpiryAndDeployFrames, false, TestName = "an expiry frame ahead of that deploy frame does not lift the bound either")]
+    [TestCase(-1, true, SenderFramePosition.BehindThePrologueDeployFrame, true, TestName = "a payer-less deploy-and-use layout is bounded too")]
+    [TestCase(-1, false, SenderFramePosition.BehindAPostPrefixDefaultFrame, false, TestName = "a SENDER frame a post-prefix DEFAULT frame could fund is not summed")]
+    public void Accept_SelfPayingSender_CountsTheValueOfALeadingSenderFrame(int balanceDelta, bool rejected, SenderFramePosition position, bool payerless)
     {
         const int frameValue = 4_000;
         TxFrame senderFrame = new(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressC, FrameTxTestFrames.PrefixFrameGas, (UInt256)frameValue, default);
-        Transaction tx = creditable
-            ? FrameTxTestFrames.FrameTx(FrameTxTestFrames.SelfVerify(), FrameTxTestFrames.Deploy(), senderFrame)
-            : FrameTxTestFrames.FrameTx(FrameTxTestFrames.SelfVerify(), senderFrame);
+        Transaction tx = FrameTxTestFrames.FrameTx(FramesFor(position, senderFrame));
         tx.DecodedMaxFeePerGas = UInt256.One;
         tx.Hash = TestItem.KeccakA;
-        tx.PayerAddress = TestItem.AddressA;
+        tx.PayerAddress = payerless ? null : TestItem.AddressA;
 
         // Priced off the fixture rather than a literal, so this pins the bound and not the gas schedule.
         Assert.That(FrameTxValidation.TryCalculateMaxCost(tx, Spec, out UInt256 maxCost), Is.True);
@@ -451,12 +471,51 @@ public class FrameTxPayerExposureFilterTests
         PayerExposureCache cache = new();
         AcceptTxResult result = Accept(new TestReadOnlyStateProvider(), cache, tx, senderAccounts);
 
-        UInt256 expectedReserved = rejected ? UInt256.Zero : creditable ? maxCost : maxCost + (UInt256)frameValue;
+        UInt256 expectedPriced = position == SenderFramePosition.BehindAPostPrefixDefaultFrame ? maxCost : maxCost + (UInt256)frameValue;
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result, Is.EqualTo(rejected ? AcceptTxResult.InsufficientFunds : AcceptTxResult.Accepted));
-            Assert.That(cache.GetReserved(TestItem.AddressA), Is.EqualTo(expectedReserved),
-                "an admitted leading SENDER frame holds its value alongside the fee, so the bucket sums it next time");
+            // The payer-less leg records the price without reserving it; that record is what the bucket walk sums.
+            Assert.That(tx.PayerExposure, rejected ? Is.Null : Is.EqualTo(expectedPriced),
+                "an admitted leading SENDER frame is priced with its value alongside the fee");
+            Assert.That(cache.GetReserved(TestItem.AddressA), Is.EqualTo(rejected || payerless ? UInt256.Zero : expectedPriced));
+        }
+    }
+
+    private static TxFrame[] FramesFor(SenderFramePosition position, TxFrame senderFrame) => position switch
+    {
+        SenderFramePosition.BehindThePrologueDeployFrame => [FrameTxTestFrames.Deploy(), FrameTxTestFrames.SelfVerify(), senderFrame],
+        SenderFramePosition.BehindTheExpiryAndDeployFrames => [FrameTxTestFrames.Expiry(), FrameTxTestFrames.Deploy(), FrameTxTestFrames.SelfVerify(), senderFrame],
+        SenderFramePosition.BehindAPostPrefixDefaultFrame => [FrameTxTestFrames.SelfVerify(), FrameTxTestFrames.Deploy(), senderFrame],
+        _ => [FrameTxTestFrames.SelfVerify(), senderFrame],
+    };
+
+    // The sponsor's reservation prices gas alone, so folding the sender's value into it would gate the wrong
+    // account: the same frame must meet the same balance requirement whoever pays the fee.
+    [TestCase(0, false, TestName = "a sponsored sender holds the leading frame's value")]
+    [TestCase(-1, true, TestName = "a sponsored sender falls one wei short of it")]
+    public void Accept_SponsoredFrameTx_HoldsTheSenderToItsOwnLeadingFrameValue(int balanceDelta, bool rejected)
+    {
+        const int frameValue = 4_000;
+        TxFrame senderFrame = new(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressC, FrameTxTestFrames.PrefixFrameGas, (UInt256)frameValue, default);
+        Transaction tx = FrameTxTestFrames.FrameTx(FrameTxTestFrames.OnlyVerify(), FrameTxTestFrames.Pay(Payer), senderFrame);
+        tx.DecodedMaxFeePerGas = UInt256.One;
+        tx.Hash = TestItem.KeccakA;
+        tx.PayerAddress = Payer;
+
+        // The sponsor is funded well past the fee, so only the sender's own balance can decide this.
+        Assert.That(FrameTxValidation.TryCalculateMaxCost(tx, Spec, out UInt256 maxCost), Is.True);
+        TestReadOnlyStateProvider senderAccounts = new();
+        senderAccounts.CreateAccount(TestItem.AddressA, (UInt256)(frameValue + balanceDelta));
+
+        PayerExposureCache cache = new();
+        AcceptTxResult result = Accept(StateWithPayerBalance(long.MaxValue), cache, tx, senderAccounts);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(rejected ? AcceptTxResult.InsufficientFunds : AcceptTxResult.Accepted));
+            Assert.That(cache.GetReserved(Payer), Is.EqualTo(rejected ? UInt256.Zero : maxCost),
+                "the sponsor still reserves the fee alone, the sender's value never being its liability");
         }
     }
 
@@ -699,14 +758,12 @@ public class FrameTxPayerExposureFilterTests
     private static AcceptTxResult Accept(TestReadOnlyStateProvider state, PayerExposureCache cache, Transaction tx, IAccountStateProvider? senderAccounts = null, TxDistinctSortedPool? pending = null,
         TxHandlingOptions handlingOptions = TxHandlingOptions.None)
     {
-        IChainHeadSpecProvider specProvider = Substitute.For<IChainHeadSpecProvider>();
-        specProvider.GetCurrentHeadSpec().Returns(Spec);
-
         // The displaced tx sits in whichever pool matches its shape, so both are wired as TxPool does.
         (TxDistinctSortedPool standard, TxDistinctSortedPool blob) = tx.CarriesBlobs
             ? (Pool(blobs: false), pending ?? Pool(blobs: true))
             : (pending ?? Pool(blobs: false), Pool(blobs: true));
-        FrameTxPayerExposureFilter filter = new(specProvider, state, standard, blob, cache, LimboLogs.Instance.GetClassLogger<FrameTxPayerExposureFilterTests>());
+        // The filter takes no spec provider, so the spec below is the only one it can price against.
+        FrameTxPayerExposureFilter filter = new(state, standard, blob, cache, LimboLogs.Instance.GetClassLogger<FrameTxPayerExposureFilterTests>());
         TxFilteringState filteringState = new(tx, senderAccounts ?? Substitute.For<IAccountStateProvider>(), Spec);
         return filter.Accept(tx, ref filteringState, handlingOptions);
     }

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerExposureFilterTests.cs
@@ -427,6 +427,39 @@ public class FrameTxPayerExposureFilterTests
         Assert.That(result, Is.EqualTo(rejected ? AcceptTxResult.InsufficientFunds : AcceptTxResult.Accepted));
     }
 
+    // TXPARAM(0x06) prices gas alone, so the wei a SENDER frame moves sits outside it. One in the leading static
+    // run needs the balance to already hold it; one behind a DEFAULT frame may be funded by what that frame does.
+    [TestCase(0, false, false, TestName = "the sender covers the fee and the leading frame's value")]
+    [TestCase(-1, true, false, TestName = "the sender falls one wei short of the leading frame's value")]
+    [TestCase(-1, false, true, TestName = "a SENDER frame an earlier DEFAULT frame could fund is not summed")]
+    public void Accept_SelfPayingSender_CountsTheValueOfALeadingSenderFrame(int balanceDelta, bool rejected, bool creditable)
+    {
+        const int frameValue = 4_000;
+        TxFrame senderFrame = new(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressC, FrameTxTestFrames.PrefixFrameGas, (UInt256)frameValue, default);
+        Transaction tx = creditable
+            ? FrameTxTestFrames.FrameTx(FrameTxTestFrames.SelfVerify(), FrameTxTestFrames.Deploy(), senderFrame)
+            : FrameTxTestFrames.FrameTx(FrameTxTestFrames.SelfVerify(), senderFrame);
+        tx.DecodedMaxFeePerGas = UInt256.One;
+        tx.Hash = TestItem.KeccakA;
+        tx.PayerAddress = TestItem.AddressA;
+
+        // Priced off the fixture rather than a literal, so this pins the bound and not the gas schedule.
+        Assert.That(FrameTxValidation.TryCalculateMaxCost(tx, Spec, out UInt256 maxCost), Is.True);
+        TestReadOnlyStateProvider senderAccounts = new();
+        senderAccounts.CreateAccount(TestItem.AddressA, maxCost + (UInt256)(frameValue + balanceDelta));
+
+        PayerExposureCache cache = new();
+        AcceptTxResult result = Accept(new TestReadOnlyStateProvider(), cache, tx, senderAccounts);
+
+        UInt256 expectedReserved = rejected ? UInt256.Zero : creditable ? maxCost : maxCost + (UInt256)frameValue;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result, Is.EqualTo(rejected ? AcceptTxResult.InsufficientFunds : AcceptTxResult.Accepted));
+            Assert.That(cache.GetReserved(TestItem.AddressA), Is.EqualTo(expectedReserved),
+                "an admitted leading SENDER frame holds its value alongside the fee, so the bucket sums it next time");
+        }
+    }
+
     // Result equality is by id, so nothing else here would notice the split; a remote submitter never reads the
     // detail, and composing it on the path an unfunded flood walks is what the sibling filters guard against.
     [TestCase(false, TxHandlingOptions.None, false, TestName = "a remote self-paid rejection is message-free")]

--- a/src/Nethermind/Nethermind.TxPool.Test/GasLimitTxFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/GasLimitTxFilterTests.cs
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.TxPool.Filters;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.TxPool.Test;
+
+/// <summary>The pre-hash block-gas gate, which prices an EIP-8141 frame transaction's block reservations.</summary>
+public class GasLimitTxFilterTests
+{
+    private const ulong OrdinaryGasLimit = 21_000;
+
+    // EIP-2780 charges a value-bearing frame, so the two specs price one transaction differently and the
+    // verdict says which was used. The pinned one is the whole submission's, however the head has since moved.
+    [TestCase(true, false, TestName = "the pinned spec is the charging one")]
+    [TestCase(false, true, TestName = "the head has moved to the charging one")]
+    public void Accept_FrameTx_JudgesItAgainstTheSpecPinnedForTheSubmission(bool pinnedCharges, bool headCharges)
+    {
+        ReleaseSpec lenient = SpecCharging(false);
+        Assert.That(FrameTxValidation.TryCalculateBlockGasReservations(ValueBearingFrameTx(), lenient, out ulong affordable, out _), Is.True);
+        Assert.That(FrameTxValidation.TryCalculateBlockGasReservations(ValueBearingFrameTx(), SpecCharging(true), out ulong charged, out _), Is.True);
+        Assert.That(charged, Is.GreaterThan(affordable), "the two specs must disagree, or this pins nothing");
+
+        // Exactly the lenient reservation: the charging spec is the only one that overshoots it.
+        AcceptTxResult result = Accept(ValueBearingFrameTx(), affordable, SpecCharging(pinnedCharges), SpecCharging(headCharges));
+
+        Assert.That(result, Is.EqualTo(pinnedCharges ? AcceptTxResult.GasLimitExceeded : AcceptTxResult.Accepted));
+    }
+
+    [Test]
+    public void Accept_OrdinaryTx_ReadsNoSpecAtAll()
+    {
+        // Every pre-fork transaction walks this filter, and only a frame transaction has a budget to price.
+        IChainHeadSpecProvider specProvider = Substitute.For<IChainHeadSpecProvider>();
+        Transaction tx = Build.A.Transaction.WithGasLimit(OrdinaryGasLimit).TestObject;
+
+        AcceptTxResult result = Accept(tx, OrdinaryGasLimit, SpecCharging(false), specProvider);
+
+        Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+        specProvider.DidNotReceive().GetCurrentHeadSpec();
+    }
+
+    // Negative control: the ordinary leg reads no spec either way, so its verdict is unmoved by all of the above.
+    [TestCase(OrdinaryGasLimit, false, TestName = "an ordinary tx at the block gas limit")]
+    [TestCase(OrdinaryGasLimit - 1, true, TestName = "an ordinary tx over the block gas limit")]
+    public void Accept_OrdinaryTx_GatesOnTheBlockGasLimit(ulong blockGasLimit, bool rejected)
+    {
+        Transaction tx = Build.A.Transaction.WithGasLimit(OrdinaryGasLimit).TestObject;
+
+        AcceptTxResult result = Accept(tx, blockGasLimit, SpecCharging(false), SpecCharging(true));
+
+        Assert.That(result, Is.EqualTo(rejected ? AcceptTxResult.GasLimitExceeded : AcceptTxResult.Accepted));
+    }
+
+    private static ReleaseSpec SpecCharging(bool valueTransfers) => new() { IsEip2780Enabled = valueTransfers };
+
+    /// <summary>A frame transaction whose SENDER frame moves wei to a third party, which EIP-2780 prices.</summary>
+    private static Transaction ValueBearingFrameTx() => FrameTxTestFrames.FrameTx(
+        FrameTxTestFrames.SelfVerify(),
+        new TxFrame(TxFrame.ModeSender, TxFrame.ApproveScopeNone, TestItem.AddressC, OrdinaryGasLimit, UInt256.One, default));
+
+    private static AcceptTxResult Accept(Transaction tx, ulong blockGasLimit, IReleaseSpec pinnedSpec, IReleaseSpec headSpec)
+    {
+        IChainHeadSpecProvider specProvider = Substitute.For<IChainHeadSpecProvider>();
+        specProvider.GetCurrentHeadSpec().Returns(headSpec);
+        return Accept(tx, blockGasLimit, pinnedSpec, specProvider);
+    }
+
+    private static AcceptTxResult Accept(Transaction tx, ulong blockGasLimit, IReleaseSpec pinnedSpec, IChainHeadSpecProvider specProvider)
+    {
+        IChainHeadInfoProvider headInfo = Substitute.For<IChainHeadInfoProvider>();
+        headInfo.BlockGasLimit.Returns(blockGasLimit);
+        headInfo.SpecProvider.Returns(specProvider);
+
+        GasLimitTxFilter filter = new(headInfo, new TxPoolConfig(), LimboLogs.Instance);
+        TxFilteringState state = new(tx, Substitute.For<IAccountStateProvider>(), pinnedSpec);
+        return filter.Accept(tx, ref state, TxHandlingOptions.None);
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
@@ -17,10 +17,11 @@ namespace Nethermind.TxPool.Filters;
 /// only affordability gate a frame transaction meets: the sender-balance filters skip them, since their fees are
 /// the payer's liability. Whenever the sender is what pays — its own prefix, or one no payer resolved for — the
 /// bound the sibling filters held is taken here instead, over the sender's whole pending bucket rather than this
-/// transaction alone, so nothing the ledger cannot see goes unsummed. A free transaction is carved out of the
-/// zero-balance leg only, not of the bound: exempting the branch would skip the reservation along with it.</remarks>
+/// transaction alone, so nothing the ledger cannot see goes unsummed. A sponsored transaction is bounded against
+/// both accounts, the sponsor owing the fee and the sender the wei its own frames move. A free transaction is
+/// carved out of the zero-balance leg only, not of the bound: exempting the branch would skip the reservation
+/// along with it.</remarks>
 internal sealed class FrameTxPayerExposureFilter(
-    IChainHeadSpecProvider specProvider,
     IReadOnlyStateProvider stateProvider,
     TxDistinctSortedPool standardPool,
     TxDistinctSortedPool blobPool,
@@ -35,8 +36,9 @@ internal sealed class FrameTxPayerExposureFilter(
         }
 
         // The upper-bound TXPARAM(0x06), priced with the processor's helper so the admission bound
-        // and the payer-solvency gate cannot drift.
-        IReleaseSpec spec = specProvider.GetCurrentHeadSpec();
+        // and the payer-solvency gate cannot drift. The spec pinned for the submission, not the head's:
+        // a head that moves mid-pipeline would price this against rules AddCore never validated the pool for.
+        IReleaseSpec spec = state.HeadSpec;
         if (!FrameTxValidation.TryCalculateMaxCost(tx, spec, out UInt256 maxCost))
         {
             // Unincludable rather than malformed: Invalid is the one result that disconnects the relaying peer.
@@ -89,6 +91,15 @@ internal sealed class FrameTxPayerExposureFilter(
         {
             // A simulated third-party payer must be read from state, or the bound gates the wrong account.
             balance = stateProvider.TryGetAccount(payer, out AccountStruct payerAccount) ? payerAccount.Balance : UInt256.Zero;
+
+            // A sponsor's reservation covers the fee alone, leaving the leading frame's wei owed by the sender
+            // whoever pays: bounded against the sender here, as the branch above bounds it there.
+            UInt256 senderValue = LeadingSenderFrameValue(tx);
+            UInt256 senderBalance = state.SenderAccount.Balance;
+            if (senderValue > senderBalance)
+            {
+                return RejectUnderfundedSender(tx, UInt256.Zero, senderValue, senderBalance, txHandlingOptions);
+            }
         }
 
         // AddCore settles the replacement later. The discount is ignored with no reservation held, so skip the walk.
@@ -106,17 +117,21 @@ internal sealed class FrameTxPayerExposureFilter(
     }
 
     /// <summary>The wei <paramref name="tx"/>'s SENDER frames move that its sender must already hold.</summary>
-    /// <remarks>Frames run in order and only VERIFY and POST_TX frames are static, so every other frame may credit
-    /// the sender before the frames behind it run — a SENDER frame's own target included, once that frame's value
-    /// has moved. The first frame past the leading static run is therefore the only one this balance bounds;
-    /// summing the rest would refuse a transaction whose later frames are funded by its earlier ones. An
-    /// underfunded SENDER frame reverts rather than invalidating the transaction, so the residue is pool quality.</remarks>
+    /// <remarks>Frames run in order, so the first frame able to credit the sender ends what a balance bounds:
+    /// summing past it would refuse a transaction whose later frames are funded by its earlier ones. VERIFY and
+    /// POST_TX frames are static, and the deploy frame EIP-8141's prologue admits — the only non-static frame a
+    /// recognized validation prefix contains — moves no wei either: a non-SENDER frame's value must be zero, and
+    /// the mempool trace rules bar the prefix from any value-carrying call, endowed create or SELFDESTRUCT. The
+    /// first frame past that prologue is therefore the one this bounds; skipping it would leave the deploy-and-use
+    /// layout, a sender's first transaction, outside every balance the pool applies. An underfunded SENDER frame
+    /// reverts rather than invalidating the transaction, so the residue is pool quality.</remarks>
     private static UInt256 LeadingSenderFrameValue(Transaction tx)
     {
-        foreach (TxFrame frame in tx.Frames!)
+        TxFrame[] frames = tx.Frames!;
+        for (int i = FrameTxValidation.ApprovalSearchStart(frames); i < frames.Length; i++)
         {
-            if (frame.Mode is TxFrame.ModeVerify or TxFrame.ModePostTx) continue;
-            return frame.Mode == TxFrame.ModeSender ? frame.Value : UInt256.Zero;
+            if (frames[i].Mode is TxFrame.ModeVerify or TxFrame.ModePostTx) continue;
+            return frames[i].Mode == TxFrame.ModeSender ? frames[i].Value : UInt256.Zero;
         }
 
         return UInt256.Zero;

--- a/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/FrameTxPayerExposureFilter.cs
@@ -44,9 +44,17 @@ internal sealed class FrameTxPayerExposureFilter(
         }
 
         Address? payer = tx.PayerAddress;
+        UInt256 cost = maxCost;
         UInt256 balance;
         if (payer is null || payer == tx.SenderAddress)
         {
+            // TXPARAM(0x06) prices gas alone, so wherever the sender is also what pays, the wei its own frames
+            // move is added to the bound. Only the part no earlier frame could have funded: see the helper.
+            if (UInt256.AddOverflow(maxCost, LeadingSenderFrameValue(tx), out cost))
+            {
+                return AcceptTxResult.Int256Overflow.WithMessage("Frame transaction maximum cost cannot be priced");
+            }
+
             AccountStruct sender = state.SenderAccount;
             // The sender-balance filters defer to this one, so their cumulative bound is taken here. Only what
             // the payer ledger does not already sum is counted, or a self-paid reservation would count twice.
@@ -63,7 +71,7 @@ internal sealed class FrameTxPayerExposureFilter(
             // hold even at zero cost, or a zero-fee prefix buys a pool slot no account could have paid for.
             if (pending > sender.Balance || (sender.Balance.IsZero && !tx.IsFree()))
             {
-                return RejectUnderfundedSender(tx, pending, maxCost, sender.Balance, txHandlingOptions);
+                return RejectUnderfundedSender(tx, pending, cost, sender.Balance, txHandlingOptions);
             }
 
             balance = sender.Balance - pending;
@@ -71,9 +79,9 @@ internal sealed class FrameTxPayerExposureFilter(
             {
                 // Nothing to reserve against, so the sender bound is the whole gate. The price is still recorded:
                 // it is what the bound above sums this transaction at once it is one of the pending ones.
-                if (maxCost > balance) return RejectUnderfundedSender(tx, pending, maxCost, sender.Balance, txHandlingOptions);
+                if (cost > balance) return RejectUnderfundedSender(tx, pending, cost, sender.Balance, txHandlingOptions);
 
-                tx.PayerExposure = maxCost;
+                tx.PayerExposure = cost;
                 return AcceptTxResult.Accepted;
             }
         }
@@ -85,16 +93,33 @@ internal sealed class FrameTxPayerExposureFilter(
 
         // AddCore settles the replacement later. The discount is ignored with no reservation held, so skip the walk.
         Hash256? replaced = exposure.GetReserved(payer).IsZero ? null : PendingReplacement.Find(tx, standardPool, blobPool)?.Hash;
-        if (!exposure.TryReserve(payer, tx.Hash!, maxCost, balance, out UInt256 reserved, replaced))
+        if (!exposure.TryReserve(payer, tx.Hash!, cost, balance, out UInt256 reserved, replaced))
         {
             return payer == tx.SenderAddress
-                ? RejectUnderfundedSender(tx, reserved, maxCost, balance, txHandlingOptions)
-                : RejectOverExposed(tx, payer, reserved, maxCost, balance);
+                ? RejectUnderfundedSender(tx, reserved, cost, balance, txHandlingOptions)
+                : RejectOverExposed(tx, payer, reserved, cost, balance);
         }
 
         // Recorded for the restart-time restore; the ledger owns what a removal releases.
-        tx.PayerExposure = maxCost;
+        tx.PayerExposure = cost;
         return AcceptTxResult.Accepted;
+    }
+
+    /// <summary>The wei <paramref name="tx"/>'s SENDER frames move that its sender must already hold.</summary>
+    /// <remarks>Frames run in order and only VERIFY and POST_TX frames are static, so every other frame may credit
+    /// the sender before the frames behind it run — a SENDER frame's own target included, once that frame's value
+    /// has moved. The first frame past the leading static run is therefore the only one this balance bounds;
+    /// summing the rest would refuse a transaction whose later frames are funded by its earlier ones. An
+    /// underfunded SENDER frame reverts rather than invalidating the transaction, so the residue is pool quality.</remarks>
+    private static UInt256 LeadingSenderFrameValue(Transaction tx)
+    {
+        foreach (TxFrame frame in tx.Frames!)
+        {
+            if (frame.Mode is TxFrame.ModeVerify or TxFrame.ModePostTx) continue;
+            return frame.Mode == TxFrame.ModeSender ? frame.Value : UInt256.Zero;
+        }
+
+        return UInt256.Zero;
     }
 
     /// <remarks>Atomic: this filter runs under the pool's head read lock, so payers reject concurrently.</remarks>

--- a/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GasLimitTxFilter.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Nethermind.Core;
-using Nethermind.Core.Specs;
 using Nethermind.Logging;
 
 namespace Nethermind.TxPool.Filters
@@ -21,12 +20,13 @@ namespace Nethermind.TxPool.Filters
         {
             ulong gasLimit = Math.Min(chainHeadInfoProvider.BlockGasLimit ?? ulong.MaxValue, _configuredGasLimit);
 
-            IReleaseSpec spec = chainHeadInfoProvider.SpecProvider.GetCurrentHeadSpec();
             bool exceedsLimit;
             ulong rejectedBudget;
             if (tx.SupportsFrames)
             {
-                bool calculated = FrameTxValidation.TryCalculateBlockGasReservations(tx, spec, out ulong executionReservation, out ulong stateReservation);
+                // The spec pinned for the submission, not the head's: a head that moves mid-pipeline would
+                // otherwise price this transaction under rules no other filter, nor AddCore, judged it by.
+                bool calculated = FrameTxValidation.TryCalculateBlockGasReservations(tx, state.HeadSpec, out ulong executionReservation, out ulong stateReservation);
                 rejectedBudget = calculated ? Math.Max(executionReservation, stateReservation) : ulong.MaxValue;
                 exceedsLimit = !calculated || executionReservation > gasLimit || stateReservation > gasLimit;
             }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -308,7 +308,7 @@ namespace Nethermind.TxPool
 
             // EIP-8141: must follow both resolvers — it prices whichever payer they recorded, and a
             // second registration would reserve every frame tx's cost twice.
-            postHashFilters.Add(new FrameTxPayerExposureFilter(_specProvider, chainHeadInfoProvider.ReadOnlyStateProvider, _transactions, _blobTransactions, _payerExposure, _logger));
+            postHashFilters.Add(new FrameTxPayerExposureFilter(chainHeadInfoProvider.ReadOnlyStateProvider, _transactions, _blobTransactions, _payerExposure, _logger));
 
             _postHashFilters = postHashFilters.ToArray();
 


### PR DESCRIPTION
## Changes

Addresses two review threads on #12526, both on pool filters.

**`FrameTxPayerExposureFilter` — SENDER frame value.** This filter is the single affordability gate a frame transaction meets, and `FrameTxValidation.TryCalculateMaxCost` is `maxGas * maxFeePerGas + blobGas * maxFeePerBlobGas` — gas only. `FrameTxDecoder` never populates `Transaction.Value`, and `IsOverflowWhenAddingPricedCostToCumulative` prefers `PayerExposure` over the `+ tx.Value` leg, so the wei a SENDER frame moves was outside every balance bound the pool applies.

The sender-funded and payer-less legs now add the part of that value the sender's balance certainly has to hold: the value of the first frame past the leading run of static (VERIFY / POST_TX) frames, when that frame is a SENDER one. Nothing behind it is soundly checkable — frames run in order, and any non-static frame may credit the sender before the frames after it, a SENDER frame's own target included once that frame's value has moved. Summing them all would refuse transactions whose later frames are funded by their earlier ones. The figure is used for the gate, the ledger reservation and the recorded price alike, so a pending frame transaction is now summed at it by `BalanceTooLowFilter` and the retention sweep too.

**`GasLimitTxFilter` — pinned spec.** It re-read `SpecProvider.GetCurrentHeadSpec()` rather than `TxFilteringState.HeadSpec`, the spec captured once for the submission and the one `AddCore` compares against `_validatedSpec`. The read also sat ahead of the `tx.SupportsFrames` branch, so every pre-fork transaction paid a spec lookup in a pre-hash filter that previously touched no spec. Both go away by moving the read inside the frame branch and taking it from the pinned state.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: <!--Description-->

## Testing

Every behaviour change has a red/green pair reverting only that change, plus a negative control green in both states.

- `FrameTxPayerExposureFilterTests.Accept_SelfPayingSender_CountsTheValueOfALeadingSenderFrame` — the two non-creditable cases fail with the filter reverted (a sender one wei short of the leading frame's value is admitted, and an admitted one reserves the fee alone). The third case, a SENDER frame behind a DEFAULT frame, is the negative control: not summed, admitted either way. The balance is priced off the fixture through `TryCalculateMaxCost` rather than a literal, so it pins the bound and not the gas schedule.
- `GasLimitTxFilterTests.Accept_FrameTx_JudgesItAgainstTheSpecPinnedForTheSubmission` and `Accept_OrdinaryTx_ReadsNoSpecAtAll` — all three cases fail with the filter reverted. `Accept_OrdinaryTx_GatesOnTheBlockGasLimit` is the negative control. The two specs are asserted to actually disagree before the verdict is read.

`Nethermind.TxPool.Test` (1193) and `Nethermind.Blockchain.Test` (2028) pass in release and in checked (`DefineConstants=TRACE;DEBUG`, positive-controlled by finding the `#if DEBUG` bookkeeping strings in the built assembly). CI's lint invocation is clean, positive-controlled with an injected unused `using`.

### Requires testing

- [ ] Yes
- [x] No
