### PR TITLE
perf(evm): trim initialized memory checks

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
@@ -1209,6 +1209,58 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
         }
     }
 
+    [Test]
+    public void Load32BytesAfterGas_OnDirtyReusedMemory_PreservesPrefixAndZeroesTail(
+        [Values(false, true)] bool inline,
+        [Values(0, 16, 1000, 32760)] int offset)
+    {
+        using ThreadCacheReservation cacheReservation = PrimeDirtyBuffer();
+        using EvmFrameMemory owner = new();
+        owner.GetSpan().Fill(0xa7);
+        EvmPooledMemory memory = inline ? new(owner) : default;
+        byte[] prefix = CreatePattern(EvmPooledMemory.WordSize, 0x31);
+        byte[] expected = new byte[AlignToWord(offset + EvmPooledMemory.WordSize)];
+        prefix.CopyTo(expected, 0);
+
+        try
+        {
+            UInt256 start = UInt256.Zero;
+            memory.CalculateMemoryCost(in start, EvmPooledMemory.WordSize, out _);
+            memory.SaveAfterGas(in start, prefix);
+            Assert.That(GetInitializedSize(ref memory), Is.EqualTo((ulong)prefix.Length),
+                "precondition: only the written prefix is initialized");
+            if (!inline)
+            {
+                AssertDirtyTailWasReused(ref memory);
+            }
+
+            UInt256 location = (UInt256)offset;
+            memory.CalculateMemoryCost(in location, EvmPooledMemory.WordSize, out bool outOfGas);
+            Assert.That(outOfGas, Is.False, "the requested read fits the EVM memory limit");
+
+            byte[] actual = MemoryMarshal.CreateReadOnlySpan(
+                ref memory.Load32BytesAfterGas(in location), EvmPooledMemory.WordSize).ToArray();
+            byte[] repeated = MemoryMarshal.CreateReadOnlySpan(
+                ref memory.Load32BytesAfterGas(in location), EvmPooledMemory.WordSize).ToArray();
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(actual, Is.EqualTo(expected.AsSpan(offset, EvmPooledMemory.WordSize).ToArray()),
+                    "unwritten bytes must be zero even across a spill or buffer growth");
+                Assert.That(repeated, Is.EqualTo(actual), "the initialized fast path must return identical bytes");
+                Assert.That(GetInitializedSize(ref memory),
+                    Is.LessThanOrEqualTo((ulong)(memory.BackingArray?.Length ?? EvmPooledMemory.InlineCapacity)),
+                    "the initialized prefix must fit its backing storage");
+                Assert.That(ReadVisibleMemory(ref memory), Is.EqualTo(expected),
+                    "materializing a read must preserve the written prefix and logical memory size");
+            }
+        }
+        finally
+        {
+            memory.Dispose();
+        }
+    }
+
     private static ThreadCacheReservation PrimeDirtyBuffer()
     {
         ThreadCacheReservation cacheReservation = new();

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -338,7 +338,7 @@ public struct EvmPooledMemory
         int offset = TruncateToInt32(location.u0);
         ulong overwriteEnd = location.u0 + WordSize;
         byte[]? memory = _memory;
-        if (memory is not null && overwriteEnd <= (ulong)memory.Length)
+        if (memory is not null)
         {
             ulong initializedSize = _initializedSize;
             if (overwriteEnd <= initializedSize)
@@ -347,7 +347,7 @@ public struct EvmPooledMemory
                 return;
             }
 
-            if (location.u0 <= initializedSize)
+            if (location.u0 <= initializedSize && overwriteEnd <= (ulong)memory.Length)
             {
                 WriteWord(memory, offset, word);
                 _initializedSize = overwriteEnd;
@@ -394,7 +394,7 @@ public struct EvmPooledMemory
         int offset = TruncateToInt32(location.u0);
         ulong overwriteEnd = location.u0 + 1;
         byte[]? memory = _memory;
-        if (memory is not null && overwriteEnd <= (ulong)memory.Length && overwriteEnd <= _initializedSize)
+        if (memory is not null && overwriteEnd <= _initializedSize)
         {
             ref byte memoryData = ref MemoryMarshal.GetArrayDataReference(memory);
             Unsafe.Add(ref memoryData, offset) = value;
@@ -687,7 +687,8 @@ public struct EvmPooledMemory
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void EnsureRented(ulong requiredEnd)
     {
-        if (requiredEnd > GetBackingCapacity() || requiredEnd > _initializedSize)
+        Debug.Assert(_initializedSize <= GetBackingCapacity());
+        if (requiredEnd > _initializedSize)
         {
             RentSlow(requiredEnd);
         }


### PR DESCRIPTION
## Changes

- Avoid redundant backing-capacity checks when EVM memory accesses fit within the initialized prefix. Word stores retain the capacity check when extending that prefix; growth, zeroing and gas accounting are unchanged.
- Add eight parameterized cases covering dirty inline/array storage, reads crossing the initialized prefix, inline spill and array growth.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

### Requires testing

- [x] Yes
- [ ] No

### If yes, did you write tests?

- [x] Yes
- [ ] No

### Notes on testing

- Release build of `Nethermind.Evm.Test` passed with zero warnings and errors; test execution awaits CI.
- `git diff --check` passed.

### ARM64 RPC benchmark

[Successful benchmark run](https://github.com/NethermindEth/nethermind/actions/runs/34480692412) using the private 497-call 0x corpus on the same ARM64 runner and flat-state snapshot at block 25490000.

- Baseline: `nethermindeth/nethermind:master-268ed1d`.
- Candidate: `nethermindeth/nethermind:ethcall-tip-0x-268ed1d-v1` (commit `d11383a02eef71a59a0b3ef6d5c901086f44b97c`).
- A/B/B/A order, 20,000 requested calls per load cell, 1,000 VUs, and a 120-second warmup capped at 150 rps per arm.
- All eight load cells and all warmups reported 0% failures. Both candidate response-parity passes matched the baseline on 497/497 calls.

| Load | Master mean latency | Candidate mean latency | Change |
| --- | ---: | ---: | ---: |
| 100 rps | 15.81 ms | 15.64 ms | -1.12% |
| 300 rps | 15.89 ms | 15.65 ms | -1.52% |

Values are arithmetic averages of the two per-run mean latencies for each image. These are small observed improvements, not a statistically established speedup: the baseline's 300-rps mean moved from 16.02 ms to 15.76 ms between repetitions, comparable to the measured difference. This static-snapshot benchmark does not measure live block-import or reorg contention. AMD64 results are pending.

[Download aggregate results](https://github.com/NethermindEth/nethermind/actions/runs/34480692412/artifacts/10154867352).

## Documentation

### Requires documentation update

- [ ] Yes
- [x] No

### Requires explanation in Release Notes

- [ ] Yes
- [x] No
