### PR TITLE
perf(evm): unroll ADD carry chain

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/AddTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/AddTests.cs
@@ -26,6 +26,18 @@ public class AddTests : VirtualMachineTestsBase
         "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         "0x0000000000000000000000000000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000000000000000000000000000000")]
+    [TestCase(
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe")]
+    [TestCase(
+        "0x00000000000000007fffffffffffffffffffffffffffffffffffffffffffffff",
+        "0x0000000000000000800000000000000000000000000000000000000000000001",
+        "0x0000000000000001000000000000000000000000000000000000000000000000")]
+    [TestCase(
+        "0x0000000000000000ffffffffffffffff7fffffffffffffffffffffffffffffff",
+        "0x0000000000000000000000000000000080000000000000000000000000000001",
+        "0x0000000000000001000000000000000000000000000000000000000000000000")]
     public void Add_carries_across_words(string aHex, string bHex, string resultHex)
     {
         byte[] code = Prepare.EvmCode

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math2Param.cs
@@ -90,18 +90,24 @@ public static partial class EvmInstructions
             ulong carry = limb < augend ? 1UL : 0UL;
             Add(ref top, 3) = swap.Bswap64(limb);
 
-            for (nint i = 2; i >= 0; i--)
-            {
-                augend = swap.Bswap64(Add(ref top, i));
-                addend = swap.Bswap64(Add(ref popped, i));
-                limb = augend + addend;
-                // The two carries are mutually exclusive: a wrap on augend + addend leaves a result
-                // below both, which cannot then be ulong.MaxValue and wrap again on the incoming carry.
-                ulong wrapped = limb < augend ? 1UL : 0UL;
-                limb += carry;
-                carry = wrapped + (limb < carry ? 1UL : 0UL);
-                Add(ref top, i) = swap.Bswap64(limb);
-            }
+            augend = swap.Bswap64(Add(ref top, 2));
+            addend = swap.Bswap64(Add(ref popped, 2));
+            limb = augend + addend;
+            ulong wrapped = limb < augend ? 1UL : 0UL;
+            limb += carry;
+            carry = wrapped + (limb < carry ? 1UL : 0UL);
+            Add(ref top, 2) = swap.Bswap64(limb);
+
+            augend = swap.Bswap64(Add(ref top, 1));
+            addend = swap.Bswap64(Add(ref popped, 1));
+            limb = augend + addend;
+            wrapped = limb < augend ? 1UL : 0UL;
+            limb += carry;
+            carry = wrapped + (limb < carry ? 1UL : 0UL);
+            Add(ref top, 1) = swap.Bswap64(limb);
+
+            limb = swap.Bswap64(top) + swap.Bswap64(popped) + carry;
+            top = swap.Bswap64(limb);
 
             if (TTracingInst.IsActive) stack.ReportPushWord(ref addTopRef);
             return EvmExceptionType.None;


### PR DESCRIPTION
## Changes

- Unroll the ADD carry chain with constant limb offsets and omit the discarded final outgoing carry. Gas accounting, stack checks and tracing are unchanged.
- Extend the existing ADD tests with three overflow and mixed-limb carry cases.
- Merged latest master (`397668a8dc8e2775308c4f9b3d44eaf06de8eb9f`), which includes #13358. The diff against master contains only the ADD change and its tests.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

### Requires testing

- [x] Yes
- [ ] No

### If yes, did you write tests?

- [x] Yes
- [ ] No

### Notes on testing

- Release build of Nethermind.Evm.Test passed with zero warnings and errors. Tests have not been executed locally; correctness verification is pending CI.
- git diff --check passed.

### ARM64 0x corpus results

[Benchmark run](https://github.com/NethermindEth/nethermind/actions/runs/34487509655) completed successfully. [Aggregate results](https://github.com/NethermindEth/nethermind/actions/runs/34487509655/artifacts/10157959651).

- Baseline: `nethermindeth/nethermind:master-ad832ee`.
- Candidate: `nethermindeth/nethermind:ethcall-add-ad832ee-v2`, commit `df57f5bcd92829767f8f458e6884aae6b9d15b9c`.
- This measures the pre-merge ADD-only change against its matching master commit. Neither image includes #13358; it does not measure interactions with the later master merge in the current PR head.
- Same ARM64 runner and private 497-call 0x corpus, flat snapshot 25490000, A/B/B/A, 100/300 rps, 20,000 requested calls per cell, 1,000 VUs, 120-second warmup capped at 150 rps, and a 1% failure gate.

| Load | Master mean latency | ADD mean latency | Latency change | CPU/request change |
| --- | ---: | ---: | ---: | ---: |
| 100 rps | 15.76 ms | 15.55 ms | -1.34% | -1.00% |
| 300 rps | 15.82 ms | 15.58 ms | -1.53% | -1.24% |

Values are arithmetic averages of the two per-run means for each image. Both candidate repetitions had lower mean latency than both baseline repetitions at each rate. All warmups and load cells reported 0% request failures; checks passed, no iterations were dropped, and both candidate parity passes matched 497/497 responses.

These are small observed improvements from one A/B/B/A run, not a statistically established or cross-platform speedup. The workflow also reported one node-log `ERROR` line per arm for both images; the underlying messages were not included in the aggregate artifact and remain unresolved. Generated native code has not been compared. The static snapshot does not measure live block-import or reorg contention.

AMD64 comparison using the same pinned pre-merge image pair: [run 34505206786](https://github.com/NethermindEth/nethermind/actions/runs/34505206786), results pending.

## Documentation

### Requires documentation update

- [ ] Yes
- [x] No

### Requires explanation in Release Notes

- [ ] Yes
- [x] No
