### PR TITLE
test: fix flaky WaitForImprovedBlock_with_minTransactions payload retrieval

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -463,9 +463,6 @@ public partial class EngineModuleTests
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyB, TestItem.AddressF, 1, 10, out _, out _));
         await minTxWait;
 
-        // An improvement is published to the payload store only after its build finishes, so the wait above
-        // can fire while retrieval would still return the empty one. The replaced context is disposed as it
-        // is swapped out, and retrieval is one-shot, so wait for that before asking for the payload.
         Assert.That(() => emptyImprovement.Disposed, Is.True.After(5000, 10));
 
         ExecutionPayload payload = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -459,8 +459,14 @@ public partial class EngineModuleTests
         await anyWait;
         Assert.That(minTxWait.IsCompleted, Is.False, "an empty improvement must not satisfy minTransactions");
 
+        IBlockImprovementContext emptyImprovement = chain.StoringBlockImprovementContextFactory.SnapshotCreatedContexts()[^1];
         chain.AddTransactions(BuildTransactions(chain, startingHead, TestItem.PrivateKeyB, TestItem.AddressF, 1, 10, out _, out _));
         await minTxWait;
+
+        // An improvement is published to the payload store only after its build finishes, so the wait above
+        // can fire while retrieval would still return the empty one. The replaced context is disposed as it
+        // is swapped out, and retrieval is one-shot, so wait for that before asking for the payload.
+        Assert.That(() => emptyImprovement.Disposed, Is.True.After(5000, 10));
 
         ExecutionPayload payload = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
         Assert.That(payload.TryGetTransactions().Data!, Has.Length.AtLeast(1));


### PR DESCRIPTION
## Changes

- Make `WaitForImprovedBlock_with_minTransactions_ignores_the_empty_first_improvement` wait for the transaction-carrying improvement to reach the payload store before retrieving the payload.

`StoringBlockImprovementContextFactory` raises `BlockImproved` from a continuation on `ImprovementTask`, which it attaches when the context is *created*. `PayloadPreparationService.ImproveBlock` publishes that context into `_payloadStorage` only afterwards. When the build finishes inside that window, the test's `minTransactions` wait is released while storage still holds the previous, empty context, and the `engine_getPayloadV1` that follows returns it:

```
Assert.That(payload.TryGetTransactions().Data, Has.Length.AtLeast(1))
  Expected: property Length greater than or equal to 1
  But was:  0
```

`GetPayload`'s 50 ms wait-for-a-non-empty-block branch does not cover this, because the stored context's improvement task is already complete.

No further improvement round starts at that point — the pool sees no new transactions, so the improvement loop just spins in its delay — so the test cannot wait on a later context being created. It waits instead on the empty context being disposed, which `ImproveBlock` does immediately before swapping in the replacement.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Flaky test fix

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

Reproduced deterministically by temporarily delaying publication (a `Thread.Sleep(300)` at the end of `CreateBlockImprovementContext`): the test fails 2/2 without this change with the signature above, and passes 2/2 with it. Clean tree: 3 runs, 2/2 passing each.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
