### PR TITLE
perf(evm): trim cached jump validation

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/EvmStackTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmStackTests.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Nethermind.Core;
+using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
@@ -17,6 +18,35 @@ namespace Nethermind.Evm.Test;
 
 public class EvmStackTests
 {
+    [Test]
+    public void IsValidJumpDestination_AtBitmapBoundaries_RejectsPaddingAndPushData(
+        [Values(0, 1, 2, 63, 64, 65, 127, 128, 129)] int codeLength,
+        [Values] bool cached)
+    {
+        byte[] code = new byte[codeLength];
+        Array.Fill(code, (byte)Instruction.JUMPDEST);
+        if (codeLength > 1) code[0] = (byte)Instruction.PUSH1;
+        CodeInfo codeInfo = new(code);
+        byte slot = 0;
+
+        for (int destination = -1; destination <= codeLength + 64; destination++)
+        {
+            EvmStack stack = new(0, ref slot, code, codeInfo);
+            if (cached && codeLength > 0) stack.IsValidJumpDestination(0);
+            bool expected = destination >= (codeLength > 1 ? 2 : 0) && destination < codeLength;
+
+            Assert.That(stack.IsValidJumpDestination(destination), Is.EqualTo(expected), $"destination {destination}");
+        }
+
+        EvmStack extremeStack = new(0, ref slot, code, codeInfo);
+        if (cached && codeLength > 0) extremeStack.IsValidJumpDestination(0);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(extremeStack.IsValidJumpDestination(int.MinValue), Is.False);
+            Assert.That(extremeStack.IsValidJumpDestination(int.MaxValue), Is.False);
+        }
+    }
+
     [Test]
     public void UInt256_writeback_preserves_aliases_and_unaligned_slots(
         [Values(0, 1, 7, 8, 31)] int offset, [Values] bool alias)

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -71,21 +71,25 @@ public ref partial struct EvmStack
     private readonly CodeInfo? _codeInfo;
     private long[]? _jumpDestinations;
 
-    /// <summary>The jump-destination bitmap of <see cref="Code"/>, resolved on the first in-range jump and kept in the frame.</summary>
+    /// <summary>Validates a jump against the bitmap resolved on the first in-range jump and kept in the frame.</summary>
     /// <remarks>
     /// Kept on the stack so a jump validates against the frame it is executing without walking
     /// <c>vm.VmState.Env.CodeInfo</c>. Resolving lazily keeps the analysis off the path of frames that
     /// never jump. Only a stack built over no code may omit the code info; the empty bitmap then rejects
     /// every destination.
     /// </remarks>
-    internal long[] JumpDestinations
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool IsValidJumpDestination(int destination)
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get
+        long[]? jumpDestinations = _jumpDestinations;
+        if (jumpDestinations is null)
         {
+            if ((uint)destination >= (uint)CodeLength) return false;
             Debug.Assert(_codeInfo is not null || CodeLength == 0, "A stack that executes code must carry that code's CodeInfo.");
-            return _jumpDestinations ??= _codeInfo?.JumpDestinationBitmap ?? JumpDestinationAnalyzer.EmptyBitmap;
+            _jumpDestinations = jumpDestinations = _codeInfo?.JumpDestinationBitmap ?? JumpDestinationAnalyzer.EmptyBitmap;
         }
+
+        return JumpDestinationAnalyzer.IsJumpDestination(jumpDestinations, destination);
     }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.ControlFlow.cs
@@ -6,7 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.X86;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
-using Nethermind.Evm.CodeAnalysis;
 using Nethermind.Evm.GasPolicy;
 using Nethermind.Evm.State;
 
@@ -373,8 +372,7 @@ public static partial class EvmInstructions
     /// <inheritdoc cref="JumpDestination(ref byte, ref EvmStack)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static nint JumpDestination(int jumpDestination, ref EvmStack stack) =>
-        (uint)jumpDestination < (uint)stack.CodeLength
-            && JumpDestinationAnalyzer.IsJumpDestination(stack.JumpDestinations, jumpDestination)
+        stack.IsValidJumpDestination(jumpDestination)
             ? jumpDestination
             : -1;
 


### PR DESCRIPTION
## Changes

- Validate warmed EVM jump destinations using the cached bitmap's bounds check and bit test, avoiding a repeated bytecode-length check.
- Preserve the bytecode-length check before the first bitmap lookup so invalid cold jumps do not trigger code analysis.
- Apply the same validation to JUMP, JUMPI, and the fused PUSH2 jump path, without changing gas charging, stack checks, or tracing behavior.
- Add cold/cached validation cases for bitmap boundaries, padding, PUSH immediate data, and extreme destinations.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Release build of Nethermind.Evm.Test succeeded with zero warnings and errors, including after merging master. Tests were not executed locally.
- ARM64 FullOpts disassembly confirms the cached validation path skips a code-length load, comparison, and conditional branch. This is code-generation evidence, not an end-to-end speedup measurement.
- The ARM 0x CPU profile in https://github.com/NethermindEth/nethermind/actions/runs/34525611136 attributed 10.54% of samples directly to OpPush2, which includes fused jump execution. This identifies an investigation target, not the gain expected from this change.

### Matched RPC benchmark results

Workload: **EthCallChaos high-gas multicall #1, not the 0x corpus**. Target 100 requests/s, 1,000 VUs, two rounds in ABBA order. Each image run uses 120 seconds of same-workload ISO conditioning followed by 120 seconds of measured MIX load. Results below include MIX only; profiling was disabled.

Matched images: master `master-9ab390d` (commit `9ab390d443d7899e0bcd5b0de6eecf9202a0d209`) versus candidate `ethcall-jump-bitmap-9ab390d-v1` (commit `e03e1b3c10367744c8452d709f3a42644da05fc2`). These results predate the subsequent merge of master into this PR and do not measure the current head `a9b8dfc789d7f3c2a0ec0aeb60d0c40dd3120a35`.

| Architecture | Master mean latency, rounds 1 / 2 | Candidate mean latency, rounds 1 / 2 | Change in mean of round means |
|---|---:|---:|---:|
| ARM64 | 215.36 / 216.49 ms | 215.48 / 214.66 ms | -0.40% |
| AMD64 | 27.79 / 26.63 s | 26.41 / 26.72 s | -2.37% |

- [ARM64 run](https://github.com/NethermindEth/nethermind/actions/runs/34529288960): all four measured cells achieved approximately 99.83 requests/s, with 0% HTTP failures and 100% checks passed. The small latency difference is within the observed round-to-round spread: effectively neutral, not an established speedup.
- [AMD64 run](https://github.com/NethermindEth/nethermind/actions/runs/34529464557): mean reported throughput was 31.38 requests/s for master versus 32.02 for the candidate (+2.02%). Both were severely overloaded relative to the 100 requests/s target. Master dropped 15,490 of 24,002 scheduled iterations (64.54%); the candidate dropped 14,831 of 24,002 (61.79%). Sent requests had 0% HTTP failures and 100% checks passed; this does not imply the requested load was sustained.
- Interpretation: ARM64 is neutral; AMD64 shows a small directional improvement under overload, with mixed per-round latency results. These measurements do not establish a stable performance gain. The PR remains draft.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This targets the normal EVM and is independent of the native stack layout already merged in #13323. Master, including #13338's std/zk split, has been merged into this branch. The cached-path optimization now lives in the normal-EVM implementation; the zkEVM implementation retains the original unconditional code-length guard before incremental analysis.
