### PR TITLE
test: let the cancelled improvement disposal land after getPayload

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -606,8 +606,6 @@ public partial class EngineModuleTests
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
 
         Assert.That(getPayloadResult.TryGetTransactions().Data, Has.Length.EqualTo(3));
-        // The retrieval cancels the round, but the context may be published just after that:
-        // ImproveBlock then disposes it right after publishing, which can land after getPayload returns.
         Assert.That(() => cancelledContext.Disposed, Is.True.After(5000, 10));
     }
 

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.PayloadProduction.cs
@@ -606,7 +606,9 @@ public partial class EngineModuleTests
         ExecutionPayload getPayloadResult = (await rpc.engine_getPayloadV1(Bytes.FromHexString(payloadId))).Data!;
 
         Assert.That(getPayloadResult.TryGetTransactions().Data, Has.Length.EqualTo(3));
-        Assert.That(cancelledContext?.Disposed, Is.True);
+        // The retrieval cancels the round, but the context may be published just after that:
+        // ImproveBlock then disposes it right after publishing, which can land after getPayload returns.
+        Assert.That(() => cancelledContext.Disposed, Is.True.After(5000, 10));
     }
 
     [Test]


### PR DESCRIPTION
## Changes

- `getPayloadV1_does_not_wait_for_improvement_when_block_is_not_empty` asserted `cancelledContext.Disposed` synchronously right after `engine_getPayloadV1` returned. The retrieval cancels the round *before* it disposes, so a context published in that window is disposed by `ImproveBlock` right after it publishes — on the improvement-loop thread, which can land just after `getPayload` has returned. Poll for the disposal instead, matching `PayloadPreparationServiceTests.GetPayload_disposes_the_replacement_published_after_it_cancelled`, which already pins the same case with `Is.True.After(5000, 10)`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: test fix (flaky test)

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Observed on #13337: `Nethermind.Merge.AuRa.Test [no-intrinsics]`, `Assert.That(cancelledContext?.Disposed, Is.True)` → `But was: False`, with the transaction-count assert above it passing. Eventual disposal is guaranteed on every path in `PayloadPreparationService` (post-publish cancel check plus `RetainRetrievedContext`), so a real leak regression still fails the test.

Ran the test 6x locally in release: green.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
