### PR TITLE
perf: remove unused code override hash

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Benchmark/CodeOverrideBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/CodeOverrideBenchmark.cs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Autofac;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.State;
+using Nethermind.Specs.Forks;
+using Nethermind.State.OverridableEnv;
+
+namespace Nethermind.Evm.Benchmark;
+
+[MemoryDiagnoser]
+public class CodeOverrideBenchmark
+{
+    private IContainer _container = null!;
+    private ILifetimeScope _scope = null!;
+    private IOverridableCodeInfoRepository _repository = null!;
+    private CodeInfo _code = null!;
+
+    [Params(32, 1024, 24576)]
+    public int CodeLength { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _container = new ContainerBuilder().AddModule(new TestNethermindModule()).Build();
+        IOverridableEnv env = _container.Resolve<IOverridableEnvFactory>().Create();
+        _scope = _container.BeginLifetimeScope(builder => builder.AddModule(env));
+        _repository = _scope.Resolve<IOverridableCodeInfoRepository>();
+        byte[] bytes = new byte[CodeLength];
+        new System.Random(42).NextBytes(bytes);
+        _code = new CodeInfo(bytes);
+    }
+
+    [Benchmark]
+    public void SetCodeOverride() => _repository.SetCodeOverride(Prague.Instance, TestItem.AddressA, _code);
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _scope.Dispose();
+        _container.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/OverridableEnv/DisposableScopeOverridableEnvTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/OverridableEnv/DisposableScopeOverridableEnvTests.cs
@@ -14,6 +14,7 @@ using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.State;
 using Nethermind.State.OverridableEnv;
+using Nethermind.Specs.Forks;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test.OverridableEnv;
@@ -21,6 +22,26 @@ namespace Nethermind.Evm.Test.OverridableEnv;
 [Parallelizable(ParallelScope.All)]
 public class DisposableScopeOverridableEnvTests
 {
+    [Test]
+    public void Code_override_remains_available_to_execution_and_state([Values(0, 32, 1024)] int length)
+    {
+        using TestContext ctx = new();
+        byte[] code = new byte[length];
+        new Random(42).NextBytes(code);
+        using Scope<Components> scope = ctx.Env.BuildAndOverride(
+            Build.A.BlockHeader.TestObject,
+            new Dictionary<Address, AccountOverride>
+            {
+                { TestItem.AddressA, new AccountOverride { Code = code } }
+            });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(scope.Component.WorldState.GetCodeHash(TestItem.AddressA), Is.EqualTo(Keccak.Compute(code)));
+            Assert.That(scope.Component.CodeInfoRepository.GetCachedCodeInfo(TestItem.AddressA, false, Prague.Instance, out _).Code.ToArray(), Is.EqualTo(code));
+        }
+    }
+
     [Test]
     public void Create_ReturnsEnvWithOverriddenComponents()
     {

--- a/src/Nethermind/Nethermind.State/OverridableEnv/OverridableCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.State/OverridableEnv/OverridableCodeInfoRepository.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
-using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.CodeAnalysis;
@@ -15,7 +14,7 @@ namespace Nethermind.State.OverridableEnv;
 
 public class OverridableCodeInfoRepository(ICodeInfoRepository codeInfoRepository, IWorldState worldState) : IOverridableCodeInfoRepository
 {
-    private readonly Dictionary<Address, (CodeInfo codeInfo, ValueHash256 codeHash)> _codeOverrides = [];
+    private readonly Dictionary<Address, CodeInfo> _codeOverrides = [];
     private readonly Dictionary<Address, (CodeInfo codeInfo, Address initialAddr)> _precompileOverrides = [];
 
     public bool IsCodeOverridable => true;
@@ -26,13 +25,13 @@ public class OverridableCodeInfoRepository(ICodeInfoRepository codeInfoRepositor
         // Moved precompiles are rare, so skip the hash lookup when there are none.
         if (_precompileOverrides.Count != 0 && _precompileOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, Address initialAddr) precompile)) return precompile.codeInfo;
 
-        if (_codeOverrides.TryGetValue(codeSource, out (CodeInfo codeInfo, ValueHash256 codeHash) result))
+        if (_codeOverrides.TryGetValue(codeSource, out CodeInfo? result))
         {
-            return !result.codeInfo.IsEmpty &&
-                   ICodeInfoRepository.TryGetDelegatedAddress(result.codeInfo.CodeSpan, out delegationAddress) &&
+            return !result.IsEmpty &&
+                   ICodeInfoRepository.TryGetDelegatedAddress(result.CodeSpan, out delegationAddress) &&
                    followDelegation
                 ? GetCachedCodeInfo(delegationAddress, false, vmSpec, out Address? _)
-                : result.codeInfo;
+                : result;
         }
 
         return codeInfoRepository.GetCachedCodeInfo(codeSource, followDelegation, vmSpec, out delegationAddress);
@@ -44,12 +43,12 @@ public class OverridableCodeInfoRepository(ICodeInfoRepository codeInfoRepositor
     public void SetCodeOverride(
         IReleaseSpec vmSpec,
         Address key,
-        CodeInfo value) => _codeOverrides[key] = (value, ValueKeccak.Compute(value.Code.Span));
+        CodeInfo value) => _codeOverrides[key] = value;
 
     public void MovePrecompile(IReleaseSpec vmSpec, Address precompileAddr, Address targetAddr)
     {
         _precompileOverrides[targetAddr] = (this.GetCachedCodeInfo(precompileAddr, vmSpec), precompileAddr);
-        _codeOverrides[precompileAddr] = (new CodeInfo(worldState.GetCode(precompileAddr)), worldState.GetCodeHash(precompileAddr));
+        _codeOverrides[precompileAddr] = new CodeInfo(worldState.GetCode(precompileAddr));
     }
 
     public void SetDelegation(Address codeSource, Address authority, IReleaseSpec spec) =>
@@ -57,8 +56,8 @@ public class OverridableCodeInfoRepository(ICodeInfoRepository codeInfoRepositor
 
     public bool TryGetDelegation(Address address, IReleaseSpec vmSpec,
         [NotNullWhen(true)] out Address? delegatedAddress) =>
-        _codeOverrides.TryGetValue(address, out (CodeInfo codeInfo, ValueHash256 codeHash) result)
-            ? ICodeInfoRepository.TryGetDelegatedAddress(result.codeInfo.CodeSpan, out delegatedAddress)
+        _codeOverrides.TryGetValue(address, out CodeInfo? result)
+            ? ICodeInfoRepository.TryGetDelegatedAddress(result.CodeSpan, out delegatedAddress)
             : codeInfoRepository.TryGetDelegation(address, vmSpec, out delegatedAddress);
 
 


### PR DESCRIPTION
## Changes

- Code overrides retain a code hash that no consumer reads. Store CodeInfo directly, removing the redundant Keccak in SetCodeOverride and the unused hash lookup when moving a precompile. The world state still computes and stores the required code hash. Add a production-DI microbenchmark for override installation.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

65 override/environment/code-repository tests passed, including coverage that overridden code remains available to execution and has the correct world-state hash. Release build, whitespace formatting and git diff --check passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

BenchmarkDotNet ShortRun, .NET 10 x64, identical benchmark source against master 2d9f97138b. Measures SetCodeOverride with a preconstructed CodeInfo resolved through production DI:

| Code size | Baseline mean | This PR mean |
|---|---:|---:|
| 32 bytes | 371.2 ns | 11.81 ns |
| 1,024 bytes | 2,905.6 ns | 10.70 ns |
| 24,576 bytes | 50,400.6 ns | 10.36 ns |

Both arms allocate zero bytes per operation. ShortRun confidence intervals are wide; these are approximate magnitudes for installation alone, not full eth_call latency. Reproduce with `dotnet run -c release --project src/Nethermind/Nethermind.Evm.Benchmark -- --filter '*CodeOverrideBenchmark*' --job short --inProcess`.

