### PR TITLE
Keep the keyed nonce domain out of two account-nonce sites in the pool

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolSenderTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolSenderTests.cs
@@ -17,40 +17,72 @@ public class TxPoolSenderTests
     [Test]
     public void SendTransaction_FrameTransaction_NotRejectedAsSignFailed()
     {
+        TxPoolSender sender = BuildSender(out INonceManager _);
+
+        (Hash256 _, AcceptTxResult? result) = sender.SendTransaction(FrameTx(nonce: 0), TxHandlingOptions.None).Result;
+
+        Assert.That(result, Is.Not.EqualTo(AcceptTxResult.SignFailed));
+    }
+
+    /// <remarks>An EIP-8250 keyed sequence is not an account nonce, so recording one as consumed would hand the next
+    /// managed-nonce reservation a nonce above the account's, leaving whatever is built on it unmineable.</remarks>
+    [TestCase(true, 0UL, TestName = "a keyed nonce_seq reserves no account nonce")]
+    [TestCase(false, 1UL, TestName = "an account-domain nonce still does")]
+    public void SendTransaction_ReservesTheAccountNonce_OnlyForTheAccountDomain(bool keyed, ulong expectedReservation)
+    {
+        TxPoolSender sender = BuildSender(out INonceManager nonceManager);
+        Transaction tx = FrameTx(nonce: 0, nonceKeys: keyed ? [1] : null);
+
+        (Hash256 _, AcceptTxResult? result) = sender.SendTransaction(tx, TxHandlingOptions.None).Result;
+        Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted), "the submission must be accepted, or this pins nothing");
+
+        using NonceLocker locker = nonceManager.ReserveNonce(TestItem.AddressA, out ulong reservedNonce);
+        Assert.That(reservedNonce, Is.EqualTo(expectedReservation));
+    }
+
+    /// <remarks><c>eth_sendTransaction</c> reaches this whenever the caller supplies no nonce; overwriting nonce_seq
+    /// with an account nonce would submit a sequence the sender never selected.</remarks>
+    [Test]
+    public void SendTransaction_ManagedNonce_DoesNotOverwriteAKeyedSequence()
+    {
+        TxPoolSender sender = BuildSender(out INonceManager _);
+        Transaction tx = FrameTx(nonce: 7, nonceKeys: [1]);
+
+        (Hash256 _, AcceptTxResult? result) = sender.SendTransaction(tx, TxHandlingOptions.ManagedNonce).Result;
+
+        Assert.That(result, Is.EqualTo(AcceptTxResult.Accepted));
+        Assert.That(tx.Nonce, Is.EqualTo(7UL));
+    }
+
+    private static TxPoolSender BuildSender(out INonceManager nonceManager)
+    {
         ITxPool txPool = Substitute.For<ITxPool>();
         txPool.SubmitTx(Arg.Any<Transaction>(), Arg.Any<TxHandlingOptions>()).Returns(AcceptTxResult.Accepted);
 
-        ITxSigner txSigner = Substitute.For<ITxSigner>();
-
-        TxSealer sealer = new(txSigner, Timestamper.Default);
+        TxSealer sealer = new(Substitute.For<ITxSigner>(), Timestamper.Default);
 
         // NonceLocker is a ref struct, so INonceManager cannot be substituted; use the real one.
         IAccountStateProvider accountStateProvider = Substitute.For<IAccountStateProvider>();
         accountStateProvider.GetNonce(TestItem.AddressA).Returns(0UL);
-        INonceManager nonceManager = new NonceManager(accountStateProvider);
+        nonceManager = new NonceManager(accountStateProvider);
 
-        IEthereumEcdsa ecdsa = Substitute.For<IEthereumEcdsa>();
-
-        TxPoolSender sender = new(txPool, sealer, nonceManager, ecdsa);
-
-        Transaction frameTx = new()
-        {
-            Type = TxType.FrameTx,
-            SenderAddress = TestItem.AddressA,
-            Nonce = 0,
-            ChainId = 1,
-            GasLimit = 1_000_000,
-            GasPrice = 1,
-            DecodedMaxFeePerGas = 100,
-            Frames =
-            [
-                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, Array.Empty<byte>()),
-            ],
-            FrameSignatures = [],
-        };
-
-        (Hash256 _, AcceptTxResult? result) = sender.SendTransaction(frameTx, TxHandlingOptions.None).Result;
-
-        Assert.That(result, Is.Not.EqualTo(AcceptTxResult.SignFailed));
+        return new TxPoolSender(txPool, sealer, nonceManager, Substitute.For<IEthereumEcdsa>());
     }
+
+    private static Transaction FrameTx(ulong nonce, UInt256[] nonceKeys = null) => new()
+    {
+        Type = TxType.FrameTx,
+        SenderAddress = TestItem.AddressA,
+        Nonce = nonce,
+        ChainId = 1,
+        GasLimit = 1_000_000,
+        GasPrice = 1,
+        DecodedMaxFeePerGas = 100,
+        Frames =
+        [
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, Array.Empty<byte>()),
+        ],
+        FrameSignatures = [],
+        NonceKeys = nonceKeys,
+    };
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -16,6 +16,7 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Threading;
 using Nethermind.Crypto;
 using Nethermind.Db;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.JavaScript;
 using Nethermind.Int256;
 using Nethermind.Logging;
@@ -5333,6 +5334,52 @@ namespace Nethermind.TxPool.Test
                 "a bucket whose lowest entry is keyed must not be filtered out wholesale");
             Assert.That(readyForSender, Has.Length.EqualTo(1));
         }
+
+        /// <remarks>A keyed sequence starts at 0, so a blob-carrying frame transaction sorts ahead of the sender's
+        /// type-3 transactions; evicting it consumes no account nonce, so it leaves no gap for them to cascade over.</remarks>
+        [Test]
+        public async Task Evicting_a_keyed_blob_carrying_frame_tx_does_not_cascade_into_the_senders_blob_txs()
+        {
+            const ulong nonceKey = 0xbeef;
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.InMemory, Size = 128 };
+            _txPool = CreatePool(txPoolConfig, KeyedNonceSpecProvider());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+
+            // The account nonce advances independently of the key, whose sequence stays at 0 and sorts first.
+            _stateProvider.IncrementNonce(TestItem.AddressA);
+
+            Transaction keyed = BuildBlobFrameTx(nonce: 0, blobCount: 1, withSidecar: true, nonceKeys: [nonceKey]);
+            Assert.That(_txPool.SubmitTx(keyed, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(OrdinaryBlobTx(TestItem.PrivateKeyA, 1), TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(OrdinaryBlobTx(TestItem.PrivateKeyA, 2), TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            // Control: an all-ordinary sender whose lowest entry goes stale must still cascade into the rest of its bucket.
+            Assert.That(_txPool.SubmitTx(OrdinaryBlobTx(TestItem.PrivateKeyB, 0), TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(OrdinaryBlobTx(TestItem.PrivateKeyB, 1), TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            _stateProvider.Set(KeyedNonceManager.StorageSlot(TestItem.AddressA, nonceKey), [1]);
+            _stateProvider.IncrementNonce(TestItem.AddressB);
+
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).TestObject);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(_txPool.TryGetPendingTransaction(keyed.Hash!, out _), Is.False,
+                    "the keyed entry must be evicted, or this pins nothing");
+                Assert.That(_txPool.GetPendingLightBlobTransactionsBySender(TestItem.AddressA), Has.Length.EqualTo(2),
+                    "a keyed eviction must not take the sender's unrelated blob transactions with it");
+                Assert.That(_txPool.GetPendingLightBlobTransactionsBySender(TestItem.AddressB), Is.Empty,
+                    "an ordinary sender's stale lowest entry must still cascade");
+            }
+        }
+
+        private Transaction OrdinaryBlobTx(PrivateKey sender, ulong nonce) => Build.A.Transaction
+            .WithShardBlobTxTypeAndFields(spec: Eip8141Prototype.Instance)
+            .WithNonce(nonce)
+            .WithMaxFeePerGas(1.GWei)
+            .WithMaxPriorityFeePerGas(1.GWei)
+            .SignedAndResolved(_ethereumEcdsa, sender).TestObject;
 
         private Transaction BuildBlobFrameTx(ulong nonce, int blobCount, ulong? deadline = null, UInt256? maxFeePerBlobGas = null, bool withSidecar = false, UInt256[] nonceKeys = null, Address paymaster = null, PrivateKey sender = null)
         {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -5345,6 +5345,7 @@ namespace Nethermind.TxPool.Test
             _txPool = CreatePool(txPoolConfig, KeyedNonceSpecProvider());
             EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
             EnsureSenderBalance(TestItem.AddressB, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressC, UInt256.MaxValue);
 
             // The account nonce advances independently of the key, whose sequence stays at 0 and sorts first.
             _stateProvider.IncrementNonce(TestItem.AddressA);
@@ -5358,8 +5359,16 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(OrdinaryBlobTx(TestItem.PrivateKeyB, 0), TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
             Assert.That(_txPool.SubmitTx(OrdinaryBlobTx(TestItem.PrivateKeyB, 1), TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
 
+            // Control: the set [0] aliases the account nonce, so this blob-carrying frame tx does spend it and must
+            // cascade like any other type-3 entry — the exemption is the keyed domain, not the frame format.
+            Transaction accountDomainFrame = BuildBlobFrameTx(nonce: 0, blobCount: 1, withSidecar: true,
+                nonceKeys: [UInt256.Zero], sender: TestItem.PrivateKeyC);
+            Assert.That(_txPool.SubmitTx(accountDomainFrame, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(OrdinaryBlobTx(TestItem.PrivateKeyC, 1), TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
             _stateProvider.Set(KeyedNonceManager.StorageSlot(TestItem.AddressA, nonceKey), [1]);
             _stateProvider.IncrementNonce(TestItem.AddressB);
+            _stateProvider.IncrementNonce(TestItem.AddressC);
 
             await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).TestObject);
 
@@ -5371,6 +5380,36 @@ namespace Nethermind.TxPool.Test
                     "a keyed eviction must not take the sender's unrelated blob transactions with it");
                 Assert.That(_txPool.GetPendingLightBlobTransactionsBySender(TestItem.AddressB), Is.Empty,
                     "an ordinary sender's stale lowest entry must still cascade");
+                Assert.That(_txPool.GetPendingLightBlobTransactionsBySender(TestItem.AddressC), Is.Empty,
+                    "a stale account-domain frame transaction must still cascade");
+            }
+        }
+
+        /// <remarks>GapNonceFilter sizes a sender's nonce window by its pending count, and a keyed frame transaction
+        /// shares the sender's bucket while spending no account nonce — counting it would admit a gap nothing fills.</remarks>
+        [TestCase(true, TestName = "a keyed frame transaction shares the sender's bucket")]
+        [TestCase(false, TestName = "the sender's bucket is empty")]
+        public void Keyed_blob_carrying_frame_tx_does_not_widen_the_senders_nonce_gap_window(bool submitKeyed)
+        {
+            const ulong nonceKey = 0xbeef;
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.InMemory, Size = 128 };
+            _txPool = CreatePool(txPoolConfig, KeyedNonceSpecProvider());
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            if (submitKeyed)
+            {
+                Transaction keyed = BuildBlobFrameTx(nonce: 0, blobCount: 1, withSidecar: true, nonceKeys: [nonceKey]);
+                Assert.That(_txPool.SubmitTx(keyed, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            }
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(_txPool.SubmitTx(OrdinaryBlobTx(TestItem.PrivateKeyA, 1), TxHandlingOptions.PersistentBroadcast),
+                    Is.EqualTo(AcceptTxResult.NonceGap),
+                    "nothing sits at the account nonce, so nonce 1 is a gap however the bucket is filled");
+                Assert.That(_txPool.SubmitTx(OrdinaryBlobTx(TestItem.PrivateKeyA, 0), TxHandlingOptions.PersistentBroadcast),
+                    Is.EqualTo(AcceptTxResult.Accepted),
+                    "the account's own nonce must still be admitted");
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -5044,6 +5044,36 @@ namespace Nethermind.TxPool.Test
                 "a valid plain transaction must survive an over-value keyed transaction sharing its sender bucket");
         }
 
+        /// <remarks>Feeds <c>eth_getTransactionCount(pending)</c> and the <c>eth_sendTransaction</c> auto-nonce. A keyed
+        /// transaction's <c>Nonce</c> is a nonce_seq in its own domain, so counting it hands a wallet a nonce gap.</remarks>
+        [TestCase(4ul, TestName = "keyed sequence sorting behind the account nonce")]
+        [TestCase(0ul, TestName = "keyed sequence sorting ahead of the account nonce")]
+        public void Pending_nonce_ignores_a_keyed_frame_tx_sharing_the_senders_bucket(ulong keyedSequence)
+        {
+            const ulong accountNonce = 3;
+            const ulong nonceKey = 1;
+            _txPool = CreatePool(null, KeyedNonceSpecProvider());
+            Address sender = TestItem.PrivateKeyA.Address;
+            _stateProvider.CreateAccount(sender, 100.Ether, accountNonce);
+            if (keyedSequence > 0)
+            {
+                _stateProvider.Set(KeyedNonceManager.StorageSlot(sender, nonceKey), [(byte)keyedSequence]);
+            }
+
+            Transaction plain = Build.A.Transaction
+                .WithNonce(accountNonce)
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .WithGasLimit(21_000)
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+            Assert.That(_txPool.SubmitTx(plain, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Transaction keyed = BuildKeyedFrameTx(sender, nonceKey, seq: keyedSequence, value: UInt256.Zero, maxFee: 1.GWei);
+            Assert.That(_txPool.SubmitTx(keyed, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            Assert.That(_txPool.GetLatestPendingNonce(sender), Is.EqualTo(accountNonce + 1));
+        }
+
         /// <remarks>Admission sums a sender's keyed and account-domain liabilities against one balance; the
         /// per-head sweep has to price them the same way, or a balance drop leaves both pending and announced.</remarks>
         [TestCase(true, 1, TestName = "the balance covers each alone but not both")]

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -5046,9 +5046,12 @@ namespace Nethermind.TxPool.Test
 
         /// <remarks>Feeds <c>eth_getTransactionCount(pending)</c> and the <c>eth_sendTransaction</c> auto-nonce. A keyed
         /// transaction's <c>Nonce</c> is a nonce_seq in its own domain, so counting it hands a wallet a nonce gap.</remarks>
-        [TestCase(4ul, TestName = "keyed sequence sorting behind the account nonce")]
-        [TestCase(0ul, TestName = "keyed sequence sorting ahead of the account nonce")]
-        public void Pending_nonce_ignores_a_keyed_frame_tx_sharing_the_senders_bucket(ulong keyedSequence)
+        [TestCase(1, 4ul, 4ul, TestName = "keyed sequence sorting behind the account nonce")]
+        [TestCase(1, 0ul, 4ul, TestName = "keyed sequence sorting ahead of the account nonce")]
+        [TestCase(3, 0ul, 6ul, TestName = "keyed sequence sorting ahead of a contiguous run")]
+        [TestCase(3, 4ul, 6ul, TestName = "keyed sequence sorting inside a contiguous run")]
+        [TestCase(3, 5ul, 6ul, TestName = "keyed sequence tying the highest nonce of a contiguous run")]
+        public void Pending_nonce_ignores_a_keyed_frame_tx_sharing_the_senders_bucket(int plainCount, ulong keyedSequence, ulong expectedPendingNonce)
         {
             const ulong accountNonce = 3;
             const ulong nonceKey = 1;
@@ -5060,18 +5063,23 @@ namespace Nethermind.TxPool.Test
                 _stateProvider.Set(KeyedNonceManager.StorageSlot(sender, nonceKey), [(byte)keyedSequence]);
             }
 
-            Transaction plain = Build.A.Transaction
-                .WithNonce(accountNonce)
-                .WithMaxFeePerGas(1.GWei)
-                .WithMaxPriorityFeePerGas(1.GWei)
-                .WithGasLimit(21_000)
-                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
-            Assert.That(_txPool.SubmitTx(plain, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            for (int i = 0; i < plainCount; i++)
+            {
+                Transaction plain = Build.A.Transaction
+                    .WithNonce(accountNonce + (ulong)i)
+                    .WithMaxFeePerGas(1.GWei)
+                    .WithMaxPriorityFeePerGas(1.GWei)
+                    .WithGasLimit(21_000)
+                    .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+                Assert.That(_txPool.SubmitTx(plain, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            }
 
             Transaction keyed = BuildKeyedFrameTx(sender, nonceKey, seq: keyedSequence, value: UInt256.Zero, maxFee: 1.GWei);
             Assert.That(_txPool.SubmitTx(keyed, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
 
-            Assert.That(_txPool.GetLatestPendingNonce(sender), Is.EqualTo(accountNonce + 1));
+            // The bucket's tie-break decides whether a keyed entry sorting at a plain nonce is seen before or after
+            // it, so a run the keyed entry only interrupts must come out the same either way.
+            Assert.That(_txPool.GetLatestPendingNonce(sender), Is.EqualTo(expectedPendingNonce));
         }
 
         /// <remarks>Admission sums a sender's keyed and account-domain liabilities against one balance; the

--- a/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/Collections/TxDistinctSortedPool.cs
@@ -9,6 +9,7 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Threading;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.TxPool.Comparison;
@@ -22,6 +23,7 @@ namespace Nethermind.TxPool.Collections
 
         private readonly UpdateTransactionDelegate _updateTx;
         private readonly List<Transaction> _transactionsToRemove = [];
+        private readonly Dictionary<AddressAsKey, int> _keyedNonceCounts = [];
         protected int _poolCapacity;
 
         public TxDistinctSortedPool(int capacity, IComparer<Transaction> comparer, ILogManager logManager)
@@ -37,6 +39,80 @@ namespace Nethermind.TxPool.Collections
 
         protected override AddressAsKey MapToGroup(Transaction value) => value.MapTxToGroup() ?? throw new ArgumentException("MapTxToGroup() returned null!");
         protected override ValueHash256 GetKey(Transaction value) => value.Hash!;
+
+        protected override bool InsertCore(ValueHash256 key, Transaction value, AddressAsKey groupKey)
+        {
+            if (!base.InsertCore(key, value, groupKey))
+            {
+                return false;
+            }
+
+            if (KeyedNonceManager.UsesKeyedNonce(value))
+            {
+                _keyedNonceCounts[groupKey] = _keyedNonceCounts.GetValueOrDefault(groupKey) + 1;
+            }
+
+            return true;
+        }
+
+        protected override bool Remove(ValueHash256 key, out Transaction? value)
+        {
+            if (!base.Remove(key, out value))
+            {
+                return false;
+            }
+
+            if (value is not null && KeyedNonceManager.UsesKeyedNonce(value))
+            {
+                AddressAsKey groupKey = MapToGroup(value);
+                if (_keyedNonceCounts.TryGetValue(groupKey, out int keyedCount))
+                {
+                    if (keyedCount > 1)
+                    {
+                        _keyedNonceCounts[groupKey] = keyedCount - 1;
+                    }
+                    else
+                    {
+                        _keyedNonceCounts.Remove(groupKey);
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>Number of a sender's pending transactions that consume its account nonce.</summary>
+        /// <remarks>An EIP-8250 keyed transaction shares the sender's bucket but spends no account nonce, so an
+        /// account-nonce caller sizing the sender's nonce window by the raw bucket count would widen it by entries
+        /// that never fill it.</remarks>
+        internal int GetAccountDomainBucketCount(AddressAsKey group)
+        {
+            using McsLock.Disposable lockRelease = Lock.Acquire();
+
+            return _buckets.TryGetValue(group, out EnhancedSortedSet<Transaction>? bucket)
+                ? bucket.Count - _keyedNonceCounts.GetValueOrDefault(group)
+                : 0;
+        }
+
+        /// <summary>The nonce following a sender's pending transactions when the bucket count alone settles it,
+        /// without walking the bucket.</summary>
+        /// <remarks>Declines whenever the bucket holds an EIP-8250 keyed entry: its <c>Nonce</c> is a sequence in
+        /// its own domain, so it neither advances the count nor bounds the bucket's highest account nonce.</remarks>
+        internal bool TryGetContiguousPendingNonce(AddressAsKey group, ulong accountNonce, out ulong pendingNonce)
+        {
+            using McsLock.Disposable lockRelease = Lock.Acquire();
+
+            if (!_keyedNonceCounts.ContainsKey(group)
+                && _buckets.TryGetValue(group, out EnhancedSortedSet<Transaction>? bucket)
+                && accountNonce + (ulong)bucket.Count - 1 == bucket.Max!.Nonce)
+            {
+                pendingNonce = bucket.Max.Nonce + 1;
+                return true;
+            }
+
+            pendingNonce = accountNonce;
+            return false;
+        }
 
         protected override void UpdateGroup(AddressAsKey groupKey, EnhancedSortedSet<Transaction> bucket, Func<AddressAsKey, IReadOnlySortedSet<Transaction>, IEnumerable<(Transaction Tx, Action<Transaction>? Change)>> changingElements)
         {

--- a/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+++ b/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
@@ -32,9 +32,11 @@ namespace Nethermind.TxPool.Filters
                 return AcceptTxResult.Accepted;
             }
 
+            // Keyed entries share the sender's bucket but spend no account nonce, so counting them would widen the
+            // sender's nonce window by nonces nothing behind them will ever fill.
             int numberOfSenderTxsInPending = tx.CarriesBlobs
-                ? _blobTxs.GetBucketCount(tx.SenderAddress!)
-                : _txs.GetBucketCount(tx.SenderAddress!); // since unknownSenderFilter will run before this one
+                ? _blobTxs.GetAccountDomainBucketCount(tx.SenderAddress!)
+                : _txs.GetAccountDomainBucketCount(tx.SenderAddress!); // since unknownSenderFilter will run before this one
             ulong currentNonce = state.SenderAccount.Nonce;
             ulong nextNonceInOrder = currentNonce + (ulong)numberOfSenderTxsInPending;
             bool isTxNonceNextInOrder = tx.Nonce <= nextNonceInOrder;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -2427,6 +2427,13 @@ namespace Nethermind.TxPool
             }
 
             TxDistinctSortedPool relevantPool = (hasPendingTxs ? _transactions : _blobTransactions);
+            // A gap-free bucket holding no keyed entry is settled by its highest nonce, so the common sender skips
+            // the walk that would otherwise run under the pool-wide lock on every poll.
+            if (relevantPool.TryGetContiguousPendingNonce(address, maxPendingNonce, out ulong contiguousNonce))
+            {
+                return contiguousNonce;
+            }
+
             // we are not doing any updating, but lets just use a thread-safe method without any data copying like snapshot
             relevantPool.UpdateGroup(address, (_, transactions) =>
             {

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1661,8 +1661,7 @@ namespace Nethermind.TxPool
                             if (!keyedValidation.Validation)
                             {
                                 invalidatedByFork++;
-                                // Keyed sequences advance independently, so no unconditional cascade here; a
-                                // blob-carrying frame tx still cascades through MarkForEviction's CarriesBlobs arm.
+                                // Keyed sequences advance independently, so removing this leaves no nonce gap to cascade over.
                                 MarkForEviction(tx, revalidation.RecordEviction(tx, keyedValidation));
                                 continue;
                             }
@@ -1765,8 +1764,9 @@ namespace Nethermind.TxPool
                 _broadcaster.StopBroadcast(tx.Hash!);
                 if (allowLaterPoolReentrance) _hashCache.DeleteFromLongTerm(tx.Hash!);
                 updateTx(transactions, tx, null, lastElement);
-                // evict all following txs to prevent nonce gaps between blob tx
-                evictNextTxs |= tx.CarriesBlobs || evictFollowingTransactions;
+                // Evict all following txs to prevent nonce gaps between blob tx, but a keyed tx spends no account
+                // nonce, so removing it leaves no gap for the account-domain txs sorted behind it.
+                evictNextTxs |= (tx.CarriesBlobs && !KeyedNonceManager.UsesKeyedNonce(tx)) || evictFollowingTransactions;
             }
         }
 
@@ -2431,31 +2431,21 @@ namespace Nethermind.TxPool
             relevantPool.UpdateGroup(address, (_, transactions) =>
             {
                 // This is under the assumption that the addressTransactions are sorted by Nonce.
-                if (transactions.Count > 0)
+                // A keyed transaction's Nonce is an EIP-8250 nonce_seq in its own domain: it consumes no account
+                // nonce, so it neither advances the count nor bounds the bucket's highest account nonce.
+                foreach (Transaction transaction in transactions)
                 {
-                    // if we don't have any gaps we can easily calculate the nonce
-                    Transaction lastTransaction = transactions.Max!;
-                    ulong pendingCount = (ulong)transactions.Count;
-                    if (maxPendingNonce + pendingCount - 1 == lastTransaction.Nonce)
+                    if (KeyedNonceManager.UsesKeyedNonce(transaction))
                     {
-                        maxPendingNonce = lastTransaction.Nonce + 1;
+                        continue;
                     }
 
-                    // we have a gap, need to scan the transactions
-                    else
+                    if (transaction.Nonce != maxPendingNonce)
                     {
-                        foreach (Transaction transaction in transactions)
-                        {
-                            if (transaction.Nonce == maxPendingNonce)
-                            {
-                                maxPendingNonce++;
-                            }
-                            else
-                            {
-                                break;
-                            }
-                        }
+                        break;
                     }
+
+                    maxPendingNonce++;
                 }
 
                 // we won't do any actual changes

--- a/src/Nethermind/Nethermind.TxPool/TxPoolSender.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPoolSender.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Crypto;
+using Nethermind.Evm.TransactionProcessing;
 
 namespace Nethermind.TxPool
 {
@@ -29,9 +30,13 @@ namespace Nethermind.TxPool
                 tx.SenderAddress = senderAddress;
             }
 
-            AcceptTxResult result = manageNonce
-                ? SubmitTxWithManagedNonce(tx, txHandlingOptions)
-                : SubmitTxWithNonce(tx, txHandlingOptions);
+            // An EIP-8250 keyed sequence lives in NONCE_MANAGER, not the sender's account nonce: there is nothing to
+            // reserve, and recording one would push the managed reservation past a nonce the sender never consumes.
+            AcceptTxResult result = KeyedNonceManager.UsesKeyedNonce(tx)
+                ? SubmitTx(tx, txHandlingOptions)
+                : manageNonce
+                    ? SubmitTxWithManagedNonce(tx, txHandlingOptions)
+                    : SubmitTxWithNonce(tx, txHandlingOptions);
 
             return new ValueTask<(Hash256, AcceptTxResult?)>((tx.Hash!, result)); // The sealer calculates the hash
         }
@@ -52,10 +57,7 @@ namespace Nethermind.TxPool
 
         private AcceptTxResult SubmitTx(NonceLocker locker, Transaction tx, TxHandlingOptions txHandlingOptions)
         {
-            if (!_sealer.TrySeal(tx, txHandlingOptions))
-                return AcceptTxResult.SignFailed;
-
-            AcceptTxResult result = _txPool.SubmitTx(tx, txHandlingOptions);
+            AcceptTxResult result = SubmitTx(tx, txHandlingOptions);
 
             if (result == AcceptTxResult.Accepted)
             {
@@ -64,5 +66,10 @@ namespace Nethermind.TxPool
 
             return result;
         }
+
+        private AcceptTxResult SubmitTx(Transaction tx, TxHandlingOptions txHandlingOptions) =>
+            _sealer.TrySeal(tx, txHandlingOptions)
+                ? _txPool.SubmitTx(tx, txHandlingOptions)
+                : AcceptTxResult.SignFailed;
     }
 }


### PR DESCRIPTION
## Changes

Addresses two **Major** review threads on #12526, both in `Nethermind.TxPool/TxPool.cs`.

**1. `GetLatestPendingNonce` counted a keyed transaction's `nonce_seq` as an account nonce.**

A keyed frame transaction shares its sender's bucket while consuming no account nonce, and its `Nonce` field holds an EIP-8250 `nonce_seq` in a separate domain. Both of the method's paths compared it against the account nonce:

- fast path — `maxPendingNonce + pendingCount - 1 == lastTransaction.Nonce` counted the keyed entry and, when the sequence sorted last, read its sequence number as the highest pending account nonce;
- scan path — `transaction.Nonce == maxPendingNonce` broke out on the keyed entry, which sorts first whenever its sequence is below the account nonce.

With account nonce 3, one plain transaction at nonce 3 and one keyed transaction, the method returned **5** (sequence 4, fast path) or **3** (sequence 0, scan path) where **4** is correct. That reaches `EthRpcModule` as both `eth_getTransactionCount(…, "pending")` and the `eth_sendTransaction` auto-nonce, so a wallet mixing frame and ordinary transactions was handed a self-inflicted nonce gap.

The two paths are now one scan that skips `KeyedNonceManager.UsesKeyedNonce` entries. The fast path was a pure shortcut over the same walk — for a bucket with no keyed entries it is exactly equivalent — and making it domain-aware would have needed the walk anyway, so it goes.

**2. Evicting a keyed blob-carrying frame transaction cascaded into the sender's unrelated type-3 transactions.**

The keyed branch in `UpdateGasBottleneckAndMarkForEviction` deliberately avoids the unconditional cascade, but `MarkForEviction` re-armed `evictNextTxs` for any `CarriesBlobs` transaction. A blob-carrying frame transaction lives in `_blobTransactions` alongside the sender's type-3 transactions, buckets are ordered by `Nonce`, and a keyed sequence starts at 0 — so it sorts ahead of them. When its keys advanced, every following blob transaction in the bucket was evicted, though no nonce gap had been created, which is the cascade's sole justification. The `CarriesBlobs` arm now carries the same domain carve-out.

The related account-nonce assumption in the per-head retention sweep (`tx.Nonce == currentNonce + i`) is a distinct site and is left for its own change.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring / code cleanup
- [ ] Other (please describe)

## Testing

Each fix has a red/green pair reverting only that change, plus a negative control green in both states.

**Thread 1** — `Pending_nonce_ignores_a_keyed_frame_tx_sharing_the_senders_bucket` (2 cases, one per path). Reverting the change alone: `Expected 4, But was 5` (fast path) and `Expected 4, But was 3` (scan path). Control: the existing `get_next_pending_nonce`, which covers an ordinary sender's gap-free, gapped and stale shapes, stays green in both states.

**Thread 2** — `Evicting_a_keyed_blob_carrying_frame_tx_does_not_cascade_into_the_senders_blob_txs`. One sender holds a keyed blob-carrying frame transaction plus two ordinary type-3 transactions; a second, all-ordinary sender holds two whose lowest entry goes stale. Reverting the change alone: the keyed sender's surviving count is `Expected 2, But was 0`. The control assertion — the all-ordinary sender's bucket still cascading to empty — passes in both states, so the fix removes only the illegitimate cascade. The assertion that the keyed entry is itself evicted also holds in both states, so the test cannot pass vacuously.

Suites run in release and in checked (`-p:DefineConstants=TRACE;DEBUG`), all green in both:

| suite | total | failed | skipped |
|---|---|---|---|
| `Nethermind.TxPool.Test` | 1188 | 0 | 24 |
| `Nethermind.JsonRpc.Test` | 2132 | 0 | 22 |
| `Nethermind.Blockchain.Test` | 2028 | 0 | 151 |

The checked build was positive-controlled by finding the `#if DEBUG` ledger-symmetry assertion messages in the built `Nethermind.TxPool.dll` as UTF-16LE. Code Lint's exact invocation is clean, positive-controlled with an injected unused `using` (`warning IDE0005`).

## Documentation

Requires documentation update

- [ ] Yes
- [x] No

Requires explanation in Release Notes

- [ ] Yes
- [x] No
