### PR TITLE
perf(core): specialize 64-byte Keccak cache hits

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/KeccakCacheTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/KeccakCacheTests.cs
@@ -121,14 +121,16 @@ namespace Nethermind.Core.Test
         }
 
         [Test]
-        public void Hash256_32_byte_path()
+        public void Compute_WithUnalignedInput_MatchesUncachedHash(
+            [Values(20, 32, 63, 64, 65, 92)] int length,
+            [Values(0, 1, 7, 15)] int offset)
         {
-            // Tests the optimized 32-byte path (most common - Hash256/UInt256)
             Random random = new(42);
             for (int i = 0; i < 1000; i++)
             {
-                byte[] bytes = new byte[32];
-                random.NextBytes(bytes);
+                byte[] buffer = new byte[length + offset];
+                random.NextBytes(buffer);
+                ReadOnlySpan<byte> bytes = buffer.AsSpan(offset, length);
 
                 ValueHash256 expected = ValueKeccak.Compute(bytes);
                 ValueHash256 actual = KeccakCache.Compute(bytes);
@@ -143,33 +145,11 @@ namespace Nethermind.Core.Test
         }
 
         [Test]
-        public void Address_20_byte_path()
-        {
-            // Tests the optimized 20-byte path (Address)
-            Random random = new(42);
-            for (int i = 0; i < 1000; i++)
-            {
-                byte[] bytes = new byte[20];
-                random.NextBytes(bytes);
-
-                ValueHash256 expected = ValueKeccak.Compute(bytes);
-                ValueHash256 actual = KeccakCache.Compute(bytes);
-                using (Assert.EnterMultipleScope())
-                {
-                    Assert.That(actual, Is.EqualTo(expected));
-
-                    // Second call should hit cache
-                    Assert.That(KeccakCache.Compute(bytes), Is.EqualTo(expected));
-                }
-            }
-        }
-
-        [Test]
-        public void Concurrent_read_write_stress()
+        public void Concurrent_read_write_stress([Values(32, 64)] int length)
         {
             // Stress test the seqlock pattern with concurrent readers and writers
             const int iterations = 100_000;
-            byte[] bytes = new byte[32];
+            byte[] bytes = new byte[length];
             new Random(123).NextBytes(bytes);
 
             // Prime the cache
@@ -183,7 +163,7 @@ namespace Nethermind.Core.Test
             int found = 1;
             while (found < 4)
             {
-                byte[] candidate = new byte[32];
+                byte[] candidate = new byte[length];
                 random.NextBytes(candidate);
                 if (KeccakCache.GetBucket(candidate) == bucket)
                 {

--- a/src/Nethermind/Nethermind.Core/Crypto/KeccakCache.std.cs
+++ b/src/Nethermind/Nethermind.Core/Crypto/KeccakCache.std.cs
@@ -124,6 +124,27 @@ public static unsafe partial class KeccakCache
                     return;
                 }
             }
+            else if (input.Length == 64)
+            {
+                Vector256<byte> copyLow = Unsafe.ReadUnaligned<Vector256<byte>>(ref e.Value.Start);
+                Vector256<byte> copyHigh = Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.Add(ref e.Value.Start, 32));
+                ValueHash256 cachedKeccak = e.Keccak256;
+
+                if (!Sse.IsSupported)
+                    Interlocked.MemoryBarrier();
+
+                if (seq1 == Volatile.Read(ref e.Combined))
+                {
+                    ref byte inputRef = ref MemoryMarshal.GetReference(input);
+                    Vector256<byte> difference = (copyLow ^ Unsafe.ReadUnaligned<Vector256<byte>>(ref inputRef)) |
+                        (copyHigh ^ Unsafe.ReadUnaligned<Vector256<byte>>(ref Unsafe.Add(ref inputRef, 32)));
+                    if (difference == Vector256<byte>.Zero)
+                    {
+                        keccak256 = cachedKeccak;
+                        return;
+                    }
+                }
+            }
             else
             {
                 // Uncommon path: copy full Payload for other lengths


### PR DESCRIPTION
## Changes

- Specialize 64-byte cache hits in the normal client's `KeccakCache.std.cs`: snapshot only the 64-byte input and compare it in registers rather than copying the full payload and using a variable-length comparison.
- Preserve the cache layout, complete input comparison, memory barrier, sequence validation, and miss/write paths. No zkEVM changes.
- Parameterize existing tests across input lengths 20/32/63/64/65/92 and offsets 0/1/7/15; extend the existing collision stress case to 64 bytes.
- Based solely on master `31772fa713332f35a1dfb223cda13eaad8ed8ea1`. 

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Release builds of Core and Core.Test passed with zero warnings/errors. Tests were not executed locally; correctness verification remains for CI.
- `git diff --check` passed.
- Apple ARM64 FullOpts disassembly confirms that the 64-byte hit path removes the payload stack copy and comparison-helper call while retaining the memory barrier and second sequence read.
- Whole-method code size grows from 1,292 to 1,420 bytes; stack frame grows from 320 to 352 bytes. This is not production Linux/Tier1-PGO timing evidence.
### 0x eth_call corpus benchmarks

Matching images: baseline `nethermindeth/nethermind:master-31772fa` versus candidate `nethermindeth/nethermind:ethcall-keccak64-31772fa-v1` (commit `cba97f7467a37d593498a0781b90e409bd3a0859`).

Each architecture ran its own A/B/B/A comparison on the same runner: private 497-record 0x corpus, flat snapshot 25490000, 100/300 rps, 20,000 requested calls per cell, 1,000 VUs, and a discarded 120-second warmup capped at 150 rps. Figures below are arithmetic averages of the two per-run means, not pooled latency distributions. Negative changes mean lower latency/CPU cost. Do not compare absolute timings between architectures.

| Architecture | Load | Master mean latency | Candidate mean latency | Latency change | CPU/request change |
| --- | ---: | ---: | ---: | ---: | ---: |
| AMD64 | 100 rps | 23.104 ms | 22.626 ms | -2.07% | -1.88% |
| AMD64 | 300 rps | 32.121 ms | 30.841 ms | -3.98% | -1.89% |
| ARM64 | 100 rps | 15.633 ms | 15.666 ms | +0.21% | ~0.00% |
| ARM64 | 300 rps | 15.730 ms | 15.674 ms | -0.36% | -0.18% |

**AMD64:** [run 34509643113](https://github.com/NethermindEth/nethermind/actions/runs/34509643113), [aggregate artifact](https://github.com/NethermindEth/nethermind/actions/runs/34509643113/artifacts/10168986448). Both candidate repetitions had lower mean latency than both master repetitions at each rate. All 100-rps cells had 0% request failures. At 300 rps, master failed 1.12%/1.19% of requests, exceeding the 1% gate; candidate failed 0.64%/0.91%. The workflow completed all repetitions and saved their summaries, then failed because the two master cells exceeded the gate. The 300-rps figures include failed requests and are supporting evidence only, not a clean successful-request latency comparison. Both candidate parity passes matched 497/497 responses.

**ARM64:** [run 34509637178](https://github.com/NethermindEth/nethermind/actions/runs/34509637178), [aggregate artifact](https://github.com/NethermindEth/nethermind/actions/runs/34509637178/artifacts/10167435814). The workflow succeeded; all warmups/load cells had 0% request failures, all checks passed, no iterations were dropped, and both candidate parity passes matched 497/497 responses. The result is effectively neutral.

**Caveats:** AMD64 reported a 0-MB-free disk warning before load. Both architectures reported one node-log `ERROR` line per repetition for both images; the underlying messages remain uninvestigated. These warnings do not establish the cause of the HTTP failures. This is one A/B/B/A run per architecture: a consistent positive AMD64 signal, particularly at 100 rps, not a statistically established or guaranteed cross-platform speedup. The corpus's 64-byte cache-hit frequency has not been measured, and the parked snapshot does not measure live import/reorg contention.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This changes native-client cache hits, not the actual Keccak permutation optimized by #12844/#12843 or the guest memoization in #13217. #13323 does not modify this cache. Open PR file lists were checked for overlap before implementation.

