### PR TITLE
EIP-8141: make the pool's admission verdict agree with execution

### DIFF
--- a/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
+++ b/src/Nethermind/Nethermind.Core/Eip8141Constants.cs
@@ -37,4 +37,14 @@ public static class Eip8141Constants
     public static readonly byte[] ExpiryVerifierCode = Bytes.FromHexString("0x60083614600a575f5ffd5b5f3560c01c4211601657005b5f5ffd");
 
     public static readonly ValueHash256 ExpiryVerifierCodeHash = ValueKeccak.Compute(ExpiryVerifierCode);
+
+    /// <summary>Execution gas a well-formed expiry frame must budget to run: its predeploy target's cold account
+    /// access plus what <see cref="ExpiryVerifierCode"/> itself draws on the path that does not revert.</summary>
+    /// <remarks>Fixed because every input is: the code is a predeploy and the calldata length is structural. Cold
+    /// access is the worst case, a pre-warmed target only costing less. Whether the deadline has passed is a
+    /// separate question, and a reverting expiry frame invalidates the transaction whatever it budgeted.
+    /// Pinned by <c>Execute_ExpiryFrameAtItsExactCost_IsTheBoundary</c>.</remarks>
+    public const ulong ExpiryFrameExecutionGas = Eip8038Constants.ColdAccountAccess + ExpiryVerifierCodeGas;
+
+    private const ulong ExpiryVerifierCodeGas = 51;
 }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -167,6 +167,39 @@ public class FrameTxValidationPrefixSimulationTests
     }
 
     [Test]
+    public void SimulationAndExecution_PayFrameTargetingTheBeneficiary_ReachTheSameVerdict()
+    {
+        // Budgeted between warm and cold access, so the frame succeeds only where the coinbase is pre-warmed:
+        // the two paths have to run against the same block beneficiary to agree.
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecution), 1.Ether);
+        DeployContract(Beneficiary, ApproveCode(TxFrame.ApprovePayment), 1.Ether);
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApprovePayment, Beneficiary, gasLimit: 2_000, UInt256.Zero, default));
+
+        AssertPrefixVerdictParity(tx, expectedValid: true);
+    }
+
+    // The expiry verifier is a predeploy, not a precompile, so a leading expiry frame owes a cold account access
+    // before its code runs. The pool's native shortcut prices the frame at exactly this floor.
+    [TestCase(Eip8141Constants.ExpiryFrameExecutionGas - 1, false, TestName = "Parity_ExpiryFrameOneGasBelowItsCost_InvalidatesTheTransaction")]
+    [TestCase(Eip8141Constants.ExpiryFrameExecutionGas, true, TestName = "Parity_ExpiryFrameAtItsExactCost_IsValid")]
+    public void Execute_ExpiryFrameAtItsExactCost_IsTheBoundary(ulong expiryGasLimit, bool expectedValid)
+    {
+        FundAccount(Sender, 1.Ether);
+        DeployContract(Eip8141Constants.ExpiryVerifierAddress, Eip8141Constants.ExpiryVerifierCode);
+        byte[] deadline = new byte[Eip8141Constants.ExpiryDataLength];
+        BinaryPrimitives.WriteUInt64BigEndian(deadline, ulong.MaxValue);
+
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveScopeNone, Eip8141Constants.ExpiryVerifierAddress, expiryGasLimit, UInt256.Zero, deadline),
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, Eip8038Constants.WarmAccess, UInt256.Zero, default));
+        FrameTxTestFrames.SignSecp256k1(tx, TestItem.PrivateKeyA, null);
+
+        AssertPrefixVerdictParity(tx, expectedValid);
+    }
+
+    [Test]
     public void Simulate_PrefixNeverSetsPayer_Rejected()
     {
         DeployContract(Sender, Prepare.EvmCode.Op(Instruction.STOP).Done, 1.Ether);
@@ -1005,8 +1038,11 @@ public class FrameTxValidationPrefixSimulationTests
 
     private TransactionResult Run(Transaction tx, FrameTxValidationTracer tracer, ulong? slotNumber = null, ExecutionOptions extraOptions = ExecutionOptions.None)
     {
+        // The same beneficiary Execute uses, so the two paths pre-warm the same addresses and execution
+        // mode is the only difference a parity case can be measuring.
         Block block = Build.A.Block.WithNumber(1)
             .WithBaseFeePerGas(0)
+            .WithBeneficiary(Beneficiary)
             .WithTransactions(tx)
             .WithSlotNumber(slotNumber)
             .WithGasLimit(30_000_000).TestObject;

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -39,6 +39,7 @@ public class FrameTxValidationPrefixSimulationTests
     private static readonly Address Sender = TestItem.AddressA;
     private static readonly Address Sponsor = TestItem.AddressD;
     private static readonly Address Factory = TestItem.AddressB;
+    private static readonly Address Beneficiary = TestItem.AddressE;
     private static readonly Address IdentityPrecompile = Address.FromNumber(4);
     private static readonly byte[] Salt = new byte[32];
 
@@ -127,6 +128,42 @@ public class FrameTxValidationPrefixSimulationTests
             Assert.That(FrameTxValidation.HasVerifyFrameAfterPrefix(tx), Is.True,
                 "the pool bound must claim the trailing VERIFY frame the simulation never reaches");
         }
+    }
+
+    private static IEnumerable<TestCaseData> PrefixVerdictParityCases()
+    {
+        // The frame fields whose value the simulation has to reproduce, each read by a sponsor that
+        // approves payment only on the answer named here.
+        yield return ParityCase("SponsorRequiresZeroExecutionGasUsed", 0x0A, approveWhenZero: true, expectedValid: false);
+        yield return ParityCase("SponsorRequiresNonZeroExecutionGasUsed", 0x0A, approveWhenZero: false, expectedValid: true);
+        // Frame status is recorded on both paths, so it agrees whatever the gas receipts do.
+        yield return ParityCase("SponsorRequiresSuccessfulPredecessor", 0x05, approveWhenZero: false, expectedValid: true);
+    }
+
+    [TestCaseSource(nameof(PrefixVerdictParityCases))]
+    public void SimulationAndExecution_SponsorReadsThePrecedingFrame_ReachTheSameVerdict(byte param, bool approveWhenZero, bool expectedValid)
+    {
+        DeployContract(Sender, ApproveCode(TxFrame.ApproveExecution), 1.Ether);
+        DeployContract(Sponsor, ApprovesOnFrameReading(param, approveWhenZero, TxFrame.ApprovePayment), 1.Ether);
+        Transaction tx = FrameTx(nonce: 0,
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecution, target: null, gasLimit: 200_000, UInt256.Zero, default),
+            new TxFrame(TxFrame.ModeVerify, TxFrame.ApprovePayment, Sponsor, gasLimit: 200_000, UInt256.Zero, default));
+
+        AssertPrefixVerdictParity(tx, expectedValid);
+    }
+
+    [Test]
+    public void SimulationAndExecution_SenderReadsTheDeployFramesStateGas_ReachTheSameVerdict()
+    {
+        // The opening deploy frame is the one prefix frame that spends state gas, so it is the only
+        // shape from which a following frame reads a non-zero gas_used.state.
+        byte[] initCode = Prepare.EvmCode
+            .PushData(1).PushData(0).Op(Instruction.SSTORE)
+            .ForInitOf(ApprovesOnFrameReading(0x0B, approveWhenZero: false, TxFrame.ApproveExecutionAndPayment)).Done;
+        Address deployed = InstallFactory(initCode);
+        FundAccount(deployed, 1.Ether);
+
+        AssertPrefixVerdictParity(DeployTx(deployed), expectedValid: true);
     }
 
     [Test]
@@ -910,6 +947,51 @@ public class FrameTxValidationPrefixSimulationTests
         byte[] data = new byte[length];
         data.AsSpan().Fill(0xff);
         return data;
+    }
+
+    private static TestCaseData ParityCase(string name, byte param, bool approveWhenZero, bool expectedValid) =>
+        new TestCaseData(param, approveWhenZero, expectedValid).SetName($"Parity_{name}");
+
+    /// <summary>
+    /// Asserts that the pool's validation-prefix simulation reaches the same verdict on
+    /// <paramref name="tx"/> as full execution does.
+    /// </summary>
+    /// <remarks>Simulation runs first because it rolls its state back; execution then runs against the
+    /// state the pool judged. A divergence either admits a transaction execution rejects, or drops one
+    /// it would have accepted.</remarks>
+    private void AssertPrefixVerdictParity(Transaction tx, bool expectedValid)
+    {
+        (TransactionResult simulated, FrameTxValidationTracer tracer) = Simulate(tx);
+        TransactionResult executed = Execute(tx);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Violated, Is.False, tracer.ViolationReason);
+            Assert.That(executed.TransactionExecuted, Is.EqualTo(expectedValid), executed.ErrorDescription);
+            Assert.That(simulated.TransactionExecuted, Is.EqualTo(executed.TransactionExecuted),
+                $"simulation said '{simulated.ErrorDescription ?? "valid"}', execution said '{executed.ErrorDescription ?? "valid"}'");
+        }
+    }
+
+    /// <summary>Code approving <paramref name="scope"/> only when <c>FRAMEPARAM</c> field
+    /// <paramref name="param"/> of frame 0 reads as zero, or only when it does not.</summary>
+    /// <remarks>An approval the context refuses reverts the frame, so a scope of zero is the rejection.</remarks>
+    private static byte[] ApprovesOnFrameReading(byte param, bool approveWhenZero, byte scope)
+    {
+        Prepare code = Prepare.EvmCode.PushData(param).PushData(0).Op(Instruction.FRAMEPARAM).Op(Instruction.ISZERO);
+        if (!approveWhenZero) code = code.Op(Instruction.ISZERO);
+        // APPROVE stack order (top to bottom): offset, length, scope.
+        return code.PushData(scope).Op(Instruction.MUL).PushData(0).PushData(0).Op(Instruction.APPROVE).Done;
+    }
+
+    private TransactionResult Execute(Transaction tx)
+    {
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+        return _transactionProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), NullTxTracer.Instance);
     }
 
     private (TransactionResult, FrameTxValidationTracer) Simulate(Transaction tx, ulong? slotNumber = null, ExecutionOptions extraOptions = ExecutionOptions.None)

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -637,6 +637,9 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 }
 
                 frameContext.MarkFrameSucceeded(i);
+                // As full execution records it: a later prefix frame reading gas_used through FRAMEPARAM
+                // must see the same value here, or admission disagrees with execution.
+                frameContext.RecordFrameReceipt(i, frameGasUsed - (ulong)frameStateGas, (ulong)frameStateGas);
 
                 // A deploy frame that leaves tx.sender codeless would have the VERIFY frames behind it
                 // validate against default code instead of the account being deployed.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -637,8 +637,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 }
 
                 frameContext.MarkFrameSucceeded(i);
-                // As full execution records it: a later prefix frame reading gas_used through FRAMEPARAM
-                // must see the same value here, or admission disagrees with execution.
+                // As full execution records it, so a later prefix frame reading gas_used through FRAMEPARAM sees
+                // the same value — except behind a capped frame, whose run had the smaller allowance.
                 frameContext.RecordFrameReceipt(i, frameGasUsed - (ulong)frameStateGas, (ulong)frameStateGas);
 
                 // A deploy frame that leaves tx.sender codeless would have the VERIFY frames behind it

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerResolverTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerResolverTests.cs
@@ -69,10 +69,37 @@ public class FrameTxPayerResolverTests
                 return FrameTx([SelfVerify(PrefixFrameGas), Pay(Sponsor, PrefixFrameGas)], [Secp256k1Signature(Sender), Secp256k1Signature(Sponsor)]);
             }, FrameTxPayerOutcome.RequiresSimulation, null);
 
-        // A never-seen sender still resolves: the zeroed account reads as default (empty) code.
-        yield return Case("SelfVerify_NonExistentSender_PayerIsSender",
+        // A never-seen sender reads as default (empty) code, but approving payment also creates the
+        // account, a state charge the frame's budget may not cover.
+        yield return Case("SelfVerify_NonExistentSender_RequiresSimulation",
             _ => FrameTx([SelfVerify(PrefixFrameGas)], [Secp256k1Signature(Sender)]),
-            FrameTxPayerOutcome.Resolved, Sender);
+            FrameTxPayerOutcome.RequiresSimulation, null);
+
+        // The default code halts before it runs unless the frame can pay its target's warm access, so a
+        // budget under that charge is not the provable success the shortcut stands on.
+        yield return Case("SelfVerify_FrameBelowItsEntryCharge_RequiresSimulation",
+            state =>
+            {
+                DefaultCodeAccount(state, Sender);
+                return FrameTx([SelfVerify(Eip8038Constants.WarmAccess - 1)], [Secp256k1Signature(Sender)]);
+            }, FrameTxPayerOutcome.RequiresSimulation, null);
+
+        yield return Case("SelfVerify_FrameCoveringItsEntryCharge_PayerIsSender",
+            state =>
+            {
+                DefaultCodeAccount(state, Sender);
+                return FrameTx([SelfVerify(Eip8038Constants.WarmAccess)], [Secp256k1Signature(Sender)]);
+            }, FrameTxPayerOutcome.Resolved, Sender);
+
+        // EIP-8250: a fresh key's slot is a state charge whose size depends on state the resolver is not given.
+        yield return Case("SelfVerify_NonceKeys_RequiresSimulation",
+            state =>
+            {
+                DefaultCodeAccount(state, Sender);
+                Transaction tx = FrameTx([SelfVerify(PrefixFrameGas)], [Secp256k1Signature(Sender)]);
+                tx.NonceKeys = [UInt256.One];
+                return tx;
+            }, FrameTxPayerOutcome.RequiresSimulation, null);
 
         yield return Case("OnlyVerifyWithoutPay_NoPayer",
             state =>

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerResolverTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPayerResolverTests.cs
@@ -37,7 +37,9 @@ public class FrameTxPayerResolverTests
 
     private static FrameTxPayerResolution Resolve(Transaction tx, TestReadOnlyStateProvider state)
     {
-        state.TryGetAccount(tx.SenderAddress!, out AccountStruct senderAccount);
+        // As every production caller does: a missing sender is normalised to the empty account, never left
+        // as the zeroed out-value, whose IsNull the resolver would then answer on.
+        if (!state.TryGetAccount(tx.SenderAddress!, out AccountStruct senderAccount)) senderAccount = AccountStruct.TotallyEmpty;
         return FrameTxPayerResolver.Resolve(tx, senderAccount);
     }
 
@@ -75,6 +77,11 @@ public class FrameTxPayerResolverTests
             _ => FrameTx([SelfVerify(PrefixFrameGas)], [Secp256k1Signature(Sender)]),
             FrameTxPayerOutcome.RequiresSimulation, null);
 
+        // Budgeting the creation charge covers the worst case, so the shortcut needs no lookup to know it.
+        yield return Case("SelfVerify_NonExistentSenderBudgetingItsCreation_PayerIsSender",
+            _ => FrameTx([SelfVerifyWithStateGas((ulong)GasCostOf.NewAccountState)], [Secp256k1Signature(Sender)]),
+            FrameTxPayerOutcome.Resolved, Sender);
+
         // The default code halts before it runs unless the frame can pay its target's warm access, so a
         // budget under that charge is not the provable success the shortcut stands on.
         yield return Case("SelfVerify_FrameBelowItsEntryCharge_RequiresSimulation",
@@ -91,8 +98,9 @@ public class FrameTxPayerResolverTests
                 return FrameTx([SelfVerify(Eip8038Constants.WarmAccess)], [Secp256k1Signature(Sender)]);
             }, FrameTxPayerOutcome.Resolved, Sender);
 
-        // EIP-8250: a fresh key's slot is a state charge whose size depends on state the resolver is not given.
-        yield return Case("SelfVerify_NonceKeys_RequiresSimulation",
+        // EIP-8250: a fresh key's slot is a state charge, and a frame budgeting none of it cannot afford
+        // the set it declares.
+        yield return Case("SelfVerify_NonceKeysWithoutStateGas_RequiresSimulation",
             state =>
             {
                 DefaultCodeAccount(state, Sender);
@@ -100,6 +108,35 @@ public class FrameTxPayerResolverTests
                 tx.NonceKeys = [UInt256.One];
                 return tx;
             }, FrameTxPayerOutcome.RequiresSimulation, null);
+
+        // Pricing every key as a first use is the worst case, so a frame budgeting it needs no chain state.
+        yield return Case("SelfVerify_NonceKeysBudgetingEveryKeyAsFirstUse_PayerIsSender",
+            state =>
+            {
+                DefaultCodeAccount(state, Sender);
+                Transaction tx = FrameTx([SelfVerifyWithStateGas(2 * (ulong)GasCostOf.SSetState)], [Secp256k1Signature(Sender)]);
+                tx.NonceKeys = [UInt256.One, (UInt256)2];
+                return tx;
+            }, FrameTxPayerOutcome.Resolved, Sender);
+
+        yield return Case("SelfVerify_NonceKeysOneSlotShortOfTheWorstCase_RequiresSimulation",
+            state =>
+            {
+                DefaultCodeAccount(state, Sender);
+                Transaction tx = FrameTx([SelfVerifyWithStateGas(2 * (ulong)GasCostOf.SSetState - 1)], [Secp256k1Signature(Sender)]);
+                tx.NonceKeys = [UInt256.One, (UInt256)2];
+                return tx;
+            }, FrameTxPayerOutcome.RequiresSimulation, null);
+
+        // The set [0] aliases the account nonce and writes no NONCE_MANAGER slot, so it owes no state gas.
+        yield return Case("SelfVerify_AccountNonceKeySet_PayerIsSender",
+            state =>
+            {
+                DefaultCodeAccount(state, Sender);
+                Transaction tx = FrameTx([SelfVerify(PrefixFrameGas)], [Secp256k1Signature(Sender)]);
+                tx.NonceKeys = [UInt256.Zero];
+                return tx;
+            }, FrameTxPayerOutcome.Resolved, Sender);
 
         yield return Case("OnlyVerifyWithoutPay_NoPayer",
             state =>
@@ -190,6 +227,22 @@ public class FrameTxPayerResolverTests
                 return FrameTx([ExpiryAt(9999), SelfVerify(PrefixFrameGas)], [Secp256k1Signature(Sender)]);
             }, FrameTxPayerOutcome.Resolved, Sender);
 
+        // A skipped expiry frame still has to run ahead of the self relay, and its predeploy target owes a cold
+        // account access plus the verifier's own draw before it can succeed.
+        yield return Case("ExpiryAtItsExactCostThenSelfVerify_PayerIsSender",
+            state =>
+            {
+                DefaultCodeAccount(state, Sender);
+                return FrameTx([ExpiryAt(9999, Eip8141Constants.ExpiryFrameExecutionGas), SelfVerify(PrefixFrameGas)], [Secp256k1Signature(Sender)]);
+            }, FrameTxPayerOutcome.Resolved, Sender);
+
+        yield return Case("ExpiryOneGasBelowItsCostThenSelfVerify_RequiresSimulation",
+            state =>
+            {
+                DefaultCodeAccount(state, Sender);
+                return FrameTx([ExpiryAt(9999, Eip8141Constants.ExpiryFrameExecutionGas - 1), SelfVerify(PrefixFrameGas)], [Secp256k1Signature(Sender)]);
+            }, FrameTxPayerOutcome.RequiresSimulation, null);
+
         // The only shape where both prefix skips apply; the deploy frame still forces simulation.
         yield return Case("ExpiryThenDeployThenSelfVerify_RequiresSimulation",
             state =>
@@ -264,6 +317,9 @@ public class FrameTxPayerResolverTests
         FrameTxTestFrames.FrameTx(Sender, signatures, frames);
 
     private static TxFrame Frame(byte mode) => new(mode, flags: 0, target: null, gasLimit: 50_000, UInt256.Zero, default);
+
+    private static TxFrame SelfVerifyWithStateGas(ulong stateGasLimit) =>
+        new(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, PrefixFrameGas, stateGasLimit, UInt256.Zero, default);
 
     private static TxFrame DeployFrame() => Frame(TxFrame.ModeDefault);
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -3994,6 +3994,30 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        // The native shortcut skips simulation, so it may only name a payer for a frame that provably
+        // succeeds. One that cannot pay the access charge its own dispatch owes does not, and admitting
+        // it hands the pool a transaction execution rejects.
+        [TestCase(0UL, false, TestName = "SubmitTx_SelfVerifyFrameBelowItsEntryCharge_IsSimulated")]
+        [TestCase(Eip8038Constants.WarmAccess - 1, false, TestName = "SubmitTx_SelfVerifyFrameOneGasBelowItsEntryCharge_IsSimulated")]
+        [TestCase(Eip8038Constants.WarmAccess, true, TestName = "SubmitTx_SelfVerifyFrameCoveringItsEntryCharge_TakesTheNativeShortcut")]
+        public void SubmitTx_NativeSelfVerifyFrame_IsSimulatedUnlessItCanPayItsEntryCharge(ulong executionGasLimit, bool shortcut)
+        {
+            IFrameTxPrefixSimulator simulator = CreatePoolWithSimulator(FrameTxSimulationResult.Reject("validation prefix frame reverted"));
+            Transaction tx = SignedFrameTx([
+                new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, executionGasLimit, UInt256.Zero, Array.Empty<byte>())
+            ]);
+
+            AcceptTxResult result = _txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(shortcut ? AcceptTxResult.Accepted : AcceptTxResult.FrameSimulationFailed));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(shortcut ? 1 : 0));
+                Assert.That(tx.PayerAddress, shortcut ? Is.EqualTo(TestItem.PrivateKeyA.Address) : Is.Null);
+                simulator.Received(shortcut ? 0 : 1).Simulate(tx, Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<bool>());
+            }
+        }
+
         [Test]
         public void SubmitTx_SponsoredFrameTx_IsAdmittedWithAnUnfundedSender()
         {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -4018,6 +4018,26 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        // A skipped leading expiry frame still has to run successfully ahead of the approving one, and its
+        // predeploy target owes a cold account access plus the verifier's own draw before it can.
+        [TestCase(Eip8141Constants.ExpiryFrameExecutionGas - 1, false, TestName = "SubmitTx_LeadingExpiryFrameBelowItsEntryCharge_IsSimulated")]
+        [TestCase(Eip8141Constants.ExpiryFrameExecutionGas, true, TestName = "SubmitTx_LeadingExpiryFrameCoveringItsEntryCharge_TakesTheNativeShortcut")]
+        public void SubmitTx_SelfVerifyBehindALeadingExpiryFrame_IsSimulatedUnlessThatFrameCanPayItsEntryCharge(ulong expiryGasLimit, bool shortcut)
+        {
+            IFrameTxPrefixSimulator simulator = CreatePoolWithSimulator(FrameTxSimulationResult.Reject("validation prefix frame reverted"));
+            Transaction tx = SignedFrameTx([FrameTxTestFrames.ExpiryAt(ulong.MaxValue, expiryGasLimit), SelfVerifyPrefixFrame()]);
+
+            AcceptTxResult result = _txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(shortcut ? AcceptTxResult.Accepted : AcceptTxResult.FrameSimulationFailed));
+                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(shortcut ? 1 : 0));
+                Assert.That(tx.PayerAddress, shortcut ? Is.EqualTo(TestItem.PrivateKeyA.Address) : Is.Null);
+                simulator.Received(shortcut ? 0 : 1).Simulate(tx, Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<bool>());
+            }
+        }
+
         [Test]
         public void SubmitTx_SponsoredFrameTx_IsAdmittedWithAnUnfundedSender()
         {
@@ -4061,7 +4081,9 @@ namespace Nethermind.TxPool.Test
         [Test]
         public void SubmitTx_UnfundedSender_PayingForItsOwnFrameTx_IsRejected()
         {
-            CreatePoolWithSimulator(FrameTxSimulationResult.Accept(TestItem.AddressD));
+            // An unfunded sender reads back as the empty account, which the resolver cannot tell from one
+            // execution has to create, so it takes the simulated verdict — the sender either way.
+            CreatePoolWithSimulator(FrameTxSimulationResult.Accept(TestItem.PrivateKeyA.Address));
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.Zero);
 
             Assert.That(_txPool.SubmitTx(SelfPayingFrameTx(nonce: 0, feePerGas: 1), TxHandlingOptions.None),

--- a/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
+++ b/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using Nethermind.Core;
+using Nethermind.Evm.TransactionProcessing;
 
 namespace Nethermind.TxPool;
 
@@ -38,10 +39,9 @@ internal static class FrameTxPayerResolver
         // Self relay: a self_verify frame approves both sender and payer, so the payer is the sender.
         if (FrameTxValidation.IsSelfVerifyFrame(verifyFrame, sender))
         {
-            // A deployed or EIP-7702-delegated sender runs its own account code and must be simulated. So
-            // does a codeless one behind a deploy frame: by the time the VERIFY frame runs, that frame has
-            // installed code at tx.sender, so the default-code inference below reads the wrong account.
-            if (senderHasCode || (index > 0 && FrameTxValidation.IsDeployFrame(frames[index - 1])))
+            // A deployed or EIP-7702-delegated sender runs its own account code and must be simulated, as does
+            // a prefix ahead of this frame that cannot be priced from the frame list alone.
+            if (senderHasCode || !LeadingFramesProvablyRun(frames, index))
             {
                 return Unresolved(FrameTxPayerOutcome.RequiresSimulation);
             }
@@ -91,19 +91,49 @@ internal static class FrameTxPayerResolver
         || (FrameTxValidation.IsOnlyVerifyFrame(frames[index], sender) && index + 1 >= frames.Length);
 
 
+    /// <summary>Whether every frame the prologue skipped ahead of <paramref name="index"/> provably runs to
+    /// completion, its failure being what would invalidate the transaction the approving frame is named payer of.</summary>
+    /// <remarks>
+    /// Only a leading expiry frame is priceable from the frame list, at <see cref="Eip8141Constants.ExpiryFrameExecutionGas"/>.
+    /// Whether its deadline has passed is <see cref="Filters.ExpiredFrameTxFilter"/>'s question.
+    /// A leading deploy frame defers whatever it budgets: by the time the VERIFY frame runs it has installed code
+    /// at tx.sender, so the default-code inference would read the wrong account.
+    /// </remarks>
+    private static bool LeadingFramesProvablyRun(TxFrame[] frames, int index) =>
+        index switch
+        {
+            0 => true,
+            1 => FrameTxValidation.IsExpiryVerifyFrame(frames[0])
+                 && frames[0].ExecutionGasLimit >= Eip8141Constants.ExpiryFrameExecutionGas,
+            _ => false,
+        };
+
     /// <summary>Whether a default-code <c>VERIFY</c> frame provably affords everything running it charges.</summary>
     /// <remarks>
     /// The frame pays its target's access before dispatch, warm because the transaction warms its sender, and
     /// the default code itself draws no further execution gas — the boundary <c>Execute_DefaultCodeFrame_PaysItsTargetAccess</c>
-    /// and <c>Execute_DefaultCodeFrameGasBelowItsTargetAccess_InvalidatesTheTransaction</c> pin. The state dimension
-    /// is left to simulation instead of priced here: an approval creating the sender or consuming EIP-8250 nonce
-    /// keys owes state gas that depends on chain state this resolver is not given. Both arms only ever defer, so a
-    /// charge growing past what this knows costs a simulation rather than admitting what execution rejects.
+    /// and <c>Execute_DefaultCodeFrameGasBelowItsTargetAccess_InvalidatesTheTransaction</c> pin. Both arms only
+    /// ever defer, so a charge growing past what this knows costs a simulation rather than admitting what
+    /// execution rejects.
     /// </remarks>
     private static bool DefaultCodeChargesAreCovered(TxFrame verifyFrame, Transaction tx, in AccountStruct senderAccount) =>
         verifyFrame.ExecutionGasLimit >= Eip8038Constants.WarmAccess
-        && tx.NonceKeys is null
-        && !senderAccount.IsNull;
+        && NonceStateGasIsCovered(verifyFrame, tx, in senderAccount);
+
+    /// <summary>Whether <paramref name="verifyFrame"/> budgets the state gas the approval's nonce consumption
+    /// can owe, mirroring <c>FrameTxContext.NonceStateGas</c> at its worst case.</summary>
+    /// <remarks>The branches are exclusive as they are there, and both bounds read no chain state: a keyed set
+    /// never creates the sender and writes at most one <c>NONCE_MANAGER</c> slot per key, while the account-nonce
+    /// set (<c>null</c> or <c>[0]</c>) writes no slot and owes a creation only for a sender that does not exist —
+    /// which an account reading back as empty may be.</remarks>
+    private static bool NonceStateGasIsCovered(TxFrame verifyFrame, Transaction tx, in AccountStruct senderAccount)
+    {
+        ulong worstCase = tx.NonceKeys is { } nonceKeys && KeyedNonceManager.UsesKeyedDomain(nonceKeys)
+            ? (ulong)nonceKeys.Length * (ulong)GasCostOf.SSetState
+            : senderAccount.IsTotallyEmpty ? (ulong)GasCostOf.NewAccountState : 0;
+
+        return worstCase <= verifyFrame.StateGasLimit;
+    }
 
     /// <summary>Structural check that index-0 is a canonical-hash (empty <c>msg</c>) secp256k1 signature by the sender.</summary>
     /// <remarks>Cryptographic verification is a separate upstream gate.</remarks>

--- a/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
+++ b/src/Nethermind/Nethermind.TxPool/FrameTxPayerResolver.cs
@@ -52,6 +52,13 @@ internal static class FrameTxPayerResolver
                 return Unresolved(FrameTxPayerOutcome.RequiresSimulation);
             }
 
+            // The default code's mandatory charges have to be provably covered, or the frame halts on gas
+            // where the shortcut called it approved.
+            if (!DefaultCodeChargesAreCovered(verifyFrame, tx, in senderAccount))
+            {
+                return Unresolved(FrameTxPayerOutcome.RequiresSimulation);
+            }
+
             // A non-matching signature shape is not proof of invalidity, so defer rather than drop.
             return DefaultCodeApproves(signatures, sender)
                 ? new FrameTxPayerResolution(FrameTxPayerOutcome.Resolved, sender)
@@ -83,6 +90,20 @@ internal static class FrameTxPayerResolver
         index >= frames.Length
         || (FrameTxValidation.IsOnlyVerifyFrame(frames[index], sender) && index + 1 >= frames.Length);
 
+
+    /// <summary>Whether a default-code <c>VERIFY</c> frame provably affords everything running it charges.</summary>
+    /// <remarks>
+    /// The frame pays its target's access before dispatch, warm because the transaction warms its sender, and
+    /// the default code itself draws no further execution gas — the boundary <c>Execute_DefaultCodeFrame_PaysItsTargetAccess</c>
+    /// and <c>Execute_DefaultCodeFrameGasBelowItsTargetAccess_InvalidatesTheTransaction</c> pin. The state dimension
+    /// is left to simulation instead of priced here: an approval creating the sender or consuming EIP-8250 nonce
+    /// keys owes state gas that depends on chain state this resolver is not given. Both arms only ever defer, so a
+    /// charge growing past what this knows costs a simulation rather than admitting what execution rejects.
+    /// </remarks>
+    private static bool DefaultCodeChargesAreCovered(TxFrame verifyFrame, Transaction tx, in AccountStruct senderAccount) =>
+        verifyFrame.ExecutionGasLimit >= Eip8038Constants.WarmAccess
+        && tx.NonceKeys is null
+        && !senderAccount.IsNull;
 
     /// <summary>Structural check that index-0 is a canonical-hash (empty <c>msg</c>) secp256k1 signature by the sender.</summary>
     /// <remarks>Cryptographic verification is a separate upstream gate.</remarks>


### PR DESCRIPTION
## Changes

Two P2 review findings on #12526, both cases of the pool admitting a transaction execution then rejects. Base is `eip8141-frame-txs-devnet7` at `5a7918b0da`, the reviewed commit.

**1. Validation-prefix simulation records no frame gas receipts.** `SimulateFrameValidationPrefix` called `MarkFrameSucceeded` without the matching `RecordFrameReceipt` the outer loop makes, so a later prefix frame reading the previous frame's `gas_used` through `FRAMEPARAM(0x0A/0x0B)` observed zero during simulation and the real charge during execution. Fixed by recording both dimensions for a successfully simulated frame.

**2. The native verification shortcut accepted a frame that cannot pay its entry charge.** `FrameTxPayerResolver` named the sender as payer from code and signature shape alone; once `PayerAddress` is set, `FrameTxSimulationFilter` skips simulation entirely. A self-verifying transaction whose VERIFY frame budgets less execution gas than the warm sender access its dispatch charges was `Accepted` and retained, though execution halts that frame and invalidates the transaction.

### Which of the two options for finding 2, and why

Pricing the frame inline would mean reproducing the whole charge model in the pool — the entry access (spec- and gas-policy-parameterised), the value-transfer rule, and the approval's `nonce_state_gas` (which needs chain state) — a second source of truth across three rules that would drift silently. Deferring everything to simulation loses the shortcut on the common path, which exists precisely because simulation is expensive and the frame filters are ordered last to avoid paying for it.

So: **defer when success has not been established**, with the condition chosen so the shortcut survives on real traffic. The resolver keeps it only where the frame provably affords the default code's mandatory charges, and defers otherwise:

- the execution dimension is a single constant, `Eip8038Constants.WarmAccess` — a self-verify frame targets the sender, which the transaction warms, and the default code draws nothing beyond that entry access;
- the state dimension is not priced at all: an approval that creates the sender, or consumes EIP-8250 nonce keys, owes state gas the resolver cannot size without state, so those defer.

The one duplicated number is already pinned to executed behaviour by existing tests (`Execute_DefaultCodeFrame_PaysItsTargetAccess` and `Execute_DefaultCodeFrameGasBelowItsTargetAccess_InvalidatesTheTransaction` bracket it exactly), so a drift in the charge breaks a test rather than reopening the hole. Every arm only ever defers, so the failure mode of a charge growing past what the resolver knows is a wasted simulation, not an admission.

A normal self-verifying transaction budgets far more than 100 gas for its VERIFY frame, so the shortcut still covers the common path.

### Parity coverage

The property the new tests establish is that the pool's verdict and execution's verdict agree, not just that these two instances are fixed. `FrameTxValidationPrefixSimulationTests` gains `AssertPrefixVerdictParity`, which runs the same transaction through prefix simulation and then full execution and asserts both the shared verdict and execution's own, over a table of prefixes that read a preceding frame:

- a sponsor approving payment only on zero execution gas used (simulation accepted, execution rejected before the fix);
- the same on non-zero (simulation rejected, execution accepted before the fix);
- a deploy prefix whose deployed sender reads the deploy frame's state gas, covering the `0x0B` dimension;
- frame status as a negative control, already consistent and green in both states.

## Types of changes

- [x] Bug fix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality
      to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Configuration change
- [ ] Tests
- [ ] Other (please describe)

## Testing

Both findings reproduced before fixing, then a red/green pair for each reverting only that change:

| Reverted | Red | Green |
|---|---|---|
| receipt recording | 3 parity cases fail; frame-status control green | all 76 pass |
| resolver guard | 3 resolver cases + 2 pool cases fail; the covering-charge arms green | all pass |

`Nethermind.Evm.Test`, `Nethermind.TxPool.Test` and `Nethermind.Blockchain.Test` in release (10888 / 1219 / 2034, 0 failed) and in checked, `-p:DefineConstants=TRACE;DEBUG`, artifacts cleared between configs (10886 / 1219 / 2034, 0 failed). Frame lanes on `tests-frames-devnet@v0.3.0` with `--forkAlias Bogota=Eip8141Prototype`: `blockTest` 218/218 and `engineTest` 218/218. CI's lint invocation is clean at 0 IDE/CA warnings, positive-controlled with an injected unused `using`.

### Requires testing

- [ ] Yes
- [x] No
