### PR TITLE
perf: reuse witness block tree during stateless execution

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/Stateless/WitnessTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Stateless/WitnessTests.cs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Consensus.Stateless;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
+using NUnit.Framework;
+
+namespace Nethermind.Consensus.Test.Stateless;
+
+public class WitnessTests
+{
+    [Test]
+    public void Decoded_headers_preserve_chain_linkage([Values(1, 2, 256)] int count, [Values] bool breakChain)
+    {
+        ArrayPoolList<byte[]> encoded = new(count);
+        Hash256 parent = Keccak.Zero;
+        for (int i = 0; i < count; i++)
+        {
+            BlockHeader header = Build.A.BlockHeader.WithNumber(i).WithParentHash(breakChain ? Keccak.Zero : parent).TestObject;
+            byte[] bytes = Rlp.Encode(header).Bytes;
+            encoded.Add(bytes);
+            parent = Keccak.Compute(bytes);
+        }
+        using Witness witness = new()
+        {
+            Headers = encoded,
+            Codes = IOwnedReadOnlyList<byte[]>.Empty,
+            State = IOwnedReadOnlyList<byte[]>.Empty,
+            Keys = IOwnedReadOnlyList<byte[]>.Empty
+        };
+        if (breakChain && count > 1)
+        {
+            Assert.That(() => witness.DecodeHeaders(), Throws.TypeOf<InvalidOperationException>());
+        }
+        else
+        {
+            using ArrayPoolList<BlockHeader> decoded = witness.DecodeHeaders();
+            Assert.That(decoded.Count, Is.EqualTo(count));
+            Assert.That(decoded[^1].Hash, Is.EqualTo(parent));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/StatelessBlockProcessingEnv.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Runtime.CompilerServices;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.BeaconBlockRoot;
 using Nethermind.Blockchain.Blocks;
@@ -20,6 +21,8 @@ using Nethermind.Logging;
 using Nethermind.State;
 using Nethermind.Trie;
 
+[assembly: InternalsVisibleTo("Nethermind.Stateless.Executor")]
+
 namespace Nethermind.Consensus.Stateless;
 
 public class StatelessBlockProcessingEnv(
@@ -30,6 +33,15 @@ public class StatelessBlockProcessingEnv(
 {
     private IBlockProcessor? _blockProcessor;
     private IWorldState? _worldState;
+    private readonly StatelessBlockTree? _blockTree;
+
+    internal StatelessBlockProcessingEnv(
+        Witness witness,
+        ISpecProvider specProvider,
+        ISealValidator sealValidator,
+        ILogManager logManager,
+        StatelessBlockTree blockTree) : this(witness, specProvider, sealValidator, logManager)
+        => _blockTree = blockTree;
     // Per-block: StaticCodeCache.Instance would leak code across blocks and mask deliberately missing
     // witness code. The first fetch of each hash still reads through the world state.
     private readonly StaticCodeCache _codeCache = new(CodeCacheCapacity);
@@ -51,8 +63,8 @@ public class StatelessBlockProcessingEnv(
 
     private BlockProcessor GetProcessor()
     {
-        using ArrayPoolList<BlockHeader> readOnlyCollection = witness.DecodeHeaders();
-        StatelessBlockTree statelessBlockTree = new(readOnlyCollection);
+        using ArrayPoolList<BlockHeader>? readOnlyCollection = _blockTree is null ? witness.DecodeHeaders() : null;
+        StatelessBlockTree statelessBlockTree = _blockTree ?? new(readOnlyCollection!);
         BlockhashProvider blockhashProvider = new(statelessBlockTree, WorldState, logManager);
         EthereumTransactionProcessor txProcessor = CreateTransactionProcessor(WorldState, blockhashProvider);
         BlockAccessListManager blockAccessListManager = new(

--- a/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/Witness.cs
@@ -75,7 +75,10 @@ public static class WitnessExtensions
                     if (i > 0 && (decodedHeaders[i].ParentHash is null || decodedHeaders[i].ParentHash.ValueHash256 != previousHeaderHash))
                         throw new InvalidOperationException("Witness headers are not contiguous");
 
-                    previousHeaderHash = ValueKeccak.Compute(headers[i]);
+                    if (i + 1 < headersSpan.Length)
+                    {
+                        previousHeaderHash = ValueKeccak.Compute(headers[i]);
+                    }
                 }
 
                 return decodedHeaders;

--- a/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
+++ b/src/Nethermind/Nethermind.Stateless.Executor/StatelessExecutor.cs
@@ -125,7 +125,7 @@ public static class StatelessExecutor
         }
 
         StatelessBlockProcessingEnv blockProcessingEnv = new(
-            witness, specProvider, Always.Valid, NullLogManager.Instance);
+            witness, specProvider, Always.Valid, NullLogManager.Instance, blockTree);
 
         using IDisposable scope = blockProcessingEnv.WorldState.BeginScope(parentHeader);
 


### PR DESCRIPTION
## Changes

- StatelessExecutor decodes witness headers and constructs a block tree for validation, then StatelessBlockProcessingEnv repeats that work. Reuse the execution-local tree through an internal constructor while preserving the existing public constructor. Also omit the final raw header hash, which has no subsequent linkage check. Intermediate linkage hashes still cover the original raw bytes.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

25 stateless consensus tests passed, including valid and broken witness chains up to 256 headers. Guest build passed all ISA and embedded-resource checks. Whitespace formatting and git diff --check passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

On mainnet block 25,532,382, against master 2d9f97138b with the same pinned compiler and ZisK emulator:

| Metric | Baseline | This PR | Change |
|---|---:|---:|---:|
| Instructions | 342,352,195 | 342,294,642 | -0.01681% |
| Weighted ZisK cost | 40,476,096,315 | 40,469,421,221 | -0.01649% |

Both runs returned identical successful output. This fixture contains only one witness header, so the measured end-to-end benefit is tiny. No performance claim is made for longer chains; weighted emulator cost is not measured proving time.

