### PR TITLE
test(eip8141): make the atomic-batch unroll test exercise a rollback

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1977,16 +1977,23 @@ public class FrameTxProcessorTests
 
         Transaction tx = FrameTx(nonce: 0,
             SelfVerifyFrame(),
-            new TxFrame(TxFrame.ModeSender, TxFrame.AtomicBatchFlag, Observer, gasLimit: 200_000, UInt256.Zero, default),
+            Frame(TxFrame.ModeSender, TxFrame.AtomicBatchFlag, target: Observer),
             Frame(TxFrame.ModeSender, target: Recipient),
             Frame(TxFrame.ModePostTx, target: Observer));
 
-        CallOutputTracer tracer = new();
+        FrameReceiptTracer tracer = new();
 
         Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
-        Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure),
-            "the POST_TX write halts against the state the unroll restored");
-        AssertStorage(Observer, 0, UInt256.Zero, "the batch write is gone and the assertion added none");
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess),
+                "the batch write has to land for the unroll to have anything to undo");
+            Assert.That(tracer.FrameReceipts[2].Status, Is.EqualTo(TxFrameReceipt.StatusFailure),
+                "the batch's terminal frame is the one whose failure unrolls it");
+            Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure),
+                "the POST_TX write halts against the state the unroll restored");
+            AssertStorage(Observer, 0, UInt256.Zero, "the batch write is gone and the assertion added none");
+        }
     }
 
     // A failure in a later assertion must unwind the whole body, not only what ran after the first.

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1969,30 +1969,39 @@ public class FrameTxProcessorTests
 
     // A batch unrolling entirely inside the body leaves the assertion running against the restored state.
     [Test]
-    public void Execute_AtomicBatchInTheBodyUnrolls_PostTxStillAsserts()
+    public void Execute_AtomicBatchInTheBodyUnrolls_PostTxAssertsAgainstTheRestoredState()
     {
+        Address assertion = TestItem.AddressF;
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         DeployContract(Observer, Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
         DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+        // TXDIFF 0x01 is a live read, so the frame passes only once the unroll has taken the write back out.
+        DeployContract(assertion, PostTxAssertAll((Txdiff(0x01, Observer, 0), To32(UInt256.Zero))));
 
         Transaction tx = FrameTx(nonce: 0,
             SelfVerifyFrame(),
             Frame(TxFrame.ModeSender, TxFrame.AtomicBatchFlag, target: Observer),
             Frame(TxFrame.ModeSender, target: Recipient),
-            Frame(TxFrame.ModePostTx, target: Observer));
+            Frame(TxFrame.ModePostTx, target: assertion));
 
         FrameReceiptTracer tracer = new();
 
-        Assert.That(Process(tx, tracer: tracer).TransactionExecuted, Is.True);
+        Assert.That(ProcessTraced(tx, tracer).TransactionExecuted, Is.True);
         using (Assert.EnterMultipleScope())
         {
             Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess),
                 "the batch write has to land for the unroll to have anything to undo");
             Assert.That(tracer.FrameReceipts[2].Status, Is.EqualTo(TxFrameReceipt.StatusFailure),
                 "the batch's terminal frame is the one whose failure unrolls it");
-            Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Failure),
-                "the POST_TX write halts against the state the unroll restored");
-            AssertStorage(Observer, 0, UInt256.Zero, "the batch write is gone and the assertion added none");
+            Assert.That(tracer.FrameReceipts[3].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess),
+                "the assertion reads the unrolled slot back as empty");
+            Assert.That(tracer.FrameReceipts[1].StateGasUsed, Is.Zero,
+                "the unrolled write's state charge goes back with its state");
+            Assert.That(tracer.FrameReceipts[1].ExecutionGasUsed, Is.Not.Zero,
+                "an unrolled frame keeps the execution gas it burned");
+            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(1ul), "an unroll leaves the transaction valid");
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether - (UInt256)tracer.GasSpent),
+                "the payer is still charged for the unrolled work");
         }
     }
 


### PR DESCRIPTION
Addresses finding 3 of @benaadams' review of #12526 (commit 5a7918b): `Execute_AtomicBatchInTheBodyUnrolls_PostTxStillAsserts` passed without exercising the rollback it names.

## Changes

Two defects, not one.

1. **The writing frame was never funded.** It was built with the execution-only `gasLimit` overload, leaving `limits.state == 0`. It halted before its SSTORE, the successor meant to unroll the batch was skipped instead of run, and the final empty-storage assertion passed on a batch that had never written anything. The frame now goes through the fixture's `Frame(...)` helper (default state budget).

2. **The POST_TX frame masked the unroll.** It targeted `Observer`, a writer — and POST_TX frames run static, so it halted on a static-call violation. A failing POST_TX frame does `WorldState.Restore(prefixEndSnapshot)`, and `prefixEndSnapshot` is taken at frame 0, *before* the batch. The unwind therefore wiped the batch write whether or not the batch ever unrolled, and the same branch's `ClearFrameStateGasUsed` loop zeroed `FrameReceipts[1].StateGasUsed` too. No assertion added to that fixture could have distinguished an unrolled batch from no batching at all.

The POST_TX frame now targets a dedicated contract built with the fixture's existing `PostTxAssertAll` helper, asserting `TXDIFF 0x01` (storage-after, a live read) of the batch's slot is zero. The frame passes only when the unroll has taken the write back out, so its receipt status is the observation. The retained half of the unroll — the execution charge kept on the unrolled frame, the spent nonce, the payer charge — is asserted alongside the given-back state charge.

The test is renamed to `Execute_AtomicBatchInTheBodyUnrolls_PostTxAssertsAgainstTheRestoredState`, since the assertion now genuinely reads that state.

## Vacuity, reproduced first

Adding only a receipt-status assertion for the writing frame to the original test, exactly as reported:

```
Assert.That(tracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess))
  Expected: 1
  But was:  0
```

The first round's fix repaired that but left defect 2 standing. Reproduced by mutation: with `TxFrame.IsAtomicBatch => false` — atomic batching removed from the node entirely — that revision of the test still passed, and across all 267 `FrameTxProcessorTests` the only red was `Execute_AtomicBatch_FrameFails_RollsBackBatchAndSkipsRemaining`, failing on `Assert.That(tx.Frames![1].IsAtomicBatch, Is.True)` — a direct read of the mutated property, not a behavioural signal. Its behavioural `AssertStorage` check sits after the `EnterMultipleScope` block and never ran.

## The repaired test is load-bearing

Six mutations, each built and run on its own (`Nethermind.Core`/`Nethermind.Evm` restored to HEAD between runs); the pre-PR test body is the one on the base branch.

| # | mutation | pre-PR body | current body |
|---|---|---|---|
| M1 | unrolled members lose their status (`earlier.Status` → `StatusSkipped`) | passes | **fails** — frame 1 expected 1, was 2 |
| M2 | skip-marking starts at the failing frame (`s = i + 1` → `s = i`) | passes | **fails** — frame 2 expected 0, was 2 |
| M3 | `TxFrame.IsAtomicBatch => false` | passes | **fails** — frame 3 expected 1, was 0 |
| M4 | `WorldState.Restore(batchStartSnapshot)` deleted | passes | **fails** — frame 3 expected 1, was 0 |
| M5 | unrolled receipt keeps its state gas (`0` → `earlier.StateGasUsed`) | — | **fails** — frame 1 state gas expected 0, was 97920 |
| M6 | unrolled receipt loses its execution gas (`earlier.ExecutionGasUsed` → `0`) | — | **fails** — frame 1 execution gas expected non-zero, was 0 |

Each mutant is caught by a different assertion, so none of them is redundant. M1 and M2 are the two from the first round, still discriminating after the POST_TX frame was repointed. M4 is the one the previous revision could not see: this PR previously reported deleting the batch restore as leaving the test green, and that no longer holds.

Positive control on the new assertion contract: flipping its expected word from `0` to `1` turns the test red on unmutated code, so the TXDIFF read is live rather than trivially satisfied.

Other tests red under M3, across the whole of `Nethermind.Evm.Test`: `Execute_AtomicBatch_FrameFails_RollsBackBatchAndSkipsRemaining` (property read, as above), `FrameTxBlockGasTests.Execute_AtomicBatchUnrolls_GivesBackTheStateGasOfTheRolledBackFrames`, `UnrolledBatch_DiscardsBatchLogsKeepsPreAndPostBatchLogs`, `TwoBatches_EachClearsOnlyItsOwnFrames_CommittedLogsBetweenSurvive(True|False)` and `AtomicApproveAndSwap_NoDanglingApprovalWhenSwapReverts(True)` — six before this change, seven after.

## One coverage observation (not changed here)

The sibling `Execute_AtomicBatchUnrollsTheApprovingFrame_InvalidatesTheTransaction` never reaches the unroll at all. It is rejected by structural validation first — probing the result gives `MalformedTransaction / "the atomic batch flag must not be set on a VERIFY frame"` — so the `prefixEndIndex >= batchStartIndex` fix-up its comment describes is untested. Deleting that fix-up block leaves all 411 `FrameTx*`/`Eip8141*` cases green. Reaching it needs a batch opened by a deploy-prefix frame rather than a VERIFY frame, and since `FrameTxValidation` rejects any approval scope on a batch member it may not be reachable at all — worth settling separately, because if it is unreachable it is dead defence rather than a coverage gap.

No other atomic-batch or rollback test uses the execution-only overload where state gas is needed; the rest go through `Frame(...)` or pass `stateGasLimit` explicitly.

## Verification

`Nethermind.Evm.Test`, clean `artifacts/{bin,obj}` between configurations, before and after this PR:

- release: 10884 total, 0 failed, 19 skipped (both)
- checked (`-p:DefineConstants=TRACE%3BDEBUG`): 10882 total, 0 failed, 19 skipped (both)

Case counts are unchanged and the generated name sets differ only by the rename, in both configurations, after collapsing the randomised-name sources (`Eip2565Tests` and `SecP256r1PrecompileTests` hex vectors, and `Simple_routine(<seed>)`) — that noise was characterised by listing the *same* binary twice, which differs by 437 lines on its own and normalises to zero.

Lint: CI's exact `code-lint.yml` invocation, 0 IDE/CA warnings, positive-controlled with an injected unused `using` (flagged IDE0005 as expected). `dotnet format whitespace --verify-no-changes` clean.

## Types of changes

- [x] Bug fix (a non-breaking change that fixes an issue)

## Testing

- [x] Tests added
