### PR TITLE
perf(state): skip clearing discarded contract storage maps

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -81,13 +81,11 @@ public class StorageProviderTests(bool useFlat)
 
     [Test]
     [NonParallelizable]
-    public void Oversized_per_contract_state_dictionary_is_trimmed_when_returned()
+    public void Oversized_per_contract_state_dictionary_is_trimmed_when_returned([Values(1_024, 16_384)] int changeCount)
     {
-        const int ChangeCount = 1_024;
-
         using Context ctx = new(useFlat);
         WorldState provider = BuildStorageProvider(ctx);
-        for (int i = 0; i < ChangeCount; i++)
+        for (int i = 0; i < changeCount; i++)
         {
             provider.Set(new StorageCell(ctx.Address1, (UInt256)i), _values[1]);
         }
@@ -103,6 +101,7 @@ public class StorageProviderTests(bool useFlat)
             Assert.That(capacityBeforeReturn, Is.GreaterThan(512));
             Assert.That(GetCapacity(blockChange), Is.GreaterThan(0));
             Assert.That(GetCapacity(blockChange), Is.LessThan(capacityBeforeReturn));
+            Assert.That(((IDictionary)GetDictionary(blockChange)).Count, Is.Zero);
         }
     }
 

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -714,7 +714,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             }
 
             _spare = null;
-            _dictionary.ClearAndTrim(capacity, capacity);
+            if (_dictionary.Count > capacity)
+            {
+                // These arrays will be discarded; clearing their entries first only adds writes.
+                _dictionary = new Dictionary<UInt256, StorageChangeTrace>(capacity, UInt256Comparer.Instance);
+            }
+            else
+            {
+                _dictionary.ClearAndTrim(capacity, capacity);
+            }
         }
         public void ClearAndSetMissingAsDefault()
         {


### PR DESCRIPTION
## Changes

- When a per-contract storage map contains more entries than the pool retains, replace it directly instead of clearing its large arrays immediately before trimming them. Smaller maps keep the existing clear/trim behavior.
- Extend the existing reset test to 1,024 and 16,384 changes on both state backends and check that the retained map is empty.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`dotnet test --project src/Nethermind/Nethermind.State.Test/Nethermind.State.Test.csproj -c release -- --filter FullyQualifiedName~StorageProviderTests`

138 tests passed, covering both state backends.

Local .NET 10 x64 probe on a Ryzen 7 5800X, measuring the production `DefaultableDictionary.Reset` through a compiled delegate. Dictionary preparation is outside the timer; 50 resets per size, first 10 discarded, process order A/B/B/A. Ranges below are the two process medians for each arm.

| Live entries | Before | After |
|---|---:|---:|
| 128 | 0.8 us | 0.9–1.1 us |
| 1,024 | 11.7–11.8 us | 8.1–10.0 us |
| 16,384 | 31.2–34.8 us | 2.1–2.2 us |
| 131,072 | 322–459 us | 2.5–2.6 us |

The small cases are too short/noisy for a useful speedup claim. Oversized resets allocate 80 additional bytes for the replacement dictionary object. These measurements isolate cache reset; they do not establish a whole-block or RPC throughput improvement.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
