### PR TITLE
Pin the BAL no-op nonce probe and the zero-blob type-3 shape

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/PredeployInstallerTests.cs
@@ -4,8 +4,15 @@
 using System;
 using Nethermind.Consensus.Processing;
 using Nethermind.Core;
+using Nethermind.Core.BlockAccessLists;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using Nethermind.State;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -44,6 +51,42 @@ public class PredeployInstallerTests
         // Re-creating the account each block would land back in the BAL, which is the failure this predeploy's
         // null nonce exists to avoid.
         writeState.DidNotReceiveWithAnyArgs().CreateAccountIfNotExists(default!, default, default);
+    }
+
+    /// <remarks>The install is the only in-tree writer of a no-op nonce, so it is the only way EIP-7928's
+    /// "record a nonce change only when the nonce changes" rule can be observed from block processing.</remarks>
+    [Test]
+    public void Predeploy_already_at_its_nonce_but_missing_its_code_records_only_the_code_change()
+    {
+        IReleaseSpec spec = new OverridableReleaseSpec(Amsterdam.Instance) { IsEip8250Enabled = true };
+        Address predeploy = Eip8250Constants.NonceManagerAddress;
+
+        IWorldState inner = TestWorldStateFactory.CreateForTest();
+        Hash256 stateRoot;
+        using (inner.BeginScope(IWorldState.PreGenesis))
+        {
+            inner.CreateAccount(predeploy, 0, nonce: 1);
+            inner.Commit(spec, isGenesis: true);
+            inner.CommitTree(0);
+            stateRoot = inner.StateRoot;
+        }
+
+        TracedAccessWorldState traced = new(inner, parallel: false);
+        traced.SetGeneratingBlockAccessList(new());
+        using (traced.BeginScope(Build.A.BlockHeader.WithStateRoot(stateRoot).WithNumber(0).TestObject))
+        {
+            traced.SetIndex(0);
+
+            PredeployInstaller.Install(inner, traced, spec);
+
+            AccountChangesAtIndex changes = traced.GetGeneratingBlockAccessList().GetAccountChanges(predeploy);
+            Assert.That(changes, Is.Not.Null);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(changes.CodeChange, Is.Not.Null);
+                Assert.That(changes.NonceChange, Is.Null, "re-writing the nonce it already holds is not a state transition");
+            }
+        }
     }
 
     private static (IReleaseSpec Spec, IReadOnlyStateProvider ReadState, IWorldState WriteState) Install(

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -118,8 +118,8 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
     {
         if (_generatingBlockAccessList is null) { base.SetNonce(address, nonce); return; }
 
-        // Deliberately no AddAccountRead: this probe belongs to the tracer, not to the caller, so a write
-        // leaving the nonce unchanged must leave the BAL untouched (EIP-7928 `if nonce_changed(addr)`).
+        // Deliberately no AddAccountRead: the probe belongs to the tracer, not the caller, and EIP-7928 lists
+        // only actual changes. PredeployInstaller.Install is the sole caller that can write a no-op nonce.
         ulong oldNonce = GetNonceInternal(address);
         base.SetNonce(address, nonce);
         if (nonce != oldNonce)

--- a/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
+++ b/src/Nethermind/Nethermind.State/TracedAccessWorldState.cs
@@ -118,6 +118,8 @@ public class TracedAccessWorldState(IWorldState state, bool parallel) : WorldSta
     {
         if (_generatingBlockAccessList is null) { base.SetNonce(address, nonce); return; }
 
+        // Deliberately no AddAccountRead: this probe belongs to the tracer, not to the caller, so a write
+        // leaving the nonce unchanged must leave the BAL untouched (EIP-7928 `if nonce_changed(addr)`).
         ulong oldNonce = GetNonceInternal(address);
         base.SetNonce(address, nonce);
         if (nonce != oldNonce)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -10,6 +10,7 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
+using Nethermind.Core.Messages;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
@@ -20,6 +21,7 @@ using Nethermind.Blockchain.Tracing.GethStyle.Custom.JavaScript;
 using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Network.Contract.Messages;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.ChainSpecStyle;
 using Nethermind.Specs.ChainSpecStyle.Json;
@@ -60,6 +62,48 @@ namespace Nethermind.TxPool.Test
                 ? AcceptTxResult.Accepted
                 : AcceptTxResult.NotSupportedTxType));
         }
+
+        // A type-3 declaring no blobs is the only shape on which Transaction.SupportsBlobs (type-3) and
+        // Transaction.CarriesBlobs (blob present) disagree, so pin that no pool path can hold one.
+        [Test]
+        public void should_reject_blob_tx_with_empty_blob_hashes()
+        {
+            _txPool = CreatePool(new TxPoolConfig(), GetCancunSpecProvider());
+
+            Transaction tx = BuildBlobTxDeclaringNoBlobs([])
+                .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+            EnsureSenderBalance(TestItem.AddressA, UInt256.MaxValue);
+
+            AcceptTxResult result = _txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(AcceptTxResult.Invalid));
+                Assert.That(result.ToString(), Does.Contain(TxErrorMessages.BlobTxMissingBlobs));
+                Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.Zero);
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero);
+            }
+        }
+
+        // The absent-hash-list variant never reaches the pool at all: it cannot be encoded, so it cannot be
+        // signed, hashed, gossiped or stored. Decoding always yields a list, so only the empty one arrives.
+        [Test]
+        public void blob_tx_with_absent_blob_hashes_cannot_be_encoded()
+        {
+            Transaction tx = BuildBlobTxDeclaringNoBlobs(null).TestObject;
+
+            Assert.That(() => TxDecoder.Instance.Encode(tx), Throws.TypeOf<RlpException>());
+        }
+
+        private static TransactionBuilder<Transaction> BuildBlobTxDeclaringNoBlobs(byte[][] blobVersionedHashes) =>
+            Build.A.Transaction
+                .WithType(TxType.Blob)
+                .WithNonce(0)
+                .WithTo(TestItem.AddressB)
+                .WithMaxFeePerBlobGas(1)
+                .WithBlobVersionedHashes(blobVersionedHashes)
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei);
 
         [Test]
         public void should_reject_blob_tx_if_max_size_is_exceeded([Values(true, false)] bool sizeExceeded, [Values(1, 2, 3, 4, 5, 6)] int numberOfBlobs)

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -63,8 +63,8 @@ namespace Nethermind.TxPool.Test
                 : AcceptTxResult.NotSupportedTxType));
         }
 
-        // A type-3 declaring no blobs is the only shape on which Transaction.SupportsBlobs (type-3) and
-        // Transaction.CarriesBlobs (blob present) disagree, so pin that no pool path can hold one.
+        // A type-3 declaring no blobs is the SupportsBlobs-true/CarriesBlobs-false shape; the inverse, a
+        // blob-carrying frame tx, is pinned by Frame_tx_pool_routing_follows_the_blob_count. New here: the pool counts.
         [Test]
         public void should_reject_blob_tx_with_empty_blob_hashes()
         {
@@ -85,14 +85,15 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        // The absent-hash-list variant never reaches the pool at all: it cannot be encoded, so it cannot be
-        // signed, hashed, gossiped or stored. Decoding always yields a list, so only the empty one arrives.
+        // The absent-hash-list variant cannot be encoded, so it cannot be signed, hashed, gossiped or stored, and
+        // decoding always yields a list. In-process producers normalise it to the empty list covered above.
         [Test]
         public void blob_tx_with_absent_blob_hashes_cannot_be_encoded()
         {
             Transaction tx = BuildBlobTxDeclaringNoBlobs(null).TestObject;
 
-            Assert.That(() => TxDecoder.Instance.Encode(tx), Throws.TypeOf<RlpException>());
+            Assert.That(() => TxDecoder.Instance.Encode(tx), Throws.TypeOf<RlpException>()
+                .With.Message.Contains($"{nameof(Transaction.BlobVersionedHashes)} is required"));
         }
 
         private static TransactionBuilder<Transaction> BuildBlobTxDeclaringNoBlobs(byte[][] blobVersionedHashes) =>


### PR DESCRIPTION
## Changes

Follow-up to two review threads on #12526, both asking whether a frames change silently altered behaviour for non-frame traffic. Both were verified against the code first; neither turned out to need a behavioural fix, so this carries only the documentation and the pins that were missing.

**`TracedAccessWorldState.SetNonce` (BAL nonce changes).** The guard that skips a no-op nonce write is spec-correct, not a divergence: EIP-7928 builds the list from actual state transitions (`if nonce_changed(addr): ... append`), and the previous unconditional `AddNonceChange` also went through `GetOrAddAccountChanges`, so it could manufacture a whole account entry for an account nothing touched. It landed as its own change, #12830, with its own regression test. The only caller that can genuinely write a no-op nonce while a BAL slice is live is `PredeployInstaller.Install`, and only via the nonce manager: its code is non-empty and it does not preserve a higher nonce, so an unsatisfied code check with the nonce already at 1 rewrites 1 over 1. All three predeploys gate on EIP-8141/8250/8272, so nothing on a non-frames chain moves. Added the comment the review asked for on the non-recording nonce probe.

**`SupportsBlobs` -> `CarriesBlobs` (zero-blob type-3).** Benign, and the missing pin is added. A type-3 with an absent hash list cannot be encoded at all (`BlobTxDecoder` throws), so it cannot be signed, hashed, gossiped or stored; decoding always yields a list. A type-3 with an empty list is rejected by `BlobFieldsTxValidator`, and every pool entry point runs `MalformedTxFilter` before any renamed site that could admit, so the pool cannot hold one. `BlockValidator.ValidateTransactions` likewise runs before `ValidateEip4844Fields`, so the renamed line there is unreachable for that shape — and the rename incidentally removes a latent null dereference of `BlobVersionedHashes!.Length` on that line.

## Types of changes

- [x] Documentation update
- [x] Testing improvement

## Testing

New pins in `TxPoolTests.Blobs`: the empty-hash-list type-3 is rejected with `BlobTxMissingBlobs` and lands in neither sub-pool; the absent-hash-list variant cannot be encoded, raising `BlobVersionedHashes is required` rather than any RLP-layer failure. New pin in `PredeployInstallerTests`: a predeploy already at its required nonce but missing its code records only the code change in the BAL — red when the `if (nonce != oldNonce)` guard is removed, with the other 273 `Nethermind.Consensus.Test` cases as the control.

Red/green for the BAL guard: reverting it turns `SetNonce_UnchangedValue_RecordsNoNonceChange` red in both fixture variants; `SetNonce_ChangedValue_RecordsNonceChange` is the negative control and stays green in both states. Frame lanes are 218/218 on `blockTest` and `engineTest` with and without the guard (`tests-frames-devnet@v0.3.0`, `--forkAlias Bogota=Eip8141Prototype`), so no BAL-bearing fixture moves either way.

Red/green for the blob predicate, corrected from the first round. Reverting `tx.CarriesBlobs` to `tx.SupportsBlobs` across `Nethermind.TxPool` and `Nethermind.Evm/TransactionExtensions.cs` turns 33 of 1187 `Nethermind.TxPool.Test` cases and 2 of 10880 `Nethermind.Evm.Test` cases red: pool routing (`blob_carrying_frame_tx_is_routed_to_blob_pool`), gossip (`Withholds_frame_blob_tx_lacking_a_sidecar`, `Gossips_frame_blob_tx_only_with_current_proof_version_sidecar`), receipts (`GetGasInfo_reports_blob_gas_for_blob_carrying_frame_tx`, `GetGasInfo_BlobCarryingFrameTx_ReportsBlobGas`), and the blob-frame accept/expiry/restart/payer-exposure set. Every failure is a blob-carrying frame transaction; no type-3 and no pre-frames shape moves, which is the evidence that the substitution is benign off the frames path. The two new pins here stay green under that revert — they pin the opposite shape, the zero-blob type-3, out of both sub-pools, and the earlier "no red/green pair exists" reading came from re-running only those two tests rather than the suites.

Suites green in release and checked: State, TxPool, Blockchain, Evm, Consensus.

## Documentation

No documentation changes required.

