### PR TITLE
fix(network): reject Hello whose node ID differs from the authenticated peer

### DIFF
--- a/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Network.Test/P2P/P2PProtocolHandlerTests.cs
@@ -35,6 +35,8 @@ namespace Nethermind.Network.Test.P2P
         public void Setup()
         {
             _session = Substitute.For<ISession>();
+            // PublicKeyA is this node's own identity; the tests treat PublicKeyB as the authenticated remote one.
+            _session.RemoteNodeId.Returns(TestItem.PublicKeyB);
             _serializer = new MessageSerializationService(
                 SerializerInfo.Create(new HelloMessageSerializer()),
                 SerializerInfo.Create(new PingMessageSerializer()),
@@ -311,6 +313,31 @@ namespace Nethermind.Network.Test.P2P
             p2PProtocolHandler.HandleMessage(CreateP2PPacket(message));
 
             _session.Received(1).InitiateDisconnect(DisconnectReason.IdentitySameAsSelf, Arg.Any<string>());
+        }
+
+        [Test]
+        public void On_hello_claiming_another_node_id_than_authenticated_disconnects()
+        {
+            P2PProtocolHandler p2PProtocolHandler = CreateSession();
+            p2PProtocolHandler.AddSupportedCapability(new Capability(Protocol.Eth, 68));
+            List<ProtocolEventArgs> requestedProtocols = [];
+            p2PProtocolHandler.SubprotocolRequested += (_, args) => requestedProtocols.Add(args);
+
+            using HelloMessage message = new()
+            {
+                Capabilities = new ArrayPoolList<Capability>(1) { new(Protocol.Eth, 68) },
+                NodeId = TestItem.PublicKeyC,
+                ClientId = "Nethermind/v1.0",
+                ListenPort = 30303,
+                P2PVersion = 5,
+            };
+
+            p2PProtocolHandler.HandleMessage(CreateP2PPacket(message));
+
+            _session.Received(1).InitiateDisconnect(DisconnectReason.UnexpectedIdentity, Arg.Any<string>());
+            Assert.That(requestedProtocols, Is.Empty);
+            Assert.That(p2PProtocolHandler.AgreedCapabilities, Is.Empty);
+            Assert.That(p2PProtocolHandler.AvailableCapabilities, Is.Empty);
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
+++ b/src/Nethermind/Nethermind.Network/P2P/ProtocolHandlers/P2PProtocolHandler.cs
@@ -273,10 +273,13 @@ public class P2PProtocolHandler(
             return;
         }
 
+        // Nothing from the Hello may be applied until the identity it claims agrees with the authenticated one.
         if (!hello.NodeId.Equals(Session.RemoteNodeId))
         {
             if (Logger.IsDebug) DebugInconsistentNodeId(hello, isInbound);
-            // it does not really matter if there is mismatch - we do not use it anywhere
+            Session.InitiateDisconnect(DisconnectReason.UnexpectedIdentity,
+                $"expected {Session.RemoteNodeId}, received hello with {hello.NodeId}");
+            return;
         }
 
         RemoteClientId = hello.ClientId;


### PR DESCRIPTION
## Changes

`P2PProtocolHandler.HandleHello` detected that the node ID in a peer's `Hello` disagrees with the ID the RLPx handshake authenticated, logged it at Debug, and carried on:

```csharp
if (Logger.IsDebug) DebugInconsistentNodeId(hello, isInbound);
// it does not really matter if there is mismatch - we do not use it anywhere
```

That comment is accurate as far as it goes. `hello.NodeId` is read nowhere else in the codebase, so no impersonation follows from the mismatch: every consumer of peer identity (`Session.Node`, sync pool, tx pool, node stats, discovery) uses `Session.RemoteNodeId`, which `NettyHandshakeHandler` sets from the auth result before the P2P handler is wired into the pipeline.

The problem is what happens next. The rest of a Hello that just failed its own integrity check is still applied in full: `RemoteClientId` and `Session.Node.ClientId` are overwritten with attacker-chosen text, capabilities are negotiated, protocol init is published, and `ProtocolsManager.AddNodeToDiscovery` mutates `session.Node.Port` from `hello.ListenPort` and re-registers the node for discovery. A peer that contradicts its own authenticated identity gets full trust for everything else in the same packet, plus a peer slot and Debug-log spam. An attacker can only poison the node record it authenticated under, so the impact is limited — but the check was already there and cost nothing to honour.

This rejects the Hello instead: disconnect with `UnexpectedIdentity` (0x09) and `return` before any state is touched.

`UnexpectedIdentity` is the reason `Session.Handshake` already uses for the same contradiction one step earlier (authenticated ID vs expected ID), and it sits alongside the `IdentitySameAsSelf` guard from #12812 immediately above this block. `BreachOfProtocol` (0x02) was considered and rejected: in this codebase 0x02 is the encoding/framing bucket (oversized frames, unknown message types, RLP decode failures), the Hello here decoded fine, and devp2p documents 0x02 as "a malformed message, bad RLP", which would mislead the remote peer's operator. The two are behaviourally identical — same 15 min reconnect delay, same -10000 reputation, both disconnect privileged peers — so this is purely about keeping the identity signal in one bucket.

Note that `devp2p/rlpx.md` defines `nodeId` as "the secp256k1 public key corresponding to the node's private key" but states no MUST-disconnect requirement, so this is conformance and fail-closed hygiene rather than a spec violation. It is a wire-behaviour change: a client that really does send a mismatched Hello will now be dropped rather than tolerated.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`On_hello_claiming_another_node_id_than_authenticated_disconnects` asserts the disconnect and that no capability is agreed and no subprotocol is started. Mutation-checked: reverting only the handler change makes it fail.

`P2PProtocolHandlerTests` mocked `ISession` without stubbing `RemoteNodeId`, so it returned null and every existing hello test was silently riding the mismatch path. Stubbed in `[SetUp]` rather than `CreateSession()` because NSubstitute is last-configured-wins and `On_hello_from_a_session_authenticated_as_this_node_disconnects` sets it before calling `CreateSession()`. `ProtocolsManagerTests` needed no change — it uses a real `Session` with `Handshake(PublicKeyB)` and hellos carrying `PublicKeyB`.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Verification on the PR base:

- `Nethermind.Network.Test.P2P` (includes the new test): 953 passed, 0 failed
- `ProtocolsManagerTests`: 25 passed, 0 failed
- `dotnet format whitespace src/Nethermind/ --folder --verify-no-changes`: clean

Hive does not run on pull requests (`hive-tests.yml` triggers on push to master/tags and `workflow_dispatch`; `hive-consensus-tests.yml` on `release/*` and `workflow_dispatch`). The PR-side coverage that matters for a handshake change is `Integration tests (E2E)`, which builds the image and runs multi-node integration tests, and `Sync PR Gate (Hoodi)`, which syncs the PR image against the live network and so exercises handshakes with real peers. Happy to dispatch the `devp2p` hive suite against the branch as well if useful.
