### PR TITLE
perf(zk): index witness nodes in bounded hash buckets

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/Stateless/HashKeyedNodeStorageTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/Stateless/HashKeyedNodeStorageTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using Nethermind.Consensus.Stateless;
 using Nethermind.Core;
@@ -112,6 +113,50 @@ public class HashKeyedNodeStorageTests
 
         Assert.That(storage.Get(null, TreePath.Empty, first), Is.EqualTo(new byte[] { 0x01 }));
         Assert.That(storage.Get(null, TreePath.Empty, second), Is.EqualTo(new byte[] { 0x02 }));
+    }
+
+    [Test]
+    public void Resolves_colliding_witness_buckets_before_and_after_writes([Values(2, 8, 9, 16)] int count)
+    {
+        int mask = (int)BitOperations.RoundUpToPowerOf2((uint)count + 1) - 1;
+        int bucket = ((int)(BitConverter.ToUInt32(Keccak.EmptyTreeHash.Bytes) & (uint)mask) + 1) & mask;
+        byte[][] nodes = new byte[count + 1][];
+        int found = 0;
+        for (int candidate = 0; found < nodes.Length; candidate++)
+        {
+            byte[] node = BitConverter.GetBytes(candidate);
+            if ((BitConverter.ToUInt32(HashOf(node).Bytes) & (uint)mask) == bucket) nodes[found++] = node;
+        }
+        HashKeyedNodeStorage storage = new(nodes.AsSpan(0, count));
+
+        for (int phase = 0; phase < 2; phase++)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(storage.Get(null, TreePath.Empty, HashOf(nodes[i])), Is.EqualTo(nodes[i]));
+                    Assert.That(storage.KeyExists(null, TreePath.Empty, HashOf(nodes[i])), Is.True);
+                }
+            }
+            Assert.That(storage.Get(null, TreePath.Empty, HashOf(nodes[^1])), Is.Null);
+            storage.Set(null, TreePath.Empty, UnknownHash, [0x01]);
+        }
+        storage.Set(null, TreePath.Empty, HashOf(nodes[0]), null);
+        Assert.That(storage.Get(null, TreePath.Empty, HashOf(nodes[0])), Is.Null);
+        Assert.That(storage.KeyExists(null, TreePath.Empty, HashOf(nodes[0])), Is.False);
+    }
+
+    [Test]
+    public void Duplicate_witness_nodes_resolve_and_can_be_evicted([Values(1, 9)] int count)
+    {
+        byte[][] nodes = new byte[count][];
+        Array.Fill(nodes, Nodes[1]);
+        HashKeyedNodeStorage storage = Storage(nodes);
+        ValueHash256 hash = HashOf(Nodes[1]);
+        Assert.That(storage.Get(null, TreePath.Empty, hash), Is.EqualTo(Nodes[1]));
+        storage.Set(null, TreePath.Empty, hash, null);
+        Assert.That(storage.Get(null, TreePath.Empty, hash), Is.Null);
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Consensus/Stateless/HashKeyedNodeStorage.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/HashKeyedNodeStorage.cs
@@ -17,7 +17,14 @@ namespace Nethermind.Consensus.Stateless;
 /// The alternative is a <c>MemDb</c> behind <see cref="NodeStorage"/>, which keys a dictionary by
 /// <c>byte[]</c>: every witness node pays a key-array allocation on load, and every read builds a
 /// key span, hashes its bytes and compares them against the stored array. Here the keccak is the key,
-/// so reads compare the keccak word-wise.
+/// so witness-bucket reads compare the keccak word-wise. After the first write, reads first probe the
+/// seeded write dictionary, whose null tombstones must override the original witness.
+/// <para>
+/// The masked leading bytes are unseeded, so an offline grind can crowd the same bucket across payloads.
+/// Buckets larger than eight entries use the seeded overflow dictionary instead of scanning; a crowded
+/// witness therefore loses the bucket optimization but cannot make the array scan unbounded. Duplicate
+/// witness entries consume separate slots, and overflow entries remain retained in both representations.
+/// </para>
 /// <para>
 /// Only the zkEVM guest uses this (see <c>WitnessNodeStorage.zkevm.cs</c>). It is not thread-safe, and
 /// the host commits storage tries in parallel — <c>PersistentStorageProvider.UpdateRootHashesMultiThread</c>

--- a/src/Nethermind/Nethermind.Consensus/Stateless/HashKeyedNodeStorage.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/HashKeyedNodeStorage.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -27,24 +28,42 @@ internal sealed class HashKeyedNodeStorage : INodeStorage, INodeStorage.IWriteBa
 {
     private static readonly NodeKey EmptyRootKey = new(Keccak.EmptyTreeHash.ValueHash256);
 
-    private readonly Dictionary<NodeKey, byte[]> _nodes;
+    private readonly Dictionary<NodeKey, byte[]?> _nodes = [];
+    private readonly Dictionary<NodeKey, byte[]> _overflow = [];
+    private readonly NodeKey[] _keys;
+    private readonly byte[][] _values;
+    private readonly int[] _starts;
+    private readonly int _bucketMask;
+    private const int MaxBucketLength = 8;
 
     /// <param name="state">The witness' state nodes, each keyed by the keccak of its own bytes.</param>
     public HashKeyedNodeStorage(ReadOnlySpan<byte[]> state)
     {
-        Dictionary<NodeKey, byte[]> nodes = new(state.Length + 1);
-
-        foreach (byte[] stateElement in state)
+        int count = state.Length + 1;
+        int bucketCount = (int)BitOperations.RoundUpToPowerOf2((uint)count);
+        _bucketMask = bucketCount - 1;
+        _starts = new int[bucketCount + 1];
+        NodeKey[] unsorted = new NodeKey[count];
+        for (int i = 0; i < count; i++)
         {
-            nodes[new NodeKey(ValueKeccak.Compute(stateElement))] = stateElement;
+            NodeKey key = i == state.Length ? EmptyRootKey : new NodeKey(ValueKeccak.Compute(state[i]));
+            unsorted[i] = key;
+            _starts[key.Bucket(_bucketMask) + 1]++;
         }
-
-        // Some of the code does not save the empty tree at all, so the empty root has to resolve
-        // whether the witness carries it or not. Seeding it here keeps NodeStorage's special case
-        // out of every read.
-        nodes[EmptyRootKey] = [128];
-
-        _nodes = nodes;
+        for (int i = 1; i < _starts.Length; i++) _starts[i] += _starts[i - 1];
+        int[] cursors = (int[])_starts.Clone();
+        _keys = new NodeKey[count];
+        _values = new byte[count][];
+        for (int i = 0; i < count; i++)
+        {
+            NodeKey key = unsorted[i];
+            byte[] value = i == state.Length ? [128] : state[i];
+            int bucket = key.Bucket(_bucketMask);
+            int slot = cursors[bucket]++;
+            _keys[slot] = key;
+            _values[slot] = value;
+            if (_starts[bucket + 1] - _starts[bucket] > MaxBucketLength) _overflow[key] = value;
+        }
     }
 
     /// <inheritdoc/>
@@ -63,7 +82,19 @@ internal sealed class HashKeyedNodeStorage : INodeStorage, INodeStorage.IWriteBa
     /// a half-path key under <see cref="INodeStorage.KeyScheme.Hash"/>, so that probe can only miss here.
     /// </remarks>
     public byte[]? Get(Hash256? address, in TreePath path, in ValueHash256 keccak, ReadFlags readFlags = ReadFlags.None)
-        => _nodes.TryGetValue(new NodeKey(keccak), out byte[]? node) ? node : null;
+        => Find(new NodeKey(keccak));
+
+    private byte[]? Find(NodeKey key)
+    {
+        if (_nodes.Count != 0 && _nodes.TryGetValue(key, out byte[]? value)) return value;
+        int bucket = key.Bucket(_bucketMask);
+        int start = _starts[bucket];
+        int end = _starts[bucket + 1];
+        if (end - start > MaxBucketLength) return _overflow.GetValueOrDefault(key);
+        for (int i = end - 1; i >= start; i--)
+            if (_keys[i].Equals(key)) return _values[i];
+        return null;
+    }
 
     /// <inheritdoc/>
     /// <remarks>
@@ -82,7 +113,7 @@ internal sealed class HashKeyedNodeStorage : INodeStorage, INodeStorage.IWriteBa
 
         if (data.IsNull())
         {
-            _nodes.Remove(key);
+            _nodes[key] = null;
         }
         else
         {
@@ -92,7 +123,7 @@ internal sealed class HashKeyedNodeStorage : INodeStorage, INodeStorage.IWriteBa
 
     // The empty root is seeded, so it needs no special case here.
     public bool KeyExists(in ValueHash256? address, in TreePath path, in ValueHash256 keccak)
-        => _nodes.ContainsKey(new NodeKey(keccak));
+        => Find(new NodeKey(keccak)) is not null;
 
     public INodeStorage.IWriteBatch StartWriteBatch() => this;
 
@@ -130,6 +161,8 @@ internal sealed class HashKeyedNodeStorage : INodeStorage, INodeStorage.IWriteBa
     private readonly struct NodeKey(in ValueHash256 hash) : IEquatable<NodeKey>
     {
         private readonly ValueHash256 _hash = hash;
+
+        internal int Bucket(int mask) => (int)Unsafe.ReadUnaligned<uint>(ref Unsafe.As<ValueHash256, byte>(ref Unsafe.AsRef(in _hash))) & mask;
 
         public bool Equals(NodeKey other)
         {

--- a/src/Nethermind/Nethermind.Consensus/Stateless/HashKeyedNodeStorage.cs
+++ b/src/Nethermind/Nethermind.Consensus/Stateless/HashKeyedNodeStorage.cs
@@ -17,7 +17,7 @@ namespace Nethermind.Consensus.Stateless;
 /// The alternative is a <c>MemDb</c> behind <see cref="NodeStorage"/>, which keys a dictionary by
 /// <c>byte[]</c>: every witness node pays a key-array allocation on load, and every read builds a
 /// key span, hashes its bytes and compares them against the stored array. Here the keccak is the key,
-/// so a read is one word-wise probe.
+/// so reads compare the keccak word-wise.
 /// <para>
 /// Only the zkEVM guest uses this (see <c>WitnessNodeStorage.zkevm.cs</c>). It is not thread-safe, and
 /// the host commits storage tries in parallel — <c>PersistentStorageProvider.UpdateRootHashesMultiThread</c>
@@ -143,6 +143,10 @@ internal sealed class HashKeyedNodeStorage : INodeStorage, INodeStorage.IWriteBa
     /// <see cref="ValueHash256.Equals(ValueHash256)"/>, which compares
     /// <see cref="System.Runtime.Intrinsics.Vector256{T}"/>s and so expands to a byte-at-a-time loop on
     /// the guest's target.
+    /// <para>
+    /// The overflow and write dictionaries use the hash code below; ordinary witness buckets compare
+    /// full keys directly, with their scan length bounded by <see cref="MaxBucketLength"/>.
+    /// </para>
     /// <para>
     /// The hash code goes through the run-seeded mixer rather than the keccak's own leading bytes: those
     /// are uniformly distributed, which answers accidental collisions but not a chosen witness. Unseeded,


### PR DESCRIPTION
## Changes

- Build an immutable bucket index over witness-node digests so ordinary reads compare full keys without dictionary hashing.
- Bound linear scans to eight entries and retain the existing seeded dictionary for overflow buckets. Writes and deletion tombstones use a separate overlay dictionary.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

19 existing HashKeyedNodeStorage tests pass after rebase onto master `c49db69407`.

`dotnet test --project src/Nethermind/Nethermind.Consensus.Test/Nethermind.Consensus.Test.csproj -c release -- --filter FullyQualifiedName~HashKeyedNodeStorageTests`

| Build | Instructions | Weighted guest cost |
|---|---:|---:|
| Master c49db69407 | 342,352,195 | 40,476,096,315 |
| This PR | 339,695,328 | 40,218,017,241 |

**0.64% lower weighted guest cost** on master. The same index previously measured **0.67% lower cost** over #13323.

One mainnet fixture: block 25,532,382, 1,232 transactions. Release guest builds using bflat-riscv64 `acee0ec11a2bb2199e941380ae0336caa429cdea` and ZisK `1.2.0-alpha` (`ziskemu -X`). Both arms return identical successful output and pass ISA/resource checks. These are deterministic instruction counts and modeled proving cost, not wall-clock proving times. Input SHA-256: `1706a8838f8cbb36f78bfdca3d83f8c9779a06dc0e50541172f099b9107c6a2a`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Draft: add targeted coverage for bucket boundaries, overflow collisions, duplicate witness nodes, and overlay updates/deletions before marking ready. The index adds retained arrays and transient construction memory; memory usage and performance on a wider witness corpus still need evaluation. The overflow dictionary retains the existing hashing defense; this does not solve the broader chosen-witness input-bounding problem.


Review follow-up: 25 targeted tests pass, including 2/8/9/16 colliding witness nodes, same-bucket misses, lookups after writes, tombstones, and duplicate-induced overflow. The unseeded masked buckets can be crowded by an offline grind; the seeded overflow dictionary bounds scans at eight entries. Duplicate slots and overflow arrays remain allocated, and any write adds a seeded dictionary probe before witness lookup.
