### PR TITLE
perf: skip unobserved logs during transaction prewarming

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Benchmark/LogEmissionBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/LogEmissionBenchmark.cs
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Autofac;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Core.Test.Modules;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+
+namespace Nethermind.Evm.Benchmark;
+
+[MemoryDiagnoser]
+public class LogEmissionBenchmark
+{
+    private IContainer _container = null!;
+    private ILifetimeScope _scope = null!;
+    private IDisposable _stateScope = null!;
+    private IWorldState _state = null!;
+    private ITransactionProcessor _processor = null!;
+    private Transaction _transaction = null!;
+    private BlockHeader _header = null!;
+    private Snapshot _snapshot;
+
+    [Params(0, 100)]
+    public int LogCount { get; set; }
+
+    [Params(false, true)]
+    public bool Warmup { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _container = new ContainerBuilder().AddModule(new TestNethermindModule(Osaka.Instance)).Build();
+        IWorldStateScopeProvider scopeProvider = _container.Resolve<IWorldStateManager>().GlobalWorldState;
+        _scope = _container.BeginLifetimeScope(builder =>
+            builder.RegisterInstance(scopeProvider).As<IWorldStateScopeProvider>().ExternallyOwned());
+        _state = _scope.Resolve<IWorldState>();
+        _stateScope = _state.BeginScope(IWorldState.PreGenesis);
+        _state.CreateAccount(TestItem.AddressA, 1.Ether);
+        _state.CreateAccount(TestItem.AddressB, 0);
+        byte[] code = new byte[LogCount * 11 + 1];
+        for (int i = 0; i < LogCount; i++)
+        {
+            // Four zero topics, 1 KiB of data at offset 1 KiB.
+            new byte[] { 0x5f, 0x5f, 0x5f, 0x5f, 0x61, 0x04, 0x00, 0x61, 0x04, 0x00, 0xa4 }
+                .CopyTo(code, i * 11);
+        }
+        _state.InsertCode(TestItem.AddressB, Keccak.Compute(code), code, Osaka.Instance);
+        _state.Commit(Osaka.Instance);
+        _snapshot = _state.TakeSnapshot();
+        _processor = _scope.Resolve<ITransactionProcessor>();
+        _header = Build.A.BlockHeader.WithNumber(1).WithGasLimit(30_000_000).WithBaseFee(0).TestObject;
+        _processor.SetBlockExecutionContext(_header);
+        _transaction = Build.A.Transaction.WithTo(TestItem.AddressB).WithGasLimit(10_000_000)
+            .WithGasPrice(1).SignedAndResolved(TestItem.PrivateKeyA).TestObject;
+        if (!Execute().TransactionExecuted) throw new InvalidOperationException("Benchmark transaction did not execute.");
+    }
+
+    [Benchmark]
+    public TransactionResult Execute()
+    {
+        _header.GasUsed = 0;
+        TransactionResult result = Warmup
+            ? _processor.Warmup(_transaction, NullTxTracer.Instance)
+            : _processor.BuildUp(_transaction, NullTxTracer.Instance);
+        _state.Restore(_snapshot);
+        return result;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _stateScope.Dispose();
+        _scope.Dispose();
+        _container.Dispose();
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorWarmupTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorWarmupTests.cs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
@@ -42,6 +44,111 @@ public class TransactionProcessorWarmupTests
 
     [TearDown]
     public void TearDown() => _worldStateCloser?.Dispose();
+
+    [Test]
+    public void Unobserved_logs_preserve_warmup_gas_and_memory([Range(0, 4)] int topicCount, [Values] bool receiptTracer)
+    {
+        Hash256[] topics = new Hash256[topicCount];
+        Array.Fill(topics, TestItem.KeccakA);
+        byte[] code = Prepare.EvmCode.Log(128, 1024, topics)
+            .Op(Instruction.MSIZE).PushData(0).Op(Instruction.SSTORE).Done;
+        (Transaction tx, Snapshot snapshot) = PrepareLogTransaction(code, 500_000);
+        using LogCaptureTracer tracer = new(receiptTracer);
+
+        _transactionProcessor.Warmup(tx, tracer);
+        UInt256 expectedBalance = _stateProvider.GetBalance(TestItem.AddressA);
+        _stateProvider.Restore(snapshot);
+        TransactionResult result = _transactionProcessor.Warmup(tx, NullTxTracer.Instance);
+
+        Assert.That(tracer.Logs, Has.Count.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(_stateProvider.GetBalance(TestItem.AddressA), Is.EqualTo(expectedBalance));
+            Assert.That(_stateProvider.GetNonce(TestItem.AddressA), Is.EqualTo(1UL));
+            Assert.That(new UInt256(_stateProvider.Get(new StorageCell(TestItem.AddressB, 0)), isBigEndian: true), Is.EqualTo(new UInt256(1152)));
+            Assert.That(tracer.Logs[0].Topics, Is.EqualTo(topics));
+            Assert.That(tracer.Logs[0].Data, Is.EqualTo(new byte[128]));
+        }
+    }
+
+    private static IEnumerable<TestCaseData> FailedLogs()
+    {
+        yield return new TestCaseData(Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.LOG4).Done, 500_000UL)
+            .SetName("Unobserved_log_checks_topic_stack_underflow");
+        yield return new TestCaseData(Prepare.EvmCode.PushData(1).PushData(UInt256.MaxValue).Op(Instruction.LOG0).Done, 500_000UL)
+            .SetName("Unobserved_log_checks_memory_overflow");
+        yield return new TestCaseData(Prepare.EvmCode.Log(1024, 0).Done, 22_000UL)
+            .SetName("Unobserved_log_checks_emission_gas");
+    }
+
+    [TestCaseSource(nameof(FailedLogs))]
+    public void Unobserved_logs_preserve_failure(byte[] code, ulong gasLimit)
+    {
+        (Transaction tx, Snapshot snapshot) = PrepareLogTransaction(code, gasLimit);
+        using LogCaptureTracer tracer = new(receiptTracer: true);
+        _transactionProcessor.Warmup(tx, tracer);
+        Assert.That(tracer.Failed, Is.True);
+        _stateProvider.Restore(snapshot);
+
+        TransactionResult result = _transactionProcessor.Warmup(tx, NullTxTracer.Instance);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(_stateProvider.GetBalance(TestItem.AddressA), Is.EqualTo(1.Ether - gasLimit));
+            Assert.That(_stateProvider.GetNonce(TestItem.AddressA), Is.EqualTo(1UL));
+        }
+    }
+
+    [Test]
+    public void Unobserved_logs_still_fail_in_static_calls()
+    {
+        _stateProvider.CreateAccount(TestItem.AddressC, 0);
+        _stateProvider.InsertCode(TestItem.AddressC, Prepare.EvmCode.Log(0, 0).Done, _specProvider.GenesisSpec);
+        byte[] code = Prepare.EvmCode.StaticCall(TestItem.AddressC, 50_000).Op(Instruction.ISZERO)
+            .PushData(0).Op(Instruction.SSTORE).Done;
+        (Transaction tx, _) = PrepareLogTransaction(code, 500_000);
+
+        _transactionProcessor.Warmup(tx, NullTxTracer.Instance);
+
+        Assert.That(new UInt256(_stateProvider.Get(new StorageCell(TestItem.AddressB, 0)), isBigEndian: true), Is.EqualTo(UInt256.One));
+    }
+
+    private (Transaction, Snapshot) PrepareLogTransaction(byte[] code, ulong gasLimit)
+    {
+        _stateProvider.CreateAccount(TestItem.AddressA, 1.Ether);
+        _stateProvider.CreateAccount(TestItem.AddressB, 0);
+        _stateProvider.InsertCode(TestItem.AddressB, code, _specProvider.GenesisSpec);
+        _stateProvider.Commit(_specProvider.GenesisSpec);
+        _stateProvider.CommitTree(0);
+        Snapshot snapshot = _stateProvider.TakeSnapshot();
+        Transaction tx = Build.A.Transaction.WithTo(TestItem.AddressB).WithGasLimit(gasLimit)
+            .WithGasPrice(1).SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).WithBaseFee(0).TestObject;
+        _transactionProcessor.SetBlockExecutionContext(header);
+        return (tx, snapshot);
+    }
+
+    private sealed class LogCaptureTracer : TxTracer
+    {
+        public List<LogEntry> Logs { get; } = [];
+        public bool Failed { get; private set; }
+
+        public LogCaptureTracer(bool receiptTracer)
+        {
+            IsTracingReceipt = receiptTracer;
+            IsTracingLogs = !receiptTracer;
+        }
+
+        public override void ReportLog(LogEntry log) => Logs.Add(log);
+
+        public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null)
+            => Logs.AddRange(logs);
+
+        public override void MarkAsFailed(Address recipient, in GasConsumed gasSpent, byte[] output, string? error, Hash256? stateRoot = null)
+            => Failed = true;
+    }
 
     // Warmup must take the real execution path: no-op fee/nonce handling made same-sender
     // warm sequences run with undebited balances and unbumped nonces, so deploy chains

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorWarmupTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorWarmupTests.cs
@@ -125,9 +125,38 @@ public class TransactionProcessorWarmupTests
         Snapshot snapshot = _stateProvider.TakeSnapshot();
         Transaction tx = Build.A.Transaction.WithTo(TestItem.AddressB).WithGasLimit(gasLimit)
             .WithGasPrice(1).SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
-        BlockHeader header = Build.A.BlockHeader.WithNumber(1).WithBaseFee(0).TestObject;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).WithGasLimit(30_000_000).WithBaseFee(0).TestObject;
         _transactionProcessor.SetBlockExecutionContext(header);
         return (tx, snapshot);
+    }
+
+    [Test]
+    public void Warmup_preserves_memory_access_for_instruction_tracers()
+    {
+        byte[] code = Prepare.EvmCode.Log(32, 0x100800).Op(Instruction.STOP).Done;
+        (Transaction tx, _) = PrepareLogTransaction(code, 5_000_000);
+        using MemoryWordTracer tracer = new();
+
+        _transactionProcessor.Warmup(tx, tracer);
+
+        Assert.That(tracer.LastWord, Is.EqualTo(new byte[32]));
+    }
+
+    private sealed class MemoryWordTracer : TxTracer
+    {
+        public byte[]? LastWord { get; private set; }
+
+        public MemoryWordTracer()
+        {
+            IsTracingInstructions = true;
+            IsTracingMemory = true;
+        }
+
+        public override void SetOperationMemory(TraceMemory memoryTrace)
+        {
+            if (memoryTrace.Size != 0)
+                LastWord = memoryTrace.Slice((int)memoryTrace.Size - 32, 32).ToArray();
+        }
     }
 
     private sealed class LogCaptureTracer : TxTracer

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -1150,6 +1150,13 @@ public static partial class EvmInstructions
         ulong dataSize = (ulong)length;
         if (!TGasPolicy.TryConsumeLogEmission(ref gas, topicsCount, dataSize)) goto OutOfGas;
 
+        if (vm.TxExecutionContext.SuppressLogs)
+        {
+            for (int i = 0; i < TOpCount.Count; i++)
+                if (!stack.PopLimbo()) goto StackUnderflow;
+            return EvmExceptionType.None;
+        }
+
         // Load the log data from memory.
         if (!vmState.Memory.TryLoad(in position, length, out ReadOnlyMemory<byte> data))
             goto OutOfGas;

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -309,7 +309,7 @@ namespace Nethermind.Evm.TransactionProcessing
         {
             VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress!, _codeInfoRepository, tx.BlobVersionedHashes, in opcodeGasPrice)
             {
-                SuppressLogs = opts.HasFlag(ExecutionOptions.Warmup) && !tracer.IsTracingReceipt && !tracer.IsTracingLogs
+                SuppressLogs = opts.HasFlag(ExecutionOptions.Warmup) && ReferenceEquals(tracer, NullTxTracer.Instance)
             });
             // Top-level CREATE tx; the opcode-level CREATE/CREATE2 path bumps this counter from EvmInstructions.Create.
             if (tx.IsContractCreation) Metrics.IncrementCreates();

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -307,7 +307,10 @@ namespace Nethermind.Evm.TransactionProcessing
             CodeInfo? preloadedCodeInfo,
             Address? preloadedDelegationAddress)
         {
-            VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress!, _codeInfoRepository, tx.BlobVersionedHashes, in opcodeGasPrice));
+            VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress!, _codeInfoRepository, tx.BlobVersionedHashes, in opcodeGasPrice)
+            {
+                SuppressLogs = opts.HasFlag(ExecutionOptions.Warmup) && !tracer.IsTracingReceipt && !tracer.IsTracingLogs
+            });
             // Top-level CREATE tx; the opcode-level CREATE/CREATE2 path bumps this counter from EvmInstructions.Create.
             if (tx.IsContractCreation) Metrics.IncrementCreates();
             // substate.Logs contains a reference to accessTracker.Logs so we can't Dispose until end of the method

--- a/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
+++ b/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
@@ -17,5 +17,7 @@ namespace Nethermind.Evm
         public readonly ICodeInfoRepository CodeInfoRepository = codeInfoRepository;
         public readonly byte[]?[]? BlobVersionedHashes = blobVersionedHashes;
         public readonly UInt256 GasPrice = gasPrice;
+
+        internal bool SuppressLogs { get; init; }
     }
 }


### PR DESCRIPTION
## Changes

- Skip `LOG0`–`LOG4` data, topic and log-entry allocations during transaction prewarming with the `NullTxTracer.Instance` singleton. The prewarmer discards these logs; all custom tracers retain full log/memory materialization.
- Preserve log gas charges, logical memory expansion, topic-stack checks and static-call restrictions. Fee/nonce handling and ordinary transaction execution retain their existing behavior.
- Add regression coverage and a transaction benchmark using production DI with in-memory state.

Final revision compared with master `84317ada53`, Windows x64, Ryzen 7 5800X, .NET 10.0.9, BenchmarkDotNet 0.15.8:

| Workload | Baseline mean | Candidate mean | Allocated before → after |
|---|---:|---:|---:|
| Warmup, 100 LOG4 emissions with 1 KiB data each | 14.671 µs | 3.298 µs | 134,032 → 432 B |
| Normal execution, same logs | 19.363 µs | 16.666 µs | 134,032 → 134,032 B |
| Warmup, no logs | 1.051 µs | 1.062 µs | 432 → 432 B |
| Normal execution, no logs | 0.995 µs | 1.006 µs | 432 → 432 B |

The final log-heavy warmup case is **4.45× faster and allocates 99.68% less**. Earlier repeated comparisons measured 15.21–16.50 µs versus 2.98–3.04 µs before the tracer gate was narrowed; the final null-tracer workload retains the allocation reduction. The very short no-log controls are noisy; these measurements do not establish an end-to-end block throughput improvement. Runs used identical benchmark source, five warmups, eight measured 250 ms iterations and the in-process toolchain, with no concurrent builds or benchmarks. The final order was candidate / baseline.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- 228 selected EVM tests passed: transaction warmup and call/log coverage.
- New cases cover LOG0–LOG4, both receipt and log tracers, memory expansion observed through MSIZE, unchanged gas/nonce effects, topic stack underflow, oversized memory, emission out-of-gas, static-call rejection and custom instruction/memory tracers reading the expanded memory tail. The latter regression was reproduced failing before narrowing the gate to the null-tracer singleton.
- Release benchmark build and whitespace formatting passed.
- Reproduce timings with `LogEmissionBenchmark`, copying the same benchmark file to the baseline worktree.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
