### PR TITLE
perf: cut the large-object churn that stalls newPayload behind background GCs

### DIFF
--- a/src/Nethermind/Nethermind.Runner.Test/Monitoring/DataFeedTests.cs
+++ b/src/Nethermind/Nethermind.Runner.Test/Monitoring/DataFeedTests.cs
@@ -49,6 +49,14 @@ public class DataFeedTests
         Assert.That(data, Is.Null);
     }
 
+    [TestCase(null, "processed,log,forkChoice,txLinks,system,peers")]
+    [TestCase("", "processed,log,forkChoice,txLinks,system,peers")]
+    [TestCase("processed", "processed")]
+    [TestCase(" Processed , forkchoice,processed", "processed,forkChoice")]
+    [TestCase("nodeData,bogus", "processed,log,forkChoice,txLinks,system,peers")]
+    public void Requested_events_resolve_to_streamed_entry_types(string? events, string expected) =>
+        Assert.That(string.Join(',', DataFeed.ParseRequestedEvents(events)), Is.EqualTo(expected));
+
     [Test]
     public void Channel_subscription_stops_when_cancelled_before_data_arrives()
     {

--- a/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
+++ b/src/Nethermind/Nethermind.Runner/Monitoring/DataFeed.cs
@@ -45,7 +45,11 @@ public class DataFeed
     private readonly ILogger _logger;
     private readonly CancellationToken _lifetime;
 
-    private long _subscribers;
+    // Per event type, so a subscriber that only wants processing statistics does not make the node
+    // build the forkChoice payload - the whole head block with every transaction, receipt and log.
+    private readonly long[] _subscribersByType = new long[Enum.GetValues<EntryType>().Length];
+    private static readonly EntryType[] StreamedEntryTypes =
+        [EntryType.processed, EntryType.log, EntryType.forkChoice, EntryType.txLinks, EntryType.system, EntryType.peers];
 
     public DataFeed(
         ITxPool txPool,
@@ -82,10 +86,11 @@ public class DataFeed
 
     public async Task ProcessingFeedAsync(HttpContext ctx, CancellationToken ct)
     {
-        Interlocked.Increment(ref _subscribers);
+        EntryType[] requested = ParseRequestedEvents(ctx.Request.Query["events"]);
+        foreach (EntryType type in requested) Interlocked.Increment(ref _subscribersByType[(int)type]);
         try
         {
-            await ProcessingFeeds(ctx, ct);
+            await ProcessingFeeds(ctx, requested, ct);
         }
         catch (OperationCanceledException)
         {
@@ -97,11 +102,28 @@ public class DataFeed
         }
         finally
         {
-            Interlocked.Decrement(ref _subscribers);
+            foreach (EntryType type in requested) Interlocked.Decrement(ref _subscribersByType[(int)type]);
         }
     }
 
-    private async Task ProcessingFeeds(HttpContext ctx, CancellationToken ct)
+    /// <summary>Resolves the <c>events</c> query parameter (comma-separated <see cref="EntryType"/> names) to the streamed event types; absent or empty means all of them.</summary>
+    internal static EntryType[] ParseRequestedEvents(string? events)
+    {
+        if (string.IsNullOrWhiteSpace(events)) return StreamedEntryTypes;
+
+        List<EntryType> requested = [];
+        foreach (string name in events.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (Enum.TryParse(name, ignoreCase: true, out EntryType type) && Array.IndexOf(StreamedEntryTypes, type) >= 0 && !requested.Contains(type))
+            {
+                requested.Add(type);
+            }
+        }
+
+        return requested.Count == 0 ? StreamedEntryTypes : requested.ToArray();
+    }
+
+    private async Task ProcessingFeeds(HttpContext ctx, EntryType[] requested, CancellationToken ct)
     {
         ctx.Response.ContentType = "text/event-stream";
         ctx.Response.Headers["X-Accel-Buffering"] = "no";
@@ -120,7 +142,7 @@ public class DataFeed
 
         Channel<ChannelEntry> channel = Channel.CreateUnbounded<ChannelEntry>();
 
-        InitializeChannelSubscriptions(channel, ct);
+        InitializeChannelSubscriptions(channel, requested, ct);
 
         await foreach (ChannelEntry entry in channel.Reader.ReadAllAsync(ct))
         {
@@ -171,14 +193,22 @@ public class DataFeed
         }
     }
 
-    private void InitializeChannelSubscriptions(Channel<ChannelEntry> channel, CancellationToken ct)
+    private void InitializeChannelSubscriptions(Channel<ChannelEntry> channel, EntryType[] requested, CancellationToken ct)
     {
-        _ = ChannelSubscribe(EntryType.processed, () => _processing.Task, channel, ct);
-        _ = ChannelSubscribe(EntryType.log, () => _log.Task, channel, ct);
-        _ = ChannelSubscribe(EntryType.forkChoice, () => _forkChoice.Task, channel, ct);
-        _ = ChannelSubscribe(EntryType.txLinks, () => _txFlow.Task, channel, ct);
-        _ = ChannelSubscribe(EntryType.system, () => _systemStats.Task, channel, ct);
-        _ = ChannelSubscribe(EntryType.peers, () => _peers.Task, channel, ct);
+        foreach (EntryType type in requested)
+        {
+            Func<Task<byte[]>> nextTask = type switch
+            {
+                EntryType.processed => () => _processing.Task,
+                EntryType.log => () => _log.Task,
+                EntryType.forkChoice => () => _forkChoice.Task,
+                EntryType.txLinks => () => _txFlow.Task,
+                EntryType.system => () => _systemStats.Task,
+                EntryType.peers => () => _peers.Task,
+                _ => throw new ArgumentOutOfRangeException(nameof(requested), type, "Not a streamed event type")
+            };
+            _ = ChannelSubscribe(type, nextTask, channel, ct);
+        }
     }
 
     private static byte[] GetNodeData()
@@ -193,7 +223,7 @@ public class DataFeed
         {
             await TaskExtensions.DelaySafe(millisecondsDelay: 1000, _lifetime);
             // No subscribers, no need to prepare event data
-            if (!HaveSubscribers) continue;
+            if (!HaveSubscribers(EntryType.txLinks)) continue;
 
             byte[] data = GetTxFlowTask();
 
@@ -228,7 +258,7 @@ public class DataFeed
         Environment.ProcessCpuUsage cpuUsage = Environment.CpuUsage;
         long timeStamp = Stopwatch.GetTimestamp();
 
-        if (!HaveSubscribers)
+        if (!HaveSubscribers(EntryType.system))
         {
             _lastCpuUsage = cpuUsage;
             _lastTimeStamp = timeStamp;
@@ -259,7 +289,7 @@ public class DataFeed
         {
             await TaskExtensions.DelaySafe(millisecondsDelay: 1000, _lifetime);
             // No subscribers, no need to prepare event data
-            if (!HaveSubscribers) continue;
+            if (!HaveSubscribers(EntryType.peers)) continue;
 
             byte[] data = GetPeersTask();
             DataCompletion peers = _peers;
@@ -318,7 +348,7 @@ public class DataFeed
     private void OnNewProcessingStatistics(object? sender, BlockStatistics stats)
     {
         // No subscribers, no need to prepare event data
-        if (!HaveSubscribers) return;
+        if (!HaveSubscribers(EntryType.processed)) return;
 
         DataCompletion processing = _processing;
         _processing = new DataCompletion(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -329,7 +359,7 @@ public class DataFeed
     private void OnForkChoiceUpdated(object? sender, IBlockTree.ForkChoiceUpdateEventArgs choice)
     {
         // No subscribers, no need to prepare event data
-        if (!HaveSubscribers) return;
+        if (!HaveSubscribers(EntryType.forkChoice)) return;
 
         Task.Run(() =>
         {
@@ -484,7 +514,7 @@ public class DataFeed
     private void OnConsoleLineWritten(object? sender, string logLine)
     {
         // No subscribers, no need to prepare event data
-        if (!HaveSubscribers) return;
+        if (!HaveSubscribers(EntryType.log)) return;
 
         DataCompletion log = _log;
         _log = new DataCompletion(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -492,7 +522,7 @@ public class DataFeed
         log.TrySetResult(JsonSerializer.SerializeToUtf8Bytes(new[] { logLine }, JsonSerializerOptions.Web));
     }
 
-    private bool HaveSubscribers => Volatile.Read(ref _subscribers) > 0;
+    private bool HaveSubscribers(EntryType type) => Volatile.Read(ref _subscribersByType[(int)type]) > 0;
 }
 
 internal class SystemStats

--- a/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
+++ b/src/Nethermind/Nethermind.State.Flat.Test/SnapshotTests.cs
@@ -1,8 +1,10 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Reflection;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Db;
@@ -154,13 +156,38 @@ public class SnapshotTests
 
             if (shouldShrink)
             {
-                Assert.That(original.Nodes.Capacity, Is.GreaterThan(0));
+                Assert.That(original.Nodes.Capacity, Is.LessThanOrEqualTo(4_096));
                 Assert.That(original.Nodes.Capacity, Is.LessThan(capacityBeforeClear));
             }
             else
             {
                 Assert.That(original.Nodes.Capacity, Is.EqualTo(capacityBeforeClear));
             }
+        }
+    }
+
+    [Test]
+    public void AddressOwnedStorageNodesReuseRetainedLargeDictionaryForLargeBatches()
+    {
+        // A size no other test requests, so the retained dictionary found is the one released here.
+        const int LargeBatch = 12_345;
+        AddressStorageNodeDictionary storageNodes = new();
+        Hash256 addressA = TestItem.AddressA.ToAccountPath.ToCommitment();
+        Hash256 addressB = TestItem.AddressB.ToAccountPath.ToCommitment();
+        AddressStorageNodeDictionary.AddressNodes first = storageNodes.GetOrAddAddress(addressA);
+        first.EnsureAdditionalCapacity(LargeBatch);
+        Dictionary<HashedKey<TreePath>, TrieNode> large = first.Nodes;
+        first.Set(TreePath.Empty, new TrieNode(NodeType.Unknown, TestItem.KeccakA));
+
+        storageNodes.NoLockClear();
+        AddressStorageNodeDictionary.AddressNodes second = storageNodes.GetOrAddAddress(addressB);
+        second.EnsureAdditionalCapacity(LargeBatch);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(second.Nodes, Is.SameAs(large));
+            Assert.That(second.Nodes, Is.Empty);
+            Assert.That(second.Nodes.Capacity, Is.GreaterThanOrEqualTo(LargeBatch));
         }
     }
 

--- a/src/Nethermind/Nethermind.State.Flat/AddressStorageNodeDictionary.cs
+++ b/src/Nethermind/Nethermind.State.Flat/AddressStorageNodeDictionary.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Crypto;
 using Nethermind.Trie;
@@ -22,6 +23,10 @@ public sealed class AddressStorageNodeDictionary : IReadOnlyCollection<KeyValueP
 {
     private const int MaxPooledNodeDictionaries = 1_024;
     private const int PooledNodeCapacity = 4_096;
+    // A contract touching tens of thousands of slots in one block needs a dictionary far above the pooled
+    // capacity; trimming it on return made every such block re-grow it through LOH-sized doublings. Those
+    // dictionaries are retained whole instead, under a total entry budget (~64 B per entry).
+    private const long MaxRetainedLargeNodeEntries = 2L * 1024 * 1024;
 
     private readonly ConcurrentDictionary<Hash256AsKey, AddressNodes> _byAddress = new();
     private IEnumerator<KeyValuePair<Hash256AsKey, AddressNodes>>? _cachedAddressEnumerator;
@@ -110,12 +115,86 @@ public sealed class AddressStorageNodeDictionary : IReadOnlyCollection<KeyValueP
 
     internal sealed class AddressNodes
     {
-        internal Dictionary<HashedKey<TreePath>, TrieNode> Nodes { get; } = [];
+        private Dictionary<HashedKey<TreePath>, TrieNode>? _spare;
 
-        internal void EnsureAdditionalCapacity(int additionalCapacity) =>
-            Nodes.EnsureCapacity(Nodes.Count + additionalCapacity);
+        internal Dictionary<HashedKey<TreePath>, TrieNode> Nodes { get; private set; } = [];
+
+        internal void EnsureAdditionalCapacity(int additionalCapacity)
+        {
+            int required = Nodes.Count + additionalCapacity;
+            if (required <= Nodes.Capacity) return;
+
+            // An empty dictionary about to take a large batch swaps in a retained large one instead of growing.
+            if (Nodes.Count == 0 && required > PooledNodeCapacity
+                && LargeNodeDictionaryPool.TryRent(required, out Dictionary<HashedKey<TreePath>, TrieNode>? large))
+            {
+                _spare = Nodes;
+                Nodes = large;
+                return;
+            }
+
+            Nodes.EnsureCapacity(required);
+        }
 
         internal void Set(in TreePath path, TrieNode node) => Nodes[path] = node;
+
+        internal void ResetForPooling()
+        {
+            if (Nodes.Capacity > PooledNodeCapacity)
+            {
+                Dictionary<HashedKey<TreePath>, TrieNode> large = Nodes;
+                Nodes = _spare ?? [];
+                _spare = null;
+                large.Clear();
+                LargeNodeDictionaryPool.Return(large);
+            }
+
+            Nodes.ClearAndTrim(PooledNodeCapacity, PooledNodeCapacity);
+        }
+    }
+
+    private static class LargeNodeDictionaryPool
+    {
+        private static readonly Lock Lock = new();
+        private static readonly List<Dictionary<HashedKey<TreePath>, TrieNode>> Retained = [];
+        private static long _retainedEntries;
+
+        /// <summary>Takes the smallest retained dictionary with at least <paramref name="minCapacity"/> entries of capacity.</summary>
+        public static bool TryRent(int minCapacity, [NotNullWhen(true)] out Dictionary<HashedKey<TreePath>, TrieNode>? dictionary)
+        {
+            lock (Lock)
+            {
+                int best = -1;
+                for (int i = 0; i < Retained.Count; i++)
+                {
+                    int capacity = Retained[i].Capacity;
+                    if (capacity >= minCapacity && (best < 0 || capacity < Retained[best].Capacity)) best = i;
+                }
+
+                if (best < 0)
+                {
+                    dictionary = null;
+                    return false;
+                }
+
+                dictionary = Retained[best];
+                Retained.RemoveAt(best);
+                _retainedEntries -= dictionary.Capacity;
+                return true;
+            }
+        }
+
+        /// <summary>Retains a cleared dictionary while the total retained capacity stays within budget; otherwise it is dropped.</summary>
+        public static void Return(Dictionary<HashedKey<TreePath>, TrieNode> dictionary)
+        {
+            lock (Lock)
+            {
+                if (_retainedEntries + dictionary.Capacity > MaxRetainedLargeNodeEntries) return;
+
+                Retained.Add(dictionary);
+                _retainedEntries += dictionary.Capacity;
+            }
+        }
     }
 
     private static class AddressNodesPool
@@ -142,7 +221,7 @@ public sealed class AddressStorageNodeDictionary : IReadOnlyCollection<KeyValueP
                 return;
             }
 
-            nodes.Nodes.ClearAndTrim(PooledNodeCapacity, PooledNodeCapacity);
+            nodes.ResetForPooling();
             Pool.Enqueue(nodes);
         }
     }

--- a/src/Nethermind/Nethermind.State.Flat/ScopeProvider/AbstractMinimalTrieStore.cs
+++ b/src/Nethermind/Nethermind.State.Flat/ScopeProvider/AbstractMinimalTrieStore.cs
@@ -34,8 +34,13 @@ public abstract class AbstractMinimalTrieStore : IScopedTrieStore
     public abstract class AbstractMinimalCommitter(ConcurrencyController quota) : ICommitter
     {
         private const int InitialNodeBufferCapacity = 128;
+        // A large block's parallel commit fills more buffers than the default pool retains, so the
+        // dropped ones re-grew through LOH-sized doublings on every block; retain enough of them,
+        // bounded per buffer so an outlier block cannot pin memory.
+        private const int MaxRetainedNodeBuffers = 256;
+        private const int MaxRetainedNodeBufferCapacity = 1 << 16;
         private static readonly ObjectPool<NodeBuffer> NodeBufferPool =
-            new DefaultObjectPool<NodeBuffer>(new NodeBufferPoolPolicy());
+            new DefaultObjectPool<NodeBuffer>(new NodeBufferPoolPolicy(), MaxRetainedNodeBuffers);
 
         private ThreadLocal<NodeBuffer>? _parallelBuffers;
 
@@ -103,6 +108,8 @@ public abstract class AbstractMinimalTrieStore : IScopedTrieStore
 
             public bool Return(NodeBuffer buffer)
             {
+                if (buffer.Capacity > MaxRetainedNodeBufferCapacity) return false;
+
                 buffer.Clear();
                 return true;
             }


### PR DESCRIPTION
## Changes



Three independent reductions of large-object-heap allocation on the block-processing path, which together cut the number and cost of background gen2 collections and with them the `engine_newPayload` latency that is invisible to the client's own processing metric.



- **`DataFeed` builds only the event types someone subscribed to.** `/data/events` accepts `?events=processed,log,forkChoice,txLinks,system,peers`; an absent, empty, or entirely unrecognized event list keeps today's behaviour (all types). Previously a single connected client made the node prepare every event, including `forkChoice`, which serializes the whole head block with every transaction, receipt and log to JSON. On a 1 GGas block that is ~60 MB of JSON plus the writer's growth buffers, allocated on the LOH on every `forkchoiceUpdated` and built on a thread-pool thread while the next block is being processed.

- **Trie-commit node buffers are retained across blocks.** A large block's parallel commit fills more per-thread buffers than the default object pool kept (2 x processor count), so the extras were recreated at 128 entries and re-grown through LOH-sized doublings every block. The pool now retains up to 256 buffers and drops only those above 65536 entries, for a process-wide ceiling of 16,777,216 retained tuple entries, excluding in-use buffers; node references are cleared on return.

- **Large per-address storage-node dictionaries are kept whole between blocks.** Returning an address's dictionary to the pool trimmed it to 4096 entries, so a contract touching tens of thousands of slots re-grew its dictionary through LOH allocations on every block. Dictionaries above the pooled capacity are retained under a 2M-entry budget, and an empty dictionary about to receive a large batch takes a retained one instead of growing. The returned address holder keeps an existing small spare or starts empty; scalar-only writes may regrow it, avoiding a second eager 4096-entry allocation alongside the pooled large dictionary.



## Why



On the superblocks benchmark, K6 TTFB averaged twice the processing time the client reports over its SSE feed. The difference is not processing: `GC.TryStartNoGCRegion`, which `engine_newPayload` calls to bracket a payload, reaches `GCHeap::GarbageCollect` in blocking mode, which waits for any running background gen2 collection (`background_gc_wait`) before the region opens. dotTrace attributed 71 s of a 100-block run to `GCKeeper.TryStartNoGCRegion`; an EventPipe GC trace matched every payload with a gap above 300 ms to a background collection in flight at its start. Those collections are triggered by large-object allocation, one every one to two blocks, and grow from 0.2 s to 4.3 s as the heap climbs from 2 GB to 25 GB.



An earlier attempt removed the wait itself, letting the payload run without a region. It moved the stall inside processing instead of removing it, because a block that allocates without a region blocks in the allocator on the same collection, so processing time rose 23%. This PR keeps the wait and removes what causes the collections.



A stack-resolved allocation profile of a 30-block window attributed the per-block LOH churn as: data-feed JSON ~125 MB, trie-commit buffer doublings ~14 MB, per-address dictionary regrowth ~5-10 MB, with the remainder retained sorted snapshots rather than churn.



## Benchmarks



> **Read this before the numbers.** All three arms below ran with a harness that subscribes to the data feed as `?events=processed`, which is what lets the first commit take effect. That landed in `execution-payloads-benchmarks` via NethermindEth/execution-payloads-benchmarks#30, and the automated comparison re-run afterwards reproduces the TTFB figure here to within half a percent on AVG, independently and on a different day ([details](https://github.com/NethermindEth/nethermind/pull/13334#issuecomment-5618696425)). An [earlier automated comparison](https://github.com/NethermindEth/nethermind/pull/13334#issuecomment-5616794342) in this thread predates that merge, ran with the commit switched off, and should be disregarded.



amd64 `reproducible-benchmarks` runner, flat layout, superblocks (100 blocks of ~1.1 GGas / 12.6k txs). Three batches pooled, both arm orders: master n=14, this branch n=15. `aa-master-df655ae` (n=10) is master republished under a second tag, so its delta is the measured floor for arm position and host drift.



| superblocks, pooled | master | A/A control | this PR |
|---|---:|---:|---:|
| TTFB − SSE gap, avg / median / p90 (ms) | 673 / 138 / 2206 | 672 / 135 / 2153 | **289 / 116 / 709** |
| payloads with gap > 1 s, per run | 24.1 | 25.9 | **7.7** |
| K6 TTFB avg / median / p90 (ms) | 1429 / 927 / 3085 | 1415 / 920 / 2976 | **1033 / 840 / 1755** |
| SSE avg / median (ms) | 756 / 722 | 743 / 709 | 744 / 703 |
| TTFB run-mean CV | 5.88% | 6.34% | **4.18%** |



Paired per-payload deltas against master, sign test over 99 payloads:



| arm | SSE median Δ | z | TTFB median Δ | TTFB mean Δ | z |
|---|---:|---:|---:|---:|---:|
| A/A control | −15.5 ms | −6.5 | −19.7 ms | −7.0 ms | −3.5 |
| this PR | −16.4 ms | −7.5 | −48.4 ms | −263.9 ms | −8.5 |



Processing time is neutral in aggregate: the paired SSE delta is indistinguishable from the byte-identical control arm. That is the property this PR is being held to. Two caveats to that statement are in [this comment](https://github.com/NethermindEth/nethermind/pull/13334#issuecomment-5621523098) and should be read alongside it, one about the single slowest block and one about run-to-run spread.



TTFB run-to-run variance also roughly halves, 84.8 ms standard deviation across the 24 master-equivalent runs against 43.2 ms here, permutation p = 0.0002.



The TTFB column needs a caveat rather than a headline. It improves twelve times more than the control floor and stabilizes per run, 967-1075 ms against 1296-1523 ms on master, but most of that comes from the data-feed commit, which only helps a subscriber that asks for a subset of events. A node with nothing subscribed never paid that cost, and a dashboard that legitimately wants every event still pays it. The client-side change is the pair of flat-state commits, and their size on its own is still being measured.



The mechanism, from EventPipe GC traces of a 30-block window ([master](https://github.com/NethermindEth/nethermind/actions/runs/34422987867), [PR](https://github.com/NethermindEth/nethermind/actions/runs/34425202650)):



| | master | this PR |
|---|---:|---:|
| LOH allocation per block | 284 MB | 130 MB |
| gen2 collections | 25 | 14 |
| background GC wall time | 13.3 s | 7.1 s |
| peak managed heap | 12.5 GB | 8.4 GB |



Fusaka, 1000 blocks, n=3 ([34425182394](https://github.com/NethermindEth/nethermind/actions/runs/34425182394)): SSE 26.4 → 26.3 ms with a paired delta of −0.1 ms against a control of +0.0 ms, TTFB 34.5 → 33.1 ms, TTFB max 780 → 487 ms. Neutral to slightly better, as expected where blocks are small enough that LOH pressure is not the constraint.



## Types of changes



#### What types of changes does your code introduce?



- [x] Optimization



## Testing



#### Requires testing



- [x] Yes



#### If yes, did you write tests?



- [x] Yes



#### Notes on testing



`DataFeedTests.Requested_events_resolve_to_streamed_entry_types` covers the query parsing including the absent, empty and unknown-name cases. `DataFeedTests.Event_subscriptions_only_prepare_requested_data` drives a feed through the production modules (`TestNethermindModule`, real block tree and processor, only the receipt finder substituted) and checks that a `?events=processed` subscriber gets its statistics while the fork-choice preparation is never queued, and that the default subscription still gets both. `SnapshotTests.AddressOwnedStorageNodesReuseRetainedLargeDictionaryForLargeBatches` covers the retained-dictionary handoff, and the existing capacity test was updated for the new trim boundary. At cf1a46c2c9, `SnapshotTests` 48/48 and `DataFeedTests` 9/9 passed locally; the capacity regression explicitly checks the empty fallback after releasing a large dictionary.



## Documentation



#### Requires documentation update



- [ ] No



#### Requires explanation in Release Notes



- [x] Yes



The monitoring data feed at `/data/events` accepts an `events=` query parameter to subscribe to a subset of event types. Clients that only consume processing statistics should pass `?events=processed`, which stops the node from serializing every block for them.



## Remarks



**Draft, because two questions are open.** Both concern how the result should be read, not whether the changes are correct. The runs that would have closed them were cancelled part-way; full detail in [this comment](https://github.com/NethermindEth/nethermind/pull/13334#issuecomment-5621523098).



1. **How much of the TTFB win applies to production.** Master only serializes each block for the data feed because something is subscribed to it, and in this benchmark that subscriber is the harness's own metrics feed. A production node with no dashboard open never pays that cost, and one with a dashboard open still pays it because the dashboard wants every event. So the data-feed commit is best understood as stopping the benchmark from perturbing what it measures, plus a genuine saving for any future lightweight subscriber, rather than as a client-side speedup. The two flat-state commits are the client-side change. A three-arm run comparing master, the two flat commits alone, and this branch was queued to size them but never got any jobs, so this split remains unmeasured. The image `nethermindeth/nethermind:perf-loh-churn-flat-only` exists if anyone wants to run it.

2. **The slowest block.** Block 22364870, 2.05 GGas, is bimodal in every arm and lands in its slow mode 9 of 15 times here against 7 of 24 across the master-equivalent arms, Fisher p = 0.094, median +319 ms. It moved further that way as runs accumulated rather than regressing toward the null. Every other block in the top five improved, and the block's whole wall time is markedly lower here, so what shifts is the processing window inside it. The randomised flat-DB compaction offset was ruled out as the cause. Settling it needs a GC-aligned trace of that block on both arms.



The retained-dictionary budget adds a bounded ~140 MB of dictionary capacity; measured peak heap still fell by 4 GB because the churn it prevents dominates.



The companion harness change is NethermindEth/execution-payloads-benchmarks#30: it subscribes the metrics client to `?events=processed`, stops the dotnet-trace collector before the client so the runtime's method rundown lands and stacks resolve, and allows overriding the sidecar's CLR event set so allocation profiles can be captured at all. It is backward compatible with any node, since an older one ignores the query string, and it is now merged, so PR-triggered runs here exercise all three commits.


