### PR TITLE
test: fix flaky prune_on_disk_multiple_times wait budget

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -176,9 +176,6 @@ public class FullPruningDiskTest
         Assert.That(args.Status, Is.EqualTo(isEnoughSpace ? PruningStatus.Starting : PruningStatus.NotEnoughDiskSpace));
     }
 
-    // A prune completes only once processed blocks pass the pruning boundary, so the wait below keeps
-    // feeding blocks; on a loaded runner both production and processing take longer. Bound the wait by
-    // wall clock rather than by a poll count, well inside the MaxTime the pruning tests run under.
     private static readonly TimeSpan PruningWaitBudget = TimeSpan.FromMilliseconds(Timeout.LongTestTime / 4);
 
     private static async Task RunPruning(PruningTestBlockchain chain, int time, bool onlyFirstRuns)

--- a/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/FullPruning/FullPruningDiskTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
@@ -175,6 +176,11 @@ public class FullPruningDiskTest
         Assert.That(args.Status, Is.EqualTo(isEnoughSpace ? PruningStatus.Starting : PruningStatus.NotEnoughDiskSpace));
     }
 
+    // A prune completes only once processed blocks pass the pruning boundary, so the wait below keeps
+    // feeding blocks; on a loaded runner both production and processing take longer. Bound the wait by
+    // wall clock rather than by a poll count, well inside the MaxTime the pruning tests run under.
+    private static readonly TimeSpan PruningWaitBudget = TimeSpan.FromMilliseconds(Timeout.LongTestTime / 4);
+
     private static async Task RunPruning(PruningTestBlockchain chain, int time, bool onlyFirstRuns)
     {
         chain.FullPruner.WaitHandle.Reset();
@@ -188,7 +194,8 @@ public class FullPruningDiskTest
 
         HashSet<byte[]> allItems = chain.DbProvider.StateDb.GetAllValues().ToHashSet(Bytes.EqualityComparer);
         bool pruningFinished = false;
-        for (int i = 0; i < 100 && !pruningFinished; i++)
+        long waitStart = Stopwatch.GetTimestamp();
+        while (!pruningFinished && Stopwatch.GetElapsedTime(waitStart) < PruningWaitBudget)
         {
             pruningFinished = chain.FullPruner.WaitHandle.WaitOne(TimeSpan.FromMilliseconds(100));
             await chain.AddBlockDoNotWaitForHead();


### PR DESCRIPTION
## Changes

- Bound `FullPruningDiskTest.RunPruning`'s wait for a prune to complete by wall clock (a quarter of the long-test budget) instead of a fixed 100 polls.

`FullPruner` finishes only once `BestPersistedState` catches up and the processed head passes `state + PruningBoundary` (64), and the poll loop itself is what feeds those blocks. At 100 x 100 ms the margin is thin in both time and blocks, so on a loaded runner `prune_on_disk_multiple_times` fails as:

```
Assert.That(pruningFinished, Is.True)
  Expected: True
  But was:  False
```

The happy path is unchanged — it exits on the first signals — so the larger budget is only spent by a round that would otherwise fail, and a failing round aborts the test, keeping the worst case inside the fixture's 120 s `MaxTime`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: Flaky test fix

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### If yes, did you write tests?

- [ ] Yes
- [ ] No

#### Notes on testing

`FullPruningDiskTest` passes 6/6 locally, with the same runtime as before the change.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
