### PR TITLE
perf: drop redundant SSZ merkleization scratch clears

### DIFF
--- a/src/Nethermind/Nethermind.Serialization.Ssz.Test/MerkleTests.cs
+++ b/src/Nethermind/Nethermind.Serialization.Ssz.Test/MerkleTests.cs
@@ -48,6 +48,31 @@ public class MerkleTests
         Assert.That(actual, Is.EqualTo(tree[0]));
     }
 
+    [Test]
+    public void Merkleizer_does_not_read_scratch_it_has_not_written([Values(1, 2, 3, 4, 7, 8, 9, 31, 32, 33)] int count)
+    {
+        UInt256[] chunks = new UInt256[count];
+        for (int i = 0; i < count; i++) chunks[i] = (UInt256)(i + 1);
+        int width = 1;
+        while (width < count) width *= 2;
+
+        Span<UInt256> scratch = stackalloc UInt256[Merkle.NextPowerOfTwoExponent((ulong)width) + 1];
+        scratch.Fill(UInt256.MaxValue);
+        Merkleizer merkleizer = new(scratch);
+        for (int i = 0; i < count; i++) merkleizer.Feed(chunks[i]);
+        merkleizer.CalculateRoot(out UInt256 actual);
+
+        Merkle.Merkleize(out UInt256 expected, chunks, (ulong)width);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Merkleize_empty_is_the_zero_chunk([Values(0UL, 1UL)] ulong limit)
+    {
+        Merkle.Merkleize(out UInt256 root, ReadOnlySpan<UInt256>.Empty, limit);
+        Assert.That(root, Is.EqualTo(UInt256.Zero));
+    }
+
     [TestCase(ulong.MinValue, 0UL)]
     [TestCase(1UL, 0UL)]
     [TestCase(2UL, 1UL)]

--- a/src/Nethermind/Nethermind.Serialization.Ssz.Test/MerkleTests.cs
+++ b/src/Nethermind/Nethermind.Serialization.Ssz.Test/MerkleTests.cs
@@ -49,11 +49,12 @@ public class MerkleTests
     }
 
     [Test]
-    public void Merkleizer_does_not_read_scratch_it_has_not_written([Values(1, 2, 3, 4, 7, 8, 9, 31, 32, 33)] int count)
+    public void Merkleizer_does_not_read_scratch_it_has_not_written(
+        [Values(0, 1, 2, 3, 4, 7, 8, 9, 31, 32, 33)] int count, [Values(2, 1024)] int minimumWidth)
     {
         UInt256[] chunks = new UInt256[count];
         for (int i = 0; i < count; i++) chunks[i] = (UInt256)(i + 1);
-        int width = 1;
+        int width = minimumWidth;
         while (width < count) width *= 2;
 
         Span<UInt256> scratch = stackalloc UInt256[Merkle.NextPowerOfTwoExponent((ulong)width) + 1];
@@ -63,6 +64,27 @@ public class MerkleTests
         merkleizer.CalculateRoot(out UInt256 actual);
 
         Merkle.Merkleize(out UInt256 expected, chunks, (ulong)width);
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void Partial_byte_chunks_match_poisoned_scratch([Values(1, 31, 33, 65)] int length, [Values(0UL, 1024UL)] ulong limit)
+    {
+        byte[] bytes = new byte[length];
+        for (int i = 0; i < bytes.Length; i++) bytes[i] = (byte)(i + 1);
+        int count = (length + 31) / 32;
+        Span<UInt256> scratch = stackalloc UInt256[Merkle.NextPowerOfTwoExponent(limit == 0 ? (ulong)count : limit) + 1];
+        scratch.Fill(UInt256.MaxValue);
+        Merkleizer merkleizer = new(scratch);
+        for (int i = 0; i < count; i++)
+        {
+            byte[] chunk = new byte[32];
+            bytes.AsSpan(i * 32, Math.Min(32, length - i * 32)).CopyTo(chunk);
+            merkleizer.Feed(new UInt256(chunk));
+        }
+        merkleizer.CalculateRoot(out UInt256 expected);
+
+        Merkle.Merkleize(out UInt256 actual, bytes.AsSpan(), limit);
         Assert.That(actual, Is.EqualTo(expected));
     }
 

--- a/src/Nethermind/Nethermind.Serialization.Ssz/Merkleization/Merkle.cs
+++ b/src/Nethermind/Nethermind.Serialization.Ssz/Merkleization/Merkle.cs
@@ -293,7 +293,6 @@ public static partial class Merkle
 
         int depth = NextPowerOfTwoExponent(limit == 0UL ? (uint)(value.Length + lastChunk.Length) : limit);
         Span<UInt256> scratch = stackalloc UInt256[depth + 1];
-        scratch.Clear();
         Merkleizer merkleizer = new(scratch);
         int length = value.Length;
         for (int i = 0; i < length; i++)
@@ -311,15 +310,15 @@ public static partial class Merkle
 
     public static void Merkleize(out UInt256 root, ReadOnlySpan<UInt256> value, ulong limit = 0UL)
     {
-        if (limit <= 1 && value.Length == 1)
+        // A single-chunk tree is its own root, and an empty one is the zero chunk.
+        if (limit <= 1 && value.Length <= 1)
         {
-            root = value[0];
+            root = value.Length == 1 ? value[0] : UInt256.Zero;
             return;
         }
 
         int depth = NextPowerOfTwoExponent(limit == 0UL ? (ulong)value.Length : limit);
         Span<UInt256> scratch = stackalloc UInt256[depth + 1];
-        scratch.Clear();
         Merkleizer merkleizer = new(scratch);
         int length = value.Length;
         for (int i = 0; i < length; i++)

--- a/src/Nethermind/Nethermind.Serialization.Ssz/Merkleization/Merkle.cs
+++ b/src/Nethermind/Nethermind.Serialization.Ssz/Merkleization/Merkle.cs
@@ -285,9 +285,9 @@ public static partial class Merkle
 
     private static void Merkleize(out UInt256 root, ReadOnlySpan<UInt256> value, ReadOnlySpan<UInt256> lastChunk, ulong limit = 0)
     {
-        if (limit <= 1 && (value.Length + lastChunk.Length == 1))
+        if (limit <= 1 && value.Length + lastChunk.Length <= 1)
         {
-            root = value.Length == 0 ? lastChunk[0] : value[0];
+            root = value.Length == 1 ? value[0] : lastChunk.Length == 1 ? lastChunk[0] : UInt256.Zero;
             return;
         }
 
@@ -311,6 +311,7 @@ public static partial class Merkle
     public static void Merkleize(out UInt256 root, ReadOnlySpan<UInt256> value, ulong limit = 0UL)
     {
         // A single-chunk tree is its own root, and an empty one is the zero chunk.
+        // With no chunks fed, CalculateRoot's final top-slot read would use unwritten scratch.
         if (limit <= 1 && value.Length <= 1)
         {
             root = value.Length == 1 ? value[0] : UInt256.Zero;


### PR DESCRIPTION
## Changes

Follow-up to #13331. That PR moved the SSZ merkleization scratch to `stackalloc` and then cleared it on every call. The clear is redundant: `Merkleizer` reads `_chunks[i]` only under its `_filled` bit, and that bit is set on write, so the scratch never has to start zeroed.

There is one exception, which this PR closes rather than papers over: with zero chunks at depth 0 (a one-slot scratch), `CalculateRoot` breaks immediately and returns the top slot without anything ever having written it. That path is reachable — `Merkleize(out root, ReadOnlySpan<byte>.Empty)` gives `limit == 0` and an empty value. Today it reads as zero only because `stackalloc` is implicitly zeroed (this assembly sets no `SkipLocalsInit`), which is a silent dependency. The empty case now returns the zero chunk from the fast path, so the result no longer rides on locals-init, and it skips building the tree at all.

- Drop `scratch.Clear()` in both `Merkle.Merkleize` overloads
- Widen both overloads' single-chunk fast paths to cover the empty input

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Regression coverage includes zero-fed trees, limits up to 1024, and partial final byte chunks (1, 31, 33 and 65 bytes), with poisoned scratch. 157 SSZ tests pass after the review fixes. Original validation: `Merkleizer_does_not_read_scratch_it_has_not_written` pre-fills the scratch with `UInt256.MaxValue` and checks the root still matches `Merkle.Merkleize` across 10 chunk counts — the executable form of the invariant this removal rests on. `Merkleize_empty_is_the_zero_chunk` pins the empty root for `limit` 0 and 1.

Nethermind.Serialization.Ssz.Test 137/137, Nethermind.Serialization.SszGenerator.Test 64/64, Ethereum.Ssz.Test 2509/2509. Whitespace formatting and `git diff --check` clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

On mainnet block 25,532,382 against #13331 as merged (84317ada53), same pinned bflat and ZisK emulator images. Both runs returned the identical output.

| Metric | Baseline | This PR | Change |
|---|---:|---:|---:|
| Steps | 383,005,999 | 382,948,177 | -0.01510% |
| Weighted ZisK cost | 44,038,119,996 | 44,033,461,235 | -0.01058% |

The `--ref-stats` diff leaves `PRECOMPILES` and `BASE` bit-identical, so hashing work and hit rates are untouched and the whole delta is main-trace work: MAIN -3,931,896, OPCODES -405,753, MEMORY -321,112, FROPS -939,060. Opcode counts move only where a `Span.Clear` loop would (`add` -9,207, `and` -3,054, `srl` -1,518); the only increase is `eq` +10 from the widened comparison, so the empty short-circuit fires ~10 times in this block. Weighted emulator cost is not measured proving time.

The removed Clear was redundant with implicit stackalloc initialization on the host; this change does not add SkipLocalsInit, so that runtime initialization remains. The measured gain is correspondingly small.
