### PR TITLE
test(sync): fit the BAL sync budget inside the CI hang dump timeout

### DIFF
--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -110,7 +110,10 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
 
     private const int ChainLength = 1000;
     private const ulong HeadPivotDistance = 500;
-    private static TimeSpan BalSyncTestTimeout = TimeSpan.FromMinutes(10);
+    // Both attempts of a retried timeout have to fit inside the CI hang dump timeout (8m of
+    // inactivity), which kills the whole run with a dump and no test report. A normal run of
+    // either block-access-list test is well under a minute.
+    private static readonly TimeSpan BalSyncTestTimeout = TimeSpan.FromMinutes(3);
     private const int BalSyncChainLength = 5_000;
     private const int PartialBalSyncChainLength = 1_000;
     private const int PartialBalActivationBlock = 400;
@@ -598,49 +601,48 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             Assert.Ignore("BAL sync regression is only executed for the default post-merge fixture.");
         }
 
-        // Not routed through RunWithTimeout: at a 10-minute budget a retried timeout would exceed the
-        // job budget, turning a clean error into a report-less job timeout.
-        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(BalSyncTestTimeout);
-
-        PrivateKey serverKey = TestItem.PrivateKeyE;
-        await using IContainer server = await CreateNode(serverKey, (cfg, spec) =>
+        await RunWithTimeout(BalSyncTestTimeout, async cancellationToken =>
         {
-            EnableBlockAccessListsFromGenesis(spec);
-            ConfigureLocalNetwork(cfg, AllocatePort());
-            return Task.CompletedTask;
-        }, serverKey);
+            PrivateKey serverKey = TestItem.PrivateKeyE;
+            await using IContainer server = await CreateNode(serverKey, (cfg, spec) =>
+            {
+                EnableBlockAccessListsFromGenesis(spec);
+                ConfigureLocalNetwork(cfg, AllocatePort());
+                return Task.CompletedTask;
+            }, serverKey);
 
-        await StartServerAndBuildStorageChain(server, BalSyncChainLength, cancellationTokenSource.Token, "BAL sync server");
+            await StartServerAndBuildStorageChain(server, BalSyncChainLength, cancellationToken, "BAL sync server");
 
-        IBlockTree serverBlockTree = server.Resolve<IBlockTree>();
-        Assert.That(serverBlockTree.Head!.Number, Is.EqualTo(BalSyncChainLength));
+            IBlockTree serverBlockTree = server.Resolve<IBlockTree>();
+            Assert.That(serverBlockTree.Head!.Number, Is.EqualTo(BalSyncChainLength));
 
-        IBlockAccessListStore serverBalStore = server.Resolve<IBlockAccessListStore>();
-        using (MemoryManager<byte>? serverBal = serverBalStore.GetRlp(1, serverBlockTree.FindBlock(1)!.Hash!))
-        {
-            Assert.That(serverBal, Is.Not.Null);
-        }
+            IBlockAccessListStore serverBalStore = server.Resolve<IBlockAccessListStore>();
+            using (MemoryManager<byte>? serverBal = serverBalStore.GetRlp(1, serverBlockTree.FindBlock(1)!.Hash!))
+            {
+                Assert.That(serverBal, Is.Not.Null);
+            }
 
-        ulong syncPivotNumber = 0;
-        PrivateKey clientKey = TestItem.PrivateKeyF;
-        await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
-        {
-            EnableBlockAccessListsFromGenesis(spec);
+            ulong syncPivotNumber = 0;
+            PrivateKey clientKey = TestItem.PrivateKeyF;
+            await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
+            {
+                EnableBlockAccessListsFromGenesis(spec);
 
-            SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
-            syncConfig.FastSync = true;
+                SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
+                syncConfig.FastSync = true;
 
-            await SetPivot(server, syncConfig, cancellationTokenSource.Token, HeadPivotDistance);
-            syncPivotNumber = syncConfig.PivotNumber;
+                await SetPivot(server, syncConfig, cancellationToken, HeadPivotDistance);
+                syncPivotNumber = syncConfig.PivotNumber;
 
-            ConfigureLocalNetwork(cfg, AllocatePort());
-        }, serverKey);
+                ConfigureLocalNetwork(cfg, AllocatePort());
+            }, serverKey);
 
-        Assert.That(syncPivotNumber, Is.GreaterThan(1));
-        TestContext.Progress.WriteLine($"BAL sync test: head {BalSyncChainLength}, pivot {syncPivotNumber}.");
+            Assert.That(syncPivotNumber, Is.GreaterThan(1));
+            TestContext.Progress.WriteLine($"BAL sync test: head {BalSyncChainLength}, pivot {syncPivotNumber}.");
 
-        await client.Resolve<SyncTestContext>().SyncFromServerAndVerifyAccessLists(server, syncPivotNumber, cancellationTokenSource.Token);
-        Assert.That(client.Resolve<ISyncPointers>().LowestInsertedBlockAccessListBlockNumber, Is.LessThanOrEqualTo(1));
+            await client.Resolve<SyncTestContext>().SyncFromServerAndVerifyAccessLists(server, syncPivotNumber, cancellationToken);
+            Assert.That(client.Resolve<ISyncPointers>().LowestInsertedBlockAccessListBlockNumber, Is.LessThanOrEqualTo(1));
+        });
     }
 
     [Test]
@@ -679,55 +681,56 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
             Assert.Ignore("BAL sync regression is only executed for the default post-merge fixture.");
         }
 
-        using CancellationTokenSource cancellationTokenSource = new CancellationTokenSource().ThatCancelAfter(BalSyncTestTimeout);
-
-        PrivateKey serverKey = TestItem.PrivateKeyE;
-        await using IContainer server = await CreateNode(serverKey, (cfg, spec) =>
+        await RunWithTimeout(BalSyncTestTimeout, async cancellationToken =>
         {
-            EnableBlockAccessListsAtBlock(spec, PartialBalActivationBlock);
-            ConfigureLocalNetwork(cfg, AllocatePort());
-            return Task.CompletedTask;
-        }, serverKey);
+            PrivateKey serverKey = TestItem.PrivateKeyE;
+            await using IContainer server = await CreateNode(serverKey, (cfg, spec) =>
+            {
+                EnableBlockAccessListsAtBlock(spec, PartialBalActivationBlock);
+                ConfigureLocalNetwork(cfg, AllocatePort());
+                return Task.CompletedTask;
+            }, serverKey);
 
-        await StartServerAndBuildStorageChain(server, PartialBalSyncChainLength, cancellationTokenSource.Token, "Partial BAL sync server");
+            await StartServerAndBuildStorageChain(server, PartialBalSyncChainLength, cancellationToken, "Partial BAL sync server");
 
-        IBlockTree serverBlockTree = server.Resolve<IBlockTree>();
-        Assert.That(serverBlockTree.Head!.Number, Is.EqualTo(PartialBalSyncChainLength));
+            IBlockTree serverBlockTree = server.Resolve<IBlockTree>();
+            Assert.That(serverBlockTree.Head!.Number, Is.EqualTo(PartialBalSyncChainLength));
 
-        IBlockAccessListStore serverBalStore = server.Resolve<IBlockAccessListStore>();
-        Block lastPreActivationBlock = serverBlockTree.FindBlock(PartialBalActivationBlock - 1)!;
-        Block firstActivatedBlock = serverBlockTree.FindBlock(PartialBalActivationBlock)!;
-        Assert.That(lastPreActivationBlock.Header.BlockAccessListHash, Is.Null);
-        using (MemoryManager<byte>? preActivationBal = serverBalStore.GetRlp(lastPreActivationBlock.Number, lastPreActivationBlock.Hash!))
-        {
-            Assert.That(preActivationBal, Is.Null);
-        }
-        Assert.That(firstActivatedBlock.Header.BlockAccessListHash, Is.Not.Null);
-        using (MemoryManager<byte>? firstActivatedBal = serverBalStore.GetRlp(firstActivatedBlock.Number, firstActivatedBlock.Hash!))
-        {
-            Assert.That(firstActivatedBal, Is.Not.Null);
-        }
+            IBlockAccessListStore serverBalStore = server.Resolve<IBlockAccessListStore>();
+            Block lastPreActivationBlock = serverBlockTree.FindBlock(PartialBalActivationBlock - 1)!;
+            Block firstActivatedBlock = serverBlockTree.FindBlock(PartialBalActivationBlock)!;
+            Assert.That(lastPreActivationBlock.Header.BlockAccessListHash, Is.Null);
+            using (MemoryManager<byte>? preActivationBal = serverBalStore.GetRlp(lastPreActivationBlock.Number, lastPreActivationBlock.Hash!))
+            {
+                Assert.That(preActivationBal, Is.Null);
+            }
+            Assert.That(firstActivatedBlock.Header.BlockAccessListHash, Is.Not.Null);
+            using (MemoryManager<byte>? firstActivatedBal = serverBalStore.GetRlp(firstActivatedBlock.Number, firstActivatedBlock.Hash!))
+            {
+                Assert.That(firstActivatedBal, Is.Not.Null);
+            }
 
-        ulong syncPivotNumber = 0;
-        PrivateKey clientKey = TestItem.PrivateKeyF;
-        await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
-        {
-            EnableBlockAccessListsAtBlock(spec, PartialBalActivationBlock);
+            ulong syncPivotNumber = 0;
+            PrivateKey clientKey = TestItem.PrivateKeyF;
+            await using IContainer client = await CreateNode(clientKey, async (cfg, spec) =>
+            {
+                EnableBlockAccessListsAtBlock(spec, PartialBalActivationBlock);
 
-            SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
-            syncConfig.FastSync = true;
+                SyncConfig syncConfig = (SyncConfig)cfg.GetConfig<ISyncConfig>();
+                syncConfig.FastSync = true;
 
-            await SetPivot(server, syncConfig, cancellationTokenSource.Token, PartialBalSyncHeadPivotDistance);
-            syncPivotNumber = syncConfig.PivotNumber;
+                await SetPivot(server, syncConfig, cancellationToken, PartialBalSyncHeadPivotDistance);
+                syncPivotNumber = syncConfig.PivotNumber;
 
-            ConfigureLocalNetwork(cfg, AllocatePort());
-        }, serverKey);
+                ConfigureLocalNetwork(cfg, AllocatePort());
+            }, serverKey);
 
-        Assert.That(syncPivotNumber, Is.GreaterThan(PartialBalActivationBlock));
-        TestContext.Progress.WriteLine($"Partial BAL sync test: head {PartialBalSyncChainLength}, pivot {syncPivotNumber}, activation {PartialBalActivationBlock}.");
+            Assert.That(syncPivotNumber, Is.GreaterThan(PartialBalActivationBlock));
+            TestContext.Progress.WriteLine($"Partial BAL sync test: head {PartialBalSyncChainLength}, pivot {syncPivotNumber}, activation {PartialBalActivationBlock}.");
 
-        await client.Resolve<SyncTestContext>().SyncFromServerAndVerifyAccessLists(server, syncPivotNumber, cancellationTokenSource.Token);
-        Assert.That(client.Resolve<ISyncPointers>().LowestInsertedBlockAccessListBlockNumber, Is.LessThanOrEqualTo(1));
+            await client.Resolve<SyncTestContext>().SyncFromServerAndVerifyAccessLists(server, syncPivotNumber, cancellationToken);
+            Assert.That(client.Resolve<ISyncPointers>().LowestInsertedBlockAccessListBlockNumber, Is.LessThanOrEqualTo(1));
+        });
     }
 
     // Post and pre merge have slightly different operation for these.

--- a/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
+++ b/src/Nethermind/Nethermind.Synchronization.Test/E2ESyncTests.cs
@@ -110,9 +110,6 @@ public class E2ESyncTests(E2ESyncTests.DbMode dbMode, bool isPostMerge)
 
     private const int ChainLength = 1000;
     private const ulong HeadPivotDistance = 500;
-    // Both attempts of a retried timeout have to fit inside the CI hang dump timeout (8m of
-    // inactivity), which kills the whole run with a dump and no test report. A normal run of
-    // either block-access-list test is well under a minute.
     private static readonly TimeSpan BalSyncTestTimeout = TimeSpan.FromMinutes(3);
     private const int BalSyncChainLength = 5_000;
     private const int PartialBalSyncChainLength = 1_000;


### PR DESCRIPTION
## Changes

- `FastSync_downloads_block_access_lists_over_eth71` stalled and ran past the workflow's `--hangdump-timeout 8m`, which killed the whole `Nethermind.Synchronization.Test` session with a dump and no test report (exit 7). Its own 10-minute budget could never be reached, so the stall could neither report itself nor retry.
- Route both block-access-list tests through the fixture's `RunWithTimeout` and cut `BalSyncTestTimeout` to 3 minutes, so a stall becomes an assertion failure that `Retry(2)` absorbs, with both attempts inside the 8-minute window.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: test fix (flaky test)

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

Observed on #13338: hang dump log `[00:08:00] FastSync_downloads_block_access_lists_over_eth71`, `total: 2002, failed: 0`, exit code 7. Not caused by that PR — its incremental jumpdest code lives in `*.zkevm.cs`, excluded from the non-zkEVM build by `Directory.Build.targets`.

Verified with the budget temporarily at 3s: the test failed with `Test did not finish within 3s.` plus the original `TaskCanceledException` and stack, nodes disposed cleanly, exit code 2 instead of 7, and the reported elapsed time was 6s — i.e. `Retry` did re-run it. With the 3-minute budget both tests pass (~30s).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This makes the flake reportable and self-healing; it does not explain the stall itself (the Linux minidump can't be analysed locally). If it recurs, the failure message will now say which phase — chain build, connect, or sync — ran out of budget.
