### PR TITLE
perf(trie): seek and patch full branches at fixed offsets

### DIFF
--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -28,7 +28,8 @@ public class TrieNodeTests
 {
     [Test]
     public void Reencoding_full_branch_matches_fresh_encoding(
-        [Values(0, 7, 15)] int changedIndex, [Values(0, 1, 2)] int replacementKind)
+        [Values(0, 7, 15)] int changedIndex, [Values(0, 1, 2, 3)] int replacementKind,
+        [Values(0, 2, 4)] int dirtyBranchCount)
     {
         TrieNode original = new(NodeType.Branch);
         TrieNode expected = new(NodeType.Branch);
@@ -40,6 +41,7 @@ public class TrieNodeTests
         }
         TreePath path = TreePath.Empty;
         CappedArray<byte> oldRlp = original.RlpEncode(NullTrieNodeResolver.Instance, ref path);
+        Assert.That(oldRlp.Length, Is.EqualTo(532));
         TrieNode restored = new(NodeType.Branch, oldRlp);
         restored.ResolveNode(NullTrieNodeResolver.Instance, path);
         restored = restored.Clone();
@@ -51,7 +53,23 @@ public class TrieNodeTests
         };
         restored.SetChild(changedIndex, replacement);
         expected.SetChild(changedIndex, replacement);
-        CappedArray<byte> actual = restored.RlpEncode(NullTrieNodeResolver.Instance, ref path);
+        if (replacementKind == 3) restored.UnresolveChild(changedIndex);
+
+        for (int i = 1; i <= dirtyBranchCount; i++)
+        {
+            int index = (changedIndex + i) % TrieNode.BranchesCount;
+            TrieNode branch = new(NodeType.Branch);
+            for (int childIndex = 0; childIndex < TrieNode.BranchesCount; childIndex++)
+            {
+                branch.SetChild(childIndex, new TrieNode(NodeType.Unknown, Keccak.Compute([(byte)index, (byte)childIndex])));
+            }
+            restored.SetChild(index, branch);
+            expected.SetChild(index, branch);
+        }
+
+        // Four materialized children select the parallel measuring path even without AVX-512VL;
+        // two dirty branches select batched measuring on hosts that support it.
+        CappedArray<byte> actual = restored.RlpEncode(NullTrieNodeResolver.Instance, ref path, canBeParallel: dirtyBranchCount == 4);
         CappedArray<byte> expectedRlp = expected.RlpEncode(NullTrieNodeResolver.Instance, ref path);
         Assert.That(actual.ToArray(), Is.EqualTo(expectedRlp.ToArray()));
     }

--- a/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
+++ b/src/Nethermind/Nethermind.Trie.Test/TrieNodeTests.cs
@@ -26,6 +26,36 @@ namespace Nethermind.Trie.Test;
 [Parallelizable(ParallelScope.All)]
 public class TrieNodeTests
 {
+    [Test]
+    public void Reencoding_full_branch_matches_fresh_encoding(
+        [Values(0, 7, 15)] int changedIndex, [Values(0, 1, 2)] int replacementKind)
+    {
+        TrieNode original = new(NodeType.Branch);
+        TrieNode expected = new(NodeType.Branch);
+        for (int i = 0; i < 16; i++)
+        {
+            Hash256 hash = Keccak.Compute([(byte)i]);
+            original.SetChild(i, new TrieNode(NodeType.Unknown, hash));
+            expected.SetChild(i, new TrieNode(NodeType.Unknown, hash));
+        }
+        TreePath path = TreePath.Empty;
+        CappedArray<byte> oldRlp = original.RlpEncode(NullTrieNodeResolver.Instance, ref path);
+        TrieNode restored = new(NodeType.Branch, oldRlp);
+        restored.ResolveNode(NullTrieNodeResolver.Instance, path);
+        restored = restored.Clone();
+        TrieNode? replacement = replacementKind switch
+        {
+            0 => null,
+            1 => new Context().TiniestLeaf,
+            _ => new TrieNode(NodeType.Unknown, Keccak.Compute([0xff]))
+        };
+        restored.SetChild(changedIndex, replacement);
+        expected.SetChild(changedIndex, replacement);
+        CappedArray<byte> actual = restored.RlpEncode(NullTrieNodeResolver.Instance, ref path);
+        CappedArray<byte> expectedRlp = expected.RlpEncode(NullTrieNodeResolver.Instance, ref path);
+        Assert.That(actual.ToArray(), Is.EqualTo(expectedRlp.ToArray()));
+    }
+
     // private TrieNode _tiniestLeaf;
     // private TrieNode _heavyLeaf;
     // private TrieNode _accountLeaf;

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -668,7 +668,8 @@ namespace Nethermind.Trie
             private static bool TryPatchFullBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item,
                 ReadOnlySpan<byte> nodeRlp, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
-                // A canonical branch reaches 532 bytes only when all sixteen children are hashes.
+                // Nethermind branches have an empty value, so a canonical 532-byte branch has sixteen hash children.
+                Debug.Assert(nodeRlp[^1] == 128);
                 nodeRlp.Slice(3, BranchesCount * Rlp.LengthOfKeccakRlp).CopyTo(destination);
                 ref object? child = ref FirstBranchChild(item);
                 for (int i = 0; i < BranchesCount; i++, child = ref Unsafe.Add(ref child, 1))

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -26,10 +26,10 @@ namespace Nethermind.Trie
     {
         // Used to create the nibble key from bytes, and threshold before using ArrayPool for the key
         private const int StackallocByteThreshold = 384;
+        private const int FullBranchRlpLength = 532;
 
         private class TrieNodeDecoder
         {
-            private const int FullBranchRlpLength = 532;
             private const int HashPairSize = 2;
 
             /// <summary>The children of a node already known to be a branch.</summary>
@@ -590,6 +590,11 @@ namespace Nethermind.Trie
             private static int WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 ReadOnlySpan<byte> nodeRlp = item.FullRlp.AsSpan();
+                if (nodeRlp.Length == FullBranchRlpLength && destination.Length >= BranchesCount * Rlp.LengthOfKeccakRlp
+                    && TryPatchFullBranch(tree, ref path, item, nodeRlp, destination, bufferPool, canBeParallel))
+                {
+                    return BranchesCount * Rlp.LengthOfKeccakRlp;
+                }
                 int cursor = item.SeekChildPosition(nodeRlp, 0);
                 int position = 0;
                 // Unchanged children are consecutive bytes of the old RLP, so a run of them is one
@@ -658,6 +663,32 @@ namespace Nethermind.Trie
                 }
 
                 return position;
+            }
+
+            private static bool TryPatchFullBranch(ITrieNodeResolver tree, ref TreePath path, TrieNode item,
+                ReadOnlySpan<byte> nodeRlp, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
+            {
+                // A canonical branch reaches 532 bytes only when all sixteen children are hashes.
+                nodeRlp.Slice(3, BranchesCount * Rlp.LengthOfKeccakRlp).CopyTo(destination);
+                ref object? child = ref FirstBranchChild(item);
+                for (int i = 0; i < BranchesCount; i++, child = ref Unsafe.Add(ref child, 1))
+                {
+                    object? data = child;
+                    if (data is null) continue;
+                    if (ReferenceEquals(data, _nullNode)) return false;
+                    Hash256? hash = data as Hash256;
+                    if (hash is null)
+                    {
+                        TrieNode childNode = (TrieNode)data;
+                        path.AppendMut(i);
+                        childNode.ResolveKey(tree, ref path, bufferPool: bufferPool, canBeParallel: canBeParallel);
+                        path.TruncateOne();
+                        hash = childNode.Keccak;
+                        if (hash is null) return false;
+                    }
+                    Rlp.Encode(destination, i * Rlp.LengthOfKeccakRlp, hash);
+                }
+                return true;
             }
         }
     }

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -1402,6 +1402,10 @@ namespace Nethermind.Trie
         private int SeekChildPosition(ReadOnlySpan<byte> nodeRlp, int index)
         {
             Debug.Assert(!nodeRlp.IsEmpty, "Seeking a child of a node with no RLP");
+            if (nodeRlp.Length == FullBranchRlpLength && IsBranch)
+            {
+                return 3 + index * Rlp.LengthOfKeccakRlp;
+            }
             if (index == 0 && IsExtension)
             {
                 // Corner case, index is zero, but we are an extension


### PR DESCRIPTION
## Changes

- Use fixed child offsets for canonical 532-byte trie branches, whose sixteen child references are all hashes.
- Copy the existing child encodings together and patch changed hashes. Child removal and inline replacements fall back to the general encoder.
- Add coverage comparing reencoded branches with fresh encodings for first/middle/last replacement, removal, and inline children.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Full Trie suite before rebase: 568 passed, 12 skipped. After rebase onto master `c49db69407`, targeted TrieNode tests: 98 passed, 5 skipped (AVX-512VL unavailable).

`dotnet test --project src/Nethermind/Nethermind.Trie.Test/Nethermind.Trie.Test.csproj -c release -- --filter FullyQualifiedName~TrieNodeTests`

| Build | Instructions | Weighted guest cost |
|---|---:|---:|
| Master c49db69407 | 342,352,195 | 40,476,096,315 |
| This PR | 336,879,444 | 39,848,165,361 |

**1.55% lower weighted guest cost** on master. The same optimization previously measured **1.61% lower cost** over #13323's native-word stack.

One mainnet fixture: block 25,532,382, 1,232 transactions. Release guest builds using bflat-riscv64 `acee0ec11a2bb2199e941380ae0336caa429cdea` and ZisK `1.2.0-alpha` (`ziskemu -X`). Both arms return identical successful output and pass ISA/resource checks. These are deterministic instruction counts and modeled proving cost, not wall-clock proving times. Input SHA-256: `1706a8838f8cbb36f78bfdca3d83f8c9779a06dc0e50541172f099b9107c6a2a`.

The change also applies to the host. Local host probes had substantial variance; no whole-node throughput claim is made.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

