### PR TITLE
fix(build): stop the RPC JSON context target from deadlocking solution builds

### DIFF
--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -18,7 +18,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Leave room for a normal build, 15 minutes of silence, diagnostics, and artifact upload.
+    timeout-minutes: 60
     strategy:
       matrix:
         config: [release, debug]
@@ -47,15 +48,17 @@ jobs:
           DIAG_DIR: ${{ runner.temp }}/stall-diagnostics
           # A single project can legitimately compile silently for several minutes.
           STALL_SECONDS: 900
-          MSBUILDDEBUGPATH: ${{ runner.temp }}/msbuild-debug
+          MSBUILDDEBUGPATH: ${{ matrix.solution == 'EthereumTests' && format('{0}/msbuild-debug', runner.temp) || '' }}
           # Names the build requests each node is blocked on, which is what identifies a scheduler
           # deadlock. Costs no measurable build time but writes ~0.5 GB, so it is limited to the
-          # solution that has deadlocked. Remove scheduler tracing after the fix has proven stable.
+          # solution that has deadlocked. Remove scheduler tracing, its debug path, and binlogs
+          # after the fix has proven stable. Binlogs help ordinary failures; forced termination
+          # leaves an unfinished gzip stream, so stall investigations need stacks/scheduler logs.
           MSBUILDDEBUGSCHEDULER: ${{ matrix.solution == 'EthereumTests' && 1 || '' }}
         run: >
           bash scripts/ci/run-with-stall-watchdog.sh
           dotnet build src/Nethermind/${{ matrix.solution }}.slnx -c ${{ matrix.config }} --no-restore
-          -bl:${{ runner.temp }}/stall-diagnostics/build.binlog
+          ${{ matrix.solution == 'EthereumTests' && format('-bl:{0}/stall-diagnostics/build.binlog', runner.temp) || '' }}
 
       - name: Upload stall diagnostics
         if: failure()

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         config: [release, debug]
@@ -42,4 +43,23 @@ jobs:
         run: dotnet restore src/Nethermind/${{ matrix.solution }}.slnx --locked-mode
 
       - name: Build ${{ matrix.solution }}.slnx
-        run: dotnet build src/Nethermind/${{ matrix.solution }}.slnx -c ${{ matrix.config }} --no-restore
+        env:
+          DIAG_DIR: ${{ runner.temp }}/stall-diagnostics
+          MSBUILDDEBUGPATH: ${{ runner.temp }}/msbuild-debug
+          # Names the build requests each node is blocked on, which is what identifies a scheduler
+          # deadlock. Costs no measurable build time but writes ~0.5 GB, so it is limited to the
+          # solution that has deadlocked; the binary log covers the others.
+          MSBUILDDEBUGSCHEDULER: ${{ matrix.solution == 'EthereumTests' && 1 || '' }}
+        run: >
+          bash scripts/ci/run-with-stall-watchdog.sh
+          dotnet build src/Nethermind/${{ matrix.solution }}.slnx -c ${{ matrix.config }} --no-restore
+          -bl:${{ runner.temp }}/stall-diagnostics/build.binlog
+
+      - name: Upload stall diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: stall-diagnostics-${{ matrix.config }}-${{ matrix.solution }}
+          path: ${{ runner.temp }}/stall-diagnostics
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/build-solutions.yml
+++ b/.github/workflows/build-solutions.yml
@@ -45,10 +45,12 @@ jobs:
       - name: Build ${{ matrix.solution }}.slnx
         env:
           DIAG_DIR: ${{ runner.temp }}/stall-diagnostics
+          # A single project can legitimately compile silently for several minutes.
+          STALL_SECONDS: 900
           MSBUILDDEBUGPATH: ${{ runner.temp }}/msbuild-debug
           # Names the build requests each node is blocked on, which is what identifies a scheduler
           # deadlock. Costs no measurable build time but writes ~0.5 GB, so it is limited to the
-          # solution that has deadlocked; the binary log covers the others.
+          # solution that has deadlocked. Remove scheduler tracing after the fix has proven stable.
           MSBUILDDEBUGSCHEDULER: ${{ matrix.solution == 'EthereumTests' && 1 || '' }}
         run: >
           bash scripts/ci/run-with-stall-watchdog.sh

--- a/scripts/ci/run-with-stall-watchdog.sh
+++ b/scripts/ci/run-with-stall-watchdog.sh
@@ -17,14 +17,17 @@ set -uo pipefail
 
 STALL_SECONDS="${STALL_SECONDS:-300}"
 DIAG_DIR="${DIAG_DIR:-${RUNNER_TEMP:-/tmp}/stall-diagnostics}"
-POLL_SECONDS=15
+POLL_SECONDS="${POLL_SECONDS:-15}"
+DIAGNOSTIC_SECONDS="${DIAGNOSTIC_SECONDS:-120}"
+INSTALL_TIMEOUT_SECONDS="${INSTALL_TIMEOUT_SECONDS:-30}"
+STACK_TIMEOUT_SECONDS="${STACK_TIMEOUT_SECONDS:-10}"
 
 mkdir -p "$DIAG_DIR"
 log="$DIAG_DIR/command.log"
 : > "$log"
 
 # setsid puts the command in its own process group so a stall can take the whole tree down.
-setsid "$@" > "$log" 2>&1 &
+setsid --wait bash -c 'printf "%s\n" "$$" > "$1"; shift; exec "$@"' bash "$DIAG_DIR/command.pid" "$@" > "$log" 2>&1 &
 command_pid=$!
 
 # --pid makes tail drain the log and exit once the command is gone.
@@ -44,11 +47,15 @@ collect_diagnostics() {
     } > "$DIAG_DIR/system.txt" 2>&1
 
     # Managed stacks show which target or task each MSBuild node and the compiler server sit in.
-    dotnet tool install --global dotnet-stack > "$DIAG_DIR/dotnet-stack-install.log" 2>&1
+    local deadline=$((SECONDS + DIAGNOSTIC_SECONDS))
+    timeout --kill-after=1s "${INSTALL_TIMEOUT_SECONDS}s" dotnet tool install --global dotnet-stack > "$DIAG_DIR/dotnet-stack-install.log" 2>&1 || true
     export PATH="$PATH:$HOME/.dotnet/tools"
     if command -v dotnet-stack > /dev/null; then
         for pid in $(pgrep -x 'dotnet|VBCSCompiler'); do
-            dotnet-stack report --process-id "$pid" > "$DIAG_DIR/stack-$pid.txt" 2>&1
+            local remaining=$((deadline - SECONDS))
+            ((remaining > 0)) || break
+            ((remaining > STACK_TIMEOUT_SECONDS)) && remaining=$STACK_TIMEOUT_SECONDS
+            timeout --kill-after=1s "${remaining}s" dotnet-stack report --process-id "$pid" > "$DIAG_DIR/stack-$pid.txt" 2>&1 || true
         done
     fi
 
@@ -56,17 +63,20 @@ collect_diagnostics() {
         mkdir -p "$DIAG_DIR/msbuild-debug"
         # SchedulerState grows to hundreds of MB; only its tail describes the wedged build.
         for file in "$MSBUILDDEBUGPATH"/*; do
+            [[ -f "$file" ]] || continue
             tail -c 5000000 "$file" > "$DIAG_DIR/msbuild-debug/$(basename "$file")"
         done
     fi
 
-    # SIGTERM first so MSBuild gets to close its binary log.
-    kill -- "-$command_pid" 2>/dev/null || kill "$command_pid" 2>/dev/null
+    # A stalled build's binlog may be truncated; stacks and scheduler logs are the primary evidence.
+    local command_group
+    command_group=$(cat "$DIAG_DIR/command.pid")
+    kill -- "-$command_group" 2>/dev/null || kill "$command_pid" 2>/dev/null
     for _ in $(seq 30); do
         kill -0 "$command_pid" 2>/dev/null || return
         sleep 1
     done
-    kill -9 -- "-$command_pid" 2>/dev/null || kill -9 "$command_pid" 2>/dev/null
+    kill -9 -- "-$command_group" 2>/dev/null || kill -9 "$command_pid" 2>/dev/null
 }
 
 last_size=-1

--- a/scripts/ci/run-with-stall-watchdog.sh
+++ b/scripts/ci/run-with-stall-watchdog.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Run a command and, if it stops producing output, capture diagnostics before killing it.
+#
+# Usage:
+#   run-with-stall-watchdog.sh <command> [args...]
+#
+# Environment:
+#   STALL_SECONDS  Seconds of silence that count as a stall (default 300)
+#   DIAG_DIR       Where to write the log and diagnostics (default $RUNNER_TEMP/stall-diagnostics)
+#
+# Intended for builds that occasionally deadlock: a plain step timeout kills the process tree
+# before anything can be inspected, leaving nothing to debug. On a stall this dumps the process
+# tree, memory/disk state and managed stacks of every .NET process, so the artifact is enough to
+# tell what the build was waiting on.
+
+set -uo pipefail
+
+STALL_SECONDS="${STALL_SECONDS:-300}"
+DIAG_DIR="${DIAG_DIR:-${RUNNER_TEMP:-/tmp}/stall-diagnostics}"
+POLL_SECONDS=15
+
+mkdir -p "$DIAG_DIR"
+log="$DIAG_DIR/command.log"
+: > "$log"
+
+# setsid puts the command in its own process group so a stall can take the whole tree down.
+setsid "$@" > "$log" 2>&1 &
+command_pid=$!
+
+# --pid makes tail drain the log and exit once the command is gone.
+tail -n +1 --pid="$command_pid" -F "$log" 2>/dev/null &
+tail_pid=$!
+
+collect_diagnostics() {
+    echo "::error::No output for ${STALL_SECONDS}s — collecting diagnostics into $DIAG_DIR"
+
+    {
+        date -u +"stalled at %Y-%m-%dT%H:%M:%SZ"
+        echo "=== uptime / load ==="; uptime
+        echo "=== memory ==="; free -m
+        echo "=== disk ==="; df -h
+        echo "=== process tree ==="; ps -ef --forest
+        echo "=== threads ==="; ps -eLf
+    } > "$DIAG_DIR/system.txt" 2>&1
+
+    # Managed stacks show which target or task each MSBuild node and the compiler server sit in.
+    dotnet tool install --global dotnet-stack > "$DIAG_DIR/dotnet-stack-install.log" 2>&1
+    export PATH="$PATH:$HOME/.dotnet/tools"
+    if command -v dotnet-stack > /dev/null; then
+        for pid in $(pgrep -x 'dotnet|VBCSCompiler'); do
+            dotnet-stack report --process-id "$pid" > "$DIAG_DIR/stack-$pid.txt" 2>&1
+        done
+    fi
+
+    if [[ -n "${MSBUILDDEBUGPATH:-}" && -d "$MSBUILDDEBUGPATH" ]]; then
+        mkdir -p "$DIAG_DIR/msbuild-debug"
+        # SchedulerState grows to hundreds of MB; only its tail describes the wedged build.
+        for file in "$MSBUILDDEBUGPATH"/*; do
+            tail -c 5000000 "$file" > "$DIAG_DIR/msbuild-debug/$(basename "$file")"
+        done
+    fi
+
+    # SIGTERM first so MSBuild gets to close its binary log.
+    kill -- "-$command_pid" 2>/dev/null || kill "$command_pid" 2>/dev/null
+    for _ in $(seq 30); do
+        kill -0 "$command_pid" 2>/dev/null || return
+        sleep 1
+    done
+    kill -9 -- "-$command_pid" 2>/dev/null || kill -9 "$command_pid" 2>/dev/null
+}
+
+last_size=-1
+silent_for=0
+
+while kill -0 "$command_pid" 2>/dev/null; do
+    sleep "$POLL_SECONDS"
+
+    size=$(stat -c %s "$log" 2>/dev/null || echo 0)
+    if [[ "$size" == "$last_size" ]]; then
+        silent_for=$((silent_for + POLL_SECONDS))
+    else
+        last_size=$size
+        silent_for=0
+    fi
+
+    if ((silent_for >= STALL_SECONDS)); then
+        collect_diagnostics
+        wait "$command_pid"
+        wait "$tail_pid" 2>/dev/null
+        exit 1
+    fi
+done
+
+wait "$command_pid"
+status=$?
+wait "$tail_pid" 2>/dev/null
+exit $status

--- a/scripts/ci/run-with-stall-watchdog.sh
+++ b/scripts/ci/run-with-stall-watchdog.sh
@@ -21,6 +21,7 @@ POLL_SECONDS="${POLL_SECONDS:-15}"
 DIAGNOSTIC_SECONDS="${DIAGNOSTIC_SECONDS:-120}"
 INSTALL_TIMEOUT_SECONDS="${INSTALL_TIMEOUT_SECONDS:-30}"
 STACK_TIMEOUT_SECONDS="${STACK_TIMEOUT_SECONDS:-10}"
+TERMINATION_SECONDS="${TERMINATION_SECONDS:-30}"
 
 mkdir -p "$DIAG_DIR"
 log="$DIAG_DIR/command.log"
@@ -48,7 +49,9 @@ collect_diagnostics() {
 
     # Managed stacks show which target or task each MSBuild node and the compiler server sit in.
     local deadline=$((SECONDS + DIAGNOSTIC_SECONDS))
-    timeout --kill-after=1s "${INSTALL_TIMEOUT_SECONDS}s" dotnet tool install --global dotnet-stack > "$DIAG_DIR/dotnet-stack-install.log" 2>&1 || true
+    local install_seconds=$INSTALL_TIMEOUT_SECONDS
+    ((install_seconds > DIAGNOSTIC_SECONDS)) && install_seconds=$DIAGNOSTIC_SECONDS
+    timeout --kill-after=1s "${install_seconds}s" dotnet tool install --global dotnet-stack > "$DIAG_DIR/dotnet-stack-install.log" 2>&1 || true
     export PATH="$PATH:$HOME/.dotnet/tools"
     if command -v dotnet-stack > /dev/null; then
         for pid in $(pgrep -x 'dotnet|VBCSCompiler'); do
@@ -68,12 +71,13 @@ collect_diagnostics() {
         done
     fi
 
-    # A stalled build's binlog may be truncated; stacks and scheduler logs are the primary evidence.
+    # Forced termination leaves the binlog's gzip stream unfinished; use stacks and scheduler logs.
     local command_group
-    command_group=$(cat "$DIAG_DIR/command.pid")
+    command_group=$(cat "$DIAG_DIR/command.pid" 2>/dev/null) || command_group=$command_pid
+    [[ "$command_group" =~ ^[1-9][0-9]*$ ]] || command_group=$command_pid
     kill -- "-$command_group" 2>/dev/null || kill "$command_pid" 2>/dev/null
-    for _ in $(seq 30); do
-        kill -0 "$command_pid" 2>/dev/null || return
+    for ((second=0; second<TERMINATION_SECONDS; second++)); do
+        kill -0 -- "-$command_group" 2>/dev/null || return
         sleep 1
     done
     kill -9 -- "-$command_group" 2>/dev/null || kill -9 "$command_pid" 2>/dev/null

--- a/scripts/ci/test_stall_watchdog.py
+++ b/scripts/ci/test_stall_watchdog.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+# SPDX-License-Identifier: LGPL-3.0-only
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+@unittest.skipUnless(sys.platform == "linux", "watchdog uses Linux process groups")
+class WatchdogTests(unittest.TestCase):
+    def test_hung_diagnostics_are_bounded_and_build_is_killed(self):
+        for stalled_tool in ("dotnet", "dotnet-stack"):
+            with self.subTest(tool=stalled_tool), tempfile.TemporaryDirectory() as directory:
+                work = Path(directory)
+                tools = work / "tools"
+                tools.mkdir()
+                diag = work / "diagnostics"
+                scheduler = work / "scheduler"
+                scheduler.mkdir()
+                (scheduler / "SchedulerState.txt").write_text("scheduler evidence")
+                for tool in ("dotnet", "dotnet-stack", "pgrep", "setsid"):
+                    command = {
+                        "dotnet": "sleep 60" if stalled_tool == "dotnet" else "exit 0",
+                        "dotnet-stack": "sleep 60" if stalled_tool == "dotnet-stack" else "exit 0",
+                        "pgrep": 'cat "$DIAG_DIR/command.pid"',
+                        # Exercise the supervisor PID differing from the build's session leader.
+                        "setsid": f'exec {shutil.which("setsid")} --fork "$@"',
+                    }[tool]
+                    path = tools / tool
+                    path.write_text("#!/bin/bash\n" + command + "\n")
+                    path.chmod(0o755)
+                env = dict(os.environ, PATH=f"{tools}:{os.environ['PATH']}",
+                           DIAG_DIR=str(diag), MSBUILDDEBUGPATH=str(scheduler),
+                           STALL_SECONDS="1", POLL_SECONDS="1", DIAGNOSTIC_SECONDS="3",
+                           INSTALL_TIMEOUT_SECONDS="1", STACK_TIMEOUT_SECONDS="1")
+                result = subprocess.run(["bash", str(ROOT / "scripts/ci/run-with-stall-watchdog.sh"),
+                                         "sleep", "60"], env=env, capture_output=True, text=True, timeout=15)
+                self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+                self.assertEqual((diag / "msbuild-debug/SchedulerState.txt").read_text(), "scheduler evidence")
+                pid = int((diag / "command.pid").read_text())
+                with self.assertRaises(ProcessLookupError):
+                    os.kill(pid, 0)
+
+
+@unittest.skipUnless(shutil.which("dotnet"), ".NET SDK required")
+class GeneratorTargetTests(unittest.TestCase):
+    def test_missing_or_ambiguous_generator_has_actionable_error(self):
+        for count in (0, 1, 2):
+            with self.subTest(count=count), tempfile.TemporaryDirectory() as directory:
+                result = self.run_target(Path(directory), count, False)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("RPC JSON context generator", result.stdout)
+                self.assertNotIn("MSB3073", result.stdout)
+
+    def test_design_time_build_does_not_launch_generator(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_target(Path(directory), 0, True)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    @staticmethod
+    def run_target(work, count, design_time):
+        project = ET.Element("Project")
+        props = ET.SubElement(project, "PropertyGroup")
+        ET.SubElement(props, "GenerateRpcJsonContext").text = "true"
+        ET.SubElement(props, "DesignTimeBuild").text = str(design_time).lower()
+        ET.SubElement(project, "Import", Project=str(ROOT / "src/Nethermind/Directory.Build.targets"))
+        ET.SubElement(project, "Target", Name="ResolveReferences")
+        items = ET.SubElement(project, "ItemGroup")
+        for index in range(count):
+            ET.SubElement(items, "_RpcJsonContextGeneratorTool", Include=str(work / f"missing-{index}.dll"))
+        path = work / "test.proj"
+        ET.ElementTree(project).write(path)
+        return subprocess.run(["dotnet", "msbuild", str(path), "-nologo", "-t:_GenerateRpcJsonSerializerContext"],
+                              cwd=work, capture_output=True, text=True, timeout=30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/test_stall_watchdog.py
+++ b/scripts/ci/test_stall_watchdog.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 # SPDX-License-Identifier: LGPL-3.0-only
 
+import json
 import os
 from pathlib import Path
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -16,38 +18,115 @@ ROOT = Path(__file__).resolve().parents[2]
 
 @unittest.skipUnless(sys.platform == "linux", "watchdog uses Linux process groups")
 class WatchdogTests(unittest.TestCase):
+    def setUp(self):
+        directory = tempfile.TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.work = Path(directory.name)
+        self.tools = self.work / "tools"
+        self.tools.mkdir()
+        self.diag = self.work / "diagnostics"
+        self.scheduler = self.work / "scheduler"
+        self.scheduler.mkdir()
+        self.env = dict(os.environ, PATH=f"{self.tools}:{os.environ['PATH']}",
+                        DIAG_DIR=str(self.diag), MSBUILDDEBUGPATH=str(self.scheduler),
+                        STALL_SECONDS="1", POLL_SECONDS="1", DIAGNOSTIC_SECONDS="3",
+                        INSTALL_TIMEOUT_SECONDS="1", STACK_TIMEOUT_SECONDS="1", TERMINATION_SECONDS="2")
+        for tool in ("dotnet", "dotnet-stack", "pgrep"):
+            self.tool(tool, "exit 0")
+        # Exercise the supervisor PID differing from the build's session leader.
+        self.tool("setsid", f'exec {shutil.which("setsid")} --fork "$@"')
+
+    def tool(self, name, command):
+        path = self.tools / name
+        path.write_text("#!/bin/bash\n" + command + "\n")
+        path.chmod(0o755)
+
+    def run_watchdog(self, *command, **env):
+        try:
+            return subprocess.run(["bash", str(ROOT / "scripts/ci/run-with-stall-watchdog.sh"), *command],
+                                  env=self.env | env, capture_output=True, text=True, timeout=20)
+        finally:
+            # Failed assertions/timeouts must not leave our synthetic build tree running.
+            for name in ("command.pid", "fallback.pid"):
+                path = self.diag / name
+                if path.exists():
+                    self.addCleanup(self.kill_group, int(path.read_text()))
+
+    @staticmethod
+    def kill_group(pid):
+        try:
+            os.killpg(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
     def test_hung_diagnostics_are_bounded_and_build_is_killed(self):
         for stalled_tool in ("dotnet", "dotnet-stack"):
-            with self.subTest(tool=stalled_tool), tempfile.TemporaryDirectory() as directory:
-                work = Path(directory)
-                tools = work / "tools"
-                tools.mkdir()
-                diag = work / "diagnostics"
-                scheduler = work / "scheduler"
-                scheduler.mkdir()
-                (scheduler / "SchedulerState.txt").write_text("scheduler evidence")
-                for tool in ("dotnet", "dotnet-stack", "pgrep", "setsid"):
-                    command = {
-                        "dotnet": "sleep 60" if stalled_tool == "dotnet" else "exit 0",
-                        "dotnet-stack": "sleep 60" if stalled_tool == "dotnet-stack" else "exit 0",
-                        "pgrep": 'cat "$DIAG_DIR/command.pid"',
-                        # Exercise the supervisor PID differing from the build's session leader.
-                        "setsid": f'exec {shutil.which("setsid")} --fork "$@"',
-                    }[tool]
-                    path = tools / tool
-                    path.write_text("#!/bin/bash\n" + command + "\n")
-                    path.chmod(0o755)
-                env = dict(os.environ, PATH=f"{tools}:{os.environ['PATH']}",
-                           DIAG_DIR=str(diag), MSBUILDDEBUGPATH=str(scheduler),
-                           STALL_SECONDS="1", POLL_SECONDS="1", DIAGNOSTIC_SECONDS="3",
-                           INSTALL_TIMEOUT_SECONDS="1", STACK_TIMEOUT_SECONDS="1")
-                result = subprocess.run(["bash", str(ROOT / "scripts/ci/run-with-stall-watchdog.sh"),
-                                         "sleep", "60"], env=env, capture_output=True, text=True, timeout=15)
+            with self.subTest(tool=stalled_tool):
+                (self.scheduler / "SchedulerState.txt").write_text("scheduler evidence")
+                for tool in ("dotnet", "dotnet-stack"):
+                    self.tool(tool, "sleep 60" if stalled_tool == tool else "exit 0")
+                self.tool("pgrep", 'cat "$DIAG_DIR/command.pid"')
+                result = self.run_watchdog("sleep", "60")
                 self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
-                self.assertEqual((diag / "msbuild-debug/SchedulerState.txt").read_text(), "scheduler evidence")
-                pid = int((diag / "command.pid").read_text())
+                self.assertEqual((self.diag / "msbuild-debug/SchedulerState.txt").read_text(), "scheduler evidence")
+                pid = int((self.diag / "command.pid").read_text())
                 with self.assertRaises(ProcessLookupError):
                     os.kill(pid, 0)
+
+    def test_output_resets_silence_and_healthy_command_completes(self):
+        result = self.run_watchdog("bash", "-c", "for i in {1..6}; do echo tick; sleep 2; done",
+                                   STALL_SECONDS="3")
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertEqual((self.diag / "command.log").read_text().count("tick"), 6)
+        self.assertFalse((self.diag / "system.txt").exists())
+
+    def test_command_exit_code_is_preserved(self):
+        for status in (0, 7):
+            with self.subTest(status=status):
+                result = self.run_watchdog("bash", "-c", f"exit {status}")
+                self.assertEqual(result.returncode, status, result.stdout + result.stderr)
+                self.assertFalse((self.diag / "system.txt").exists())
+
+    def test_aggregate_deadline_stops_capturing_more_processes(self):
+        self.tool("pgrep", "seq 8")
+        self.tool("dotnet-stack", 'echo capture >> "$DIAG_DIR/captures"; sleep 60')
+        result = self.run_watchdog("sleep", "60")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        captures = (self.diag / "captures").read_text().splitlines()
+        self.assertGreater(len(captures), 0)
+        self.assertLessEqual(len(captures), 3)
+        self.assertEqual(list((self.diag / "msbuild-debug").iterdir()), [])
+        self.assertNotIn("cannot open", result.stderr)
+
+    def test_installation_is_clamped_to_aggregate_deadline(self):
+        self.tool("dotnet", "sleep 60")
+        self.tool("pgrep", "seq 8")
+        result = self.run_watchdog("sleep", "60", INSTALL_TIMEOUT_SECONDS="60", DIAGNOSTIC_SECONDS="1")
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertEqual(list(self.diag.glob("stack-*.txt")), [])
+
+    def test_missing_pid_file_uses_command_pid(self):
+        self.tool("setsid", f'exec {shutil.which("setsid")} "$@"')
+        result = self.run_watchdog("bash", "-c",
+                                   'mv "$DIAG_DIR/command.pid" "$DIAG_DIR/fallback.pid"; exec sleep 60')
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        self.assertNotIn("command.pid", result.stderr)
+        with self.assertRaises(ProcessLookupError):
+            os.kill(int((self.diag / "fallback.pid").read_text()), 0)
+
+    def test_child_ignoring_sigterm_is_killed_after_parent_exits(self):
+        child = (
+            "import os,signal,time; from pathlib import Path; "
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN); "
+            "Path(os.environ['DIAG_DIR'], 'child.pid').write_text(str(os.getpid())); time.sleep(60)"
+        )
+        parent = f"import subprocess,sys,time; subprocess.Popen([sys.executable, '-c', {child!r}]); time.sleep(60)"
+        result = self.run_watchdog(sys.executable, "-c", parent)
+        self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+        pid = int((self.diag / "child.pid").read_text())
+        status = Path(f"/proc/{pid}/stat")
+        # An orphaned zombie is dead but can remain until the container's init reaps it.
+        self.assertTrue(not status.exists() or status.read_text().split()[2] == "Z", "child survived cleanup")
 
 
 @unittest.skipUnless(shutil.which("dotnet"), ".NET SDK required")
@@ -65,17 +144,38 @@ class GeneratorTargetTests(unittest.TestCase):
             result = self.run_target(Path(directory), 0, True)
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
+    def test_existing_generator_executes_once_with_full_path(self):
+        with tempfile.TemporaryDirectory(prefix="generator target ") as directory:
+            work = Path(directory)
+            result = self.run_target(work, 1, False, existing=True)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            calls = (work / "calls.jsonl").read_text().splitlines()
+            self.assertEqual(len(calls), 1)
+            args = json.loads(calls[0])
+            self.assertEqual(Path(args[0]), work / "generator 0.py")
+            self.assertIn("--output", args)
+            self.assertIn("--references", args)
+
     @staticmethod
-    def run_target(work, count, design_time):
+    def run_target(work, count, design_time, existing=False):
         project = ET.Element("Project")
         props = ET.SubElement(project, "PropertyGroup")
         ET.SubElement(props, "GenerateRpcJsonContext").text = "true"
         ET.SubElement(props, "DesignTimeBuild").text = str(design_time).lower()
+        if existing:
+            ET.SubElement(props, "_DotnetHost").text = sys.executable
         ET.SubElement(project, "Import", Project=str(ROOT / "src/Nethermind/Directory.Build.targets"))
         ET.SubElement(project, "Target", Name="ResolveReferences")
         items = ET.SubElement(project, "ItemGroup")
         for index in range(count):
-            ET.SubElement(items, "_RpcJsonContextGeneratorTool", Include=str(work / f"missing-{index}.dll"))
+            name = f"generator {index}.py" if existing else f"missing-{index}.dll"
+            if existing:
+                (work / name).write_text(
+                    "import json,sys\nfrom pathlib import Path\n"
+                    "with Path(__file__).with_name('calls.jsonl').open('a') as out:\n"
+                    "    out.write(json.dumps(sys.argv) + '\\n')\n"
+                )
+            ET.SubElement(items, "_RpcJsonContextGeneratorTool", Include=name)
         path = work / "test.proj"
         ET.ElementTree(project).write(path)
         return subprocess.run(["dotnet", "msbuild", str(path), "-nologo", "-t:_GenerateRpcJsonSerializerContext"],

--- a/src/Nethermind/Directory.Build.targets
+++ b/src/Nethermind/Directory.Build.targets
@@ -21,9 +21,11 @@
     <Using Include="Nethermind.Core.Attributes.NoopThreadStaticAttribute" Alias="ThreadStaticAttribute" />
   </ItemGroup>
 
+  <!-- OutputItemType carries the generator tool's path out of the reference. Obtaining it with a
+       nested <MSBuild> call instead deadlocked parallel solution builds. -->
   <ItemGroup Condition="'$(GenerateRpcJsonContext)' == 'true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator\Nethermind.JsonRpc.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext;RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" />
-    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator.Build\Nethermind.JsonRpc.SourceGenerator.Build.csproj" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext;RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator.Build\Nethermind.JsonRpc.SourceGenerator.Build.csproj" OutputItemType="_RpcJsonContextGeneratorTool" ReferenceOutputAssembly="false" PrivateAssets="all" GlobalPropertiesToRemove="GenerateRpcJsonContext;RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" UndefineProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract" />
   </ItemGroup>
 
   <Target Name="_GenerateRpcJsonSerializerContext"
@@ -32,38 +34,21 @@
     Condition="'$(GenerateRpcJsonContext)' == 'true'">
 
     <PropertyGroup>
-      <_RpcJsonContextGeneratorProject>$(MSBuildThisFileDirectory)Nethermind.JsonRpc.SourceGenerator.Build\Nethermind.JsonRpc.SourceGenerator.Build.csproj</_RpcJsonContextGeneratorProject>
       <_RpcJsonContextOutputDir>$(IntermediateOutputPath)RpcJsonSourceGeneration\</_RpcJsonContextOutputDir>
       <_RpcJsonContextOutputFile>$(_RpcJsonContextOutputDir)GeneratedRpcJsonContext.g.cs</_RpcJsonContextOutputFile>
       <_RpcJsonContextSourcesFile>$(_RpcJsonContextOutputDir)sources.txt</_RpcJsonContextSourcesFile>
       <_RpcJsonContextReferencesFile>$(_RpcJsonContextOutputDir)references.txt</_RpcJsonContextReferencesFile>
-      <_RpcJsonContextGeneratorConfiguration>$(Configuration)</_RpcJsonContextGeneratorConfiguration>
     </PropertyGroup>
 
     <MakeDir Directories="$(_RpcJsonContextOutputDir)" />
     <WriteLinesToFile File="$(_RpcJsonContextSourcesFile)" Lines="@(Compile->'%(FullPath)')" Overwrite="true" />
     <WriteLinesToFile File="$(_RpcJsonContextReferencesFile)" Lines="@(ReferencePath->'%(FullPath)')" Overwrite="true" />
 
-    <MSBuild Projects="$(_RpcJsonContextGeneratorProject)"
-      Targets="GetTargetPath"
-      Properties="Configuration=$(_RpcJsonContextGeneratorConfiguration);GenerateRpcJsonContext=false"
-      RemoveProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract"
-      BuildInParallel="false">
-      <Output TaskParameter="TargetOutputs" PropertyName="_RpcJsonContextGeneratorPath" />
-    </MSBuild>
-
-    <MSBuild Projects="$(_RpcJsonContextGeneratorProject)"
-      Targets="Build"
-      Properties="Configuration=$(_RpcJsonContextGeneratorConfiguration);GenerateRpcJsonContext=false"
-      RemoveProperties="RuntimeIdentifier;SelfContained;PublishSingleFile;IncludeAllContentForSelfExtract"
-      BuildInParallel="false"
-      Condition="!Exists('$(_RpcJsonContextGeneratorPath)')" />
-
     <PropertyGroup>
       <_DotnetHost Condition="'$(_DotnetHost)' == '' and '$(DOTNET_HOST_PATH)' != ''">$(DOTNET_HOST_PATH)</_DotnetHost>
       <_DotnetHost Condition="'$(_DotnetHost)' == ''">dotnet</_DotnetHost>
     </PropertyGroup>
-    <Exec Command="&quot;$(_DotnetHost)&quot; &quot;$(_RpcJsonContextGeneratorPath)&quot; --output &quot;$(_RpcJsonContextOutputFile)&quot; --sources &quot;$(_RpcJsonContextSourcesFile)&quot; --references &quot;$(_RpcJsonContextReferencesFile)&quot; --assembly-name &quot;$(AssemblyName)&quot; --define-constants &quot;$(DefineConstants)&quot;" />
+    <Exec Command="&quot;$(_DotnetHost)&quot; &quot;@(_RpcJsonContextGeneratorTool)&quot; --output &quot;$(_RpcJsonContextOutputFile)&quot; --sources &quot;$(_RpcJsonContextSourcesFile)&quot; --references &quot;$(_RpcJsonContextReferencesFile)&quot; --assembly-name &quot;$(AssemblyName)&quot; --define-constants &quot;$(DefineConstants)&quot;" />
 
     <ItemGroup>
       <FileWrites Include="$(_RpcJsonContextSourcesFile)" />

--- a/src/Nethermind/Directory.Build.targets
+++ b/src/Nethermind/Directory.Build.targets
@@ -31,7 +31,12 @@
   <Target Name="_GenerateRpcJsonSerializerContext"
     BeforeTargets="CoreCompile"
     DependsOnTargets="ResolveReferences"
-    Condition="'$(GenerateRpcJsonContext)' == 'true'">
+    Condition="'$(GenerateRpcJsonContext)' == 'true' and '$(DesignTimeBuild)' != 'true'">
+
+    <Error Condition="'@(_RpcJsonContextGeneratorTool->Count())' != '1'"
+      Text="Expected exactly one RPC JSON context generator tool. Enable Nethermind.JsonRpc.SourceGenerator.Build in the solution configuration and build project references." />
+    <Error Condition="!Exists('%(_RpcJsonContextGeneratorTool.FullPath)')"
+      Text="RPC JSON context generator is missing: %(_RpcJsonContextGeneratorTool.FullPath). Build Nethermind.JsonRpc.SourceGenerator.Build before building without project references." />
 
     <PropertyGroup>
       <_RpcJsonContextOutputDir>$(IntermediateOutputPath)RpcJsonSourceGeneration\</_RpcJsonContextOutputDir>
@@ -48,7 +53,7 @@
       <_DotnetHost Condition="'$(_DotnetHost)' == '' and '$(DOTNET_HOST_PATH)' != ''">$(DOTNET_HOST_PATH)</_DotnetHost>
       <_DotnetHost Condition="'$(_DotnetHost)' == ''">dotnet</_DotnetHost>
     </PropertyGroup>
-    <Exec Command="&quot;$(_DotnetHost)&quot; &quot;@(_RpcJsonContextGeneratorTool)&quot; --output &quot;$(_RpcJsonContextOutputFile)&quot; --sources &quot;$(_RpcJsonContextSourcesFile)&quot; --references &quot;$(_RpcJsonContextReferencesFile)&quot; --assembly-name &quot;$(AssemblyName)&quot; --define-constants &quot;$(DefineConstants)&quot;" />
+    <Exec Command="&quot;$(_DotnetHost)&quot; &quot;%(_RpcJsonContextGeneratorTool.FullPath)&quot; --output &quot;$(_RpcJsonContextOutputFile)&quot; --sources &quot;$(_RpcJsonContextSourcesFile)&quot; --references &quot;$(_RpcJsonContextReferencesFile)&quot; --assembly-name &quot;$(AssemblyName)&quot; --define-constants &quot;$(DefineConstants)&quot;" />
 
     <ItemGroup>
       <FileWrites Include="$(_RpcJsonContextSourcesFile)" />


### PR DESCRIPTION
## Changes

Intermittent `EthereumTests` debug builds stalled around the RPC JSON context generator. Resolve the generator through the existing ProjectReference output instead of issuing nested MSBuild requests with differing global properties. Missing or ambiguous tools produce actionable errors; design-time builds skip generation.

Run solution builds under a watchdog with 900 seconds of allowed silence and a 60-minute job budget, leaving time for diagnostics and artifact upload. Installation and managed stack capture share a bounded diagnostic budget. Cleanup tracks the command's process group through the SIGTERM grace period and kills surviving children even after the command leader exits; the PID-file read has a fallback.

Scheduler tracing, its debug directory, and binary logs are temporary and limited to EthereumTests. Remove all three once the fix proves stable. Binlogs help ordinary build failures; forced termination leaves an unfinished gzip stream, so stalled builds require managed stacks and scheduler logs.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

All 10 tests in `scripts/ci/test_stall_watchdog.py` pass on Linux. The three generator tests also pass on Windows; the seven Linux process-group tests skip there.

Coverage includes healthy output resetting silence, success/failure exit codes, hung diagnostic installation and capture, the aggregate multi-process capture deadline, installation capped by that deadline, an empty scheduler directory, forced setsid forking, missing PID-file fallback, and a SIGTERM-ignoring child surviving its parent. Synthetic MSBuild tests cover missing/ambiguous tools, design-time skipping, and exactly one successful generator invocation with the full tool path containing spaces.

Mutation checks confirm that restoring parent-only cleanup or removing the silence reset causes the corresponding regression test to fail. Bash syntax, YAML/matrix diagnostic-scope checks, and `git diff --check` pass.

Previous validation covered identical generated RPC context output, full Debug solution builds, portable-tool generation, and a Release RPC build. Those full builds were not rerun for the watchdog follow-up. All six hosted build cells still need confirmation on the current head; local watchdog tests do not establish hosted-runner timing or prove the intermittent scheduler deadlock cannot recur.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

The nested build requests are a suspected trigger, not a proven root cause: previous wedged jobs were not inspected live. The diagnostics are intended to make a recurrence diagnosable.