### PR TITLE
perf: avoid scratch allocations in SSZ merkleization

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Ssz.Test/MerkleTests.cs
+++ b/src/Nethermind/Nethermind.Serialization.Ssz.Test/MerkleTests.cs
@@ -24,6 +24,30 @@ public static class UInt256Extensions
 [TestFixture]
 public class MerkleTests
 {
+    [Test]
+    public void Merkleize_matches_padded_binary_tree([Values(0, 1, 2, 3, 4, 7, 8, 9, 31, 32, 33)] int count)
+    {
+        UInt256[] chunks = new UInt256[count];
+        for (int i = 0; i < count; i++) chunks[i] = (UInt256)(i + 1);
+        int width = 1;
+        while (width < count) width *= 2;
+        UInt256[] tree = new UInt256[width];
+        chunks.CopyTo(tree, 0);
+        for (int length = width; length > 1; length /= 2)
+        {
+            for (int i = 0; i < length / 2; i++)
+            {
+                byte[] left = new byte[32];
+                byte[] right = new byte[32];
+                tree[i * 2].ToLittleEndian(left);
+                tree[i * 2 + 1].ToLittleEndian(right);
+                tree[i] = new UInt256(HashUtility.Hash(left, right));
+            }
+        }
+        Merkle.Merkleize(out UInt256 actual, chunks, (ulong)width);
+        Assert.That(actual, Is.EqualTo(tree[0]));
+    }
+
     [TestCase(ulong.MinValue, 0UL)]
     [TestCase(1UL, 0UL)]
     [TestCase(2UL, 1UL)]

--- a/src/Nethermind/Nethermind.Serialization.Ssz/Merkleization/Merkle.cs
+++ b/src/Nethermind/Nethermind.Serialization.Ssz/Merkleization/Merkle.cs
@@ -285,14 +285,16 @@ public static partial class Merkle
 
     private static void Merkleize(out UInt256 root, ReadOnlySpan<UInt256> value, ReadOnlySpan<UInt256> lastChunk, ulong limit = 0)
     {
-        if (limit == 0 && (value.Length + lastChunk.Length == 1))
+        if (limit <= 1 && (value.Length + lastChunk.Length == 1))
         {
             root = value.Length == 0 ? lastChunk[0] : value[0];
             return;
         }
 
         int depth = NextPowerOfTwoExponent(limit == 0UL ? (uint)(value.Length + lastChunk.Length) : limit);
-        Merkleizer merkleizer = new(depth);
+        Span<UInt256> scratch = stackalloc UInt256[depth + 1];
+        scratch.Clear();
+        Merkleizer merkleizer = new(scratch);
         int length = value.Length;
         for (int i = 0; i < length; i++)
         {
@@ -309,14 +311,16 @@ public static partial class Merkle
 
     public static void Merkleize(out UInt256 root, ReadOnlySpan<UInt256> value, ulong limit = 0UL)
     {
-        if (limit == 0 && value.Length == 1)
+        if (limit <= 1 && value.Length == 1)
         {
             root = value[0];
             return;
         }
 
         int depth = NextPowerOfTwoExponent(limit == 0UL ? (ulong)value.Length : limit);
-        Merkleizer merkleizer = new(depth);
+        Span<UInt256> scratch = stackalloc UInt256[depth + 1];
+        scratch.Clear();
+        Merkleizer merkleizer = new(scratch);
         int length = value.Length;
         for (int i = 0; i < length; i++)
         {

--- a/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
+++ b/src/Nethermind/Nethermind.Serialization.SszGenerator/SszGenerator.cs
@@ -403,8 +403,6 @@ internal static class SszCodecHelpers
         }
         try
         {
-            // Clearing the in-use prefix is sufficient; MerkleizeProgressive only reads it.
-            chunks.Clear();
             int fullByteLength = value.Length / 32 * 32;
             if (fullByteLength > 0)
             {


### PR DESCRIPTION
## Changes

- SSZ merkleization allocates a scratch array for each subtree, including one-chunk subtrees with limit 1. Use stack scratch and the existing span-based Merkleizer, add the single-chunk fast path, and remove a generated clear whose used elements are all overwritten. Partial-byte padding remains cleared.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

125 SSZ tests and 64 source-generator tests passed, including an independently computed padded-tree test. Guest build passed all ISA and embedded-resource checks. Whitespace formatting and git diff --check passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

On mainnet block 25,532,382 (1,232 transactions), against master 2d9f97138b with the same pinned compiler and ZisK emulator:

| Metric | Baseline | This PR | Change |
|---|---:|---:|---:|
| Instructions | 342,352,195 | 342,061,872 | -0.08480% |
| Weighted ZisK cost | 40,476,096,315 | 40,448,897,931 | -0.06720% |

Both runs returned identical successful output. This is a small gain on one block; weighted emulator cost is not measured proving time.

