### PR TITLE
Bound frame transaction decoding and simulation on untrusted input

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -583,6 +583,48 @@ public class FrameTxDecoderTests
         Assert.That(() => DecodeConsensusPayload(payload), Throws.InstanceOf<RlpLimitException>());
     }
 
+    // The reader spans the whole message, so a signature list declared to run past this transaction's payload
+    // would otherwise be sized from a batched message's remaining bytes: 2M entries out of 10MB. The bound is
+    // the transaction's own payload extent, so the entries beyond it are refused before the array is sized.
+    [Test]
+    public void Decode_SignatureListReachingPastThisTransaction_IsRefusedBeforeAllocating([Values] bool allowExtraBytes)
+    {
+        const int count = 64;
+        Rlp[] entries = new Rlp[count];
+        for (int i = 0; i < entries.Length; i++)
+        {
+            // The five-byte minimum: a four-item sequence of empty items.
+            entries[i] = Rlp.Encode(Rlp.OfEmptyByteArray, Rlp.OfEmptyByteArray, Rlp.OfEmptyByteArray, Rlp.OfEmptyByteArray);
+        }
+
+        byte[] body = FrameTxBody(signatures: Rlp.Encode(entries)).Bytes;
+        RlpReader walk = new(body);
+        walk.ReadSequenceLength();
+        int contentStart = walk.Position;
+        walk.DecodeULong();  // chain_id
+        walk.DecodeULong();  // nonce
+        walk.DecodeAddress();
+        walk.Position += walk.PeekNextRlpLength(); // frames
+        byte[] payload = TypedPayload(WithDeclaredContentLength(body, contentStart, walk.Position - contentStart));
+
+        Assert.That(() => DecodeConsensusPayload(payload, allowExtraBytes ? RlpBehaviors.AllowExtraBytes : RlpBehaviors.None),
+            Throws.InstanceOf<RlpLimitException>());
+    }
+
+    /// <summary>Re-emits <paramref name="body"/>'s sequence header declaring <paramref name="declared"/> content
+    /// bytes, leaving every byte of the content itself in place.</summary>
+    private static Rlp WithDeclaredContentLength(byte[] body, int contentStart, int declared)
+    {
+        byte[] header = new byte[Rlp.LengthOfSequence(declared) - declared];
+        RlpWriter headerWriter = new(header);
+        headerWriter.StartSequence(declared);
+
+        byte[] doctored = new byte[header.Length + body.Length - contentStart];
+        header.CopyTo(doctored, 0);
+        body.AsSpan(contentStart).CopyTo(doctored.AsSpan(header.Length));
+        return new Rlp(doctored);
+    }
+
     [Test]
     public void Decode_ChainIdAtTwoToThe64_ThrowsRatherThanTruncatingToU64()
     {
@@ -636,10 +678,10 @@ public class FrameTxDecoderTests
         return new Rlp(bytes);
     }
 
-    private static Transaction DecodeConsensusPayload(byte[] payload)
+    private static Transaction DecodeConsensusPayload(byte[] payload, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         RlpReader reader = new(payload);
-        return _txDecoder.DecodeGuardNotNull(ref reader, RlpBehaviors.SkipTypedWrapping);
+        return _txDecoder.DecodeGuardNotNull(ref reader, RlpBehaviors.SkipTypedWrapping | rlpBehaviors);
     }
 
     private static Transaction EncodeDecode(Transaction tx, RlpBehaviors rlpBehaviors = RlpBehaviors.None)

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxDecoderTests.cs
@@ -29,6 +29,8 @@ public class FrameTxDecoderTests
     private const int FrameDataDecodeCap = 30 * 1024 * 1024;
     // The largest RLP sequence prefix still carrying its content length inline (0xc0 + 55).
     private const int ShortSequencePrefixMax = 0xf7;
+    // What the decoder divides the available bytes by: a signature entry is a four-item sequence.
+    private const int MinSignatureRlpLength = 5;
 
     private static readonly TxDecoder _txDecoder = TxDecoder.Instance;
 
@@ -609,6 +611,37 @@ public class FrameTxDecoderTests
 
         Assert.That(() => DecodeConsensusPayload(payload, allowExtraBytes ? RlpBehaviors.AllowExtraBytes : RlpBehaviors.None),
             Throws.InstanceOf<RlpLimitException>());
+    }
+
+    // The direction an attacker uses: an honest envelope around a payload that declares more than it holds.
+    // Pre-fix the limit came from the bytes of the transaction behind it, so the list was payable and the
+    // 100,000-entry array was allocated before the over-declaration surfaced.
+    [Test]
+    public void Decode_BatchedMessageWhereATransactionOverDeclaresItsPayload_IsRefusedBeforeAllocating()
+    {
+        const int count = 100_000;
+        const int siblingBytes = MinSignatureRlpLength * count;
+
+        byte[] body = FrameTxBody(signatures: PlaceholderList(count)).Bytes;
+        RlpReader walk = new(body);
+        walk.ReadSequenceLength();
+        int contentStart = walk.Position;
+        Rlp overDeclared = WithDeclaredContentLength(body, contentStart, body.Length - contentStart + siblingBytes);
+
+        Transaction sibling = CreateFrameTx(signatures: [new TxFrameSignature(
+            TxFrameSignature.SchemeArbitrary, null, default, FilledBytes(siblingBytes, 0x01))]);
+        byte[] message = Rlp.Encode([
+            Rlp.Encode(TypedPayload(overDeclared)),
+            Rlp.Encode(EncodeConsensusPayload(sibling))]).Bytes;
+
+        Assert.That(() => DecodeMessage(message), Throws.InstanceOf<RlpLimitException>());
+    }
+
+    /// <summary>Decodes a batched <c>Transactions</c>-style message: many transactions, one reader.</summary>
+    private static Transaction[] DecodeMessage(byte[] message)
+    {
+        RlpReader reader = new(message);
+        return reader.DecodeNonNullArray(_txDecoder);
     }
 
     /// <summary>Re-emits <paramref name="body"/>'s sequence header declaring <paramref name="declared"/> content

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -2646,6 +2646,16 @@ public class FrameTxProcessorTests
         return _transactionProcessor.CallAndRestore(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
     }
 
+    private TransactionResult SimulateValidationPrefix(Transaction tx)
+    {
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(block.Header, Spec));
+        return _transactionProcessor.Process(tx, NullTxTracer.Instance, ExecutionOptions.FrameValidationPrefixOnly);
+    }
+
     private TransactionResult ProcessWithBlobHeader(Transaction tx, ulong excessBlobGas, UInt256 baseFeePerGas = default, ITxTracer? tracer = null)
     {
         Block block = Build.A.Block.WithNumber(1)
@@ -2788,11 +2798,15 @@ public class FrameTxProcessorTests
     }
 
     /// <remarks>Only the state half of the check may follow <c>SkipValidation</c>: the RPC view caps nothing,
-    /// so an oversized set would reach fixed-size buffers that assume a well-formed one.</remarks>
-    [Test]
-    public void CallAndRestore_KeyedNonceSetOverTheLimit_IsMalformedNotThrown()
+    /// so an oversized set would reach fixed-size buffers that assume a well-formed one. The in-pool prefix
+    /// simulator is the other such entry point, and <c>TXPARAM 0x0E</c> hashes the set into one of those buffers.</remarks>
+    [TestCase(false, TestName = "CallAndRestore_KeyedNonceSetOverTheLimit_IsMalformedNotThrown")]
+    [TestCase(true, TestName = "SimulateValidationPrefix_KeyedNonceSetOverTheLimit_IsMalformedNotThrown")]
+    public void KeyedNonceSetOverTheLimit_IsMalformedNotThrown(bool validationPrefixOnly)
     {
-        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeploySmartSender([
+            .. Prepare.EvmCode.PushData(0x0E).Op(Instruction.TXPARAM).Op(Instruction.POP).Done,
+            .. ApproveCode(TxFrame.ApproveExecutionAndPayment)]);
         // Full-width and strictly increasing, so the length is the only thing that is wrong with the set.
         UInt256[] keys = new UInt256[Eip8250Constants.MaxNonceKeys + 1];
         for (int i = 0; i < keys.Length; i++)
@@ -2803,9 +2817,9 @@ public class FrameTxProcessorTests
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
         tx.NonceKeys = keys;
 
-        TransactionResult result = CallAndRestore(tx);
+        TransactionResult result = validationPrefixOnly ? SimulateValidationPrefix(tx) : CallAndRestore(tx);
 
-        Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
+        Assert.That(result.ErrorDescription, Is.EqualTo("frame transaction nonce key set is not well-formed"));
     }
 
     // The property the set semantics exist for: one advanced key makes the whole set unusable.

--- a/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
+++ b/src/Nethermind/Nethermind.Evm/FrameTxContext.cs
@@ -354,8 +354,12 @@ public sealed class FrameTxContext(
     /// receipt kinds, the previous approval stage for <see cref="FrameJournalKind.ApprovalAdvanced"/>.</summary>
     private readonly record struct FrameJournalEntry(FrameJournalKind Kind, StorageCell Slot, int Value, long Amount);
 
+    /// <exception cref="ArgumentOutOfRangeException">The set is longer than a well-formed one, which the
+    /// fixed-size preimage buffer cannot hold.</exception>
     private static ValueHash256 ComputeNonceKeysHash(UInt256[] nonceKeys)
     {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(nonceKeys.Length, Eip8250Constants.MaxNonceKeys);
+
         Span<byte> input = stackalloc byte[(1 + Eip8250Constants.MaxNonceKeys) * 32];
         new UInt256((ulong)nonceKeys.Length).ToBigEndian(input[..32]);
         for (int i = 0; i < nonceKeys.Length; i++)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -94,6 +94,21 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             return TransactionResult.ErrorType.MalformedTransaction.WithDetail(malformed!);
         }
 
+        if (tx.NonceKeys is { } nonceKeys)
+        {
+            if (!spec.IsEip8250Enabled)
+            {
+                return TransactionResult.ErrorType.MalformedTransaction.WithDetail("keyed nonces are not enabled");
+            }
+
+            // Structural, so it holds even where validation is skipped: the fixed-size buffers keyed on the set
+            // take a well-formed one as their precondition, and eth_call and the simulator arrive without a validator.
+            if (!KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys))
+            {
+                return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce key set is not well-formed");
+            }
+        }
+
         if (opts.HasFlag(ExecutionOptions.FrameValidationPrefixOnly))
         {
             return SimulateFrameValidationPrefix(tx, tracer, opts, header, spec);
@@ -101,18 +116,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         Address sender = tx.SenderAddress!;
         Snapshot txSnapshot = WorldState.TakeSnapshot();
-
-        if (tx.NonceKeys is not null && !spec.IsEip8250Enabled)
-        {
-            return TransactionResult.ErrorType.MalformedTransaction.WithDetail("keyed nonces are not enabled");
-        }
-
-        // Structural, so it holds even where validation is skipped: the fixed-size buffers below take a
-        // well-formed set as their precondition, and eth_call arrives without a validator.
-        if (tx.NonceKeys is { } nonceKeys && !KeyedNonceManager.AreNonceKeysWellFormed(nonceKeys))
-        {
-            return TransactionResult.ErrorType.MalformedTransaction.WithDetail("frame transaction nonce key set is not well-formed");
-        }
 
         // Follows SkipValidation as the account-nonce path does: eth_call overwrites the supplied nonce.
         if (ShouldValidate(opts))

--- a/src/Nethermind/Nethermind.Optimism/OptimismTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Optimism/OptimismTxDecoder.cs
@@ -18,8 +18,8 @@ public sealed class OptimismTxDecoder<T>(Func<T>? transactionFactory = null)
     {
     }
 
-    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,
-        RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext, int payloadEnd,
+        RlpBehaviors rlpBehaviors)
     {
         transaction.SourceHash = decoderContext.DecodeKeccak();
         transaction.SenderAddress = decoderContext.DecodeAddress();

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/AccessListTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/AccessListTxDecoder.cs
@@ -42,11 +42,11 @@ public class BaseAccessListTxDecoder<T>(TxType txType, Func<T>? transactionFacto
             : Rlp.LengthOfSequence(1 + txPayloadLength);
     }
 
-    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,
-        RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext, int payloadEnd,
+        RlpBehaviors rlpBehaviors)
     {
         transaction.ChainId = decoderContext.DecodeULong();
-        base.DecodePayload(transaction, ref decoderContext, rlpBehaviors);
+        base.DecodePayload(transaction, ref decoderContext, payloadEnd, rlpBehaviors);
         transaction.AccessList = AccessListDecoder.Instance.Decode(ref decoderContext, rlpBehaviors);
     }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
@@ -27,7 +27,7 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
         int transactionLength = decoderContext.ReadSequenceLength();
         int lastCheck = decoderContext.Position + transactionLength;
 
-        DecodePayload(transaction, ref decoderContext, rlpBehaviors);
+        DecodePayload(transaction, ref decoderContext, lastCheck, rlpBehaviors);
 
         if (decoderContext.Position < lastCheck)
         {
@@ -97,6 +97,12 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
         int txPayloadLength = Rlp.LengthOfSequence(txContentLength);
         return txPayloadLength;
     }
+
+    /// <summary>Decodes the payload fields, given the end this transaction's payload declares.</summary>
+    /// <remarks>The reader can span a whole message, so a decoder sizing an allocation from the bytes on hand
+    /// must bound it by <paramref name="payloadEnd"/> and not by the reader's length.</remarks>
+    protected virtual void DecodePayload(Transaction transaction, ref RlpReader decoderContext, int payloadEnd, RlpBehaviors rlpBehaviors)
+        => DecodePayload(transaction, ref decoderContext, rlpBehaviors);
 
     protected virtual void DecodePayload(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
@@ -27,7 +27,10 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
         int transactionLength = decoderContext.ReadSequenceLength();
         int lastCheck = decoderContext.Position + transactionLength;
 
-        DecodePayload(transaction, ref decoderContext, lastCheck, rlpBehaviors);
+        // ReadSequenceLength does not check the declared length against the bytes on hand, so the payload
+        // extent is the envelope this transaction was handed, not what its own header claims.
+        DecodePayload(transaction, ref decoderContext,
+            Math.Min(lastCheck, txSequenceStart + transactionSequence.Length), rlpBehaviors);
 
         if (decoderContext.Position < lastCheck)
         {
@@ -98,13 +101,10 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
         return txPayloadLength;
     }
 
-    /// <summary>Decodes the payload fields, given the end this transaction's payload declares.</summary>
+    /// <summary>Decodes the payload fields, up to <paramref name="payloadEnd"/>.</summary>
     /// <remarks>The reader can span a whole message, so a decoder sizing an allocation from the bytes on hand
     /// must bound it by <paramref name="payloadEnd"/> and not by the reader's length.</remarks>
     protected virtual void DecodePayload(Transaction transaction, ref RlpReader decoderContext, int payloadEnd, RlpBehaviors rlpBehaviors)
-        => DecodePayload(transaction, ref decoderContext, rlpBehaviors);
-
-    protected virtual void DecodePayload(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
         transaction.Nonce = DecodeNonce(ref decoderContext);
         DecodeGasPrice(transaction, ref decoderContext);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
@@ -74,10 +74,10 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
             ShardBlobNetworkWrapperRlp.Encode(ref writer, GetNetworkWrapper(transaction), rlpBehaviors);
     }
 
-    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,
-        RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext, int payloadEnd,
+        RlpBehaviors rlpBehaviors)
     {
-        base.DecodePayload(transaction, ref decoderContext, rlpBehaviors);
+        base.DecodePayload(transaction, ref decoderContext, payloadEnd, rlpBehaviors);
         transaction.MaxFeePerBlobGas = decoderContext.DecodeUInt256();
         transaction.BlobVersionedHashes = decoderContext.DecodeByteArrays(BlobVersionedHashesCountLimit, innerSize: Hash256.Size);
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -24,6 +24,11 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     // Every entry is a four-item sequence, so five bytes at least.
     private const int MinSignatureRlpLength = 5;
 
+    /// <summary>The bytes this transaction's own payload still declares, as <see cref="IsNetworkWrapper"/>
+    /// bounds its peek: the reader spans the whole message, and an overlong declared length is not its bytes.</summary>
+    private static int BytesLeftInPayload(ref RlpReader decoderContext, int payloadEnd) =>
+        Math.Max(0, Math.Min(payloadEnd, decoderContext.Length) - decoderContext.Position);
+
     // The spec bounds the signature list only through gas: each entry is charged at least the ARBITRARY
     // verification price. The array is sized from the declared count, so the bytes on hand bound it too.
     private static RlpLimit SignaturesCountLimit(int bytesLeft) => RlpLimit.For<Transaction>(
@@ -132,8 +137,8 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         transaction.ReferenceCalldataStats = RecentRootReferenceDecoder.Instance.Measure(transaction.RecentRootReferences);
     }
 
-    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,
-        RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext, int payloadEnd,
+        RlpBehaviors rlpBehaviors)
     {
         // EIP8141-DEVIATION: the spec allows chain_id < 2^256; decoded as u64, the codebase-wide ChainId width.
         transaction.ChainId = decoderContext.DecodeULong();
@@ -142,7 +147,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         transaction.SenderAddress = decoderContext.DecodeAddress();
         transaction.Frames = decoderContext.DecodeNonNullArray(TxFrameDecoder.Instance, limit: FramesCountLimit);
         transaction.FrameSignatures = decoderContext.DecodeNonNullArray(TxFrameSignatureDecoder.Instance,
-            limit: SignaturesCountLimit(decoderContext.Length - decoderContext.Position));
+            limit: SignaturesCountLimit(BytesLeftInPayload(ref decoderContext, payloadEnd)));
         int feesLength = decoderContext.ReadSequenceLength();
         int feesCheck = feesLength + decoderContext.Position;
         transaction.GasPrice = decoderContext.DecodeUInt256(); // max_priority_fee_per_gas

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -24,11 +24,6 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
     // Every entry is a four-item sequence, so five bytes at least.
     private const int MinSignatureRlpLength = 5;
 
-    /// <summary>The bytes this transaction's own payload still declares, as <see cref="IsNetworkWrapper"/>
-    /// bounds its peek: the reader spans the whole message, and an overlong declared length is not its bytes.</summary>
-    private static int BytesLeftInPayload(ref RlpReader decoderContext, int payloadEnd) =>
-        Math.Max(0, Math.Min(payloadEnd, decoderContext.Length) - decoderContext.Position);
-
     // The spec bounds the signature list only through gas: each entry is charged at least the ARBITRARY
     // verification price. The array is sized from the declared count, so the bytes on hand bound it too.
     private static RlpLimit SignaturesCountLimit(int bytesLeft) => RlpLimit.For<Transaction>(
@@ -147,7 +142,7 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
         transaction.SenderAddress = decoderContext.DecodeAddress();
         transaction.Frames = decoderContext.DecodeNonNullArray(TxFrameDecoder.Instance, limit: FramesCountLimit);
         transaction.FrameSignatures = decoderContext.DecodeNonNullArray(TxFrameSignatureDecoder.Instance,
-            limit: SignaturesCountLimit(BytesLeftInPayload(ref decoderContext, payloadEnd)));
+            limit: SignaturesCountLimit(Math.Max(0, payloadEnd - decoderContext.Position)));
         int feesLength = decoderContext.ReadSequenceLength();
         int feesCheck = feesLength + decoderContext.Position;
         transaction.GasPrice = decoderContext.DecodeUInt256(); // max_priority_fee_per_gas

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/SetCodeTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/SetCodeTxDecoder.cs
@@ -16,10 +16,10 @@ public sealed class SetCodeTxDecoder<T>(Func<T>? transactionFactory = null)
 
     private static readonly AuthorizationTupleDecoder AuthTupleDecoder = AuthorizationTupleDecoder.Instance;
 
-    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext,
-        RlpBehaviors rlpBehaviors = RlpBehaviors.None)
+    protected override void DecodePayload(Transaction transaction, ref RlpReader decoderContext, int payloadEnd,
+        RlpBehaviors rlpBehaviors)
     {
-        base.DecodePayload(transaction, ref decoderContext, rlpBehaviors);
+        base.DecodePayload(transaction, ref decoderContext, payloadEnd, rlpBehaviors);
         transaction.AuthorizationList = decoderContext.DecodeNonNullArray(AuthTupleDecoder, limit: AuthorizationListLimit);
     }
 


### PR DESCRIPTION
## Changes

Addresses three review threads on #12526 about bounds on untrusted input.

- **`FrameTxDecoder` signature count** (thread on `FrameTxDecoder.cs:145`) — the byte-derived half of `SignaturesCountLimit` used `decoderContext.Length - decoderContext.Position`, the remainder of the whole *message*. In a batched `Transactions` / `PooledTransactions` message a small transaction could therefore size its signature array from the bytes of the transactions behind it. `BaseTxDecoder.Decode` now passes the declared payload end into `DecodePayload`, and the frame decoder bounds on that, clamped to the reader as `IsNetworkWrapper` already clamps its peek. Other decoders are untouched: the new overload forwards to the existing one by default.
- **Frame nonce-key envelope guards** (thread on `TransactionProcessorBase.FrameTx.cs:99`) — the prefix-simulation path returned before the `AreNonceKeysWellFormed` guard that the fixed-size nonce-key buffers declare as their precondition. Both envelope guards now sit above the `FrameValidationPrefixOnly` dispatch.
- **Signature verification before pricing** (thread on `TransactionProcessorBase.FrameTx.cs:127`) — no change; reasoning left on the thread. Every entry path bounds the signature list before the processor's `Validate`, and the processor has no cap of its own to compare a hoisted budget against.

## Types of changes

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality
      to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (including code style changes)
- [ ] Other (please describe)

## Testing

Both untrusted-input fixes ship a red/green pair.

`Decode_SignatureListReachingPastThisTransaction_IsRefusedBeforeAllocating` builds a frame transaction whose payload sequence declares its end at the start of the signature list while the list itself runs on into the following bytes. Before the fix, with `AllowExtraBytes` the 64 out-of-payload entries decoded with **no exception thrown**; without it the decode reached `Data checkpoint failed. Expected 26 and is 354` — i.e. the array was sized and every entry decoded before the rejection. After, both raise `RlpLimitException` naming `Transaction.FrameSignatures`, before anything is allocated.

`SimulateValidationPrefix_KeyedNonceSetOverTheLimit_IsMalformedNotThrown` drives `Process(..., FrameValidationPrefixOnly)` with 17 nonce keys and a VERIFY frame that runs `TXPARAM 0x0E`. Before the fix this threw `System.ArgumentOutOfRangeException` out of `FrameTxContext.ComputeNonceKeysHash` (via `InstructionTxParam` -> `SimulateFrameValidationPrefix` -> `Process`); after, it is a clean `MalformedTransaction`. It extends the existing `CallAndRestore` case rather than duplicating it.

- `Nethermind.Core.Test`, `Nethermind.Evm.Test`, `Nethermind.Network.Test`, `Nethermind.TxPool.Test` green in release and in the checked build (`-p:DefineConstants=TRACE;DEBUG`).
- Frame fixture lanes on `tests-frames-devnet@v0.3.0` with `--forkAlias Bogota=Eip8141Prototype`: `--blockTest` 218/218 and `--engineTest` 218/218.
- Code lint clean, positive-controlled with an injected unused `using`.

## Documentation

Requires documentation update

- [ ] Yes
- [x] No

Requires explanation in Release Notes

- [ ] Yes
- [x] No
