### PR TITLE
fix(eip8141): stop the receipt codec writing frame receipts it cannot read

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -228,6 +228,131 @@ public class FrameTxReceiptDecoderTests
             "the per-frame copy holds the same logs as the top-level union, the duplication this size pins");
     }
 
+    /// <summary>A pre-fork receipt's tx-hash mark and error sit in the same trailing region the frame extension
+    /// was appended to. This pins that a non-frame receipt already on disk still reads back with both fields, and
+    /// that an array of them stays aligned, under the storage behaviours the read paths use.</summary>
+    [Test]
+    public void StorageDecode_NonFrameReceiptsInTheOnDiskShape_KeepTxHashAndErrorAndStayAligned(
+        [Values(RlpBehaviors.Storage, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes)] RlpBehaviors decodeBehaviors)
+    {
+        byte[] encoded = Bytes.FromHexString(NonFrameArrayNonCompactHex);
+
+        ReceiptStorageDecoder decoder = new();
+        RlpReader reader = new(encoded);
+        TxReceipt[] decoded = decoder.DecodeArray(ref reader, decodeBehaviors)!;
+
+        Assert.That(decoded, Has.Length.EqualTo(2));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded[0].TxHash, Is.EqualTo(TestItem.KeccakA), "leading receipt tx hash");
+            Assert.That(decoded[0].Error, Is.EqualTo("error"), "leading receipt error");
+            Assert.That(decoded[0].Sender, Is.EqualTo(TestItem.AddressD), "leading receipt sender");
+            Assert.That(decoded[0].TxType, Is.EqualTo(TxType.Legacy));
+
+            Assert.That(decoded[1].TxHash, Is.EqualTo(TestItem.KeccakB), "trailing receipt tx hash");
+            Assert.That(decoded[1].Error, Is.EqualTo("error"), "trailing receipt error");
+            Assert.That(decoded[1].Sender, Is.EqualTo(TestItem.AddressE),
+                "the trailing receipt decodes intact only if the reader realigned past the leading one");
+            Assert.That(decoded[1].TxType, Is.EqualTo(TxType.Legacy));
+        }
+    }
+
+    /// <summary>The stored write path is null-tolerant on the payer while every read path is not, so a payer-less
+    /// frame receipt used to persist and then fail every later read of its block. Refused at the encoder instead.</summary>
+    [Test]
+    public void Encode_FrameTxReceiptWithoutPayer_IsRefusedRatherThanStoredUnreadable(
+        [Values(Format.NonCompactStorage, Format.CompactStorage, Format.Message)] Format format)
+    {
+        TxReceipt payerless = CreateStorageFrameReceipt(
+            [Log(0x01)], new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 5_000, [Log(0x01)]));
+        payerless.Payer = null;
+
+        Assert.That(() => EncodeStored(payerless, format), Throws.InstanceOf<RlpException>());
+    }
+
+    // The counterpart: the refusal must not stand between a payer-carrying frame receipt and the round trip.
+    [Test]
+    public void Encode_FrameTxReceiptWithPayer_RoundtripsThePayer(
+        [Values(Format.NonCompactStorage, Format.CompactStorage, Format.Message)] Format format)
+    {
+        TxReceipt receipt = CreateStorageFrameReceipt(
+            [Log(0x01)], new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 5_000, [Log(0x01)]));
+
+        Assert.That(DecodeStored(EncodeStored(receipt, format), format).Payer, Is.EqualTo(receipt.Payer));
+    }
+
+    /// <summary>The stored frames decoder reads a datadir, which a corrupted or hostile node can still supply, and
+    /// what it accepts is re-served over the wire. It therefore holds the payload decoder's frame-count bound.</summary>
+    [TestCase(Format.NonCompactStorage, Eip8141Constants.MaxFrames, false)]
+    [TestCase(Format.CompactStorage, Eip8141Constants.MaxFrames, false)]
+    [TestCase(Format.NonCompactStorage, Eip8141Constants.MaxFrames + 1, true)]
+    [TestCase(Format.CompactStorage, Eip8141Constants.MaxFrames + 1, true)]
+    public void StorageDecode_FrameCountHoldsTheWireBound(Format format, int frameCount, bool rejected)
+    {
+        TxFrameReceipt[] frames = new TxFrameReceipt[frameCount];
+        Array.Fill(frames, new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, []));
+        byte[] encoded = EncodeStored(CreateStorageFrameReceipt([], frames), format);
+
+        if (rejected)
+        {
+            Assert.That(() => DecodeStored(encoded, format), Throws.InstanceOf<RlpException>());
+        }
+        else
+        {
+            Assert.That(DecodeStored(encoded, format).FrameReceipts, Has.Length.EqualTo(frameCount));
+        }
+    }
+
+    // Same reasoning for the status byte: AggregateStatus folds anything but success to failure while RPC surfaces
+    // the raw byte, so an undefined status reads differently at the two ends of the same stored receipt.
+    [TestCase(Format.NonCompactStorage, TxFrameReceipt.StatusFailure, false)]
+    [TestCase(Format.NonCompactStorage, TxFrameReceipt.StatusSuccess, false)]
+    [TestCase(Format.NonCompactStorage, TxFrameReceipt.StatusSkipped, false)]
+    [TestCase(Format.NonCompactStorage, (byte)3, true)]
+    [TestCase(Format.NonCompactStorage, byte.MaxValue, true)]
+    [TestCase(Format.CompactStorage, TxFrameReceipt.StatusSkipped, false)]
+    [TestCase(Format.CompactStorage, (byte)3, true)]
+    [TestCase(Format.CompactStorage, byte.MaxValue, true)]
+    public void StorageDecode_FrameStatusOutsideThePayloadValues_Throws(Format format, byte status, bool rejected)
+    {
+        byte[] encoded = EncodeStored(
+            CreateStorageFrameReceipt([], new TxFrameReceipt(status, 21_000, 0, [])), format);
+
+        if (rejected)
+        {
+            Assert.That(() => DecodeStored(encoded, format), Throws.InstanceOf<RlpException>());
+        }
+        else
+        {
+            Assert.That(DecodeStored(encoded, format).FrameReceipts![0].Status, Is.EqualTo(status));
+        }
+    }
+
+    /// <summary>The receipt codecs a frame receipt can be written through.</summary>
+    public enum Format
+    {
+        NonCompactStorage,
+        CompactStorage,
+        Message,
+    }
+
+    private static RlpDecoder<TxReceipt> DecoderFor(Format format) => format switch
+    {
+        Format.NonCompactStorage => new ReceiptStorageDecoder(),
+        Format.CompactStorage => new CompactReceiptStorageDecoder(),
+        _ => new ReceiptMessageDecoder(),
+    };
+
+    private static byte[] EncodeStored(TxReceipt receipt, Format format) => format == Format.Message
+        ? new ReceiptMessageDecoder().EncodeNew(receipt, RlpBehaviors.None)
+        : DecoderFor(format).EncodeAsBytes(receipt, RlpBehaviors.Storage | RlpBehaviors.Eip658Receipts);
+
+    private static TxReceipt DecodeStored(byte[] encoded, Format format)
+    {
+        RlpReader reader = new(encoded);
+        return DecoderFor(format).Decode(ref reader, format == Format.Message ? RlpBehaviors.None : RlpBehaviors.Storage)!;
+    }
+
     private static LogEntry[] DecodeLogs(scoped ReadOnlySpan<byte> logsRlp, bool compact)
     {
         RlpReader reader = new(logsRlp);
@@ -334,6 +459,10 @@ public class FrameTxReceiptDecoderTests
         "f905a5f901ce01a0017e667f4b8c174291d1543c466717566e206df1bfd6f30271055ddafdb18f72020294475674cb523a0a2736b7f7534390288fce16982c94942921b14f1b1c385cd7e0cc2ef7abe5598c83589476e68a8696537e4141926f3e528733af9e237d69648203e8b9010000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000800000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000f83af838940000000000000000000000000000000000000000e1a0000000000000000000000000000000000000000000000000000000000000000080ffa003783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760856572726f72b9020006f901fc018080809476e68a8696537e4141926f3e528733af9e237d6980808082c738b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000002000000000000000000000000000000080000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000f83af83894942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd201ff808094b7705ae4c6f81b66cdb323c65f4e8133690fc099f884f84001825208f83af83894942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd201f84080827530f83af83894942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a0f2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f202f901ce01a0017e667f4b8c174291d1543c466717566e206df1bfd6f30271055ddafdb18f720202942d36e6c27c34ea22620e7b7c45de774599406cf394942921b14f1b1c385cd7e0cc2ef7abe5598c83589476e68a8696537e4141926f3e528733af9e237d69648207d0b9010000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000800000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000f83af838940000000000000000000000000000000000000000e1a0000000000000000000000000000000000000000000000000000000000000000080ffa003783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760856572726f72";
     private const string OldArrayCompactHex =
         "7ff9015ef40194475674cb523a0a2736b7f7534390288fce16982c8203e8dad9940000000000000000000000000000000000000000c1008080f8f3019476e68a8696537e4141926f3e528733af9e237d6982c738f83bf83994942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2800194b7705ae4c6f81b66cdb323c65f4e8133690fc099f886f84101825208f83bf83994942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd28001f84180827530f83bf83994942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a0f2ee15ea639b73fa3db9b34a245bdfa015c260c598b211bf05a1ecc4b3e3b4f28002f401942d36e6c27c34ea22620e7b7c45de774599406cf38207d0dad9940000000000000000000000000000000000000000c1008080";
+
+    // Two pre-fork receipts as the non-compact storage codec has always written them: logs, the 0xff tx-hash
+    // mark, the hash, then the error string. Captured before the frame extension was appended after it.
+    private const string NonFrameArrayNonCompactHex = "f903a2f901ce01a0017e667f4b8c174291d1543c466717566e206df1bfd6f30271055ddafdb18f72020294475674cb523a0a2736b7f7534390288fce16982c94942921b14f1b1c385cd7e0cc2ef7abe5598c83589476e68a8696537e4141926f3e528733af9e237d69648203e8b9010000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000800000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000f83af838940000000000000000000000000000000000000000e1a0000000000000000000000000000000000000000000000000000000000000000080ffa003783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760856572726f72f901ce01a0017e667f4b8c174291d1543c466717566e206df1bfd6f30271055ddafdb18f720202942d36e6c27c34ea22620e7b7c45de774599406cf394942921b14f1b1c385cd7e0cc2ef7abe5598c83589476e68a8696537e4141926f3e528733af9e237d69648203e8b9010000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000800000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000f83af838940000000000000000000000000000000000000000e1a0000000000000000000000000000000000000000000000000000000000000000080ffa01f675bff07515f5df96737194ea945c36c41e7b4fcef307b7cd4d0e602a69111856572726f72";
 
     [Test]
     public void StorageDecode_PreTwoDimensionalScalarGasUsed_ReadsExecutionWithZeroState(

--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -257,6 +257,42 @@ public class FrameTxReceiptDecoderTests
         }
     }
 
+    /// <summary>The same bytes over the struct-ref path ReceiptsIterator uses. It reads the same two trailing
+    /// fields as the object path, so a receipt cannot carry a tx hash and an error through one and not the other.</summary>
+    [Test]
+    public void StructRefDecode_NonFrameReceiptsInTheOnDiskShape_KeepTxHashAndErrorAndStayAligned(
+        [Values(RlpBehaviors.Storage, RlpBehaviors.Storage | RlpBehaviors.AllowExtraBytes)] RlpBehaviors decodeBehaviors)
+    {
+        byte[] encoded = Bytes.FromHexString(NonFrameArrayNonCompactHex);
+
+        IReceiptRefDecoder refDecoder = new ReceiptStorageDecoder();
+        RlpReader reader = new(encoded);
+        int length = reader.ReadSequenceLength() + reader.Position;
+        (string TxHash, string? Error, string Sender)[] decoded = new (string, string?, string)[2];
+        int count = 0;
+        while (reader.Position < length)
+        {
+            refDecoder.DecodeStructRef(ref reader, decodeBehaviors, out TxReceiptStructRef current);
+            if (count < decoded.Length)
+            {
+                decoded[count] = (current.TxHash.ToString(), current.Error, current.Sender.ToString());
+            }
+            count++;
+        }
+
+        Assert.That(count, Is.EqualTo(2));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded[0].TxHash, Is.EqualTo(TestItem.KeccakA.ToString()), "leading receipt tx hash");
+            Assert.That(decoded[0].Error, Is.EqualTo("error"), "leading receipt error");
+
+            Assert.That(decoded[1].TxHash, Is.EqualTo(TestItem.KeccakB.ToString()), "trailing receipt tx hash");
+            Assert.That(decoded[1].Error, Is.EqualTo("error"), "trailing receipt error");
+            Assert.That(decoded[1].Sender, Is.EqualTo(TestItem.AddressE.ToString()),
+                "the trailing receipt decodes intact only if the reader realigned past the leading one");
+        }
+    }
+
     /// <summary>The stored write path is null-tolerant on the payer while every read path is not, so a payer-less
     /// frame receipt used to persist and then fail every later read of its block. Refused at the encoder instead.</summary>
     [Test]
@@ -281,30 +317,62 @@ public class FrameTxReceiptDecoderTests
         Assert.That(DecodeStored(EncodeStored(receipt, format), format).Payer, Is.EqualTo(receipt.Payer));
     }
 
-    /// <summary>The stored frames decoder reads a datadir, which a corrupted or hostile node can still supply, and
-    /// what it accepts is re-served over the wire. It therefore holds the payload decoder's frame-count bound.</summary>
+    /// <summary>A frame transaction always executes at least one frame, so the frames-less shape is the other
+    /// receipt that still encodes but no longer decodes. Refused at the encoder, as the payer is.</summary>
+    [Test]
+    public void Encode_FrameTxReceiptWithoutFrameReceipts_IsRefusedRatherThanStoredUnreadable(
+        [Values(Format.NonCompactStorage, Format.CompactStorage, Format.Message)] Format format,
+        [Values(false, true)] bool empty)
+    {
+        TxReceipt framesless = CreateStorageFrameReceipt([Log(0x01)]);
+        framesless.FrameReceipts = empty ? [] : null;
+
+        Assert.That(() => EncodeStored(framesless, format), Throws.InstanceOf<RlpException>());
+    }
+
+    /// <summary>Both halves of the wire pair refuse it, not just the length half. Every message encoder happens to
+    /// call <c>GetPayloadLength</c> first today, so the throw lands there — a call order, not a codec invariant.</summary>
+    [Test]
+    public void EncodePayload_FrameTxReceiptWithoutPayer_IsRefusedWithoutMeasuringItFirst()
+    {
+        TxReceipt payerless = CreateStorageFrameReceipt(
+            [Log(0x01)], new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 5_000, [Log(0x01)]));
+        payerless.Payer = null;
+
+        Assert.That(() =>
+        {
+            RlpWriter writer = new(new byte[1024]);
+            FrameReceiptRlp.EncodePayload(ref writer, payerless, framesLength: 0);
+        }, Throws.InstanceOf<RlpException>());
+    }
+
+    /// <summary>The bounds the payload decoder holds are enforced on the write paths, not the stored read path:
+    /// a stored row that fails to parse takes its whole block's receipt array with it, and no encoder is left
+    /// that could reproduce the bytes to migrate it.</summary>
     [TestCase(Format.NonCompactStorage, Eip8141Constants.MaxFrames, false)]
     [TestCase(Format.CompactStorage, Eip8141Constants.MaxFrames, false)]
+    [TestCase(Format.Message, Eip8141Constants.MaxFrames, false)]
     [TestCase(Format.NonCompactStorage, Eip8141Constants.MaxFrames + 1, true)]
     [TestCase(Format.CompactStorage, Eip8141Constants.MaxFrames + 1, true)]
-    public void StorageDecode_FrameCountHoldsTheWireBound(Format format, int frameCount, bool rejected)
+    [TestCase(Format.Message, Eip8141Constants.MaxFrames + 1, true)]
+    public void Encode_FrameCountHoldsTheWireBound(Format format, int frameCount, bool rejected)
     {
         TxFrameReceipt[] frames = new TxFrameReceipt[frameCount];
         Array.Fill(frames, new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, []));
-        byte[] encoded = EncodeStored(CreateStorageFrameReceipt([], frames), format);
+        TxReceipt receipt = CreateStorageFrameReceipt([], frames);
 
         if (rejected)
         {
-            Assert.That(() => DecodeStored(encoded, format), Throws.InstanceOf<RlpException>());
+            Assert.That(() => EncodeStored(receipt, format), Throws.InstanceOf<RlpException>());
         }
         else
         {
-            Assert.That(DecodeStored(encoded, format).FrameReceipts, Has.Length.EqualTo(frameCount));
+            Assert.That(DecodeStored(EncodeStored(receipt, format), format).FrameReceipts, Has.Length.EqualTo(frameCount));
         }
     }
 
     // Same reasoning for the status byte: AggregateStatus folds anything but success to failure while RPC surfaces
-    // the raw byte, so an undefined status reads differently at the two ends of the same stored receipt.
+    // the raw byte, so an undefined status reads differently at the two ends of the same receipt.
     [TestCase(Format.NonCompactStorage, TxFrameReceipt.StatusFailure, false)]
     [TestCase(Format.NonCompactStorage, TxFrameReceipt.StatusSuccess, false)]
     [TestCase(Format.NonCompactStorage, TxFrameReceipt.StatusSkipped, false)]
@@ -313,18 +381,77 @@ public class FrameTxReceiptDecoderTests
     [TestCase(Format.CompactStorage, TxFrameReceipt.StatusSkipped, false)]
     [TestCase(Format.CompactStorage, (byte)3, true)]
     [TestCase(Format.CompactStorage, byte.MaxValue, true)]
-    public void StorageDecode_FrameStatusOutsideThePayloadValues_Throws(Format format, byte status, bool rejected)
+    [TestCase(Format.Message, TxFrameReceipt.StatusSkipped, false)]
+    [TestCase(Format.Message, (byte)3, true)]
+    [TestCase(Format.Message, byte.MaxValue, true)]
+    public void Encode_FrameStatusOutsideThePayloadValues_IsRefused(Format format, byte status, bool rejected)
     {
-        byte[] encoded = EncodeStored(
-            CreateStorageFrameReceipt([], new TxFrameReceipt(status, 21_000, 0, [])), format);
+        TxReceipt receipt = CreateStorageFrameReceipt([], new TxFrameReceipt(status, 21_000, 0, []));
 
         if (rejected)
         {
-            Assert.That(() => DecodeStored(encoded, format), Throws.InstanceOf<RlpException>());
+            Assert.That(() => EncodeStored(receipt, format), Throws.InstanceOf<RlpException>());
         }
         else
         {
-            Assert.That(DecodeStored(encoded, format).FrameReceipts![0].Status, Is.EqualTo(status));
+            Assert.That(DecodeStored(EncodeStored(receipt, format), format).FrameReceipts![0].Status, Is.EqualTo(status));
+        }
+    }
+
+    /// <summary>The third of the payload decoder's bounds: it budgets the whole receipt rather than each frame,
+    /// so two frames that are each within it can still sum past it.</summary>
+    [Test]
+    public void Encode_FrameLogsSummingOverTheReceiptBound_IsRefused(
+        [Values(Format.NonCompactStorage, Format.CompactStorage, Format.Message)] Format format,
+        [Values(false, true)] bool over)
+    {
+        // One shared entry repeated: the guard counts logs and never reaches their contents.
+        LogEntry[] half = new LogEntry[over ? FrameReceiptRlp.MaxReceiptLogs / 2 + 1 : 1];
+        Array.Fill(half, Log(0x01));
+        TxReceipt receipt = CreateStorageFrameReceipt([],
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, half),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, half));
+
+        if (over)
+        {
+            Assert.That(() => EncodeStored(receipt, format), Throws.InstanceOf<RlpException>());
+        }
+        else
+        {
+            Assert.That(DecodeStored(EncodeStored(receipt, format), format).FrameReceipts, Has.Length.EqualTo(2));
+        }
+    }
+
+    /// <summary>Rows an earlier build of this branch already wrote — <c>debug_insertReceipts</c> bounded neither
+    /// the payer nor the frame status until the guards above. They must still read back: the receipt array of a
+    /// block decodes in one pass, so refusing one row makes every receipt in its block unreadable.</summary>
+    [TestCase(Format.NonCompactStorage, PayerlessNonCompactHex)]
+    [TestCase(Format.CompactStorage, PayerlessCompactHex)]
+    public void StorageDecode_PayerlessRowFromAnEarlierBuild_ReadsBackAndOnlyTheWireEncoderRefusesIt(Format format, string hex)
+    {
+        TxReceipt decoded = DecodeStored(Bytes.FromHexString(hex), format);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.TxType, Is.EqualTo(TxType.FrameTx));
+            Assert.That(decoded.Payer, Is.Null, "the row parses; the missing payer is surfaced rather than thrown on");
+            Assert.That(decoded.FrameReceipts, Has.Length.EqualTo(1));
+        }
+
+        Assert.That(() => new ReceiptMessageDecoder().EncodeNew(decoded, RlpBehaviors.None), Throws.InstanceOf<RlpException>(),
+            "a payer-less receipt is still not servable, so the refusal belongs to the wire encoder");
+    }
+
+    [TestCase(Format.NonCompactStorage, UndefinedStatusNonCompactHex)]
+    [TestCase(Format.CompactStorage, UndefinedStatusCompactHex)]
+    public void StorageDecode_UndefinedFrameStatusFromAnEarlierBuild_ReadsBack(Format format, string hex)
+    {
+        TxReceipt decoded = DecodeStored(Bytes.FromHexString(hex), format);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(decoded.Payer, Is.EqualTo(TestItem.AddressA));
+            Assert.That(decoded.FrameReceipts![0].Status, Is.EqualTo((byte)3), "the raw status is surfaced, not rejected");
         }
     }
 
@@ -463,6 +590,13 @@ public class FrameTxReceiptDecoderTests
     // Two pre-fork receipts as the non-compact storage codec has always written them: logs, the 0xff tx-hash
     // mark, the hash, then the error string. Captured before the frame extension was appended after it.
     private const string NonFrameArrayNonCompactHex = "f903a2f901ce01a0017e667f4b8c174291d1543c466717566e206df1bfd6f30271055ddafdb18f72020294475674cb523a0a2736b7f7534390288fce16982c94942921b14f1b1c385cd7e0cc2ef7abe5598c83589476e68a8696537e4141926f3e528733af9e237d69648203e8b9010000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000800000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000f83af838940000000000000000000000000000000000000000e1a0000000000000000000000000000000000000000000000000000000000000000080ffa003783fac2efed8fbc9ad443e592ee30e61d65f471140c10ca155e937b435b760856572726f72f901ce01a0017e667f4b8c174291d1543c466717566e206df1bfd6f30271055ddafdb18f720202942d36e6c27c34ea22620e7b7c45de774599406cf394942921b14f1b1c385cd7e0cc2ef7abe5598c83589476e68a8696537e4141926f3e528733af9e237d69648203e8b9010000000000000000000080000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000800000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000f83af838940000000000000000000000000000000000000000e1a0000000000000000000000000000000000000000000000000000000000000000080ffa01f675bff07515f5df96737194ea945c36c41e7b4fcef307b7cd4d0e602a69111856572726f72";
+
+    // Rows an earlier build of this branch wrote through debug_insertReceipts, both encoders' output for a
+    // single-frame receipt: one with the payer omitted, one with a frame status of 3.
+    private const string PayerlessNonCompactHex = "b901ae06f901aa018080809476e68a8696537e4141926f3e528733af9e237d69808080826590b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000002000000000000000000000000000000080000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000f83af83894942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd201ff808080f846f84401c6825208821388f83af83894942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd201";
+    private const string PayerlessCompactHex = "f8a0019476e68a8696537e4141926f3e528733af9e237d69826590f83bf83994942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2800180f847f84501c6825208821388f83bf83994942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd28001";
+    private const string UndefinedStatusNonCompactHex = "b901c206f901be018080809476e68a8696537e4141926f3e528733af9e237d69808080826590b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000002000000000000000000000000000000080000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000f83af83894942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd201ff808094b7705ae4c6f81b66cdb323c65f4e8133690fc099f846f84403c6825208821388f83af83894942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd201";
+    private const string UndefinedStatusCompactHex = "f8b4019476e68a8696537e4141926f3e528733af9e237d69826590f83bf83994942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2800194b7705ae4c6f81b66cdb323c65f4e8133690fc099f847f84503c6825208821388f83bf83994942921b14f1b1c385cd7e0cc2ef7abe5598c8358e1a05fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd28001";
 
     [Test]
     public void StorageDecode_PreTwoDimensionalScalarGasUsed_ReadsExecutionWithZeroState(

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugModuleTests.cs
@@ -476,6 +476,22 @@ public class DebugModuleTests
         _debugBridge.DidNotReceiveWithAnyArgs().InsertReceipts(default!, default!);
     }
 
+    // The payer is written null-tolerantly and read strictly, so a payer-less frame receipt would persist and
+    // then throw on every later read of its block's receipts. It is the same failure mode as a frames-less one.
+    [Test]
+    public async Task DebugInsertReceipts_FrameTxReceiptWithoutPayer_IsRejectedAndNotStored()
+    {
+        ReceiptForRpc receipt = FrameReceiptPayload(
+            [new FrameReceiptForRpc { Status = TxFrameReceipt.StatusSuccess, ExecutionGasUsed = 21_000 }],
+            withPayer: false);
+
+        ResultWrapper<bool> result = await CreateModule().debug_insertReceipts(new BlockParameter(1), [receipt]);
+
+        Assert.That(result.Result.ResultType, Is.EqualTo(ResultType.Failure));
+        Assert.That(result.ErrorCode, Is.EqualTo(ErrorCodes.InvalidParams));
+        _debugBridge.DidNotReceiveWithAnyArgs().InsertReceipts(default!, default!);
+    }
+
     // A null array entry is a caller error too: it otherwise dereferences into an internal error.
     [Test]
     public async Task DebugInsertReceipts_NullReceiptEntry_IsRejectedAndNotStored()
@@ -507,11 +523,11 @@ public class DebugModuleTests
             Is.EqualTo(new[] { (TxFrameReceipt.StatusSuccess, 21_000UL), (TxFrameReceipt.StatusFailure, 30_000UL) }));
     }
 
-    private static ReceiptForRpc FrameReceiptPayload(FrameReceiptForRpc[]? frameReceipts) => new()
+    private static ReceiptForRpc FrameReceiptPayload(FrameReceiptForRpc[]? frameReceipts, bool withPayer = true) => new()
     {
         Type = TxType.FrameTx,
         CumulativeGasUsed = 21_000,
-        Payer = TestItem.AddressA,
+        Payer = withPayer ? TestItem.AddressA : null,
         FrameReceipts = frameReceipts,
         Logs = []
     };

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -639,6 +639,32 @@ public class FrameTransactionForRpcTests
         Assert.That(() => receiptForRpc.ToReceipt(), Throws.InstanceOf<JsonException>());
     }
 
+    /// <summary>And on the frame logs, which ConcatLogs then carries into the receipt's own log set: the element
+    /// annotation does not bind the deserializer, so <c>"logs": [null]</c> reaches the binder here too.</summary>
+    [TestCase(true)]
+    [TestCase(false)]
+    public void ReceiptForRpc_FrameTx_RejectsANullFrameLogEntry(bool withNullEntry)
+    {
+        ReceiptForRpc receiptForRpc = ToRpc(BuildFrameTxReceipt());
+        receiptForRpc.FrameReceipts =
+        [
+            new FrameReceiptForRpc
+            {
+                Status = TxFrameReceipt.StatusSuccess,
+                Logs = withNullEntry ? [null!] : [new LogEntry(TestItem.AddressA, [1], [])],
+            }
+        ];
+
+        if (withNullEntry)
+        {
+            Assert.That(() => receiptForRpc.ToReceipt(), Throws.InstanceOf<JsonException>());
+        }
+        else
+        {
+            Assert.That(receiptForRpc.ToReceipt().FrameReceipts![0].Logs, Has.Length.EqualTo(1));
+        }
+    }
+
     private const int MaxAggregateLogs = 270_000;
 
     /// <summary>The frame log union is admitted right up to the wire receipt decoder's log ceiling.</summary>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/RpcTransaction/FrameTransactionForRpcTests.cs
@@ -608,6 +608,28 @@ public class FrameTransactionForRpcTests
         Assert.That(() => receiptForRpc.ToReceipt(), Throws.InstanceOf<JsonException>());
     }
 
+    /// <summary>The stored receipt decoder holds the wire decoder's status bound, so an undefined status has to be
+    /// refused here too rather than stored as a receipt no read path, local or remote, accepts.</summary>
+    [TestCase(TxFrameReceipt.StatusFailure, false)]
+    [TestCase(TxFrameReceipt.StatusSuccess, false)]
+    [TestCase(TxFrameReceipt.StatusSkipped, false)]
+    [TestCase((byte)3, true)]
+    [TestCase(byte.MaxValue, true)]
+    public void ReceiptForRpc_FrameTx_RejectsAFrameStatusOutsideThePayloadValues(byte status, bool rejected)
+    {
+        ReceiptForRpc receiptForRpc = ToRpc(BuildFrameTxReceipt());
+        receiptForRpc.FrameReceipts = [new FrameReceiptForRpc { Status = status }];
+
+        if (rejected)
+        {
+            Assert.That(() => receiptForRpc.ToReceipt(), Throws.InstanceOf<JsonException>());
+        }
+        else
+        {
+            Assert.That(receiptForRpc.ToReceipt().FrameReceipts![0].Status, Is.EqualTo(status));
+        }
+    }
+
     /// <summary>The same hazard on the top-level logs, which every receipt type carries.</summary>
     [Test]
     public void ReceiptForRpc_RejectsANullLogEntry()

--- a/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
@@ -184,7 +184,7 @@ namespace Nethermind.JsonRpc.Data
         /// Reached with an unvalidated payload through <c>debug_insertReceipts</c>, so a shape EIP-8141
         /// cannot produce has to be rejected here rather than reaching the receipt store.
         /// </remarks>
-        /// <exception cref="JsonException">An entry is null or carries an undefined status, there are more than EIP-8141's MAX_FRAMES of them, or their logs exceed <see cref="MaxLogs"/> in aggregate.</exception>
+        /// <exception cref="JsonException">An entry is null, carries an undefined status or a null log, there are more than EIP-8141's MAX_FRAMES of them, or their logs exceed <see cref="MaxLogs"/> in aggregate.</exception>
         private TxFrameReceipt[] ToFrameReceipts()
         {
             if (FrameReceipts is not { Length: > 0 } frames)
@@ -209,6 +209,16 @@ namespace Nethermind.JsonRpc.Data
                 if (frameReceipt.Status is not (TxFrameReceipt.StatusFailure or TxFrameReceipt.StatusSuccess or TxFrameReceipt.StatusSkipped))
                 {
                     throw new JsonException($"Frame receipt {i} has status {frameReceipt.Status}, not one of failure, success or skipped.");
+                }
+
+                // As on the top-level logs: a null entry encodes but no read path takes it back, and
+                // ConcatLogs would carry it into the receipt's own log set.
+                for (int j = 0; j < frameReceipt.Logs.Length; j++)
+                {
+                    if (frameReceipt.Logs[j] is null)
+                    {
+                        throw new JsonException($"Log entry {j} of frame receipt {i} is null.");
+                    }
                 }
 
                 logCount += frameReceipt.Logs.Length;

--- a/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Data/ReceiptForRpc.cs
@@ -184,7 +184,7 @@ namespace Nethermind.JsonRpc.Data
         /// Reached with an unvalidated payload through <c>debug_insertReceipts</c>, so a shape EIP-8141
         /// cannot produce has to be rejected here rather than reaching the receipt store.
         /// </remarks>
-        /// <exception cref="JsonException">An entry is null, there are more than EIP-8141's MAX_FRAMES of them, or their logs exceed <see cref="MaxLogs"/> in aggregate.</exception>
+        /// <exception cref="JsonException">An entry is null or carries an undefined status, there are more than EIP-8141's MAX_FRAMES of them, or their logs exceed <see cref="MaxLogs"/> in aggregate.</exception>
         private TxFrameReceipt[] ToFrameReceipts()
         {
             if (FrameReceipts is not { Length: > 0 } frames)
@@ -205,6 +205,11 @@ namespace Nethermind.JsonRpc.Data
                 TxFrameReceipt frameReceipt = frames[i] is { } frame
                     ? frame.ToFrameReceipt()
                     : throw new JsonException($"Frame receipt {i} is null.");
+
+                if (frameReceipt.Status is not (TxFrameReceipt.StatusFailure or TxFrameReceipt.StatusSuccess or TxFrameReceipt.StatusSkipped))
+                {
+                    throw new JsonException($"Frame receipt {i} has status {frameReceipt.Status}, not one of failure, success or skipped.");
+                }
 
                 logCount += frameReceipt.Logs.Length;
                 if (logCount > MaxLogs)

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -320,9 +320,9 @@ public class DebugRpcModule(
 
     public Task<ResultWrapper<bool>> debug_insertReceipts(BlockParameter blockParameter, ReceiptForRpc[] receiptForRpc)
     {
-        // EIP-8141: a frame transaction always executes at least one frame, so a frames-less receipt
-        // is malformed. Its payload still encodes (as an empty frames list) but no longer decodes, so
-        // it is rejected here rather than persisted as a receipt no peer could read back.
+        // EIP-8141: a frame transaction always executes at least one frame and always settles on a payer,
+        // so a receipt missing either is malformed. Both still encode but no longer decode, so they are
+        // rejected here rather than persisted as a receipt no node could read back.
         for (int i = 0; i < receiptForRpc.Length; i++)
         {
             ReceiptForRpc receipt = receiptForRpc[i];
@@ -335,6 +335,13 @@ public class DebugRpcModule(
             {
                 return Task.FromResult(ResultWrapper<bool>.Fail(
                     $"Receipt at index {i} is a frame transaction receipt carrying no frame receipts",
+                    ErrorCodes.InvalidParams));
+            }
+
+            if (receipt.Type == TxType.FrameTx && receipt.Payer is null)
+            {
+                return Task.FromResult(ResultWrapper<bool>.Fail(
+                    $"Receipt at index {i} is a frame transaction receipt carrying no payer",
                     ErrorCodes.InvalidParams));
             }
         }

--- a/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/Modules/DebugModule/DebugRpcModule.cs
@@ -321,8 +321,8 @@ public class DebugRpcModule(
     public Task<ResultWrapper<bool>> debug_insertReceipts(BlockParameter blockParameter, ReceiptForRpc[] receiptForRpc)
     {
         // EIP-8141: a frame transaction always executes at least one frame and always settles on a payer,
-        // so a receipt missing either is malformed. Both still encode but no longer decode, so they are
-        // rejected here rather than persisted as a receipt no node could read back.
+        // so a receipt missing either is malformed. The codec refuses both; rejecting them here answers
+        // invalid params rather than an internal error.
         for (int i = 0; i < receiptForRpc.Length; i++)
         {
             ReceiptForRpc receipt = receiptForRpc[i];

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -177,8 +177,7 @@ namespace Nethermind.Serialization.Rlp
             {
                 // Repeats the logs the top-level union already holds, at the cost noted above: DecodeStructRef
                 // hands eth_getLogs one contiguous LogsRlp span, which N per-frame sequences cannot supply.
-                writer.Encode(item.Payer);
-                FrameReceiptRlp.EncodeFrames(ref writer, item.FrameReceipts ?? [], CompactLogEntryDecoder.Instance);
+                FrameReceiptRlp.EncodeStoredExtension(ref writer, item, CompactLogEntryDecoder.Instance);
             }
         }
 
@@ -208,8 +207,7 @@ namespace Nethermind.Serialization.Rlp
 
             if (item.TxType == TxType.FrameTx)
             {
-                contentLength += Rlp.LengthOf(item.Payer);
-                contentLength += Rlp.LengthOfSequence(FrameReceiptRlp.GetFramesLength(item.FrameReceipts ?? [], CompactLogEntryDecoder.Instance));
+                contentLength += FrameReceiptRlp.GetStoredExtensionLength(item, CompactLogEntryDecoder.Instance);
             }
 
             return (contentLength, logsLength);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -72,7 +72,9 @@ namespace Nethermind.Serialization.Rlp
             if (decoderContext.Position < receiptEnd)
             {
                 txReceipt.TxType = TxType.FrameTx;
-                txReceipt.Payer = decoderContext.DecodeAddress();
+                // Null-tolerant like the sender above: an earlier build wrote a payer-less receipt, and
+                // refusing to parse it would take the whole block's receipt array with it.
+                txReceipt.Payer = decoderContext.DecodeAddressOrNull();
                 txReceipt.FrameReceipts = FrameReceiptRlp.DecodeStoredFrames(ref decoderContext, CompactLogEntryDecoder.Instance);
             }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/FrameReceiptRlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/FrameReceiptRlp.cs
@@ -14,8 +14,9 @@ namespace Nethermind.Serialization.Rlp;
 /// <c>[payer, [frame_receipt, ...]]</c> extension both storage formats append.
 /// https://eips.ethereum.org/EIPS/eip-8141
 /// </summary>
-/// <remarks>The storage formats differ only in their log codec, so they pass their own, and they relax the
-/// wire's bounds only where an older on-disk shape needs it. Every format writes through the same length and
+/// <remarks>The storage formats differ only in their log codec, so they pass their own, and they decode
+/// leniently where the wire is strict: the shapes the wire refuses are refused on the write paths instead, so
+/// a row an earlier build already persisted still reads back. Every format writes through the same length and
 /// encode paths, so a change to the frame layout cannot reach one of them alone.</remarks>
 public static class FrameReceiptRlp
 {
@@ -27,7 +28,7 @@ public static class FrameReceiptRlp
     private static readonly RlpLimit FrameReceiptsRlpLimit = RlpLimit.For<TxReceipt>(Eip8141Constants.MaxFrames, nameof(TxReceipt.FrameReceipts));
 
     /// <summary>The content length of the frames list, its own header excluded.</summary>
-    internal static int GetFramesLength(TxFrameReceipt[] frameReceipts, IRlpDecoder<LogEntry?> logDecoder)
+    private static int GetFramesLength(TxFrameReceipt[] frameReceipts, IRlpDecoder<LogEntry?> logDecoder)
     {
         int framesLength = 0;
         for (int i = 0; i < frameReceipts.Length; i++)
@@ -39,26 +40,20 @@ public static class FrameReceiptRlp
     }
 
     /// <summary>Writes the frames list, its header included.</summary>
-    internal static void EncodeFrames<TWriter>(ref TWriter writer, TxFrameReceipt[] frameReceipts, IRlpDecoder<LogEntry?> logDecoder)
+    private static void EncodeFrames<TWriter>(ref TWriter writer, TxFrameReceipt[] frameReceipts, IRlpDecoder<LogEntry?> logDecoder)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
         => EncodeFrames(ref writer, frameReceipts, logDecoder, GetFramesLength(frameReceipts, logDecoder));
 
     /// <summary>Decodes the frames list of a stored receipt's <c>[payer, [frame_receipt, ...]]</c> extension.</summary>
-    /// <remarks>Lenient only where the on-disk history demands it — a pre-2D scalar <c>gas_used</c>, and an empty
-    /// frames list. The frame count and the status byte are bounded as on the wire, so a datadir cannot hold a
-    /// receipt this node reads back but no peer would accept.</remarks>
+    /// <remarks>Lenient by design: the data is locally written, and it may predate the 2D <c>gas_used</c>.</remarks>
     internal static TxFrameReceipt[] DecodeStoredFrames(ref RlpReader reader, IRlpDecoder<LogEntry?> logDecoder)
     {
         int framesEnd = reader.ReadSequenceLength() + reader.Position;
-        int frameCount = reader.PeekNumberOfItemsRemaining(framesEnd, Eip8141Constants.MaxFrames + 1);
-        reader.GuardLimit(frameCount, FrameReceiptsRlpLimit);
-
-        TxFrameReceipt[] frameReceipts = new TxFrameReceipt[frameCount];
-        for (int i = 0; i < frameCount; i++)
+        using ArrayPoolListRef<TxFrameReceipt> frameReceipts = new(Eip8141Constants.MaxFrames);
+        while (reader.Position < framesEnd)
         {
             int frameEnd = reader.ReadSequenceLength() + reader.Position;
             byte status = reader.DecodeByte();
-            GuardFrameStatus(status);
             DecodeStoredGasUsed(ref reader, out ulong executionGasUsed, out ulong stateGasUsed);
 
             int logsEnd = reader.ReadSequenceLength() + reader.Position;
@@ -68,42 +63,68 @@ public static class FrameReceiptRlp
                 frameLogs.Add(logDecoder.DecodeGuardNotNull(ref reader, RlpBehaviors.AllowExtraBytes));
             }
 
-            frameReceipts[i] = new TxFrameReceipt(status, executionGasUsed, stateGasUsed, frameLogs.ToArray());
+            frameReceipts.Add(new TxFrameReceipt(status, executionGasUsed, stateGasUsed, frameLogs.ToArray()));
             reader.Check(frameEnd);
         }
 
-        // Counting items only requires a frame to start before the declared end, so an under-declared
-        // frames header is only caught here.
-        reader.Check(framesEnd);
-        return frameReceipts;
+        return frameReceipts.ToArray();
     }
 
     /// <summary>The content length of a stored receipt's trailing <c>[payer, frames]</c> extension.</summary>
-    /// <exception cref="RlpException">The receipt carries no payer.</exception>
+    /// <exception cref="RlpException">The receipt is one no read path would take back.</exception>
     internal static int GetStoredExtensionLength(TxReceipt receipt, IRlpDecoder<LogEntry?> logDecoder)
     {
-        GuardPayer(receipt);
-        return Rlp.LengthOf(receipt.Payer)
-               + Rlp.LengthOfSequence(GetFramesLength(receipt.FrameReceipts ?? [], logDecoder));
+        TxFrameReceipt[] frameReceipts = GuardEncodable(receipt);
+        return Rlp.LengthOf(receipt.Payer) + Rlp.LengthOfSequence(GetFramesLength(frameReceipts, logDecoder));
     }
 
     /// <summary>Writes a stored receipt's trailing <c>[payer, frames]</c> extension.</summary>
-    /// <exception cref="RlpException">The receipt carries no payer.</exception>
+    /// <exception cref="RlpException">The receipt is one no read path would take back.</exception>
     internal static void EncodeStoredExtension<TWriter>(ref TWriter writer, TxReceipt receipt, IRlpDecoder<LogEntry?> logDecoder)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
-        GuardPayer(receipt);
+        TxFrameReceipt[] frameReceipts = GuardEncodable(receipt);
         writer.Encode(receipt.Payer);
-        EncodeFrames(ref writer, receipt.FrameReceipts ?? [], logDecoder);
+        EncodeFrames(ref writer, frameReceipts, logDecoder);
     }
 
-    /// <summary>Rejects a receipt the strict read side could not decode back, rather than persisting it.</summary>
-    private static void GuardPayer(TxReceipt receipt)
+    /// <summary>Rejects a receipt whose shape a read path would refuse, rather than writing it.</summary>
+    /// <remarks>The bounds are held here rather than in <see cref="DecodeStoredFrames"/> because a stored row
+    /// that fails to parse takes its whole block's receipt array with it, and no encoder could reproduce the
+    /// bytes to migrate it. Refusing on the way in keeps a row already on disk readable.</remarks>
+    /// <returns>The receipt's frame receipts, once they are known to be encodable.</returns>
+    /// <exception cref="RlpException">The receipt is one no read path would take back.</exception>
+    private static TxFrameReceipt[] GuardEncodable(TxReceipt receipt)
     {
         if (receipt.Payer is null)
         {
             ThrowMissingPayer();
         }
+
+        TxFrameReceipt[] frameReceipts = receipt.FrameReceipts ?? [];
+        if (frameReceipts.Length == 0)
+        {
+            ThrowEmptyFrameReceipts();
+        }
+
+        if (frameReceipts.Length > Eip8141Constants.MaxFrames)
+        {
+            ThrowTooManyFrames(frameReceipts.Length);
+        }
+
+        int totalLogs = 0;
+        for (int i = 0; i < frameReceipts.Length; i++)
+        {
+            GuardFrameStatus(frameReceipts[i].Status);
+            totalLogs += frameReceipts[i].Logs.Length;
+        }
+
+        if (totalLogs > MaxReceiptLogs)
+        {
+            ThrowTooManyFrameLogs(totalLogs);
+        }
+
+        return frameReceipts;
     }
 
     private static void GuardFrameStatus(byte status)
@@ -118,23 +139,24 @@ public static class FrameReceiptRlp
     /// the sequence enclosing them excluded.</summary>
     /// <param name="receipt">The frame-transaction receipt to measure.</param>
     /// <param name="framesLength">The content length of the frames list, to hand back to the encoder.</param>
-    /// <exception cref="RlpException">The receipt carries no payer.</exception>
+    /// <exception cref="RlpException">The receipt is one no read path would take back.</exception>
     public static int GetPayloadLength(TxReceipt receipt, out int framesLength)
     {
-        GuardPayer(receipt);
-        framesLength = GetFramesLength(receipt.FrameReceipts ?? [], LogEntryDecoder.Instance);
+        framesLength = GetFramesLength(GuardEncodable(receipt), LogEntryDecoder.Instance);
         return Rlp.LengthOf(receipt.GasUsedTotal)
                + Rlp.LengthOf(receipt.Payer)
                + Rlp.LengthOfSequence(framesLength);
     }
 
     /// <summary>Writes the payload fields; the caller owns the sequence enclosing them.</summary>
+    /// <exception cref="RlpException">The receipt is one no read path would take back.</exception>
     public static void EncodePayload<TWriter>(ref TWriter writer, TxReceipt receipt, int framesLength)
         where TWriter : struct, IRlpWriteBackend, allows ref struct
     {
+        TxFrameReceipt[] frameReceipts = GuardEncodable(receipt);
         writer.Encode(receipt.GasUsedTotal);
         writer.Encode(receipt.Payer);
-        EncodeFrames(ref writer, receipt.FrameReceipts ?? [], LogEntryDecoder.Instance, framesLength);
+        EncodeFrames(ref writer, frameReceipts, LogEntryDecoder.Instance, framesLength);
     }
 
     /// <summary>Decodes the payload fields into <paramref name="receipt"/>, deriving its status and logs from
@@ -212,14 +234,6 @@ public static class FrameReceiptRlp
         {
             reader.Check(receiptEnd);
         }
-
-        [DoesNotReturn, StackTraceHidden]
-        static void ThrowEmptyFrameReceipts()
-            => throw new RlpException("Frame transaction receipt carries no frame receipts");
-
-        [DoesNotReturn, StackTraceHidden]
-        static void ThrowTooManyFrameLogs(int totalLogs)
-            => throw new RlpException($"Frame transaction receipt carries {totalLogs} logs, over the {LogsRlpLimit.Limit} a receipt may hold");
     }
 
     [DoesNotReturn, StackTraceHidden]
@@ -229,6 +243,18 @@ public static class FrameReceiptRlp
     [DoesNotReturn, StackTraceHidden]
     private static void ThrowMissingPayer()
         => throw new RlpException("Frame transaction receipt carries no payer");
+
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowEmptyFrameReceipts()
+        => throw new RlpException("Frame transaction receipt carries no frame receipts");
+
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowTooManyFrames(int frameCount)
+        => throw new RlpException($"Frame transaction receipt carries {frameCount} frame receipts, over the {Eip8141Constants.MaxFrames} a transaction may hold");
+
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowTooManyFrameLogs(int totalLogs)
+        => throw new RlpException($"Frame transaction receipt carries {totalLogs} logs, over the {MaxReceiptLogs} a receipt may hold");
 
     /// <summary>
     /// Decodes a stored frame receipt's <c>gas_used</c>, tolerating both the current

--- a/src/Nethermind/Nethermind.Serialization.Rlp/FrameReceiptRlp.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/FrameReceiptRlp.cs
@@ -14,9 +14,9 @@ namespace Nethermind.Serialization.Rlp;
 /// <c>[payer, [frame_receipt, ...]]</c> extension both storage formats append.
 /// https://eips.ethereum.org/EIPS/eip-8141
 /// </summary>
-/// <remarks>The storage formats differ only in their log codec, so they pass their own, and they decode
-/// leniently where the wire is strict. Every format writes through the same length and encode paths, so a
-/// change to the frame layout cannot reach one of them alone.</remarks>
+/// <remarks>The storage formats differ only in their log codec, so they pass their own, and they relax the
+/// wire's bounds only where an older on-disk shape needs it. Every format writes through the same length and
+/// encode paths, so a change to the frame layout cannot reach one of them alone.</remarks>
 public static class FrameReceiptRlp
 {
     /// <summary>The most logs a receipt may carry: a 100M gas ceiling still allows roughly 266k LOG0
@@ -44,15 +44,21 @@ public static class FrameReceiptRlp
         => EncodeFrames(ref writer, frameReceipts, logDecoder, GetFramesLength(frameReceipts, logDecoder));
 
     /// <summary>Decodes the frames list of a stored receipt's <c>[payer, [frame_receipt, ...]]</c> extension.</summary>
-    /// <remarks>Lenient by design: the data is locally written, and it may predate the 2D <c>gas_used</c>.</remarks>
+    /// <remarks>Lenient only where the on-disk history demands it — a pre-2D scalar <c>gas_used</c>, and an empty
+    /// frames list. The frame count and the status byte are bounded as on the wire, so a datadir cannot hold a
+    /// receipt this node reads back but no peer would accept.</remarks>
     internal static TxFrameReceipt[] DecodeStoredFrames(ref RlpReader reader, IRlpDecoder<LogEntry?> logDecoder)
     {
         int framesEnd = reader.ReadSequenceLength() + reader.Position;
-        using ArrayPoolListRef<TxFrameReceipt> frameReceipts = new(Eip8141Constants.MaxFrames);
-        while (reader.Position < framesEnd)
+        int frameCount = reader.PeekNumberOfItemsRemaining(framesEnd, Eip8141Constants.MaxFrames + 1);
+        reader.GuardLimit(frameCount, FrameReceiptsRlpLimit);
+
+        TxFrameReceipt[] frameReceipts = new TxFrameReceipt[frameCount];
+        for (int i = 0; i < frameCount; i++)
         {
             int frameEnd = reader.ReadSequenceLength() + reader.Position;
             byte status = reader.DecodeByte();
+            GuardFrameStatus(status);
             DecodeStoredGasUsed(ref reader, out ulong executionGasUsed, out ulong stateGasUsed);
 
             int logsEnd = reader.ReadSequenceLength() + reader.Position;
@@ -62,19 +68,60 @@ public static class FrameReceiptRlp
                 frameLogs.Add(logDecoder.DecodeGuardNotNull(ref reader, RlpBehaviors.AllowExtraBytes));
             }
 
-            frameReceipts.Add(new TxFrameReceipt(status, executionGasUsed, stateGasUsed, frameLogs.ToArray()));
+            frameReceipts[i] = new TxFrameReceipt(status, executionGasUsed, stateGasUsed, frameLogs.ToArray());
             reader.Check(frameEnd);
         }
 
-        return frameReceipts.ToArray();
+        // Counting items only requires a frame to start before the declared end, so an under-declared
+        // frames header is only caught here.
+        reader.Check(framesEnd);
+        return frameReceipts;
+    }
+
+    /// <summary>The content length of a stored receipt's trailing <c>[payer, frames]</c> extension.</summary>
+    /// <exception cref="RlpException">The receipt carries no payer.</exception>
+    internal static int GetStoredExtensionLength(TxReceipt receipt, IRlpDecoder<LogEntry?> logDecoder)
+    {
+        GuardPayer(receipt);
+        return Rlp.LengthOf(receipt.Payer)
+               + Rlp.LengthOfSequence(GetFramesLength(receipt.FrameReceipts ?? [], logDecoder));
+    }
+
+    /// <summary>Writes a stored receipt's trailing <c>[payer, frames]</c> extension.</summary>
+    /// <exception cref="RlpException">The receipt carries no payer.</exception>
+    internal static void EncodeStoredExtension<TWriter>(ref TWriter writer, TxReceipt receipt, IRlpDecoder<LogEntry?> logDecoder)
+        where TWriter : struct, IRlpWriteBackend, allows ref struct
+    {
+        GuardPayer(receipt);
+        writer.Encode(receipt.Payer);
+        EncodeFrames(ref writer, receipt.FrameReceipts ?? [], logDecoder);
+    }
+
+    /// <summary>Rejects a receipt the strict read side could not decode back, rather than persisting it.</summary>
+    private static void GuardPayer(TxReceipt receipt)
+    {
+        if (receipt.Payer is null)
+        {
+            ThrowMissingPayer();
+        }
+    }
+
+    private static void GuardFrameStatus(byte status)
+    {
+        if (status is not (TxFrameReceipt.StatusFailure or TxFrameReceipt.StatusSuccess or TxFrameReceipt.StatusSkipped))
+        {
+            ThrowUnknownFrameStatus(status);
+        }
     }
 
     /// <summary>The content length of the payload fields <c>[cumulative_gas_used, payer, frames]</c>,
     /// the sequence enclosing them excluded.</summary>
     /// <param name="receipt">The frame-transaction receipt to measure.</param>
     /// <param name="framesLength">The content length of the frames list, to hand back to the encoder.</param>
+    /// <exception cref="RlpException">The receipt carries no payer.</exception>
     public static int GetPayloadLength(TxReceipt receipt, out int framesLength)
     {
+        GuardPayer(receipt);
         framesLength = GetFramesLength(receipt.FrameReceipts ?? [], LogEntryDecoder.Instance);
         return Rlp.LengthOf(receipt.GasUsedTotal)
                + Rlp.LengthOf(receipt.Payer)
@@ -117,12 +164,9 @@ public static class FrameReceiptRlp
         {
             int frameEnd = reader.ReadSequenceLength() + reader.Position;
             byte status = reader.DecodeByte();
-            if (status is not (TxFrameReceipt.StatusFailure or TxFrameReceipt.StatusSuccess or TxFrameReceipt.StatusSkipped))
-            {
-                // AggregateStatus folds anything but success to failure while RPC surfaces the raw byte,
-                // so an out-of-range status would read differently at the two ends of the same receipt.
-                ThrowUnknownFrameStatus(status);
-            }
+            // AggregateStatus folds anything but success to failure while RPC surfaces the raw byte,
+            // so an out-of-range status would read differently at the two ends of the same receipt.
+            GuardFrameStatus(status);
 
             int gasUsedEnd = reader.ReadSequenceLength() + reader.Position;
             ulong executionGasUsed = reader.DecodeULong();
@@ -174,13 +218,17 @@ public static class FrameReceiptRlp
             => throw new RlpException("Frame transaction receipt carries no frame receipts");
 
         [DoesNotReturn, StackTraceHidden]
-        static void ThrowUnknownFrameStatus(byte status)
-            => throw new RlpException($"Frame receipt status {status} is not one of failure, success or skipped");
-
-        [DoesNotReturn, StackTraceHidden]
         static void ThrowTooManyFrameLogs(int totalLogs)
             => throw new RlpException($"Frame transaction receipt carries {totalLogs} logs, over the {LogsRlpLimit.Limit} a receipt may hold");
     }
+
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowUnknownFrameStatus(byte status)
+        => throw new RlpException($"Frame receipt status {status} is not one of failure, success or skipped");
+
+    [DoesNotReturn, StackTraceHidden]
+    private static void ThrowMissingPayer()
+        => throw new RlpException("Frame transaction receipt carries no payer");
 
     /// <summary>
     /// Decodes a stored frame receipt's <c>gas_used</c>, tolerating both the current

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -194,8 +194,7 @@ namespace Nethermind.Serialization.Rlp
             {
                 // Repeats the logs the top-level union already holds: DecodeStructRef hands eth_getLogs one
                 // contiguous LogsRlp span, which N per-frame sequences cannot supply.
-                writer.Encode(item.Payer);
-                FrameReceiptRlp.EncodeFrames(ref writer, item.FrameReceipts ?? [], LogEntryDecoder.Instance);
+                FrameReceiptRlp.EncodeStoredExtension(ref writer, item, LogEntryDecoder.Instance);
             }
         }
 
@@ -242,8 +241,7 @@ namespace Nethermind.Serialization.Rlp
 
             if (item.TxType == TxType.FrameTx)
             {
-                contentLength += Rlp.LengthOf(item.Payer);
-                contentLength += Rlp.LengthOfSequence(FrameReceiptRlp.GetFramesLength(item.FrameReceipts ?? [], LogEntryDecoder.Instance));
+                contentLength += FrameReceiptRlp.GetStoredExtensionLength(item, LogEntryDecoder.Instance);
             }
 
             return (contentLength, logsLength);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -99,7 +99,9 @@ namespace Nethermind.Serialization.Rlp
 
             if (txReceipt.TxType == TxType.FrameTx && decoderContext.Position < receiptEnd)
             {
-                txReceipt.Payer = decoderContext.DecodeAddress();
+                // Null-tolerant like every other address here: an earlier build wrote a payer-less receipt,
+                // and refusing to parse it would take the whole block's receipt array with it.
+                txReceipt.Payer = decoderContext.DecodeAddressOrNull();
                 txReceipt.FrameReceipts = FrameReceiptRlp.DecodeStoredFrames(ref decoderContext, LogEntryDecoder.Instance);
             }
 
@@ -339,24 +341,20 @@ namespace Nethermind.Serialization.Rlp
             item.LogsRlp = decoderContext.Data.Slice(decoderContext.Position, logsBytes);
             decoderContext.SkipItem();
 
-            bool allowExtraBytes = (rlpBehaviors & RlpBehaviors.AllowExtraBytes) != 0;
-            if (!allowExtraBytes)
+            if (isStorage && supportTxHash && decoderContext.Position < receiptEnd)
             {
-                if (isStorage && supportTxHash && decoderContext.Position < receiptEnd)
+                // since txHash was added later and may not be in rlp, we provide special mark byte that it will be next
+                if (decoderContext.PeekByte() == MarkTxHashByte)
                 {
-                    // since txHash was added later and may not be in rlp, we provide special mark byte that it will be next
-                    if (decoderContext.PeekByte() == MarkTxHashByte)
-                    {
-                        decoderContext.ReadByte();
-                        decoderContext.DecodeKeccakStructRef(out item.TxHash);
-                    }
+                    decoderContext.ReadByte();
+                    decoderContext.DecodeKeccakStructRef(out item.TxHash);
                 }
+            }
 
-                // since error was added later we can only rely on it in cases where we read receipt only and no data follows, empty errors might not be serialized
-                if (decoderContext.Position < receiptEnd)
-                {
-                    item.Error = decoderContext.DecodeString();
-                }
+            // since error was added later we can only rely on it in cases where we read receipt only and no data follows, empty errors might not be serialized
+            if (decoderContext.Position < receiptEnd)
+            {
+                item.Error = decoderContext.DecodeString();
             }
 
             // EIP-8141: realign to the receipt's end so the next receipt in an array stays aligned; for a frame tx


### PR DESCRIPTION
## Changes

Addresses three review threads on #12526 on the frame-receipt storage codec, plus the eight follow-up threads on this PR.

The organising principle after review: **reject on write, stay permissive on read.** A stored row that fails to parse takes its whole block's receipt array with it (`ReceiptArrayStorageDecoder` decodes the array in one pass) and leaves no encoder that could reproduce the bytes to migrate it, so every bound the wire holds is enforced on the write paths and none of them on the stored read path.

- **Payer** — the stored `[payer, frames]` extension was written null-tolerantly (`writer.Encode(item.Payer)` emits `0x80`) and read strictly (`DecodeAddress()`), so a frame receipt with `Payer == null` encoded fine and then threw on every later read of that block's receipts. Block processing cannot produce it — `_frameTxPayer` and `_frameTxReceipts` are set by the same non-nullable `ReportFrameTxReceipt` call — so the reachable route is `debug_insertReceipts`. Both ends are closed and the read heals: the codecs refuse to write a payer-less or frames-less frame receipt, the ingress rejects both with `InvalidParams`, and `ReceiptStorageDecoder`/`CompactReceiptStorageDecoder` now read the payer with `DecodeAddressOrNull()` so a row an earlier build already wrote reads back as `Payer = null` and it is the wire encoder that refuses to serve it.
- **Stored frames vs the wire** — `DecodeStoredFrames` bounded neither the frame count nor the status byte while `DecodePayload` bounds both plus the log union. Rather than tightening the read side, all three now live in one `GuardEncodable` shared by `GetStoredExtensionLength`/`EncodeStoredExtension` and `GetPayloadLength`/`EncodePayload`, which also closes the frames-less shape and makes the wire pair symmetric. `DecodeStoredFrames` is back to its pre-PR body, pre-2D `gas_used` shim included.
- **Dedent** — `ReceiptStorageDecoder.DecodeStructRef` no longer gates the tx-hash mark and the error on `!allowExtraBytes` either, so the two decoders of the same format agree on the same bytes.
- **Frame logs on the ingress** — `ReceiptForRpc.ToFrameReceipts` rejects a null frame log entry, as `ToLogEntries` already did for the top-level logs.

### Why the read side stays permissive

Per bound, whether a build of this branch could already have written a row it would orphan:

| bound | reachable on disk? | why |
|---|---|---|
| payer `0x80` | **yes, whole branch history** | before #12923 `ToReceipt` dropped the frame fields entirely (payer `0x80` *and* empty frames); after it, `Payer` was carried but unbounded until this PR |
| frame status outside 0/1/2 | **yes, #12923 → now** | `FrameReceiptForRpc.Status` is a plain `byte`; nothing bounded it until this PR |
| frame log union > `MaxReceiptLogs` | **yes, #12923 → #13068** | the ingress `MaxLogs` cap only landed in #13068 |
| frame count > `MaxFrames` | no | `ToFrameReceipts` has capped at `MaxFrames` since #12923, the same commit that first let frames through, and the processor cannot exceed it |

The first three are why no read-side guard was added. The fourth moved to the write side anyway, because the round-trip asymmetry is real and closing it there costs nothing.

Re-storing a healed payer-less row still throws — but at the encoder, with a named `RlpException`, and without making the other receipts in its block unreadable. Existing devnet7 databases holding such a row are **readable**, not unrecoverable.

### Pinned sizes

`FrameTxReceiptDecoderTests` 435/701 are untouched: no byte layout moved.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring
- [ ] Configuration change
- [ ] Other (please describe)

## Testing

Requires testing

- [x] Yes
- [ ] No

If yes, did you write tests?

- [x] Yes
- [ ] No

Every behaviour change has a red/green pair reverting only that change, with a negative control that stays green in both states:

| change reverted | red | green control |
|---|---|---|
| payer read heals (`DecodeAddressOrNull`) | `StorageDecode_PayerlessRowFromAnEarlierBuild_...` 2/2 | `StorageRoundtrip_PreservesPayerFrameReceiptsAndUnionLogs` 2/2 |
| stored status read stays lenient | `StorageDecode_UndefinedFrameStatusFromAnEarlierBuild_ReadsBack` 2/2 | `StorageDecode_PreTwoDimensionalScalarGasUsed` 2/2 |
| write guard: frames-less | `Encode_FrameTxReceiptWithoutFrameReceipts_...` 6/6 | `Encode_FrameTxReceiptWithPayer_RoundtripsThePayer` 3/3 |
| write guard: frame count | `Encode_FrameCountHoldsTheWireBound` 3 of 6 (over the bound) | the 3 at the bound |
| write guard: status | `Encode_FrameStatusOutsideThePayloadValues_IsRefused` 6 of 11 | the 5 defined statuses |
| write guard: frame log union | `Encode_FrameLogsSummingOverTheReceiptBound_IsRefused` 3 of 6 | the 3 under the bound |
| `EncodePayload` guard | `EncodePayload_FrameTxReceiptWithoutPayer_...` 1/1 | `Roundtrip_FrameTxReceipt_PreservesPayloadFields` 4/4 |
| the struct-ref dedent | `StructRefDecode_NonFrameReceiptsInTheOnDiskShape_...` `AllowExtraBytes` case | its plain `Storage` case |
| ingress null frame log | `ReceiptForRpc_FrameTx_RejectsANullFrameLogEntry` null case | its non-null case, `ReceiptForRpc_RejectsANullLogEntry` |

The two read-side tests decode literal rows captured from the pre-guard encoder in both storage formats, so they exercise bytes the current encoder can no longer produce.

`Nethermind.Core.Test`, `Nethermind.Network.Test`, `Nethermind.Blockchain.Test` and `Nethermind.JsonRpc.Test` all pass in release (6465/1686/2028/2140) and in checked (6466/1686/2028/2140), artifacts cleaned between configurations. Lint runs clean under CI's exact invocation, positive-controlled with an injected unused `using` that produces exactly one `IDE0005`.

## Documentation

Requires documentation update

- [ ] Yes
- [x] No

Requires explanation in Release Notes

- [ ] Yes
- [x] No
