### PR TITLE
Compact storage undo records with slot indices

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Benchmark/StorageJournalBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StorageJournalBenchmarks.cs
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Autofac;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing.State;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+
+namespace Nethermind.Evm.Benchmark;
+
+/// <summary>Measures cached storage reads, journal updates, rollback and transaction commit.</summary>
+[MemoryDiagnoser]
+public class StorageJournalBenchmarks
+{
+    private IContainer _container = null!;
+    private ILifetimeScope _processingScope = null!;
+    private IDisposable _stateScope = null!;
+    private IWorldState _state = null!;
+    private StorageCell[] _cells = null!;
+    private StorageCell[] _freshCells = null!;
+    private readonly byte[] _initial = [1];
+    private readonly byte[] _updated = [2];
+    private bool _alternate;
+
+    [Params(128, 4096)]
+    public int SlotCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _container = new ContainerBuilder()
+            .AddModule(new TestNethermindModule(Osaka.Instance))
+            .Build();
+        IWorldStateScopeProvider scopeProvider = _container.Resolve<IWorldStateManager>().GlobalWorldState;
+        _processingScope = _container.BeginLifetimeScope(builder => builder.AddSingleton(scopeProvider));
+        _state = _processingScope.Resolve<IWorldState>();
+        _stateScope = _state.BeginScope(IWorldState.PreGenesis);
+        _state.CreateAccount(Address.Zero, UInt256.One);
+        _state.Commit(Osaka.Instance);
+        _cells = new StorageCell[SlotCount];
+        _freshCells = new StorageCell[SlotCount];
+        for (int i = 0; i < SlotCount; i++)
+        {
+            _cells[i] = new StorageCell(Address.Zero, (UInt256)i);
+            _freshCells[i] = new StorageCell(Address.Zero, (UInt256)(SlotCount + i));
+            _state.Set(_cells[i], _initial);
+        }
+    }
+
+    [Benchmark]
+    public int CachedReads()
+    {
+        int sum = 0;
+        for (int pass = 0; pass < 8; pass++)
+            foreach (StorageCell cell in _cells)
+                sum += _state.Get(cell)[0];
+        return sum;
+    }
+
+    [Benchmark]
+    public void RepeatedWritesAndRestore()
+    {
+        Snapshot snapshot = _state.TakeSnapshot();
+        for (int pass = 0; pass < 8; pass++)
+            foreach (StorageCell cell in _cells)
+                _state.Set(cell, _updated);
+        _state.Restore(snapshot);
+    }
+
+    [Benchmark]
+    public void FreshWritesAndRestore()
+    {
+        Snapshot snapshot = _state.TakeSnapshot();
+        foreach (StorageCell cell in _freshCells)
+            _state.Set(cell, _updated);
+        _state.Restore(snapshot);
+    }
+
+    [Benchmark]
+    public void WriteAndCommit()
+    {
+        _alternate = !_alternate;
+        byte[] value = _alternate ? _updated : _initial;
+        foreach (StorageCell cell in _cells)
+            _state.Set(cell, value);
+        _state.Commit(Osaka.Instance, NullStateTracer.Instance, commitRoots: false);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _stateScope.Dispose();
+        _processingScope.Dispose();
+        _container.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -119,7 +119,6 @@ public class StorageProviderTests(bool useFlat)
             GetPrivateField(provider._stateProvider, "_committedThisRound"),
             GetPrivateField(provider._stateProvider, "_nullAccountReads"),
             GetPrivateField(provider._persistentStorageProvider, "_originalValues"),
-            GetPrivateField(provider._persistentStorageProvider, "_committedThisRound"),
             GetPrivateField(provider._persistentStorageProvider, "_destroyedThisRound"),
         ];
         int[] capacitiesBeforeReset = new int[collections.Length];
@@ -236,6 +235,53 @@ public class StorageProviderTests(bool useFlat)
         provider.Set(cell, _values[7]);
         provider.Restore(Snapshot.EmptyPosition, mid, Snapshot.EmptyPosition);
         Assert.That(provider.GetOriginal(cell).ToArray(), Is.EqualTo(_values[1]));
+    }
+
+    [Test]
+    public void Nested_restore_reuses_slots_after_journal_growth(
+        [Values] bool transient, [Values(1, 257, 4096)] int slotCount)
+    {
+        using Context ctx = new(useFlat);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell anchor = new(ctx.Address1, UInt256.MaxValue);
+        Write(anchor, _values[1]);
+        Snapshot outer = provider.TakeSnapshot();
+        for (int i = 0; i < slotCount; i++) Write(new StorageCell(ctx.Address1, (UInt256)i), _values[2]);
+        Snapshot inner = provider.TakeSnapshot();
+        for (int i = slotCount - 1; i >= 0; i--) Write(new StorageCell(ctx.Address1, (UInt256)i), _values[3]);
+        Write(anchor, _values[4]);
+
+        provider.Restore(inner);
+        Assert.That(Read(anchor), Is.EqualTo(_values[1]));
+        for (int i = 0; i < slotCount; i++)
+            Assert.That(Read(new StorageCell(ctx.Address1, (UInt256)i)), Is.EqualTo(_values[2]));
+
+        provider.Restore(outer);
+        for (int i = 0; i < slotCount; i++)
+            Assert.That(Read(new StorageCell(ctx.Address1, (UInt256)i)), Is.EqualTo(_values[0]));
+
+        StorageCell reused = new(ctx.Address1, (UInt256)(slotCount / 2));
+        Write(reused, _values[5]);
+        Write(anchor, _values[6]);
+        provider.Restore(outer);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(Read(anchor), Is.EqualTo(_values[1]));
+            Assert.That(Read(reused), Is.EqualTo(_values[0]));
+        }
+
+        Write(reused, _values[7]);
+        provider.Commit(Frontier.Instance);
+        Assert.That(Read(reused), Is.EqualTo(transient ? _values[0] : _values[7]));
+
+        void Write(StorageCell cell, byte[] value)
+        {
+            if (transient) provider.SetTransientState(cell, value);
+            else provider.Set(cell, value);
+        }
+
+        byte[] Read(StorageCell cell) =>
+            (transient ? provider.GetTransientState(cell) : provider.Get(cell)).ToArray();
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
+++ b/src/Nethermind/Nethermind.State/PartialStorageProviderBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -19,7 +18,9 @@ namespace Nethermind.State
     /// </summary>
     internal abstract class PartialStorageProviderBase(ILogManager logManager)
     {
-        protected readonly Dictionary<StorageCell, HeadChange> _intraBlockCache = [];
+        protected readonly Dictionary<StorageCell, int> _intraBlockCache = [];
+        protected readonly List<StorageCell> _cells = [];
+        protected readonly List<HeadChange> _heads = [];
         protected readonly ILogger _logger = logManager.GetClassLogger<PartialStorageProviderBase>();
         protected readonly List<Change> _changes = new(Resettable.StartCapacity);
 
@@ -89,11 +90,7 @@ namespace Nethermind.State
                     continue;
                 }
 
-                ref HeadChange head = ref CollectionsMarshal.GetValueRefOrNullRef(_intraBlockCache, change.StorageCell);
-                if (Unsafe.IsNullRef(ref head))
-                {
-                    throw new InvalidOperationException($"Missing head entry for {change.StorageCell} at position {position}");
-                }
+                ref HeadChange head = ref CollectionsMarshal.AsSpan(_heads)[change.SlotIndex];
 
                 if (head.CurrentIdx != position)
                 {
@@ -107,7 +104,12 @@ namespace Nethermind.State
                 }
                 else
                 {
-                    _intraBlockCache.Remove(change.StorageCell);
+                    _intraBlockCache.Remove(_cells[change.SlotIndex]);
+                    // First writes create slots in journal order, so rollback retires them from the end.
+                    if (change.SlotIndex != _cells.Count - 1)
+                        throw new InvalidOperationException("Storage slots must be restored in reverse creation order");
+                    _cells.RemoveAt(change.SlotIndex);
+                    _heads.RemoveAt(change.SlotIndex);
                 }
             }
 
@@ -154,6 +156,8 @@ namespace Nethermind.State
 
             _changes.Clear();
             _intraBlockCache.ClearAndTrim();
+            _cells.Clear();
+            _heads.Clear();
             _transactionChangesSnapshots.Clear();
         }
 
@@ -167,9 +171,9 @@ namespace Nethermind.State
         {
             // If the cache is completely empty (no writes or reads yet this transaction),
             // skip hashing the 52-byte cell — TryGetValue would miss anyway.
-            if (_intraBlockCache.Count != 0 && _intraBlockCache.TryGetValue(storageCell, out HeadChange head))
+            if (_intraBlockCache.Count != 0 && _intraBlockCache.TryGetValue(storageCell, out int slotIndex))
             {
-                bytes = head.Value;
+                bytes = CollectionsMarshal.AsSpan(_heads)[slotIndex].Value;
                 return true;
             }
 
@@ -193,7 +197,14 @@ namespace Nethermind.State
         {
             // Overwrites the head in place, never removes+re-adds — ClearStorage relies on this
             // to legally call Set while enumerating _intraBlockCache.
-            ref HeadChange head = ref CollectionsMarshal.GetValueRefOrAddDefault(_intraBlockCache, cell, out bool exists);
+            ref int slotIndex = ref CollectionsMarshal.GetValueRefOrAddDefault(_intraBlockCache, cell, out bool exists);
+            if (!exists)
+            {
+                slotIndex = _cells.Count;
+                _cells.Add(cell);
+                _heads.Add(default);
+            }
+            ref HeadChange head = ref CollectionsMarshal.AsSpan(_heads)[slotIndex];
             int prevIdx = exists ? head.CurrentIdx : -1;
 
             // The first write to a cell in a tx (head at or before the tx boundary) captures the
@@ -203,14 +214,11 @@ namespace Nethermind.State
             int originalIdx = firstWriteThisTx ? prevIdx : head.OriginalIdx;
 
             head = new HeadChange(value, _changes.Count, originalIdx);
-            _changes.Add(new Change(in cell, value, StorageChangeType.Update, prevIdx, originalIdx));
+            _changes.Add(new Change(slotIndex, value, StorageChangeType.Update, prevIdx, originalIdx));
         }
 
         protected void PushStorageClear(int journalIndex)
-        {
-            StorageCell marker = default;
-            _changes.Add(new Change(in marker, StorageTree.ZeroBytes, StorageChangeType.StorageClear, journalIndex, -1));
-        }
+            => _changes.Add(new Change(-1, StorageTree.ZeroBytes, StorageChangeType.StorageClear, journalIndex, -1));
 
         protected virtual void RestoreStorageClear(int journalIndex) =>
             throw new InvalidOperationException($"{GetType().Name} cannot restore storage clear journal entry {journalIndex}");
@@ -224,7 +232,7 @@ namespace Nethermind.State
             // We are setting cached values to zero so we do not use previously set values
             // when the contract is revived with CREATE2 inside the same block.
             // Set never adds or removes keys here, so enumerating while mutating is legal.
-            foreach (KeyValuePair<StorageCell, HeadChange> cellByAddress in _intraBlockCache)
+            foreach (KeyValuePair<StorageCell, int> cellByAddress in _intraBlockCache)
             {
                 if (cellByAddress.Key.Address == address)
                 {
@@ -236,9 +244,9 @@ namespace Nethermind.State
         /// <summary>
         /// Used for tracking each change to storage
         /// </summary>
-        protected readonly struct Change(in StorageCell storageCell, byte[] value, StorageChangeType changeType, int prevIdx, int originalIdx)
+        protected readonly struct Change(int slotIndex, byte[] value, StorageChangeType changeType, int prevIdx, int originalIdx)
         {
-            public readonly StorageCell StorageCell = storageCell;
+            public readonly int SlotIndex = slotIndex;
             public readonly byte[] Value = value;
             public readonly StorageChangeType ChangeType = changeType;
 
@@ -266,8 +274,7 @@ namespace Nethermind.State
         }
 
         /// <summary>
-        /// Head of a cell's change chain, with the newest value and original-index inlined so reads
-        /// and <see cref="PersistentStorageProvider.GetOriginal"/> resolve with a single lookup.
+        /// Head of a cell's change chain, with the newest value and original-index for cached reads.
         /// </summary>
         protected readonly struct HeadChange(byte[] value, int currentIdx, int originalIdx)
         {
@@ -275,5 +282,6 @@ namespace Nethermind.State
             public readonly int CurrentIdx = currentIdx;
             public readonly int OriginalIdx = originalIdx;
         }
+
     }
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -43,7 +43,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// </summary>
     private readonly Dictionary<StorageCell, byte[]> _originalValues = [];
     private readonly HashSet<AddressAsKey> _destroyedThisRound = [];
-    private readonly HashSet<StorageCell> _committedThisRound = [];
     private readonly List<StorageClearChange> _storageClearJournal = [];
 
     // Zero means never captured, which is what a default BlockChange entry carries.
@@ -71,7 +70,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         _storageClearJournal.Clear();
         base.Reset();
         EndOriginalsRound();
-        _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
         if (resetBlockChanges)
         {
@@ -123,8 +121,9 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             throw new InvalidOperationException("Get original should only be called after get within the same caching round");
         }
 
-        if (_intraBlockCache.TryGetValue(storageCell, out HeadChange head))
+        if (_intraBlockCache.TryGetValue(storageCell, out int slotIndex))
         {
+            ref readonly HeadChange head = ref CollectionsMarshal.AsSpan(_heads)[slotIndex];
             int currentSnapshot = _transactionChangesSnapshots.TryPeek(out int s) ? s : Resettable.EmptyPosition;
             if (head.CurrentIdx <= currentSnapshot)
             {
@@ -230,7 +229,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         base.CommitCore(tracer);
         EndOriginalsRound();
-        _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
         _storageClearJournal.Clear();
 
@@ -258,24 +256,21 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 continue;
             }
 
-            if (!_committedThisRound.Add(change.StorageCell))
+            if (CollectionsMarshal.AsSpan(_heads)[change.SlotIndex].CurrentIdx != i)
             {
                 continue;
             }
-
-            // Debug-only: A broken index surfaces anyway as a storage-root mismatch on the block.
-            Debug.Assert(_intraBlockCache[change.StorageCell].CurrentIdx == i,
-                $"Expected the cached index to equal {i}");
+            ref readonly StorageCell cell = ref CollectionsMarshal.AsSpan(_cells)[change.SlotIndex];
 
             if (change.ChangeType == StorageChangeType.Update)
             {
                 // A SaveChange would resurrect the dead value over the Clear() marker;
                 // tracers still see the cell zeroed, as the journaled path reported it.
-                if (HasDestroyedAccounts.IsActive && _destroyedThisRound.Contains(change.StorageCell.Address))
+                if (HasDestroyedAccounts.IsActive && _destroyedThisRound.Contains(cell.Address))
                 {
                     if (TStorageTracing.IsActive)
                     {
-                        RequireTrace(trace)[change.StorageCell] = new StorageChangeTrace(StorageTree.ZeroBytes);
+                        RequireTrace(trace)[cell] = new StorageChangeTrace(StorageTree.ZeroBytes);
                     }
 
                     continue;
@@ -283,33 +278,33 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
                 if (_logger.IsTrace)
                 {
-                    TraceUpdate(change);
+                    TraceUpdate(in cell, change.Value);
                 }
 
-                if (_originalValues.TryGetValue(change.StorageCell, out byte[]? initialValue) &&
+                if (_originalValues.TryGetValue(cell, out byte[]? initialValue) &&
                     initialValue.AsSpan().SequenceEqual(change.Value))
                 {
                     // no need to update the tree if the value is the same
                 }
                 else
                 {
-                    toUpdateRoots.Add(change.StorageCell.Address);
+                    toUpdateRoots.Add(cell.Address);
 
-                    GetOrCreateStorage(change.StorageCell.Address)
-                        .SaveChange(change.StorageCell, change.Value);
+                    GetOrCreateStorage(cell.Address)
+                        .SaveChange(cell, change.Value);
                 }
 
                 if (TStorageTracing.IsActive)
                 {
-                    RequireTrace(trace)[change.StorageCell] = new StorageChangeTrace(change.Value);
+                    RequireTrace(trace)[cell] = new StorageChangeTrace(change.Value);
                 }
             }
         }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void TraceUpdate(in Change change)
-        => _logger.Trace($"  Update {change.StorageCell.Address}_{change.StorageCell.Index} V = {change.Value.ToHexString(true)}");
+    private void TraceUpdate(in StorageCell cell, byte[] value)
+        => _logger.Trace($"  Update {cell.Address}_{cell.Index} V = {value.ToHexString(true)}");
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Dictionary<StorageCell, StorageChangeTrace> RequireTrace(Dictionary<StorageCell, StorageChangeTrace>? trace)


### PR DESCRIPTION
## Changes

- Store slot indices in persistent and transient storage undo records. Keep slot keys and current heads in separate dense lists, restore heads by index, and identify the last surviving write directly at commit.
- Remove the storage commit deduplication set and add coverage for nested rollback, table growth and slot reuse.
- Add production-DI storage microbenchmarks with in-memory databases.

**Draft:** cached reads are slower. This is a structural experiment with gains for repeated writes and rollback; it is not ready for a general-purpose node.

BenchmarkDotNet 0.15.8, Windows .NET 10.0.9, Ryzen 7 5800X; five warmups and eight measured iterations. Baseline is master `c49db69407`. Values below are microseconds for the complete batch, including writes/reads and rollback or commit. Read and repeated-write cases make eight passes over the slot set. The full matrix has one baseline/prototype comparison; cached reads were also checked in reverse process order below.

| Workload | Slots | Master | Prototype |
|---|---:|---:|---:|
| Cached reads | 128 | 21.388 | 23.190 |
| Repeated writes + rollback | 128 | 50.553 | 34.455 |
| Fresh writes + rollback | 128 | 7.771 | 6.651 |
| Writes + commit | 128 | 9.476 | 8.557 |
| Cached reads | 4096 | 764.584 | 835.303 |
| Repeated writes + rollback | 4096 | 1946.320 | 1221.592 |
| Fresh writes + rollback | 4096 | 315.878 | 270.857 |
| Writes + commit | 4096 | 392.648 | 325.758 |

A later prototype/master cached-read comparison confirmed the regression: **25.46 vs 22.64 us at 128 slots (+12.5%)**, and **927.51 vs 774.36 us at 4096 slots (+19.8%)**. Run-to-run variance changes the magnitude; the read penalty remains material.

On guest block 25532382, total modeled ZisK cost falls from 40,476,096,315 to 40,427,568,540 (**0.120%**), with identical output. One fixture does not establish a general block-processing gain. The slot arrays add storage per unique cell while compacting repeated undo entries; steady-state allocation measurements do not account for retained capacity.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

148 targeted persistent/transient storage tests passed on both state backends. Guest Release/bflat build passed the ISA and embedded-resource gates; the complete block fixture returned the baseline output.

Run `StorageJournalBenchmarks` in `Nethermind.Evm.Benchmark` with `--job short --inProcess --warmupCount 5 --iterationCount 8`. Guest measurements use bflat `acee0ec11a2bb2199e941380ae0336caa429cdea` and ZisK `1.2.0-alpha`. Neither arm includes #13323.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Before promotion: address the cached-read regression, measure retained memory, repeat the write-workload comparisons, and validate representative block/RPC workloads. Original-value tracking remains unchanged in this prototype. #13340 independently isolates the smaller commit optimization while retaining the current read and rollback representations.
