### PR TITLE
fix(ethstats): stop a malformed ping timestamp from terminating the node

### DIFF
--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsClientTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsClientTests.cs
@@ -36,6 +36,9 @@ namespace Nethermind.EthStats.Test
         [TestCase("primus::ping::99999999999999999999999999999", TestName = "Ping_with_timestamp_tail_overflowing_long_fails_to_parse")]
         [TestCase("no-separator-at-all", TestName = "Ping_with_no_separator_at_all_fails_to_parse")]
         [TestCase("\"primus::ping::\"", TestName = "Ping_in_wire_format_with_empty_timestamp_tail_fails_to_parse")]
+        // A well-formed frame quotes only the outer message, so a quote inside the digits
+        // means the frame is malformed; this is treated as unparseable rather than stripped.
+        [TestCase("primus::ping::12\"34", TestName = "Ping_with_interior_quote_in_timestamp_is_rejected_as_malformed")]
         public void Try_parse_server_time_returns_false_for_unparseable_tail(string message)
         {
             bool parsed = EthStatsClient.TryParseServerTime(message, out long serverTime);
@@ -52,6 +55,7 @@ namespace Nethermind.EthStats.Test
         [TestCase("primus::ping::9223372036854775807", long.MaxValue, TestName = "Ping_with_long_max_value_timestamp_is_parsed")]
         [TestCase("extra::primus::ping::1690000000000", 1690000000000L, TestName = "Ping_with_extra_separators_still_parses_last_segment")]
         [TestCase("\"primus::ping::1690000000000\"", 1690000000000L, TestName = "Ping_in_wire_format_with_surrounding_quotes_is_parsed")]
+        [TestCase("12345", 12345L, TestName = "Ping_with_no_separator_and_numeric_payload_parses_whole_message")]
         public void Try_parse_server_time_returns_parsed_value_for_valid_tail(string message, long expectedServerTime)
         {
             bool parsed = EthStatsClient.TryParseServerTime(message, out long serverTime);

--- a/src/Nethermind/Nethermind.EthStats.Test/EthStatsClientTests.cs
+++ b/src/Nethermind/Nethermind.EthStats.Test/EthStatsClientTests.cs
@@ -29,5 +29,38 @@ namespace Nethermind.EthStats.Test
             EthStatsClient ethClient = new(url, 5000, Substitute.For<IMessageSender>(), LimboLogs.Instance);
             Assert.Throws<ArgumentException>(() => ethClient.BuildUrl());
         }
+
+        [TestCase("primus::ping::", TestName = "Ping_with_empty_timestamp_tail_fails_to_parse")]
+        [TestCase("primus::ping::not-a-number", TestName = "Ping_with_non_numeric_timestamp_tail_fails_to_parse")]
+        [TestCase("primus::ping::   ", TestName = "Ping_with_whitespace_only_timestamp_tail_fails_to_parse")]
+        [TestCase("primus::ping::99999999999999999999999999999", TestName = "Ping_with_timestamp_tail_overflowing_long_fails_to_parse")]
+        [TestCase("no-separator-at-all", TestName = "Ping_with_no_separator_at_all_fails_to_parse")]
+        [TestCase("\"primus::ping::\"", TestName = "Ping_in_wire_format_with_empty_timestamp_tail_fails_to_parse")]
+        public void Try_parse_server_time_returns_false_for_unparseable_tail(string message)
+        {
+            bool parsed = EthStatsClient.TryParseServerTime(message, out long serverTime);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parsed, Is.False);
+                Assert.That(serverTime, Is.EqualTo(0L));
+            }
+        }
+
+        [TestCase("primus::ping::1690000000000", 1690000000000L, TestName = "Ping_with_valid_positive_timestamp_is_parsed")]
+        [TestCase("primus::ping::-42", -42L, TestName = "Ping_with_negative_timestamp_is_parsed")]
+        [TestCase("primus::ping::9223372036854775807", long.MaxValue, TestName = "Ping_with_long_max_value_timestamp_is_parsed")]
+        [TestCase("extra::primus::ping::1690000000000", 1690000000000L, TestName = "Ping_with_extra_separators_still_parses_last_segment")]
+        [TestCase("\"primus::ping::1690000000000\"", 1690000000000L, TestName = "Ping_in_wire_format_with_surrounding_quotes_is_parsed")]
+        public void Try_parse_server_time_returns_parsed_value_for_valid_tail(string message, long expectedServerTime)
+        {
+            bool parsed = EthStatsClient.TryParseServerTime(message, out long serverTime);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parsed, Is.True);
+                Assert.That(serverTime, Is.EqualTo(expectedServerTime));
+            }
+        }
     }
 }

--- a/src/Nethermind/Nethermind.EthStats/Clients/EthStatsClient.cs
+++ b/src/Nethermind/Nethermind.EthStats/Clients/EthStatsClient.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Nethermind.Core;
@@ -123,8 +122,13 @@ namespace Nethermind.EthStats.Clients
         private async Task HandlePingAsync(string message)
         {
             long clientTime = Timestamper.Default.UnixTime.MillisecondsLong;
-            string? serverTimeString = message.Split("::").LastOrDefault()?.Replace("\"", string.Empty);
-            long serverTime = serverTimeString is null ? clientTime : long.Parse(serverTimeString);
+            bool parsed = TryParseServerTime(message, out long serverTime);
+            // The server discards the pong's payload, so any timestamp works; latency is skipped to avoid a fabricated 0 ms reading.
+            if (!parsed)
+            {
+                if (_logger.IsDebug) _logger.Debug($"Ignoring unparseable ETH stats ping timestamp in message '{message}'.");
+                serverTime = clientTime;
+            }
             long latency = clientTime >= serverTime ? clientTime - serverTime : serverTime - clientTime;
             string pong = $"\"primus::pong::{serverTime}\"";
             if (_logger.IsDebug) _logger.Debug($"Sending 'pong' message to ETH stats...");
@@ -132,8 +136,14 @@ namespace Nethermind.EthStats.Clients
             if (_client is not null)
             {
                 _client.Send(pong);
-                await _messageSender.SendAsync(_client, new LatencyMessage(latency));
+                if (parsed) await _messageSender.SendAsync(_client, new LatencyMessage(latency));
             }
+        }
+
+        internal static bool TryParseServerTime(string message, out long serverTime)
+        {
+            string serverTimeString = message.Split("::")[^1].Replace("\"", string.Empty);
+            return long.TryParse(serverTimeString, out serverTime);
         }
 
         public void Dispose() => _client?.Dispose();

--- a/src/Nethermind/Nethermind.EthStats/Clients/EthStatsClient.cs
+++ b/src/Nethermind/Nethermind.EthStats/Clients/EthStatsClient.cs
@@ -142,8 +142,13 @@ namespace Nethermind.EthStats.Clients
 
         internal static bool TryParseServerTime(string message, out long serverTime)
         {
-            string serverTimeString = message.Split("::")[^1].Replace("\"", string.Empty);
-            return long.TryParse(serverTimeString, out serverTime);
+            ReadOnlySpan<char> span = message;
+            int separatorIndex = span.LastIndexOf("::");
+            // Wire frames quote only the outer message, so a well-formed timestamp segment
+            // never contains a quote; an interior quote here is malformed input and is left
+            // in place to fail parsing rather than stripped into a different number.
+            ReadOnlySpan<char> serverTimeSpan = separatorIndex < 0 ? span : span[(separatorIndex + 2)..];
+            return long.TryParse(serverTimeSpan.Trim('"'), out serverTime);
         }
 
         public void Dispose() => _client?.Dispose();


### PR DESCRIPTION
## Changes

### What

`EthStatsClient.HandlePingAsync` parses the timestamp out of the server's `primus::ping::<ts>` heartbeat with `long.Parse`. The guard ahead of it tests the split result for `null`, but `string.Split` always yields at least one non-null element — `LastOrDefault()` returns `""` for an empty tail, not `null` — so the guard never fires. An empty or non-numeric tail throws `FormatException`; a tail beyond `long` range throws `OverflowException`.

`long.TryParse` replaces `long.Parse`, behind a new `internal static TryParseServerTime`. The dead null-conditional inherited from the `LastOrDefault()` call goes with it.

### Why it terminates the node

The subscription registered in `InitAsync` binds an `async` lambda to `Subscribe(Action<T>)`, so the handler is effectively `async void`. `AsyncVoidMethodBuilder` routes the exception to `ThrowAsync`, and with no `SynchronizationContext` installed it is rethrown on a thread-pool thread as an unhandled exception, terminating the process — `Program.cs`'s `AppDomain.UnhandledException` handler only logs it and cannot mark it handled.

This requires `EthStats.Enabled`, which is off by default, so only nodes opting into ethstats reporting are affected.

### Implementation note

On an unparseable tail the pong is still sent, using the client's own time as a placeholder: primus's server-side `incoming::pong` handler marks the node alive on arrival and discards the payload, so withholding the pong would only get the node dropped, and any timestamp carried in it is inert.

The `LatencyMessage` is skipped in that case rather than computed from the placeholder, which would publish a fabricated 0 ms reading. That matches `EthStatsIntegration`, which likewise sends no latency message when the timing is implausible.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

11 cases in `EthStatsClientTests.cs` against `TryParseServerTime`, covering empty, non-numeric, whitespace-only, overflow and no-separator tails alongside the valid forms — positive, negative, `long.MaxValue` and extra separators.

Included is the JSON-encoded wire format, where the message arrives with surrounding double quotes per primus's json parser. That is what the `Replace("\"", string.Empty)` call exists to strip, and no prior test exercised it — deleting that call left the suite green before these cases were added, and fails now.

Verified against master by reinstating `long.Parse` in the method body: the six malformed cases fail with the `FormatException`/`OverflowException` described above, and every valid case keeps passing.

`Nethermind.EthStats.Test`: 34 passing, 0 failed, 0 skipped.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Two adjacent issues in this file are deliberately left out. Both are pre-existing, and neither is introduced or widened here.

- The subscription lambda is `async void`, the `IDisposable` it returns is discarded, `Dispose()` does not null `_client`, and `EthStatsClient.Dispose()` is never called by anything — `IEthStatsClient` does not extend `IDisposable`, so `EthStatsStep` cannot reach it. `EthStatsIntegration.Dispose()` does dispose the same underlying `IWebsocketClient`, so the socket is released and the rest is hygiene rather than a live handle leak. Happy to take it as a follow-up.
- `clientTime - serverTime` is unchecked, so a negative or `long.MaxValue` timestamp wraps. Reachability is identical to master, which parses those values just as happily.
