### PR TITLE
perf: compute receipt roots without retaining a mutable trie

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.IO;
+using System;
 using System.Linq;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -9,6 +10,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
+using Nethermind.Specs.Forks;
 using Nethermind.State.Proofs;
 using Nethermind.Trie;
 using Nethermind.Trie.Pruning;
@@ -21,6 +23,85 @@ namespace Nethermind.Blockchain.Test.Proofs;
 public class ReceiptTrieTests
 {
     private static readonly ReceiptMessageDecoder _decoder = new();
+    private static readonly int[] RootCounts = [0, 1, 2, 15, 16, 17, 63, 64, 65, 127, 128, 129, 255, 256, 257, 4096];
+    private static readonly int[] InlineCounts = [1, 2, 3, 4, 8, 16, 128, 129];
+
+    [Test]
+    public void Direct_root_matches_mutable_trie(
+        [ValueSource(nameof(RootCounts))] int count,
+        [Values] bool eip658,
+        [Values] bool skipStateAndStatus)
+    {
+        IReleaseSpec spec = eip658 ? Osaka.Instance : Frontier.Instance;
+        TxReceipt[] receipts = new TxReceipt[count];
+        Random random = new(42);
+        for (int i = 0; i < count; i++)
+        {
+            byte[] data = new byte[i % 99];
+            random.NextBytes(data);
+            receipts[i] = Build.A.Receipt.WithAllFieldsFilled.WithGasUsedTotal((ulong)(i + 1) * 21000)
+                .WithStatusCode((byte)(i & 1)).WithTxType(eip658 ? (TxType)(i % 5) : TxType.Legacy)
+                .WithLogs(new LogEntry(TestItem.AddressA, data, [TestItem.KeccakA, TestItem.KeccakB])).TestObject;
+        }
+
+        AssertRootMatches(spec, receipts, new ReceiptMessageDecoder(skipStateAndStatus));
+    }
+
+    [Test, NonParallelizable]
+    public void Direct_root_matches_at_three_byte_index_boundary([Values(65535, 65536, 65537)] int count)
+    {
+        TxReceipt[] receipts = new TxReceipt[count];
+        Array.Fill(receipts, Build.A.Receipt.WithAllFieldsFilled.TestObject);
+        AssertRootMatches(Osaka.Instance, receipts, _decoder);
+    }
+
+    [Test]
+    public void Direct_root_matches_with_inline_nodes([ValueSource(nameof(InlineCounts))] int count, [Values] bool mixed)
+    {
+        TxReceipt[] receipts = new TxReceipt[count];
+        if (mixed)
+        {
+            for (int i = 1; i < count; i += 2)
+                receipts[i] = Build.A.Receipt.WithAllFieldsFilled.TestObject;
+        }
+        AssertRootMatches(Osaka.Instance, receipts, _decoder);
+    }
+
+    [Test]
+    public void Custom_receipt_codec_preserves_empty_values()
+    {
+        TxReceipt[] receipts = [Build.A.Receipt.WithAllFieldsFilled.TestObject];
+        Assert.That(ReceiptTrie.CalculateRoot(Osaka.Instance, receipts, new EmptyReceiptDecoder()), Is.EqualTo(Keccak.EmptyTreeHash));
+    }
+
+    private sealed class EmptyReceiptDecoder : RlpDecoder<TxReceipt>
+    {
+        protected override TxReceipt DecodeInternal(ref RlpReader reader, RlpBehaviors rlpBehaviors) => throw new NotSupportedException();
+        public override int GetLength(TxReceipt item, RlpBehaviors rlpBehaviors) => 0;
+        public override void Encode<TWriter>(ref TWriter writer, TxReceipt item, RlpBehaviors rlpBehaviors) { }
+    }
+
+    [Test]
+    public void Encoding_failure_does_not_poison_subsequent_calculations([Values(1, 128)] int count)
+    {
+        TxReceipt receipt = Build.A.Receipt.WithAllFieldsFilled.TestObject;
+        LogEntry[] logs = receipt.Logs!;
+        TxReceipt[] receipts = new TxReceipt[count];
+        Array.Fill(receipts, receipt);
+        receipt.Logs = null;
+
+        Assert.That(() => ReceiptTrie.CalculateRoot(Osaka.Instance, receipts, _decoder), Throws.TypeOf<RlpException>());
+
+        receipt.Logs = logs;
+        AssertRootMatches(Osaka.Instance, receipts, _decoder);
+    }
+
+    private static void AssertRootMatches(IReleaseSpec spec, TxReceipt[] receipts, IRlpDecoder<TxReceipt> decoder)
+    {
+        using TrackingCappedArrayPool pool = new();
+        Hash256 expected = new ReceiptTrie(spec, receipts, decoder, pool, canBeParallel: false).RootHash;
+        Assert.That(ReceiptTrie.CalculateRoot(spec, receipts, decoder), Is.EqualTo(expected));
+    }
 
     [Test, MaxTime(Timeout.MaxTestTime)]
     public void Can_calculate_root_no_eip_658()

--- a/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
@@ -100,7 +100,16 @@ public class ReceiptTrieTests
     {
         using TrackingCappedArrayPool pool = new();
         Hash256 expected = new ReceiptTrie(spec, receipts, decoder, pool, canBeParallel: false).RootHash;
-        Assert.That(ReceiptTrie.CalculateRoot(spec, receipts, decoder), Is.EqualTo(expected));
+        Hash256 actual = ReceiptTrie.CalculateRoot(spec, receipts, decoder);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(actual, Is.EqualTo(expected));
+            if (receipts.Length > 0)
+            {
+                byte[][] proof = ReceiptTrie.CalculateReceiptProofs(spec, receipts, receipts.Length / 2, decoder);
+                Assert.That(Keccak.Compute(proof[0]), Is.EqualTo(actual), "proof root must match the streamed root");
+            }
+        }
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Evm.Benchmark/ReceiptRootBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/ReceiptRootBenchmark.cs
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Serialization.Rlp;
+using Nethermind.Specs.Forks;
+using Nethermind.State.Proofs;
+
+namespace Nethermind.Evm.Benchmark;
+
+[MemoryDiagnoser]
+public class ReceiptRootBenchmark
+{
+    private readonly ReceiptMessageDecoder _decoder = new();
+    private TxReceipt[] _receipts = null!;
+
+    [Params(1, 128, 1024, 4096)]
+    public int Count { get; set; }
+
+    [Params(0, 1024)]
+    public int LogDataLength { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _receipts = new TxReceipt[Count];
+        byte[] data = new byte[LogDataLength];
+        new System.Random(42).NextBytes(data);
+        for (int i = 0; i < Count; i++)
+        {
+            _receipts[i] = Build.A.Receipt.WithAllFieldsFilled.WithGasUsedTotal((ulong)(i + 1) * 21000)
+                .WithTxType((TxType)(i % 5))
+                .WithLogs(new LogEntry(TestItem.AddressA, data, [TestItem.KeccakA, TestItem.KeccakB])).TestObject;
+        }
+    }
+
+    [Benchmark]
+    public Hash256 CalculateRoot() => ReceiptTrie.CalculateRoot(Osaka.Instance, _receipts, _decoder);
+}

--- a/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.RootCalculator.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.RootCalculator.cs
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.Buffers;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Cpu;
+using Nethermind.Core.Crypto;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.State.Proofs;
+
+public sealed partial class ReceiptTrie
+{
+    // The indexed trie from Yellow Paper section 4.4.2 has prefix-free RLP integer keys,
+    // ordered 1..127, 0, 128..N, so each subtree can be hashed before encoding its sibling.
+    private readonly ref struct RootCalculator(ReadOnlySpan<TxReceipt> receipts, ReceiptMessageDecoder decoder, RlpBehaviors behavior,
+        ReadOnlySpan<RootCalculator.NodeReference> leaves = default)
+    {
+        private const int LeafBatchSize = 16;
+        private const int BranchPrefixLength = 3;
+        private readonly ReadOnlySpan<TxReceipt> _receipts = receipts;
+        private readonly ReadOnlySpan<NodeReference> _leaves = leaves;
+
+        public Hash256 Calculate()
+            => RuntimeInformation.IsSingleProcessor || _receipts.Length <= MinItemsForParallelRootHash
+                ? CalculateSequential()
+                : CalculateParallel();
+
+        private Hash256 CalculateParallel()
+        {
+            using ArrayPoolList<TxReceipt> inputs = new(_receipts);
+            using ArrayPoolList<NodeReference> references = new(_receipts.Length, _receipts.Length);
+            ReceiptMessageDecoder leafDecoder = decoder;
+            RlpBehaviors leafBehavior = behavior;
+            try
+            {
+                Parallel.For(0, (_receipts.Length - 1) / LeafBatchSize + 1, RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16, batch =>
+                {
+                    RootCalculator calculator = new(inputs.AsSpan(), leafDecoder, leafBehavior);
+                    int start = batch * LeafBatchSize;
+                    int end = start + Math.Min(LeafBatchSize, inputs.Count - start);
+                    for (int position = start; position < end; position++)
+                    {
+                        Key key = calculator.GetKey(position);
+                        int depth = position == 0 ? 0 : CommonPrefix(key, calculator.GetKey(position - 1), 0);
+                        if (position + 1 < inputs.Count)
+                            depth = Math.Max(depth, CommonPrefix(key, calculator.GetKey(position + 1), 0));
+                        references[position] = calculator.Leaf(key, depth + 1, inputs[calculator.GetIndex(position)]);
+                    }
+                });
+            }
+            catch (AggregateException exception)
+            {
+                ExceptionDispatchInfo.Throw(exception.InnerExceptions[0]);
+            }
+            return new RootCalculator(_receipts, decoder, behavior, references.AsSpan()).CalculateSequential();
+        }
+
+        private Hash256 CalculateSequential()
+        {
+            NodeReference root = Build(0, _receipts.Length, 0);
+            return root.Length == 32 ? new Hash256(root.Value) : Keccak.Compute(root.Value.Bytes[..root.Length]);
+        }
+
+        [SkipLocalsInit]
+        private NodeReference Build(int start, int end, int depth)
+        {
+            Key first = GetKey(start);
+            if (end - start == 1)
+                return _leaves.IsEmpty ? Leaf(first, depth, _receipts[GetIndex(start)]) : _leaves[start];
+
+            Key last = GetKey(end - 1);
+            int commonDepth = CommonPrefix(first, last, depth);
+
+            Span<byte> encoded = stackalloc byte[BranchPrefixLength + 16 * Rlp.LengthOfKeccakRlp + 1];
+            if (commonDepth != depth)
+            {
+                Span<byte> path = stackalloc byte[6];
+                int pathLength = EncodePath(first, depth, commonDepth - depth, isLeaf: false, path);
+                NodeReference child = Build(start, end, commonDepth);
+                int contentLength = Rlp.LengthOf(path[..pathLength]) + child.EncodedLength;
+                int position = Rlp.StartSequence(encoded, 0, contentLength);
+                position = Rlp.Encode(encoded, position, path[..pathLength]);
+                position += child.WriteTo(encoded[position..]);
+                return NodeReference.FromRlp(encoded[..position]);
+            }
+
+            int cursor = start;
+            int offset = BranchPrefixLength;
+            for (int nibble = 0; nibble < 16; nibble++)
+            {
+                if (cursor == end || GetKey(cursor).Nibble(depth) != nibble)
+                {
+                    encoded[offset++] = Rlp.EmptyByteArrayByte;
+                    continue;
+                }
+
+                int next = cursor + 1;
+                while (next < end && GetKey(next).Nibble(depth) == nibble) next++;
+                NodeReference child = Build(cursor, next, depth + 1);
+                offset += child.WriteTo(encoded[offset..]);
+                cursor = next;
+            }
+            encoded[offset++] = Rlp.EmptyByteArrayByte;
+            int branchLength = offset - BranchPrefixLength;
+            int prefixLength = Rlp.StartSequence(encoded, 0, branchLength);
+            encoded.Slice(BranchPrefixLength, branchLength).CopyTo(encoded[prefixLength..]);
+            return NodeReference.FromRlp(encoded[..(prefixLength + branchLength)]);
+        }
+
+        [SkipLocalsInit]
+        private NodeReference Leaf(Key key, int depth, TxReceipt receipt)
+        {
+            Span<byte> path = stackalloc byte[6];
+            int pathLength = EncodePath(key, depth, key.Length - depth, isLeaf: true, path);
+            int valueLength = decoder.GetLength(receipt, behavior);
+            Span<byte> shortValue = stackalloc byte[1];
+            if (valueLength == 1)
+            {
+                RlpWriter shortWriter = new(shortValue);
+                decoder.Encode(ref shortWriter, receipt, behavior);
+            }
+
+            bool unprefixedByte = valueLength == 1 && shortValue[0] < 128;
+            int encodedValueLength = Rlp.LengthOfByteString(valueLength, unprefixedByte ? (byte)0 : (byte)128);
+            int contentLength = Rlp.LengthOf(path[..pathLength]) + encodedValueLength;
+            int totalLength = Rlp.LengthOfSequence(contentLength);
+            using ArrayPoolDisposableReturn rental = ArrayPoolDisposableReturn.Rent(totalLength, out byte[] buffer);
+            RlpWriter writer = new(buffer.AsSpan(0, totalLength));
+            writer.StartSequence(contentLength);
+            writer.Encode(path[..pathLength]);
+            if (valueLength <= 1)
+            {
+                writer.Encode(shortValue[..valueLength]);
+            }
+            else
+            {
+                writer.StartByteArray(valueLength, false);
+                decoder.Encode(ref writer, receipt, behavior);
+            }
+            return NodeReference.FromRlp(buffer.AsSpan(0, writer.Position));
+        }
+
+        private int GetIndex(int position)
+        {
+            int zeroPosition = Math.Min(_receipts.Length - 1, 127);
+            return position < zeroPosition ? position + 1 : position == zeroPosition ? 0 : position;
+        }
+
+        private static int CommonPrefix(Key first, Key last, int depth)
+        {
+            while (depth < Math.Min(first.Length, last.Length) && first.Nibble(depth) == last.Nibble(depth)) depth++;
+            return depth;
+        }
+
+        private Key GetKey(int position)
+        {
+            uint index = (uint)GetIndex(position);
+            if (index < 128) return new(index == 0 ? 128 : index, 2);
+            int byteCount = (32 - BitOperations.LeadingZeroCount(index) + 7) / 8;
+            return new(((ulong)(128 + byteCount) << (byteCount * 8)) | index, (byteCount + 1) * 2);
+        }
+
+        private static int EncodePath(Key key, int depth, int length, bool isLeaf, Span<byte> output)
+        {
+            int end = depth + length;
+            byte flags = isLeaf ? (byte)32 : (byte)0;
+            output[0] = (length & 1) != 0 ? (byte)(flags | 16 | key.Nibble(depth++)) : flags;
+            int position = 1;
+            while (depth < end)
+            {
+                output[position++] = (byte)((key.Nibble(depth) << 4) | key.Nibble(depth + 1));
+                depth += 2;
+            }
+            return position;
+        }
+
+        private readonly record struct Key(ulong Value, int Length)
+        {
+            public int Nibble(int depth) => (int)(Value >> ((Length - depth - 1) * 4)) & 15;
+        }
+
+        public readonly record struct NodeReference(ValueHash256 Value, int Length)
+        {
+            public int EncodedLength => Length == 32 ? 33 : Length;
+
+            public int WriteTo(Span<byte> output)
+            {
+                if (Length == 32)
+                {
+                    output[0] = 160;
+                    Value.Bytes.CopyTo(output[1..]);
+                    return 33;
+                }
+                Value.Bytes[..Length].CopyTo(output);
+                return Length;
+            }
+
+            public static NodeReference FromRlp(ReadOnlySpan<byte> encoded)
+            {
+                ValueHash256 value = default;
+                if (encoded.Length < 32)
+                {
+                    encoded.CopyTo(value.BytesAsSpan);
+                    return new(value, encoded.Length);
+                }
+                KeccakHash.ComputeHash(encoded, value.BytesAsSpan);
+                return new(value, 32);
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.RootCalculator.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.RootCalculator.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
@@ -24,6 +25,8 @@ public sealed partial class ReceiptTrie
     {
         private const int LeafBatchSize = 16;
         private const int BranchPrefixLength = 3;
+        // Prefix-free keys leave the branch value empty; each child reference occupies at most 33 bytes.
+        private const int MaxBranchContentLength = 16 * Rlp.LengthOfKeccakRlp + 1;
         private readonly ReadOnlySpan<TxReceipt> _receipts = receipts;
         private readonly ReadOnlySpan<NodeReference> _leaves = leaves;
 
@@ -78,7 +81,7 @@ public sealed partial class ReceiptTrie
             Key last = GetKey(end - 1);
             int commonDepth = CommonPrefix(first, last, depth);
 
-            Span<byte> encoded = stackalloc byte[BranchPrefixLength + 16 * Rlp.LengthOfKeccakRlp + 1];
+            Span<byte> encoded = stackalloc byte[BranchPrefixLength + MaxBranchContentLength];
             if (commonDepth != depth)
             {
                 Span<byte> path = stackalloc byte[6];
@@ -109,7 +112,9 @@ public sealed partial class ReceiptTrie
             }
             encoded[offset++] = Rlp.EmptyByteArrayByte;
             int branchLength = offset - BranchPrefixLength;
+            Debug.Assert(branchLength <= MaxBranchContentLength);
             int prefixLength = Rlp.StartSequence(encoded, 0, branchLength);
+            Debug.Assert(prefixLength <= BranchPrefixLength);
             encoded.Slice(BranchPrefixLength, branchLength).CopyTo(encoded[prefixLength..]);
             return NodeReference.FromRlp(encoded[..(prefixLength + branchLength)]);
         }
@@ -120,6 +125,7 @@ public sealed partial class ReceiptTrie
             Span<byte> path = stackalloc byte[6];
             int pathLength = EncodePath(key, depth, key.Length - depth, isLeaf: true, path);
             int valueLength = decoder.GetLength(receipt, behavior);
+            Debug.Assert(valueLength > 0, "Empty encodings require trie deletion semantics.");
             Span<byte> shortValue = stackalloc byte[1];
             if (valueLength == 1)
             {

--- a/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
@@ -14,7 +14,7 @@ namespace Nethermind.State.Proofs;
 /// <summary>
 /// Represents a Patricia trie built of a collection of <see cref="TxReceipt"/>.
 /// </summary>
-public sealed class ReceiptTrie : PatriciaTrie<TxReceipt>
+public sealed partial class ReceiptTrie : PatriciaTrie<TxReceipt>
 {
     private readonly IRlpDecoder<TxReceipt> _decoder;
     /// <inheritdoc/>
@@ -60,9 +60,19 @@ public sealed class ReceiptTrie : PatriciaTrie<TxReceipt>
 
     public static Hash256 CalculateRoot(IReceiptSpec receiptSpec, ReadOnlySpan<TxReceipt> txReceipts, IRlpDecoder<TxReceipt> decoder)
     {
-        bool canBeParallel = txReceipts.Length > MinItemsForParallelRootHash;
-        using TrackingCappedArrayPool cappedArrayPool = new(txReceipts.Length * 4, canBeParallel: canBeParallel);
-        Hash256 receiptsRoot = new ReceiptTrie(receiptSpec, txReceipts, decoder, bufferPool: cappedArrayPool, canBeParallel: canBeParallel).RootHash;
-        return receiptsRoot;
+        ArgumentNullException.ThrowIfNull(receiptSpec);
+        ArgumentNullException.ThrowIfNull(decoder);
+        if (txReceipts.IsEmpty) return Keccak.EmptyTreeHash;
+
+        if (decoder is not ReceiptMessageDecoder receiptDecoder)
+        {
+            bool canBeParallel = txReceipts.Length > MinItemsForParallelRootHash;
+            using TrackingCappedArrayPool pool = new(txReceipts.Length * 4, canBeParallel: canBeParallel);
+            return new ReceiptTrie(receiptSpec, txReceipts, decoder, pool, canBeParallel: canBeParallel).RootHash;
+        }
+
+        RlpBehaviors behavior = (receiptSpec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None)
+            | RlpBehaviors.SkipTypedWrapping;
+        return new RootCalculator(txReceipts, receiptDecoder, behavior).Calculate();
     }
 }

--- a/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Diagnostics;
 using Nethermind.Core;
 using Nethermind.Core.Buffers;
 using Nethermind.Core.Crypto;
@@ -55,7 +56,9 @@ public sealed partial class ReceiptTrie : PatriciaTrie<TxReceipt>
     {
         bool canBeParallel = receipts.Length > MinItemsForParallelRootHash;
         using TrackingCappedArrayPool cappedArrayPool = new(receipts.Length * 4, canBeParallel: canBeParallel);
-        return new ReceiptTrie(spec, receipts, decoder, cappedArrayPool, canBuildProof: true, canBeParallel: canBeParallel).BuildProof(index);
+        ReceiptTrie trie = new(spec, receipts, decoder, cappedArrayPool, canBuildProof: true, canBeParallel: canBeParallel);
+        Debug.Assert(trie.RootHash == CalculateRoot(spec, receipts, decoder), "Receipt proofs and streamed roots must agree.");
+        return trie.BuildProof(index);
     }
 
     public static Hash256 CalculateRoot(IReceiptSpec receiptSpec, ReadOnlySpan<TxReceipt> txReceipts, IRlpDecoder<TxReceipt> decoder)
@@ -64,6 +67,8 @@ public sealed partial class ReceiptTrie : PatriciaTrie<TxReceipt>
         ArgumentNullException.ThrowIfNull(decoder);
         if (txReceipts.IsEmpty) return Keccak.EmptyTreeHash;
 
+        // Custom codecs may encode an empty value, which the mutable trie treats as deletion.
+        // The streamed builder requires ReceiptMessageDecoder's nonempty encodings, including null receipts.
         if (decoder is not ReceiptMessageDecoder receiptDecoder)
         {
             bool canBeParallel = txReceipts.Length > MinItemsForParallelRootHash;


### PR DESCRIPTION
## Changes

- Receipt-root calculation currently encodes all receipts and inserts them into a mutable trie, retaining receipt buffers and trie objects until hashing finishes. Calculate the root directly from the ordered RLP transaction indices instead.
- Encode receipts directly into temporary leaf buffers, hash leaves in parallel on multicore hosts, and build branch/extension encodings with bounded stack buffers. Retain compact inline/hash references in pooled arrays rather than encoded receipts and mutable nodes.
- Keep the existing trie for proof construction and custom receipt codecs. The single-processor/zkEVM path hashes each subtree sequentially without the parallel input/reference arrays.
- Cover typed/pre-EIP-658 receipts, skipped state/status encoding, inline nodes, index and parallelism boundaries, and encoding-failure recovery against the existing trie.

At 4,096 receipts, the final repeated runs are about **9–10× faster**, with steady-state allocations falling from **5–17 MB to about 5 KB**.

| Receipts | Log data bytes/receipt | Baseline (µs) | Candidate B1 (µs) | Candidate B2 (µs) | Allocated before → after |
|---|---:|---:|---:|---:|---:|
| 1 | 0 | 0.976 | 0.844 | 0.837 | 448 → 48 B |
| 1 | 1024 | 2.907 | 2.776 | 2.745 | 448 → 48 B |
| 128 | 0 | 139.904 | 68.304 | 57.109 | 32,455 → 2,847–2,859 B |
| 128 | 1024 | 194.748 | 143.469 | 116.582 | 32,456 → 3,281–3,392 B |
| 1024 | 0 | 1,826.829 | 322.281 | 294.522 | 1,073,071 → 4,543–4,654 B |
| 1024 | 1024 | 4,431.788 | 705.752 | 657.584 | 3,429,245 → 4,588–4,895 B |
| 4096 | 0 | 9,495.017 | 1,027.608 | 1,005.612 | 5,205,179 → 4,882–4,901 B |
| 4096 | 1024 | 23,570.054 | 2,380.273 | 2,438.391 | 16,997,896 → 4,928–4,961 B |

Execution order was candidate / baseline / candidate. Earlier baseline runs measured 8.6–12.2 ms and 21.2–30.7 ms for the two 4,096-receipt cases, respectively; CPU timing varies, while the allocation reduction is consistent.

These are receipt-root component benchmarks, not end-to-end block throughput. Windows x64, Ryzen 7 5800X, .NET 10.0.9, BenchmarkDotNet 0.15.8; identical benchmark source on master `84317ada53` and this branch. Five warmups, eight measured 250 ms iterations, in-process toolchain, sequential baseline/candidate runs without concurrent builds or workloads. Allocation figures are steady-state managed allocations and exclude retained pool capacity.

Full native guest replay of mainnet block **25532382** (1,232 transactions): modeled cost **40,445,948,238 → 40,247,873,380 (−0.4897%)**, steps **342,036,218 → 339,843,106 (−0.6412%)**, with identical successful output. Both arms use master `84317ada53`, the same witness and pinned compiler/emulator images; this is a single-block guest result.

Input SHA-256: `1706a8838f8cbb36f78bfdca3d83f8c9779a06dc0e50541172f099b9107c6a2a`. Compiler: `nethermindeth/bflat-riscv64:acee0ec11a2bb2199e941380ae0336caa429cdea@sha256:ede3b4bc5f751e0acb21341bc6a75b2ac4a0bfa49a89f91f99d8a450364f04a1`. Emulator: `nethermindeth/zisk:1.2.0-alpha@sha256:7b3ea05815cf902f0bceb17458d9fbc36b34043b81370b69e57a18cbd91c2d1c`.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- 142 selected receipt/root-calculator/block-processor tests passed. The EIP-7778 receipt-root test also passed.
- Compare against the existing mutable trie at 0/1, 15/16/17, 63/64/65, 127/128/129, 255/256/257, 4,096 and 65,535/65,536/65,537 receipts; include mixed inline/hash nodes and both EIP-658 modes.
- Native guest execution checks the real block's receipt root and returns the same successful output as the baseline.
- Release host and guest builds, whitespace formatting and diff checks passed. Guest ELFs pass the no-F/D/C/A and zero-manifest-resources gates.
- Independently reviewed rental lifetimes, disjoint worker writes, exception cleanup and buffer bounds. Parallel workers use the runtime's structured startup/error handling, and encoding exceptions retain their original type.
- Reproduce the host benchmark with `ReceiptRootBenchmark`, copying that benchmark file to the baseline worktree.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
