### PR TITLE
Commit storage directly from surviving journal heads

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Benchmark/StorageJournalBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StorageJournalBenchmarks.cs
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Autofac;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing.State;
+using Nethermind.Int256;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+
+namespace Nethermind.Evm.Benchmark;
+
+/// <summary>Measures cached storage reads, journal updates, rollback and transaction commit.</summary>
+[MemoryDiagnoser]
+public class StorageJournalBenchmarks
+{
+    private IContainer _container = null!;
+    private ILifetimeScope _processingScope = null!;
+    private IDisposable _stateScope = null!;
+    private IWorldState _state = null!;
+    private StorageCell[] _cells = null!;
+    private StorageCell[] _freshCells = null!;
+    private readonly byte[] _initial = [1];
+    private readonly byte[] _updated = [2];
+    private bool _alternate;
+
+    [Params(128, 4096)]
+    public int SlotCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _container = new ContainerBuilder()
+            .AddModule(new TestNethermindModule(Osaka.Instance))
+            .Build();
+        IWorldStateScopeProvider scopeProvider = _container.Resolve<IWorldStateManager>().GlobalWorldState;
+        _processingScope = _container.BeginLifetimeScope(builder => builder.AddSingleton(scopeProvider));
+        _state = _processingScope.Resolve<IWorldState>();
+        _stateScope = _state.BeginScope(IWorldState.PreGenesis);
+        _state.CreateAccount(Address.Zero, UInt256.One);
+        _state.Commit(Osaka.Instance);
+        _cells = new StorageCell[SlotCount];
+        _freshCells = new StorageCell[SlotCount];
+        for (int i = 0; i < SlotCount; i++)
+        {
+            _cells[i] = new StorageCell(Address.Zero, (UInt256)i);
+            _freshCells[i] = new StorageCell(Address.Zero, (UInt256)(SlotCount + i));
+            _state.Set(_cells[i], _initial);
+        }
+    }
+
+    [Benchmark]
+    public int CachedReads()
+    {
+        int sum = 0;
+        for (int pass = 0; pass < 8; pass++)
+            foreach (StorageCell cell in _cells)
+                sum += _state.Get(cell)[0];
+        return sum;
+    }
+
+    [Benchmark]
+    public void RepeatedWritesAndRestore()
+    {
+        Snapshot snapshot = _state.TakeSnapshot();
+        for (int pass = 0; pass < 8; pass++)
+            foreach (StorageCell cell in _cells)
+                _state.Set(cell, _updated);
+        _state.Restore(snapshot);
+    }
+
+    [Benchmark]
+    public void FreshWritesAndRestore()
+    {
+        Snapshot snapshot = _state.TakeSnapshot();
+        foreach (StorageCell cell in _freshCells)
+            _state.Set(cell, _updated);
+        _state.Restore(snapshot);
+    }
+
+    [Benchmark]
+    public void WriteAndCommit() => WriteAndCommit(1);
+
+    [Benchmark]
+    public void RepeatedWritesAndCommit() => WriteAndCommit(8);
+
+    private void WriteAndCommit(int passes)
+    {
+        _alternate = !_alternate;
+        byte[] value = _alternate ? _updated : _initial;
+        for (int pass = 0; pass < passes; pass++)
+            foreach (StorageCell cell in _cells)
+                _state.Set(cell, value);
+        _state.Commit(Osaka.Instance, NullStateTracer.Instance, commitRoots: false);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _stateScope.Dispose();
+        _processingScope.Dispose();
+        _container.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Benchmark/StorageJournalBenchmarks.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/StorageJournalBenchmarks.cs
@@ -51,6 +51,7 @@ public class StorageJournalBenchmarks
             _freshCells[i] = new StorageCell(Address.Zero, (UInt256)(SlotCount + i));
             _state.Set(_cells[i], _initial);
         }
+        _state.Commit(Osaka.Instance, NullStateTracer.Instance, commitRoots: false);
     }
 
     [Benchmark]
@@ -88,13 +89,23 @@ public class StorageJournalBenchmarks
     [Benchmark]
     public void RepeatedWritesAndCommit() => WriteAndCommit(8);
 
-    private void WriteAndCommit(int passes)
+    [Benchmark]
+    public void RepeatedWritesRestoringOriginalAndCommit() => WriteAndCommit(8, restoreOriginal: true);
+
+    private void WriteAndCommit(int passes, bool restoreOriginal = false)
     {
+        if (restoreOriginal)
+            foreach (StorageCell cell in _cells)
+                _state.Get(cell);
+
         _alternate = !_alternate;
-        byte[] value = _alternate ? _updated : _initial;
+        byte[] value = restoreOriginal || _alternate ? _updated : _initial;
         for (int pass = 0; pass < passes; pass++)
             foreach (StorageCell cell in _cells)
                 _state.Set(cell, value);
+        if (restoreOriginal)
+            foreach (StorageCell cell in _cells)
+                _state.Set(cell, _initial);
         _state.Commit(Osaka.Instance, NullStateTracer.Instance, commitRoots: false);
     }
 

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -1113,6 +1113,8 @@ public class StorageProviderTests(bool useFlat)
             Assert.That(provider.Get(second).ToArray(), Is.EqualTo(secondValue));
             Assert.That(provider.Get(untouched).ToArray(), Is.EqualTo(_values[clearStorage && !restore ? 0 : 3]));
             Assert.That(tracer.Changes, Has.Count.EqualTo(clearStorage && !restore ? 3 : 2));
+            Assert.That(tracer.Changes[0].Cell, Is.EqualTo(first), "storage changes follow surviving-head insertion order");
+            Assert.That(tracer.Changes[1].Cell, Is.EqualTo(second));
             Assert.That(tracer.Changes.FindAll(change => change.Cell.Equals(first)), Has.Count.EqualTo(1));
             Assert.That(tracer.Changes.Find(change => change.Cell.Equals(first)).Before, Is.EqualTo(_values[1]));
             Assert.That(tracer.Changes.Find(change => change.Cell.Equals(first)).After, Is.EqualTo(firstValue));

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -119,7 +119,6 @@ public class StorageProviderTests(bool useFlat)
             GetPrivateField(provider._stateProvider, "_committedThisRound"),
             GetPrivateField(provider._stateProvider, "_nullAccountReads"),
             GetPrivateField(provider._persistentStorageProvider, "_originalValues"),
-            GetPrivateField(provider._persistentStorageProvider, "_committedThisRound"),
             GetPrivateField(provider._persistentStorageProvider, "_destroyedThisRound"),
         ];
         int[] capacitiesBeforeReset = new int[collections.Length];
@@ -1080,6 +1079,49 @@ public class StorageProviderTests(bool useFlat)
     }
 
     [Test]
+    public void Commit_reports_latest_surviving_write_once([Values] bool clearStorage, [Values] bool restore)
+    {
+        using Context ctx = new(useFlat);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell first = new(ctx.Address1, 100);
+        StorageCell second = new(ctx.Address1, 101);
+        StorageCell untouched = new(ctx.Address1, 102);
+        provider.Set(first, _values[1]);
+        provider.Set(second, _values[2]);
+        provider.Set(untouched, _values[3]);
+        provider.Commit(Frontier.Instance);
+        provider.Get(first);
+        provider.Get(second);
+        provider.Get(untouched);
+        provider.Set(first, _values[4]);
+        provider.Set(second, _values[5]);
+        Snapshot snapshot = provider.TakeSnapshot();
+        if (clearStorage) provider.ClearStorage(ctx.Address1);
+        provider.Set(first, _values[6]);
+        provider.Set(second, _values[7]);
+        provider.Set(first, _values[8]);
+        if (restore) provider.Restore(snapshot);
+        ReadCollectingStorageTracer tracer = new();
+
+        provider.Commit(Frontier.Instance, tracer);
+
+        byte[] firstValue = _values[restore ? 4 : 8];
+        byte[] secondValue = _values[restore ? 5 : 7];
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(provider.Get(first).ToArray(), Is.EqualTo(firstValue));
+            Assert.That(provider.Get(second).ToArray(), Is.EqualTo(secondValue));
+            Assert.That(provider.Get(untouched).ToArray(), Is.EqualTo(_values[clearStorage && !restore ? 0 : 3]));
+            Assert.That(tracer.Changes, Has.Count.EqualTo(clearStorage && !restore ? 3 : 2));
+            Assert.That(tracer.Changes.FindAll(change => change.Cell.Equals(first)), Has.Count.EqualTo(1));
+            Assert.That(tracer.Changes.Find(change => change.Cell.Equals(first)).Before, Is.EqualTo(_values[1]));
+            Assert.That(tracer.Changes.Find(change => change.Cell.Equals(first)).After, Is.EqualTo(firstValue));
+            Assert.That(tracer.Changes.Find(change => change.Cell.Equals(second)).Before, Is.EqualTo(_values[2]));
+            Assert.That(tracer.Changes.Find(change => change.Cell.Equals(second)).After, Is.EqualTo(secondValue));
+        }
+    }
+
+    [Test]
     public void Commit_ReadOnlyRound_ReportsStorageReadsToTracer()
     {
         using Context ctx = new(useFlat);
@@ -1479,6 +1521,7 @@ public class StorageProviderTests(bool useFlat)
     private sealed class ReadCollectingStorageTracer : IWorldStateTracer
     {
         public System.Collections.Generic.List<StorageCell> Reads { get; } = [];
+        public System.Collections.Generic.List<(StorageCell Cell, byte[] Before, byte[] After)> Changes { get; } = [];
 
         public bool IsTracingState => false;
         public bool IsTracingStorage => true;
@@ -1488,7 +1531,7 @@ public class StorageProviderTests(bool useFlat)
         public void ReportNonceChange(Address address, UInt256? before, UInt256? after) { }
         public void ReportAccountRead(Address address) { }
         public void ReportStorageChange(in ReadOnlySpan<byte> key, in ReadOnlySpan<byte> value) { }
-        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after) { }
+        public void ReportStorageChange(in StorageCell storageCell, byte[] before, byte[] after) => Changes.Add((storageCell, before, after));
         public void ReportStorageRead(in StorageCell storageCell) => Reads.Add(storageCell);
     }
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -43,7 +43,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// </summary>
     private readonly Dictionary<StorageCell, byte[]> _originalValues = [];
     private readonly HashSet<AddressAsKey> _destroyedThisRound = [];
-    private readonly HashSet<StorageCell> _committedThisRound = [];
     private readonly List<StorageClearChange> _storageClearJournal = [];
 
     // Zero means never captured, which is what a default BlockChange entry carries.
@@ -71,7 +70,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         _storageClearJournal.Clear();
         base.Reset();
         EndOriginalsRound();
-        _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
         if (resetBlockChanges)
         {
@@ -230,7 +228,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         base.CommitCore(tracer);
         EndOriginalsRound();
-        _committedThisRound.ClearAndTrim();
         _destroyedThisRound.ClearAndTrim();
         _storageClearJournal.Clear();
 
@@ -250,22 +247,9 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         Debug.Assert(TStorageTracing.IsActive == (trace is not null));
         Debug.Assert(HasDestroyedAccounts.IsActive == (_destroyedThisRound.Count != 0));
 
-        for (int i = changes.Length - 1; i >= 0; i--)
+        foreach (HeadChange head in _intraBlockCache.Values)
         {
-            ref readonly Change change = ref changes[i];
-            if (change.ChangeType == StorageChangeType.StorageClear)
-            {
-                continue;
-            }
-
-            if (!_committedThisRound.Add(change.StorageCell))
-            {
-                continue;
-            }
-
-            // Debug-only: A broken index surfaces anyway as a storage-root mismatch on the block.
-            Debug.Assert(_intraBlockCache[change.StorageCell].CurrentIdx == i,
-                $"Expected the cached index to equal {i}");
+            ref readonly Change change = ref changes[head.CurrentIdx];
 
             if (change.ChangeType == StorageChangeType.Update)
             {

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -247,46 +247,47 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         Debug.Assert(TStorageTracing.IsActive == (trace is not null));
         Debug.Assert(HasDestroyedAccounts.IsActive == (_destroyedThisRound.Count != 0));
 
+        // SaveChange and backend hints must not re-enter the journal while its heads are enumerated.
         foreach (HeadChange head in _intraBlockCache.Values)
         {
+            Debug.Assert((uint)head.CurrentIdx < (uint)changes.Length);
             ref readonly Change change = ref changes[head.CurrentIdx];
+            Debug.Assert(change.ChangeType == StorageChangeType.Update);
+            Debug.Assert(_intraBlockCache[change.StorageCell].CurrentIdx == head.CurrentIdx);
 
-            if (change.ChangeType == StorageChangeType.Update)
+            // A SaveChange would resurrect the dead value over the Clear() marker;
+            // tracers still see the cell zeroed, as the journaled path reported it.
+            if (HasDestroyedAccounts.IsActive && _destroyedThisRound.Contains(change.StorageCell.Address))
             {
-                // A SaveChange would resurrect the dead value over the Clear() marker;
-                // tracers still see the cell zeroed, as the journaled path reported it.
-                if (HasDestroyedAccounts.IsActive && _destroyedThisRound.Contains(change.StorageCell.Address))
-                {
-                    if (TStorageTracing.IsActive)
-                    {
-                        RequireTrace(trace)[change.StorageCell] = new StorageChangeTrace(StorageTree.ZeroBytes);
-                    }
-
-                    continue;
-                }
-
-                if (_logger.IsTrace)
-                {
-                    TraceUpdate(change);
-                }
-
-                if (_originalValues.TryGetValue(change.StorageCell, out byte[]? initialValue) &&
-                    initialValue.AsSpan().SequenceEqual(change.Value))
-                {
-                    // no need to update the tree if the value is the same
-                }
-                else
-                {
-                    toUpdateRoots.Add(change.StorageCell.Address);
-
-                    GetOrCreateStorage(change.StorageCell.Address)
-                        .SaveChange(change.StorageCell, change.Value);
-                }
-
                 if (TStorageTracing.IsActive)
                 {
-                    RequireTrace(trace)[change.StorageCell] = new StorageChangeTrace(change.Value);
+                    RequireTrace(trace)[change.StorageCell] = new StorageChangeTrace(StorageTree.ZeroBytes);
                 }
+
+                continue;
+            }
+
+            if (_logger.IsTrace)
+            {
+                TraceUpdate(change);
+            }
+
+            if (_originalValues.TryGetValue(change.StorageCell, out byte[]? initialValue) &&
+                initialValue.AsSpan().SequenceEqual(change.Value))
+            {
+                // no need to update the tree if the value is the same
+            }
+            else
+            {
+                toUpdateRoots.Add(change.StorageCell.Address);
+
+                GetOrCreateStorage(change.StorageCell.Address)
+                    .SaveChange(change.StorageCell, change.Value);
+            }
+
+            if (TStorageTracing.IsActive)
+            {
+                RequireTrace(trace)[change.StorageCell] = new StorageChangeTrace(change.Value);
             }
         }
     }


### PR DESCRIPTION
## Changes

Storage commit currently scans every undo entry and hashes its cell into a separate deduplication set. The existing head dictionary already identifies the latest surviving write for each cell. Enumerate those heads directly and remove the extra set and its clearing work.

Add coverage for final values and storage traces after repeated writes, storage clearing and rollback, plus storage microbenchmarks using production DI and in-memory databases.

On guest block 25532382, modeled ZisK cost falls from **40,476,096,315 to 40,417,174,905 (0.146%)**, with identical output. Instructions fall from 342,352,195 to 341,805,130. Both arms use master `c49db69407` as the base and exclude #13323.

Host BenchmarkDotNet runs used A/B/B/A process order, Windows .NET 10.0.9, Ryzen 7 5800X, five warmups and eight measured iterations. The table gives the range of the two process means in microseconds for each complete batch. Repeated-write batches make eight passes over the slots before committing.

| Batch | Slots | Master mean range (us) | PR mean range (us) |
|---|---:|---:|---:|
| Cached reads | 128 | 22.49–23.49 | 22.14–22.37 |
| Writes + commit | 128 | 12.77–13.75 | 11.69–11.70 |
| Repeated writes + commit | 128 | 58.54–68.85 | 55.36–60.35 |
| Cached reads | 4096 | 822.00–896.59 | 831.12–860.23 |
| Writes + commit | 4096 | 470.55–575.27 | 457.11–462.76 |
| Repeated writes + commit | 4096 | 2396.74–2493.02 | 2179.64–2380.19 |

Single-write commit batches improved in both process orders. Timing variance, especially for repeated writes, prevents a precise host speedup claim. These microbenchmarks and one guest fixture do not establish an aggregate normal-node block-throughput gain.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Full State suite: **1307 passed, four expected skips**, no failures. New cases run on both state backends.
- Guest Release/bflat build passes the no-F/D/C/A ISA and embedded-resource gates; the complete block fixture returns the baseline output.
- Whitespace formatting and `git diff --check` pass.

Run `StorageJournalBenchmarks` in `Nethermind.Evm.Benchmark` with `--job short --inProcess --warmupCount 5 --iterationCount 8`. Guest measurements use bflat `acee0ec11a2bb2199e941380ae0336caa429cdea` and ZisK `1.2.0-alpha`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Storage-trace change notification order follows head-dictionary enumeration; the reported cells and before/after values are unchanged. #13339 explores the larger slot-indexed journal design independently; this PR isolates commit work and retains the existing read and rollback representations.
