### PR TITLE
chore(deps): bump Nethermind.Numerics.Int256 to 1.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,7 @@
     <PackageVersion Include="Nethermind.Libp2p" Version="1.0.0-preview.45" />
     <PackageVersion Include="Nethermind.Libp2p.Protocols.PubsubPeerDiscovery" Version="1.0.0-preview.45" />
     <PackageVersion Include="Nethermind.MclBindings" Version="1.0.5" />
-    <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.7.0" />
+    <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.8.0" />
     <PackageVersion Include="Nethermind.RocksDbBindings" Version="[11.8.1-preview.92]" />
     <PackageVersion Include="Nethermind.TurboPForBindings" Version="1.0.0" />
     <PackageVersion Include="Nethermind.Zkvm.Abstractions" Version="1.0.0-preview.2" />

--- a/nix/nuget-deps.json
+++ b/nix/nuget-deps.json
@@ -801,8 +801,8 @@
   },
   {
     "pname": "Nethermind.Numerics.Int256",
-    "version": "1.7.0",
-    "hash": "sha256-FXapSQQnBbunYsUlnvSTKnBDBUcWfoH2teNBlKuShrQ="
+    "version": "1.8.0",
+    "hash": "sha256-GSOKuHxq1gj23uJgZ1UK09KHasgJkzPh6RY2qwDl5cs="
   },
   {
     "pname": "Nethermind.RocksDbBindings",

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -705,7 +705,7 @@
           "Microsoft.IdentityModel.JsonWebTokens": "[8.22.0, )",
           "Nethermind.Crypto.SecP256k1": "[1.7.0, )",
           "Nethermind.Logging": "[1.40.0-unstable, )",
-          "Nethermind.Numerics.Int256": "[1.7.0, )",
+          "Nethermind.Numerics.Int256": "[1.8.0, )",
           "Nethermind.Serialization.Ssz": "[1.40.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
           "Testably.Abstractions": "[10.3.0, )"
@@ -1107,7 +1107,7 @@
       "nethermind.serialization.ssz": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Numerics.Int256": "[1.7.0, )"
+          "Nethermind.Numerics.Int256": "[1.8.0, )"
         }
       },
       "nethermind.shutter": {
@@ -1587,9 +1587,9 @@
       },
       "Nethermind.Numerics.Int256": {
         "type": "CentralTransitive",
-        "requested": "[1.7.0, )",
-        "resolved": "1.7.0",
-        "contentHash": "7SHjmk09HTDvC6beXoqf/1OmE4jfnEt3BJhicOKk/WpJzdzFxKnozg6SGxLfXZmRxWEhr1fvDwtp2ppUUdp2/w==",
+        "requested": "[1.8.0, )",
+        "resolved": "1.8.0",
+        "contentHash": "Y+fQEFPsbfZsvzNEROU4ST86ocICVHDj6FImKxMRYfB1ka7wlQzEShLuxt50Vblo4AaLDlsUloYWyRFfSi+K6A==",
         "dependencies": {
           "System.IO.Hashing": "10.0.10"
         }


### PR DESCRIPTION
## Changes

Bumps `Nethermind.Numerics.Int256` from 1.7.0 to [1.8.0](https://github.com/NethermindEth/int256/releases/tag/v1.8.0) (released today). Three files: the central package version, the regenerated `Nethermind.Runner` lock file, and the `nix/nuget-deps.json` entry (version plus the SRI hash of the published nupkg, so the Nix flake build and the lockfile-sync check stay green).

Int256 1.8.0 contains nine PRs merged since v1.7.0, all arithmetic work:

| PR | change |
|---|---|
| [#118](https://github.com/NethermindEth/int256/pull/118) | stop reaching BigInteger from the always-reachable paths |
| [#120](https://github.com/NethermindEth/int256/pull/120) | skip the zero leading quotient digit and reuse correction products in MULMOD reduction |
| [#121](https://github.com/NethermindEth/int256/pull/121) | showcase Int256 capabilities and improve README onboarding |
| [#122](https://github.com/NethermindEth/int256/pull/122) | optimize EXP with early exits, decimal lookup and truncated binomial evaluation |
| [#123](https://github.com/NethermindEth/int256/pull/123) | optimize multiplication: lower overflow latency |
| [#124](https://github.com/NethermindEth/int256/pull/124) | optimize addition: speculative carry, ARM-focused |
| [#125](https://github.com/NethermindEth/int256/pull/125) | bump SourceLink to 10.0.111 to fix NU1902 restore failures |
| [#126](https://github.com/NethermindEth/int256/pull/126) | optimize comparisons and equality |
| [#127](https://github.com/NethermindEth/int256/pull/127) | use wraparound Add in public callers and avoid increment temporaries |

## Types of changes

- [x] Optimization

## Testing

The release was validated against the client before this bump, using staging builds of the same code (`1.8.0-rc`, int256 main at 3b1d0b2, and `1.8.0-rc2`, int256 main at c58ecdc). Each arm was master `8ceb730583` with only the package version changed, measured against master and against a second image built from identical master source, which sets the noise floor.

**Correctness**

- `eth_call` response parity: **497/497 byte-identical to master** on every corpus run, both candidates, both architectures, every round.
- Fusaka block replay: **0 invalid blocks** across 72 client jobs (999 mainnet blocks each), clean shutdown in every job.
- Local suites on the candidate package: `Nethermind.Evm.Test` 4067/4067, `Ethereum.Legacy.VM.Test` 4376/4376, and a `Ethereum.Legacy.Blockchain.Test` subset (Shift, PreCompiledContracts, Random, ZeroKnowledge, Solidity, SystemOperations, ArgsZeroOneBalance) 19365/19365.
- Full int256 CI passed on both candidates and on the release: 14 jobs across Windows, macOS, Linux and linux-arm64, with and without HWIntrinsics/AVX2, plus the zkEVM variant.

**Performance**

| workload | arm64 | amd64 |
|---|---|---|
| `eth_call` 497-record corpus | **-1.2 to -1.7%** avg, median, p90, p99; CPU/req -1.6% | neutral (+0.2% paired, inside a 1.2% control spread) |
| Fusaka block processing (999 blocks) | neutral (+0.002 ms/block vs master) | neutral (-0.02 ms/block, control -0.07) |

The arm64 `eth_call` gain reproduced across three independent batches (rc1 15.71 ms, rc2 15.71/15.75 ms, master 15.89/15.98 ms at 100 rps) and clears its A/A control spread on both avg and p99. A head-to-head run of rc2 against rc1 was neutral, so the gain comes from the #118-#124 work rather than #126/#127. Non-EVM selector classes are flat, which puts the gain in EVM arithmetic as expected.

Block processing is neutral on both architectures, which is the expected result for a pure arithmetic change against a state- and I/O-bound workload. An intermediate arm64 reading suggested a ~0.4% cost; running both candidates and master in a single batch with each arm rotated through every position inverted it, and the same image pair's delta against master was shown to swing by more than that between batches.

Full report with per-cell tables, run IDs and the two benchmark-methodology findings: https://claude.ai/code/artifact/63a7b0ad-6be0-4b26-8997-25ee4cb0dff3

## Documentation

Requires documentation update

- [ ] Yes
- [x] No
