### PR TITLE
Fix PoSSwitcher genesis nullability build error

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/PoSSwitcher.cs
@@ -114,7 +114,7 @@ namespace Nethermind.Merge.Plugin
             }
             else if (HasPostTerminalTotalDifficultyGenesis(terminalTotalDifficulty.Value))
             {
-                _finalTotalDifficulty = _chainSpec.Genesis.Difficulty;
+                _finalTotalDifficulty = _chainSpec.Genesis!.Difficulty;
             }
         }
 


### PR DESCRIPTION
## Changes

Master fails to build with CS8602 in `PoSSwitcher.LoadFinalTotalDifficulty`: the compiler cannot infer the genesis null check performed by `HasPostTerminalTotalDifficultyGenesis`. Assert non-nullness at the guarded dereference. This changes nullable analysis only; runtime behavior is unchanged.

Fixes the [master Docker build failure](https://github.com/NethermindEth/nethermind/actions/runs/34498205724) and the same failure in the [master baseline of PR #13323's opcode comparison](https://github.com/NethermindEth/nethermind/actions/runs/34500457284/job/102949832762).

## Types of changes

#### What types of changes does your code introduce?

- [x] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The [amd64/ARM64 Docker build](https://github.com/NethermindEth/nethermind/actions/runs/34500385365) passes for this exact commit. All 42 existing `PoSSwitcherTests` pass on the merged #13323 branch with identical `PoSSwitcher` and test sources, covering the guarded genesis and pivot paths. This compile-only change does not add runtime behavior.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
