### PR TITLE
fix(xdc): charge and burn gas for randomize-contract transactions

### DIFF
--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -1061,7 +1061,7 @@ namespace Nethermind.Evm.TransactionProcessing
             return opcodeGasPrice;
         }
 
-        protected bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
+        protected virtual bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
             tx.TryCalculatePremiumPerGas(baseFee, out premiumPerGas);
 
         protected virtual TransactionResult ValidateSender(Transaction tx, BlockHeader header, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts)

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
@@ -138,7 +138,10 @@ internal class XdcTransactionProcessorTests
     // A randomize transaction reaches PayFees and must pay nobody; a sign transaction is routed to
     // ExecuteSpecialTransaction long before, and is covered here only against a future routing change.
     [Test]
-    public void PayFees_SignOrRandomizeTransaction_PaysNobody([Values] bool tipTrc21FeeEnabled, [Values] bool toBlockSigner)
+    public void PayFees_SignOrRandomizeTransaction_PaysNobody(
+        [Values] bool tipTrc21FeeEnabled,
+        [Values] bool toBlockSigner,
+        [Values] bool eip1559Tx)
     {
         Address blockSigner = TestItem.AddressE;
         Address randomize = TestItem.AddressC;
@@ -157,8 +160,10 @@ internal class XdcTransactionProcessorTests
         Transaction tx = Build.A.Transaction
             .WithTo(toBlockSigner ? blockSigner : randomize)
             .WithGasPrice(2 * (UInt256)XdcBaseFeeCalculator.BaseFee)
+            .WithMaxFeePerGas(2 * (UInt256)XdcBaseFeeCalculator.BaseFee)
+            .WithMaxPriorityFeePerGas((UInt256)XdcBaseFeeCalculator.BaseFee)
             .WithGasLimit(100000)
-            .WithType(TxType.Legacy)
+            .WithType(eip1559Tx ? TxType.EIP1559 : TxType.Legacy)
             .TestObject;
 
         XdcBlockHeader header = Build.A.XdcBlockHeader()

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
@@ -135,21 +135,24 @@ internal class XdcTransactionProcessorTests
     /// carries a non-zero gas price — which stays invisible while the premium happens to be zero.
     /// </remarks>
     [Test]
-    public void PayFees_SpecialTransaction_PaysNobody([Values] bool tipTrc21FeeEnabled)
+    public void PayFees_SpecialTransaction_PaysNobody([Values] bool tipTrc21FeeEnabled, [Values] bool toBlockSigner)
     {
-        _spec.IsTipTrc21FeeEnabled.Returns(tipTrc21FeeEnabled);
-        _spec.IsEip1559Enabled.Returns(true);
-        _spec.RandomizeSMCBinary.Returns(TestItem.AddressC);
-        _spec.BlockSignerContract.Returns(TestItem.AddressB);
-
+        Address blockSigner = TestItem.AddressE;
+        Address randomize = TestItem.AddressC;
         Address beneficiary = TestItem.AddressB;
         Address owner = TestItem.AddressD;
+
+        _spec.IsTipTrc21FeeEnabled.Returns(tipTrc21FeeEnabled);
+        _spec.IsEip1559Enabled.Returns(true);
+        _spec.RandomizeSMCBinary.Returns(randomize);
+        _spec.BlockSignerContract.Returns(blockSigner);
+
         _stateProvider!.CreateAccount(beneficiary, AccountBalance);
         _stateProvider.CreateAccount(owner, UInt256.Zero);
         _masternodeVotingContract.GetCandidateOwner(Arg.Any<IWorldState>(), beneficiary).Returns(owner);
 
         Transaction tx = Build.A.Transaction
-            .WithTo(TestItem.AddressC)
+            .WithTo(toBlockSigner ? blockSigner : randomize)
             .WithGasPrice(2 * (UInt256)XdcBaseFeeCalculator.BaseFee)
             .WithGasLimit(100000)
             .WithType(TxType.Legacy)
@@ -180,9 +183,13 @@ internal class XdcTransactionProcessorTests
     /// runs <c>buyGas</c>, so a client that skips the charge computes a different state root and forks.
     /// </remarks>
     [TestCase(true, true, 0L, true, TestName = "Special transaction below the base fee is exempt from the floor")]
+    [TestCase(true, true, 1000000000L, true, TestName = "Special transaction below the base fee but non-zero is charged at its own price")]
     [TestCase(true, true, XdcBaseFeeCalculator.BaseFee, true, TestName = "Special transaction at the base fee is charged")]
+    [TestCase(true, true, 2 * XdcBaseFeeCalculator.BaseFee, true, TestName = "Special transaction above the base fee is charged")]
     [TestCase(true, false, 0L, false, TestName = "Ordinary transaction below the base fee is rejected")]
+    [TestCase(true, false, 1000000000L, false, TestName = "Ordinary transaction below the base fee but non-zero is rejected")]
     [TestCase(true, false, XdcBaseFeeCalculator.BaseFee, true, TestName = "Ordinary transaction at the base fee is charged")]
+    [TestCase(true, false, 2 * XdcBaseFeeCalculator.BaseFee, true, TestName = "Ordinary transaction above the base fee is charged")]
     // Before EIP-1559 there is no floor to waive, so a special transaction is charged like any other.
     [TestCase(false, true, 0L, true, TestName = "Pre-1559 special transaction with no gas price is free")]
     [TestCase(false, true, XdcBaseFeeCalculator.BaseFee, true, TestName = "Pre-1559 special transaction is charged")]
@@ -241,6 +248,51 @@ internal class XdcTransactionProcessorTests
             Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MaxFeePerGasBelowBaseFee));
             Assert.That(charged, Is.EqualTo(UInt256.Zero));
         }
+    }
+
+    /// <remarks>
+    /// The floor waiver does not change how much a special transaction pays: the charge still follows
+    /// the ordinary rule, <c>min(maxFeePerGas, maxPriorityFeePerGas + baseFee)</c>.
+    /// </remarks>
+    [Test]
+    public void BuyGas_SpecialEip1559Transaction_ChargesTheEffectiveGasPrice()
+    {
+        const long gasLimit = 100000;
+        Address randomizeContract = TestItem.AddressC;
+
+        XdcReleaseSpec spec = new()
+        {
+            IsEip1559Enabled = true,
+            BlockSignerContract = TestItem.AddressB,
+            RandomizeSMCBinary = randomizeContract,
+            BlackListedAddresses = [],
+        };
+        _specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
+
+        Transaction tx = Build.A.Transaction
+            .WithSenderAddress(TestItem.AddressA)
+            .WithTo(randomizeContract)
+            .WithType(TxType.EIP1559)
+            .WithMaxFeePerGas(2 * (UInt256)XdcBaseFeeCalculator.BaseFee)          // 25 gwei
+            .WithMaxPriorityFeePerGas((UInt256)XdcBaseFeeCalculator.BaseFee / 5)  // 2.5 gwei
+            .WithGasLimit(gasLimit)
+            .TestObject;
+
+        XdcBlockHeader header = Build.A.XdcBlockHeader()
+            .WithNumber(1)
+            .WithBaseFee((UInt256)XdcBaseFeeCalculator.BaseFee)                   // 12.5 gwei
+            .TestObject;
+
+        _transactionProcessor!.SetBlockExecutionContext(header);
+
+        UInt256 balanceBefore = _stateProvider!.GetBalance(TestItem.AddressA);
+        TransactionResult result = _transactionProcessor.TestBuyGas(tx, spec, out UInt256 effectiveGasPrice);
+
+        // min(25, 2.5 + 12.5) = 15 gwei, i.e. the tip is capped by the fee cap, not by the waiver.
+        Assert.That(effectiveGasPrice, Is.EqualTo((UInt256)XdcBaseFeeCalculator.BaseFee * 6 / 5));
+        Assert.That(result.TransactionExecuted, Is.True, result.ErrorDescription);
+        Assert.That(balanceBefore - _stateProvider.GetBalance(TestItem.AddressA),
+            Is.EqualTo(effectiveGasPrice * gasLimit));
     }
 
     private class TestXdcTransactionProcessor(

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
@@ -130,6 +130,51 @@ internal class XdcTransactionProcessorTests
     }
 
     /// <remarks>
+    /// The gas a special transaction spends is burned: XDPoSChain guards its whole fee payment with
+    /// <c>!types.IsSpecialTx(msg.To)</c>, so crediting it forks the chain once such a transaction
+    /// carries a non-zero gas price — which stays invisible while the premium happens to be zero.
+    /// </remarks>
+    [Test]
+    public void PayFees_SpecialTransaction_PaysNobody([Values] bool tipTrc21FeeEnabled)
+    {
+        _spec.IsTipTrc21FeeEnabled.Returns(tipTrc21FeeEnabled);
+        _spec.IsEip1559Enabled.Returns(true);
+        _spec.RandomizeSMCBinary.Returns(TestItem.AddressC);
+        _spec.BlockSignerContract.Returns(TestItem.AddressB);
+
+        Address beneficiary = TestItem.AddressB;
+        Address owner = TestItem.AddressD;
+        _stateProvider!.CreateAccount(beneficiary, AccountBalance);
+        _stateProvider.CreateAccount(owner, UInt256.Zero);
+        _masternodeVotingContract.GetCandidateOwner(Arg.Any<IWorldState>(), beneficiary).Returns(owner);
+
+        Transaction tx = Build.A.Transaction
+            .WithTo(TestItem.AddressC)
+            .WithGasPrice(2 * (UInt256)XdcBaseFeeCalculator.BaseFee)
+            .WithGasLimit(100000)
+            .WithType(TxType.Legacy)
+            .TestObject;
+
+        XdcBlockHeader header = Build.A.XdcBlockHeader()
+            .WithNumber(1)
+            .WithBaseFee((UInt256)XdcBaseFeeCalculator.BaseFee)
+            .TestObject;
+        header.Beneficiary = beneficiary;
+
+        _transactionProcessor!.SetBlockExecutionContext(header);
+
+        UInt256 beneficiaryBefore = _stateProvider.GetBalance(beneficiary);
+        UInt256 ownerBefore = _stateProvider.GetBalance(owner);
+
+        _transactionProcessor.TestPayFees(tx, header, _spec, new FeesTracer(), default, 21046,
+            premiumPerGas: (UInt256)XdcBaseFeeCalculator.BaseFee,
+            tx.CalculateEffectiveGasPrice(true, header.BaseFeePerGas), UInt256.Zero, StatusCode.Success);
+
+        Assert.That(_stateProvider.GetBalance(beneficiary), Is.EqualTo(beneficiaryBefore));
+        Assert.That(_stateProvider.GetBalance(owner), Is.EqualTo(ownerBefore));
+    }
+
+    /// <remarks>
     /// XDPoSChain waives only the EIP-1559 fee floor for the special contracts
     /// (<c>!types.IsSpecialTx(msg.To)</c> in <c>core/state_transition.go</c> <c>preCheck</c>) and still
     /// runs <c>buyGas</c>, so a client that skips the charge computes a different state root and forks.

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
@@ -118,24 +118,27 @@ internal class XdcTransactionProcessorTests
         {
             UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(_spec.IsEip1559Enabled, header.BaseFeePerGas);
             UInt256 expectedFees = effectiveGasPrice * spentGas;
-            Assert.That(ownerReceivedFees, Is.EqualTo(expectedFees));
-            Assert.That(beneficiaryReceivedFees, Is.EqualTo(UInt256.Zero));
+            Assert.Multiple(() =>
+            {
+                Assert.That(ownerReceivedFees, Is.EqualTo(expectedFees));
+                Assert.That(beneficiaryReceivedFees, Is.EqualTo(UInt256.Zero));
+            });
         }
         else
         {
             UInt256 expectedFees = premiumPerGas * spentGas;
-            Assert.That(beneficiaryReceivedFees, Is.EqualTo(expectedFees));
-            Assert.That(ownerReceivedFees, Is.EqualTo(UInt256.Zero));
+            Assert.Multiple(() =>
+            {
+                Assert.That(beneficiaryReceivedFees, Is.EqualTo(expectedFees));
+                Assert.That(ownerReceivedFees, Is.EqualTo(UInt256.Zero));
+            });
         }
     }
 
-    /// <remarks>
-    /// The gas a special transaction spends is burned: XDPoSChain guards its whole fee payment with
-    /// <c>!types.IsSpecialTx(msg.To)</c>, so crediting it forks the chain once such a transaction
-    /// carries a non-zero gas price — which stays invisible while the premium happens to be zero.
-    /// </remarks>
+    // A randomize transaction reaches PayFees and must pay nobody; a sign transaction is routed to
+    // ExecuteSpecialTransaction long before, and is covered here only against a future routing change.
     [Test]
-    public void PayFees_SpecialTransaction_PaysNobody([Values] bool tipTrc21FeeEnabled, [Values] bool toBlockSigner)
+    public void PayFees_SignOrRandomizeTransaction_PaysNobody([Values] bool tipTrc21FeeEnabled, [Values] bool toBlockSigner)
     {
         Address blockSigner = TestItem.AddressE;
         Address randomize = TestItem.AddressC;
@@ -173,28 +176,26 @@ internal class XdcTransactionProcessorTests
             premiumPerGas: (UInt256)XdcBaseFeeCalculator.BaseFee,
             tx.CalculateEffectiveGasPrice(true, header.BaseFeePerGas), UInt256.Zero, StatusCode.Success);
 
-        Assert.That(_stateProvider.GetBalance(beneficiary), Is.EqualTo(beneficiaryBefore));
-        Assert.That(_stateProvider.GetBalance(owner), Is.EqualTo(ownerBefore));
+        Assert.Multiple(() =>
+        {
+            Assert.That(_stateProvider.GetBalance(beneficiary), Is.EqualTo(beneficiaryBefore));
+            Assert.That(_stateProvider.GetBalance(owner), Is.EqualTo(ownerBefore));
+        });
     }
 
-    /// <remarks>
-    /// XDPoSChain waives only the EIP-1559 fee floor for the special contracts
-    /// (<c>!types.IsSpecialTx(msg.To)</c> in <c>core/state_transition.go</c> <c>preCheck</c>) and still
-    /// runs <c>buyGas</c>, so a client that skips the charge computes a different state root and forks.
-    /// </remarks>
-    [TestCase(true, true, 0L, true, TestName = "Special transaction below the base fee is exempt from the floor")]
-    [TestCase(true, true, 1000000000L, true, TestName = "Special transaction below the base fee but non-zero is charged at its own price")]
-    [TestCase(true, true, XdcBaseFeeCalculator.BaseFee, true, TestName = "Special transaction at the base fee is charged")]
-    [TestCase(true, true, 2 * XdcBaseFeeCalculator.BaseFee, true, TestName = "Special transaction above the base fee is charged")]
+    [TestCase(true, true, 0L, true, TestName = "Randomize transaction below the base fee is exempt from the floor")]
+    [TestCase(true, true, 1000000000L, true, TestName = "Randomize transaction below the base fee but non-zero is charged at its own price")]
+    [TestCase(true, true, XdcBaseFeeCalculator.BaseFee, true, TestName = "Randomize transaction at the base fee is charged")]
+    [TestCase(true, true, 2 * XdcBaseFeeCalculator.BaseFee, true, TestName = "Randomize transaction above the base fee is charged")]
     [TestCase(true, false, 0L, false, TestName = "Ordinary transaction below the base fee is rejected")]
     [TestCase(true, false, 1000000000L, false, TestName = "Ordinary transaction below the base fee but non-zero is rejected")]
     [TestCase(true, false, XdcBaseFeeCalculator.BaseFee, true, TestName = "Ordinary transaction at the base fee is charged")]
     [TestCase(true, false, 2 * XdcBaseFeeCalculator.BaseFee, true, TestName = "Ordinary transaction above the base fee is charged")]
-    // Before EIP-1559 there is no floor to waive, so a special transaction is charged like any other.
-    [TestCase(false, true, 0L, true, TestName = "Pre-1559 special transaction with no gas price is free")]
-    [TestCase(false, true, XdcBaseFeeCalculator.BaseFee, true, TestName = "Pre-1559 special transaction is charged")]
+    // Before EIP-1559 there is no floor to waive, so a randomize transaction is charged like any other.
+    [TestCase(false, true, 0L, true, TestName = "Pre-1559 randomize transaction with no gas price is free")]
+    [TestCase(false, true, XdcBaseFeeCalculator.BaseFee, true, TestName = "Pre-1559 randomize transaction is charged")]
     [TestCase(false, false, XdcBaseFeeCalculator.BaseFee, true, TestName = "Pre-1559 ordinary transaction is charged")]
-    public void BuyGas_SpecialTransaction_IsExemptFromTheFeeFloorButStillPaysForGas(
+    public void BuyGas_RandomizeTransaction_IsExemptFromFeeFloorButPaysForGas(
         bool eip1559Enabled,
         bool toRandomizeContract,
         long gasPrice,
@@ -203,7 +204,7 @@ internal class XdcTransactionProcessorTests
         const long gasLimit = 100000;
         Address randomizeContract = TestItem.AddressC;
 
-        // A concrete spec rather than a substitute: the processor casts to XdcReleaseSpec in places.
+        // A concrete spec, not a substitute: the processor casts to XdcReleaseSpec in places.
         XdcReleaseSpec spec = new()
         {
             IsEip1559Enabled = eip1559Enabled,
@@ -234,28 +235,26 @@ internal class XdcTransactionProcessorTests
 
         UInt256 charged = balanceBefore - _stateProvider.GetBalance(TestItem.AddressA);
 
-        // A legacy transaction's effective gas price is its gas price; asserting it keeps the charge
-        // below from passing vacuously if the price were zeroed out for these contracts.
-        Assert.That(effectiveGasPrice, Is.EqualTo((UInt256)gasPrice));
+        Assert.Multiple(() =>
+        {
+            // Asserted so the charge below cannot pass vacuously on a zeroed price.
+            Assert.That(effectiveGasPrice, Is.EqualTo((UInt256)gasPrice));
 
-        if (expectedToBeCharged)
-        {
-            Assert.That(result.TransactionExecuted, Is.True, result.ErrorDescription);
-            Assert.That(charged, Is.EqualTo(effectiveGasPrice * gasLimit));
-        }
-        else
-        {
-            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MaxFeePerGasBelowBaseFee));
-            Assert.That(charged, Is.EqualTo(UInt256.Zero));
-        }
+            if (expectedToBeCharged)
+            {
+                Assert.That(result.TransactionExecuted, Is.True, result.ErrorDescription);
+                Assert.That(charged, Is.EqualTo(effectiveGasPrice * gasLimit));
+            }
+            else
+            {
+                Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MaxFeePerGasBelowBaseFee));
+                Assert.That(charged, Is.EqualTo(UInt256.Zero));
+            }
+        });
     }
 
-    /// <remarks>
-    /// The floor waiver does not change how much a special transaction pays: the charge still follows
-    /// the ordinary rule, <c>min(maxFeePerGas, maxPriorityFeePerGas + baseFee)</c>.
-    /// </remarks>
     [Test]
-    public void BuyGas_SpecialEip1559Transaction_ChargesTheEffectiveGasPrice()
+    public void BuyGas_RandomizeEip1559Transaction_ChargesEffectiveGasPrice()
     {
         const long gasLimit = 100000;
         Address randomizeContract = TestItem.AddressC;
@@ -288,11 +287,14 @@ internal class XdcTransactionProcessorTests
         UInt256 balanceBefore = _stateProvider!.GetBalance(TestItem.AddressA);
         TransactionResult result = _transactionProcessor.TestBuyGas(tx, spec, out UInt256 effectiveGasPrice);
 
-        // min(25, 2.5 + 12.5) = 15 gwei, i.e. the tip is capped by the fee cap, not by the waiver.
-        Assert.That(effectiveGasPrice, Is.EqualTo((UInt256)XdcBaseFeeCalculator.BaseFee * 6 / 5));
-        Assert.That(result.TransactionExecuted, Is.True, result.ErrorDescription);
-        Assert.That(balanceBefore - _stateProvider.GetBalance(TestItem.AddressA),
-            Is.EqualTo(effectiveGasPrice * gasLimit));
+        Assert.Multiple(() =>
+        {
+            // min(25, 2.5 + 12.5) = 15 gwei
+            Assert.That(effectiveGasPrice, Is.EqualTo((UInt256)XdcBaseFeeCalculator.BaseFee * 6 / 5));
+            Assert.That(result.TransactionExecuted, Is.True, result.ErrorDescription);
+            Assert.That(balanceBefore - _stateProvider.GetBalance(TestItem.AddressA),
+                Is.EqualTo(effectiveGasPrice * gasLimit));
+        });
     }
 
     private class TestXdcTransactionProcessor(
@@ -304,9 +306,7 @@ internal class XdcTransactionProcessorTests
         ILogManager? logManager,
         IMasternodeVotingContract masternodeVotingContract) : XdcTransactionProcessor(blobBaseFeeCalculator, specProvider, worldState, virtualMachine, codeInfoRepository, logManager, masternodeVotingContract)
     {
-        /// <summary>
-        /// Prices and buys gas the way <c>Execute</c> does, so that an override of either step is exercised.
-        /// </summary>
+        // Prices and buys gas the way Execute does, so an override of either step is exercised.
         public TransactionResult TestBuyGas(Transaction tx, IReleaseSpec spec, out UInt256 effectiveGasPrice)
         {
             effectiveGasPrice = CalculateEffectiveGasPrice(

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcTransactionProcessorTests.cs
@@ -129,6 +129,75 @@ internal class XdcTransactionProcessorTests
         }
     }
 
+    /// <remarks>
+    /// XDPoSChain waives only the EIP-1559 fee floor for the special contracts
+    /// (<c>!types.IsSpecialTx(msg.To)</c> in <c>core/state_transition.go</c> <c>preCheck</c>) and still
+    /// runs <c>buyGas</c>, so a client that skips the charge computes a different state root and forks.
+    /// </remarks>
+    [TestCase(true, true, 0L, true, TestName = "Special transaction below the base fee is exempt from the floor")]
+    [TestCase(true, true, XdcBaseFeeCalculator.BaseFee, true, TestName = "Special transaction at the base fee is charged")]
+    [TestCase(true, false, 0L, false, TestName = "Ordinary transaction below the base fee is rejected")]
+    [TestCase(true, false, XdcBaseFeeCalculator.BaseFee, true, TestName = "Ordinary transaction at the base fee is charged")]
+    // Before EIP-1559 there is no floor to waive, so a special transaction is charged like any other.
+    [TestCase(false, true, 0L, true, TestName = "Pre-1559 special transaction with no gas price is free")]
+    [TestCase(false, true, XdcBaseFeeCalculator.BaseFee, true, TestName = "Pre-1559 special transaction is charged")]
+    [TestCase(false, false, XdcBaseFeeCalculator.BaseFee, true, TestName = "Pre-1559 ordinary transaction is charged")]
+    public void BuyGas_SpecialTransaction_IsExemptFromTheFeeFloorButStillPaysForGas(
+        bool eip1559Enabled,
+        bool toRandomizeContract,
+        long gasPrice,
+        bool expectedToBeCharged)
+    {
+        const long gasLimit = 100000;
+        Address randomizeContract = TestItem.AddressC;
+
+        // A concrete spec rather than a substitute: the processor casts to XdcReleaseSpec in places.
+        XdcReleaseSpec spec = new()
+        {
+            IsEip1559Enabled = eip1559Enabled,
+            BlockSignerContract = TestItem.AddressB,
+            RandomizeSMCBinary = randomizeContract,
+            BlackListedAddresses = [],
+        };
+        _specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(spec);
+
+        Transaction tx = Build.A.Transaction
+            .WithSenderAddress(TestItem.AddressA)
+            .WithTo(toRandomizeContract ? randomizeContract : TestItem.AddressD)
+            .WithGasPrice((UInt256)gasPrice)
+            .WithGasLimit(gasLimit)
+            .WithType(TxType.Legacy)
+            .TestObject;
+
+        XdcBlockHeader header = Build.A.XdcBlockHeader()
+            .WithNumber(1)
+            .WithBaseFee(eip1559Enabled ? (UInt256)XdcBaseFeeCalculator.BaseFee : UInt256.Zero)
+            .TestObject;
+
+        _transactionProcessor!.SetBlockExecutionContext(header);
+
+        UInt256 balanceBefore = _stateProvider!.GetBalance(TestItem.AddressA);
+
+        TransactionResult result = _transactionProcessor.TestBuyGas(tx, spec, out UInt256 effectiveGasPrice);
+
+        UInt256 charged = balanceBefore - _stateProvider.GetBalance(TestItem.AddressA);
+
+        // A legacy transaction's effective gas price is its gas price; asserting it keeps the charge
+        // below from passing vacuously if the price were zeroed out for these contracts.
+        Assert.That(effectiveGasPrice, Is.EqualTo((UInt256)gasPrice));
+
+        if (expectedToBeCharged)
+        {
+            Assert.That(result.TransactionExecuted, Is.True, result.ErrorDescription);
+            Assert.That(charged, Is.EqualTo(effectiveGasPrice * gasLimit));
+        }
+        else
+        {
+            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MaxFeePerGasBelowBaseFee));
+            Assert.That(charged, Is.EqualTo(UInt256.Zero));
+        }
+    }
+
     private class TestXdcTransactionProcessor(
         ITransactionProcessor.IBlobBaseFeeCalculator blobBaseFeeCalculator,
         ISpecProvider? specProvider,
@@ -138,6 +207,16 @@ internal class XdcTransactionProcessorTests
         ILogManager? logManager,
         IMasternodeVotingContract masternodeVotingContract) : XdcTransactionProcessor(blobBaseFeeCalculator, specProvider, worldState, virtualMachine, codeInfoRepository, logManager, masternodeVotingContract)
     {
+        /// <summary>
+        /// Prices and buys gas the way <c>Execute</c> does, so that an override of either step is exercised.
+        /// </summary>
+        public TransactionResult TestBuyGas(Transaction tx, IReleaseSpec spec, out UInt256 effectiveGasPrice)
+        {
+            effectiveGasPrice = CalculateEffectiveGasPrice(
+                tx, spec.IsEip1559Enabled, VirtualMachine.BlockExecutionContext.Header.BaseFeePerGas, out _);
+            return BuyGas(tx, spec, NullTxTracer.Instance, ExecutionOptions.None, in effectiveGasPrice, out _, out _, out _);
+        }
+
         public void TestPayFees(
             Transaction tx,
             XdcBlockHeader header,

--- a/src/Nethermind/Nethermind.Xdc/XdcTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcTransactionProcessor.cs
@@ -49,9 +49,10 @@ internal class XdcTransactionProcessor(
     {
         IXdcReleaseSpec xdcSpec = (IXdcReleaseSpec)spec;
 
-        // Randomize gas is charged in BuyGas but burned, not paid out: XDPoSChain guards its whole fee
-        // payment with !types.IsSpecialTx(msg.To) (core/state_transition.go). Sign transactions never
-        // reach here — Execute routes them to ExecuteSpecialTransaction, which charges no gas at all.
+        // Randomize gas is charged in BuyGas but burned, not paid out: the reference client guards its
+        // whole fee payment with !types.IsSpecialTx(msg.To), see XinFinOrg/XDPoSChain
+        // https://github.com/XinFinOrg/XDPoSChain/blob/5d080472c84a92a46f5fd0d343c09cca9f1b1356/core/state_transition.go#L505
+        // Sign transactions never reach here — Execute routes them to ExecuteSpecialTransaction.
         if (tx.IsSpecialTransaction(xdcSpec)) return;
 
         if (!xdcSpec.IsTipTrc21FeeEnabled)
@@ -74,9 +75,10 @@ internal class XdcTransactionProcessor(
             tracer.ReportFees(fee, UInt256.Zero);
     }
 
-    // A randomize transaction carries a zero gas price yet must execute, so XDPoSChain waives the
-    // EIP-1559 floor for it (!types.IsSpecialTx(msg.To) in preCheck) — the floor only: gas is still
-    // bought and refunded. The premium is left to the base calculation, which clamps it to zero.
+    // A randomize transaction carries a zero gas price yet must execute, so the reference client
+    // waives the EIP-1559 floor for it — the floor only: gas is still bought and refunded. The premium
+    // is left to the base calculation, which clamps it to zero. See XinFinOrg/XDPoSChain preCheck
+    // https://github.com/XinFinOrg/XDPoSChain/blob/5d080472c84a92a46f5fd0d343c09cca9f1b1356/core/state_transition.go#L356
     protected override bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
         base.TryCalculatePremiumPerGas(tx, in baseFee, out premiumPerGas)
         || tx.IsSpecialTransaction((IXdcReleaseSpec)VirtualMachine.BlockExecutionContext.Spec);

--- a/src/Nethermind/Nethermind.Xdc/XdcTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcTransactionProcessor.cs
@@ -49,8 +49,6 @@ internal class XdcTransactionProcessor(
     {
         IXdcReleaseSpec xdcSpec = (IXdcReleaseSpec)spec;
 
-        if (tx.IsSpecialTransaction(xdcSpec)) return;
-
         if (!xdcSpec.IsTipTrc21FeeEnabled)
         {
             base.PayFees(tx, header, spec, tracer, substate, spentGas, premiumPerGas, in effectiveGasPrice, blobBaseFee, statusCode);
@@ -71,19 +69,18 @@ internal class XdcTransactionProcessor(
             tracer.ReportFees(fee, UInt256.Zero);
     }
 
-    protected override TransactionResult BuyGas(Transaction tx, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts,
-        in UInt256 effectiveGasPrice, out UInt256 premiumPerGas, out UInt256 senderReservedGasPayment,
-        out UInt256 blobBaseFee)
-    {
-        if (tx.RequiresSpecialHandling((XdcReleaseSpec)spec) || tx.IsSpecialTransaction((XdcReleaseSpec)spec))
-        {
-            premiumPerGas = 0;
-            senderReservedGasPayment = 0;
-            blobBaseFee = 0;
-            return TransactionResult.Ok;
-        }
-        return base.BuyGas(tx, spec, tracer, opts, effectiveGasPrice, out premiumPerGas, out senderReservedGasPayment, out blobBaseFee);
-    }
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Transactions to the block-signer and randomize contracts are exempt from the EIP-1559 fee
+    /// floor, mirroring the <c>!types.IsSpecialTx(msg.To)</c> guard in XDPoSChain's
+    /// <c>core/state_transition.go</c> <c>preCheck</c>. The exemption covers the floor only: gas is
+    /// still bought, refunded and paid out for them, so skipping the charge forks the chain against
+    /// the reference client. The premium itself is left to the base calculation, which already
+    /// clamps it to zero for the zero-gas-price transactions the consensus engine generates.
+    /// </remarks>
+    protected override bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
+        base.TryCalculatePremiumPerGas(tx, in baseFee, out premiumPerGas)
+        || tx.IsSpecialTransaction((IXdcReleaseSpec)VirtualMachine.BlockExecutionContext.Spec);
 
     protected override TransactionResult ValidateSender(Transaction tx, BlockHeader header, IReleaseSpec spec, ITxTracer tracer, ExecutionOptions opts)
     {
@@ -151,24 +148,6 @@ internal class XdcTransactionProcessor(
             return TransactionResult.Ok;
         }
         return base.ValidateGas(tx, header, spec, in intrinsicGas, minGasRequired, validate);
-    }
-
-    protected override UInt256 CalculateEffectiveGasPrice(Transaction tx, bool eip1559Enabled, in UInt256 baseFee, out UInt256 opcodeGasPrice)
-    {
-        // IMPORTANT: if we override the effective gas price to 0, we must also set opcodeGasPrice to 0.
-        // TxExecutionContext is created with opcodeGasPrice and is later used for refunding, tracing, etc.
-        //
-        // Also: IsSpecialTransaction requires the IXdcReleaseSpec to decide Randomize vs BlockSigner, so
-        // we need the current block spec here.
-        IXdcReleaseSpec xdcSpec = (IXdcReleaseSpec)VirtualMachine.BlockExecutionContext.Spec;
-
-        if (tx.IsSpecialTransaction(xdcSpec))
-        {
-            opcodeGasPrice = UInt256.Zero;
-            return UInt256.Zero;
-        }
-
-        return base.CalculateEffectiveGasPrice(tx, eip1559Enabled, in baseFee, out opcodeGasPrice);
     }
 
     protected override IntrinsicGas<EthereumGasPolicy> CalculateIntrinsicGas(Transaction tx, IReleaseSpec spec, ulong blockGasLimit) =>

--- a/src/Nethermind/Nethermind.Xdc/XdcTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcTransactionProcessor.cs
@@ -49,6 +49,12 @@ internal class XdcTransactionProcessor(
     {
         IXdcReleaseSpec xdcSpec = (IXdcReleaseSpec)spec;
 
+        // The gas a special transaction spends is burned rather than paid out: XDPoSChain guards its
+        // whole fee payment with `!types.IsSpecialTx(msg.To)` (core/state_transition.go). Crediting it
+        // here forks the chain against the reference client whenever such a transaction carries a
+        // non-zero gas price, even though the sender is still charged for the gas in BuyGas.
+        if (tx.IsSpecialTransaction(xdcSpec)) return;
+
         if (!xdcSpec.IsTipTrc21FeeEnabled)
         {
             base.PayFees(tx, header, spec, tracer, substate, spentGas, premiumPerGas, in effectiveGasPrice, blobBaseFee, statusCode);
@@ -74,9 +80,10 @@ internal class XdcTransactionProcessor(
     /// Transactions to the block-signer and randomize contracts are exempt from the EIP-1559 fee
     /// floor, mirroring the <c>!types.IsSpecialTx(msg.To)</c> guard in XDPoSChain's
     /// <c>core/state_transition.go</c> <c>preCheck</c>. The exemption covers the floor only: gas is
-    /// still bought, refunded and paid out for them, so skipping the charge forks the chain against
-    /// the reference client. The premium itself is left to the base calculation, which already
-    /// clamps it to zero for the zero-gas-price transactions the consensus engine generates.
+    /// still bought and refunded for them, so skipping the charge forks the chain against the
+    /// reference client. What they never do is pay the fee out — see <see cref="PayFees"/>. The
+    /// premium itself is left to the base calculation, which already clamps it to zero for the
+    /// zero-gas-price transactions the consensus engine generates.
     /// </remarks>
     protected override bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
         base.TryCalculatePremiumPerGas(tx, in baseFee, out premiumPerGas)

--- a/src/Nethermind/Nethermind.Xdc/XdcTransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcTransactionProcessor.cs
@@ -49,10 +49,9 @@ internal class XdcTransactionProcessor(
     {
         IXdcReleaseSpec xdcSpec = (IXdcReleaseSpec)spec;
 
-        // The gas a special transaction spends is burned rather than paid out: XDPoSChain guards its
-        // whole fee payment with `!types.IsSpecialTx(msg.To)` (core/state_transition.go). Crediting it
-        // here forks the chain against the reference client whenever such a transaction carries a
-        // non-zero gas price, even though the sender is still charged for the gas in BuyGas.
+        // Randomize gas is charged in BuyGas but burned, not paid out: XDPoSChain guards its whole fee
+        // payment with !types.IsSpecialTx(msg.To) (core/state_transition.go). Sign transactions never
+        // reach here — Execute routes them to ExecuteSpecialTransaction, which charges no gas at all.
         if (tx.IsSpecialTransaction(xdcSpec)) return;
 
         if (!xdcSpec.IsTipTrc21FeeEnabled)
@@ -75,16 +74,9 @@ internal class XdcTransactionProcessor(
             tracer.ReportFees(fee, UInt256.Zero);
     }
 
-    /// <inheritdoc/>
-    /// <remarks>
-    /// Transactions to the block-signer and randomize contracts are exempt from the EIP-1559 fee
-    /// floor, mirroring the <c>!types.IsSpecialTx(msg.To)</c> guard in XDPoSChain's
-    /// <c>core/state_transition.go</c> <c>preCheck</c>. The exemption covers the floor only: gas is
-    /// still bought and refunded for them, so skipping the charge forks the chain against the
-    /// reference client. What they never do is pay the fee out — see <see cref="PayFees"/>. The
-    /// premium itself is left to the base calculation, which already clamps it to zero for the
-    /// zero-gas-price transactions the consensus engine generates.
-    /// </remarks>
+    // A randomize transaction carries a zero gas price yet must execute, so XDPoSChain waives the
+    // EIP-1559 floor for it (!types.IsSpecialTx(msg.To) in preCheck) — the floor only: gas is still
+    // bought and refunded. The premium is left to the base calculation, which clamps it to zero.
     protected override bool TryCalculatePremiumPerGas(Transaction tx, in UInt256 baseFee, out UInt256 premiumPerGas) =>
         base.TryCalculatePremiumPerGas(tx, in baseFee, out premiumPerGas)
         || tx.IsSpecialTransaction((IXdcReleaseSpec)VirtualMachine.BlockExecutionContext.Spec);


### PR DESCRIPTION
## Changes

The two special contracts do not behave alike, and we treated both as entirely free:

| | sign `0x…0089` | randomize `0x…0090` |
|---|---|---|
| Go path | `applyTransaction` short-circuits to `ApplySignTransaction`, before the state transition | full state transition |
| gas | never bought — free, `gasUsed = 0`, whatever gas price it declares | bought and charged to the sender |
| EIP-1559 floor | n/a | waived (`!types.IsSpecialTx(msg.To)` in `preCheck`) |
| fee | n/a | **burned** — the same guard wraps the whole `AddBalance` |
| our status | already correct | fixed here |

Only randomize transactions changed. They are now charged `gasUsed × effectiveGasPrice`, the unused gas
is refunded, `GASPRICE` sees the real price, and the fee is credited to nobody.

- `TransactionProcessor.TryCalculatePremiumPerGas` becomes `virtual` (one word, no new surface);
  `XdcTransactionProcessor` overrides it to waive the fee floor alone.
- The `BuyGas` and `CalculateEffectiveGasPrice` overrides are removed. The first is redundant once the
  floor is handled; the second was zeroing the price, and so silently zeroing both the charge and
  `GASPRICE`. The `RequiresSpecialHandling` arm of the old `BuyGas` guard was already unreachable —
  `Execute` routes those transactions away before gas is bought.
- The `PayFees` guard stays, with a comment citing the reference so it is not removed again.

**Consensus-affecting for XDC**: a node with this change and one without disagree on any block
containing a randomize transaction with a non-zero gas price, so it wants to land before any network
runs a mix of the two.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.Xdc.Test` 730/730. `XdcTransactionProcessorTests` covers randomize transactions at zero,
below the base fee but non-zero, at it, and above it, with EIP-1559 active and inactive, plus an
EIP-1559-typed one whose charge must follow `min(maxFeePerGas, tip + baseFee)`; ordinary transactions
run as controls in the same cases. Sign transactions keep their existing chain-level coverage in
`SpecialTransactionsTests`.

Red-checked both ways: re-adding the `CalculateEffectiveGasPrice` zeroing fails six cases, and
dropping the `PayFees` guard fails the burn cases.

Also swept live on a mixed-client network — two Nethermind masternodes and two `XDPoSChain
v2.9.0-devnet` (commit `5d080472`), all four validators — over sign and randomize transactions at 0, 1,
12.5 and 25 gwei with EIP-1559 on and off, plus value-bearing, low-gas-limit, oversized-gas-limit and
typed variants. Every minable case agreed on block hash, state root and balances. A type-2 randomize
transaction agrees on all three including the receipts root. At 25 gwei:

| transaction | sender debited | owner credited |
|---|---|---|
| ordinary transfer | 525000000001000 | 525000000000000 |
| → `0x…0088` (voting contract) | 526150000000000 | 526150000000000 |
| → `0x…0090` (randomize) | 526150000000000 | **0** |
| → `0x…0089` (sign) | **0** | 0 |

Before this change the two clients rejected each other's blocks with a state-root mismatch as soon as a
randomize transaction carried a non-zero gas price.

Out of scope, found while sweeping typed transactions: a **type-1 or type-2 transaction to the
block-signer contract** diverges on `receiptsRoot` (state root agrees). The reference builds that
receipt with [types.NewReceipt](https://github.com/XinFinOrg/XDPoSChain/blob/5d080472c84a92a46f5fd0d343c09cca9f1b1356/core/state_processor.go#L426)
and never sets `receipt.Type`, so it encodes a legacy receipt whatever the transaction type, while we
encode a typed one. Pre-existing and untouched by this PR, which does not alter the sign path. Filed as #13365.

Full solution suite on this branch's base: 38,613 tests, the only failures in two projects that fail
identically on an unmodified tree here (`State.Flat` Windows file-locks in TearDown, and a flaky
socket-exception-type assertion in `Init.Snapshot`).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Changes the XDC state transition: randomize-contract transactions now charge the sender for gas, and
burn it, instead of executing for free. Sign-contract transactions are unchanged and remain free.


