### PR TITLE
perf(evm): store initialized MSTORE words directly

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EvmPooledMemoryTests.cs
@@ -32,20 +32,24 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
     {
         Byte,
         BigEndianWord,
-        NativeWord
+        NativeWord,
+        StackWord
     }
 
     private static byte[]? GetBackingMemory(ref EvmPooledMemory memory) => memory.BackingArray;
 
-    private static void StoreWord(ref EvmPooledMemory memory, in UInt256 location, byte[] word, bool nativeWord)
+    private static void StoreWord(ref EvmPooledMemory memory, in UInt256 location, byte[] word, StoreKind storeKind)
     {
-        if (nativeWord)
+        if (storeKind is StoreKind.NativeWord or StoreKind.StackWord)
         {
             Span<byte> source = stackalloc byte[EvmPooledMemory.WordSize + 3];
             Span<byte> slot = source[3..];
             word.CopyTo(slot);
             slot.Reverse();
-            memory.StoreNativeWordAfterGas(in location, slot);
+            if (storeKind == StoreKind.StackWord)
+                memory.StoreStackWordAfterGas(in location, slot);
+            else
+                memory.StoreNativeWordAfterGas(in location, slot);
         }
         else
         {
@@ -55,6 +59,45 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_initializedSize")]
     private static extern ref ulong GetInitializedSize(ref EvmPooledMemory memory);
+
+    [Test]
+    public void StoreStackWordAfterGas_InitializedArray_PreservesSourceAndSurroundingBytes(
+        [Values(0, 1, 7, 31, 32)] int offset)
+    {
+        EvmPooledMemory memory = new();
+        byte[] expected = CreatePattern(96, 0xa7);
+        byte[] word = CreatePattern(EvmPooledMemory.WordSize, 0x31);
+        byte[] source = new byte[EvmPooledMemory.WordSize + 3];
+        word.CopyTo(source, 3);
+        source.AsSpan(3).Reverse();
+        byte[] originalSource = (byte[])source.Clone();
+        UInt256 start = 0;
+        UInt256 location = (UInt256)offset;
+        try
+        {
+            memory.CalculateMemoryCost(in start, (ulong)expected.Length, out bool outOfGas);
+            Assert.That(outOfGas, Is.False);
+            memory.SaveAfterGas(in start, expected);
+            byte[]? backing = memory.BackingArray;
+            ulong initializedSize = GetInitializedSize(ref memory);
+            Assert.That(backing, Is.Not.Null);
+            word.CopyTo(expected, offset);
+
+            memory.StoreStackWordAfterGas(in location, source.AsSpan(3));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(ReadVisibleMemory(ref memory), Is.EqualTo(expected));
+                Assert.That(source, Is.EqualTo(originalSource));
+                Assert.That(memory.BackingArray, Is.SameAs(backing));
+                Assert.That(GetInitializedSize(ref memory), Is.EqualTo(initializedSize));
+            }
+        }
+        finally
+        {
+            memory.Dispose();
+        }
+    }
 
     private static IEnumerable<TestCaseData> ZeroExtendedCopyCases()
     {
@@ -506,7 +549,8 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
     }
 
     [Test]
-    public void VmState_inline_storage_clears_only_the_required_gap_after_reuse([Values] bool nativeWord)
+    public void VmState_inline_storage_clears_only_the_required_gap_after_reuse(
+        [Values(StoreKind.BigEndianWord, StoreKind.NativeWord, StoreKind.StackWord)] StoreKind storeKind)
     {
         VmState<EthereumGasPolicy> owner = new();
         ref EvmPooledMemory memory = ref owner.Memory;
@@ -524,7 +568,7 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
             UInt256 destination = 64;
             memory.CalculateMemoryCost(in destination, EvmPooledMemory.WordSize, out outOfGas);
             Assert.That(outOfGas, Is.False);
-            StoreWord(ref memory, in destination, word, nativeWord);
+            StoreWord(ref memory, in destination, word, storeKind);
 
             using (Assert.EnterMultipleScope())
             {
@@ -542,7 +586,9 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
     }
 
     [Test]
-    public void Reserved_contiguous_MSTORE_does_not_materialize_unwritten_tail([Values(1, 16)] int wordCount, [Values] bool nativeWord)
+    public void Reserved_contiguous_MSTORE_does_not_materialize_unwritten_tail(
+        [Values(1, 16)] int wordCount,
+        [Values(StoreKind.BigEndianWord, StoreKind.NativeWord, StoreKind.StackWord)] StoreKind storeKind)
     {
         using ThreadCacheReservation cacheReservation = PrimeDirtyBuffer();
         const int reservationSize = 4 * 1024;
@@ -571,7 +617,7 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
             for (int i = 0; i < wordCount; i++)
             {
                 UInt256 destination = (UInt256)((i + 1) * EvmPooledMemory.WordSize);
-                StoreWord(ref memory, in destination, word, nativeWord);
+                StoreWord(ref memory, in destination, word, storeKind);
             }
 
             using (Assert.EnterMultipleScope())
@@ -1012,7 +1058,7 @@ public class EvmPooledMemoryTests : EvmMemoryTestsBase
             }
             else
             {
-                StoreWord(ref memory, in location, word, storeKind == StoreKind.NativeWord);
+                StoreWord(ref memory, in location, word, storeKind);
             }
 
             AssertDirtyTailWasReused(ref memory);

--- a/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmPooledMemory.cs
@@ -424,6 +424,23 @@ public struct EvmPooledMemory
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void StoreStackWordAfterGas(in UInt256 location, Span<byte> word)
+    {
+        Debug.Assert(location.IsUint64);
+        byte[]? memory = _memory;
+        if (memory is not null && location.u0 + WordSize <= _initializedSize)
+        {
+            EvmWord value = Unsafe.ReadUnaligned<EvmWord>(ref MemoryMarshal.GetReference(word)).ByteSwap();
+            ref byte destination = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(memory), TruncateToInt32(location.u0));
+            Unsafe.WriteUnaligned(ref destination, value);
+            return;
+        }
+
+        EvmStack.SwapSlot(ref MemoryMarshal.GetReference(word));
+        StoreWordAfterGas(in location, word);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal void StoreByteAfterGas(in UInt256 location, byte value)
     {
         Debug.Assert(location.IsUint64);

--- a/src/Nethermind/Nethermind.Evm/EvmStack.cs
+++ b/src/Nethermind/Nethermind.Evm/EvmStack.cs
@@ -175,7 +175,7 @@ public ref partial struct EvmStack
     /// limb before writing any is what lets the swap run over the slot in place.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void SwapSlot(ref byte slot)
+    internal static void SwapSlot(ref byte slot)
     {
         if (Vector256.IsHardwareAccelerated)
         {

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Storage.cs
@@ -144,7 +144,7 @@ public static partial class EvmInstructions
         UInt256 result;
         Span<byte> bytes;
         // Keep the established intrinsic path: fusion regresses AVX2 memory growth.
-        if (Vector128.IsHardwareAccelerated)
+        if (Vector128.IsHardwareAccelerated && TTracingInst.IsActive)
         {
             if (!stack.PopMemoryPositionAndWord256(out result, out bytes)) goto StackUnderflow;
         }
@@ -166,7 +166,10 @@ public static partial class EvmInstructions
 
         if (Vector128.IsHardwareAccelerated)
         {
-            vmState.Memory.StoreWordAfterGas(in result, bytes);
+            if (TTracingInst.IsActive)
+                vmState.Memory.StoreWordAfterGas(in result, bytes);
+            else
+                vmState.Memory.StoreStackWordAfterGas(in result, bytes);
         }
         else
         {


### PR DESCRIPTION
## Changes

- Store native-layout MSTORE words directly into already-initialized array-backed EVM memory, reversing byte order in registers instead of rewriting and rereading the popped stack slot.
- Keep memory expansion gas accounting before the store. Retain the existing swap-and-store fallback for inline memory, materialization, and growth.
- Leave instruction tracing and non-accelerated execution on their existing paths.
- Extend memory-store regression cases for the new path, including unaligned writes, source preservation, initialized boundaries, dirty-buffer reuse, and inline-memory fallback.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Release build of Nethermind.Evm.Test succeeded with zero warnings and errors.
- ARM64 FullOpts disassembly confirms the initialized-array fast path converts the loaded word and stores it directly to memory without writing the source stack slot. End-to-end benefit and growth-path performance still require A/B measurement.
- Tests are left to CI; no local test suite execution.
- Matched ARM64 and AMD64 multicall A/B results are pending. No end-to-end speedup is claimed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Standalone change based on master `dfd4f6e5cad84115a3d609aabfab1f1d487a8833`, not stacked on #13369. Unlike a general MSTORE fusion, the direct-store optimization only applies when an initialized array already covers the complete word; the existing growth path is retained.
