### PR TITLE
perf(evm): fuse ISZERO with the PUSH2 jump that consumes it

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/IsZeroJumpFusionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/IsZeroJumpFusionTests.cs
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Int256;
+using Nethermind.Specs;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// VM-level regression tests for the ISZERO+PUSH2+JUMPI peephole optimization in
+/// <c>InstructionIsZero</c>. The fused path branches on ISZERO's operand without writing the
+/// boolean the jump would have read back, so the branch is taken when the operand is zero -
+/// the inverse of the condition the unfused <c>PUSH2</c> path tests. It also takes over the
+/// gas, counting, and stack-limit duties of the two opcodes it swallows. Getting the
+/// direction, the fault order, or the lookahead guard wrong would diverge from consensus on
+/// virtually every non-trivial contract, so both branch outcomes, the sequences that must not
+/// fuse, and each fault path are exercised explicitly.
+/// </summary>
+[Parallelizable(ParallelScope.Self)]
+public class IsZeroJumpFusionTests : VirtualMachineTestsBase
+{
+    protected override ulong BlockNumber => MainnetSpecProvider.ParisBlockNumber;
+    protected override ulong Timestamp => MainnetSpecProvider.CancunBlockTimestamp;
+
+    // The fusion is gated on `!TTracingInst.IsActive`. The default TestAllTracerWithOutput
+    // reports instruction tracing and would select the unfused specialization, so use a tracer
+    // that still captures GasSpent but asks for no instruction-level trace.
+    protected override TestAllTracerWithOutput CreateTracer() => new NoInstructionTracer();
+
+    private sealed class NoInstructionTracer : TestAllTracerWithOutput
+    {
+        public override bool IsTracingInstructions => false;
+    }
+
+    [Test]
+    public void Zero_operand_takes_the_branch()
+    {
+        // A zero operand is what ISZERO turns into a truthy condition, so the jump is taken.
+        //   [0] PUSH1 0x00       (operand = 0)
+        //   [2] ISZERO           (fused with the PUSH2 and JUMPI that follow)
+        //   [3] PUSH2 0x000A
+        //   [6] JUMPI
+        //   [7] PUSH1 0xFF       (fall-through, MUST NOT execute)
+        //   [9] STOP
+        //   [10] JUMPDEST        <- jump target
+        //   [11] PUSH1 0x42
+        //   [13] PUSH1 0x00
+        //   [15] SSTORE
+        //   [16] STOP
+        byte[] dest = [0x00, 0x0A];
+        byte[] code = Prepare.EvmCode
+            .PushData((byte)0x00)
+            .Op(Instruction.ISZERO)
+            .PushData(dest)
+            .Op(Instruction.JUMPI)
+            .PushData((byte)0xFF)
+            .Op(Instruction.STOP)
+            .Op(Instruction.JUMPDEST)
+            .PushData((byte)0x42)
+            .PushData((byte)0x00)
+            .Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput r = Execute(code);
+        AssertStorage(0, (UInt256)0x42);
+        // 21000 intrinsic + PUSH1 3 + ISZERO 3 + PUSH2 3 + JUMPI 10 + JUMPDEST 1 + PUSH1 3
+        // + PUSH1 3 + SSTORE 20000. The pinned total catches a JUMPDEST charged twice or not
+        // at all, which is how a counter left on the marker would show up.
+        AssertGas(r, 41026);
+    }
+
+    [Test]
+    public void Non_zero_operand_falls_through()
+    {
+        //   [0] PUSH1 0x01       (operand != 0, so ISZERO is false and the jump is not taken)
+        //   [2] ISZERO
+        //   [3] PUSH2 0x000D
+        //   [6] JUMPI
+        //   [7] PUSH1 0x11       (fall-through, MUST execute)
+        //   [9] PUSH1 0x00
+        //   [11] SSTORE
+        //   [12] STOP
+        //   [13] JUMPDEST
+        //   [14] PUSH1 0x22      (MUST NOT execute)
+        //   [16] PUSH1 0x00
+        //   [18] SSTORE
+        //   [19] STOP
+        byte[] dest = [0x00, 0x0D];
+        byte[] code = Prepare.EvmCode
+            .PushData((byte)0x01)
+            .Op(Instruction.ISZERO)
+            .PushData(dest)
+            .Op(Instruction.JUMPI)
+            .PushData((byte)0x11)
+            .PushData((byte)0x00)
+            .Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Op(Instruction.JUMPDEST)
+            .PushData((byte)0x22)
+            .PushData((byte)0x00)
+            .Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput r = Execute(code);
+        AssertStorage(0, (UInt256)0x11);
+        AssertGas(r, 41025);
+    }
+
+    [Test]
+    public void Taken_branch_to_an_invalid_destination_faults()
+    {
+        // Offset 8 holds a PUSH1 opcode, not a JUMPDEST.
+        //   [0] PUSH1 0x00
+        //   [2] ISZERO
+        //   [3] PUSH2 0x0008
+        //   [6] JUMPI
+        //   [7] STOP
+        //   [8] PUSH1 0x99       (would run if the invalid jump somehow landed)
+        //   [10] PUSH1 0x00
+        //   [12] SSTORE
+        //   [13] STOP
+        byte[] dest = [0x00, 0x08];
+        byte[] code = Prepare.EvmCode
+            .PushData((byte)0x00)
+            .Op(Instruction.ISZERO)
+            .PushData(dest)
+            .Op(Instruction.JUMPI)
+            .Op(Instruction.STOP)
+            .PushData((byte)0x99)
+            .PushData((byte)0x00)
+            .Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput r = Execute(code);
+        AssertStorage(0, (UInt256)0);
+        // InvalidJumpDestination consumes all remaining gas per EVM spec.
+        AssertGas(r, 100000);
+    }
+
+    [Test]
+    public void Untaken_branch_never_validates_the_destination()
+    {
+        // Same invalid destination as above, but the operand is non-zero so the jump is not
+        // taken and the destination must never be looked at.
+        //   [0] PUSH1 0x01
+        //   [2] ISZERO
+        //   [3] PUSH2 0x0009     (offset 9 is a PUSH1 opcode, not a JUMPDEST)
+        //   [6] JUMPI
+        //   [7] PUSH1 0x33
+        //   [9] PUSH1 0x00
+        //   [11] SSTORE
+        //   [12] STOP
+        byte[] dest = [0x00, 0x09];
+        byte[] code = Prepare.EvmCode
+            .PushData((byte)0x01)
+            .Op(Instruction.ISZERO)
+            .PushData(dest)
+            .Op(Instruction.JUMPI)
+            .PushData((byte)0x33)
+            .PushData((byte)0x00)
+            .Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput r = Execute(code);
+        AssertStorage(0, (UInt256)0x33);
+        AssertGas(r, 41025);
+    }
+
+    [Test]
+    public void Unfused_ISZERO_still_leaves_its_result_on_the_stack()
+    {
+        //   [0] PUSH1 0x00
+        //   [2] ISZERO           (no PUSH2 follows, so the result has to be materialized)
+        //   [3] PUSH1 0x00
+        //   [5] SSTORE           (stores the ISZERO result under key 0)
+        //   [6] STOP
+        byte[] code = Prepare.EvmCode
+            .PushData((byte)0x00)
+            .Op(Instruction.ISZERO)
+            .PushData((byte)0x00)
+            .Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput r = Execute(code);
+        AssertStorage(0, (UInt256)1);
+        AssertGas(r, 41009);
+    }
+
+    [Test]
+    public void ISZERO_before_an_unconditional_jump_does_not_fuse()
+    {
+        // PUSH2+JUMP still fuses on its own, but ISZERO must not join it: the unconditional
+        // jump does not consume the condition, so the result stays on the stack.
+        //   [0] PUSH1 0x00
+        //   [2] ISZERO
+        //   [3] PUSH2 0x0007
+        //   [6] JUMP
+        //   [7] JUMPDEST
+        //   [8] PUSH1 0x00
+        //   [10] SSTORE          (stores the ISZERO result under key 0)
+        //   [11] STOP
+        byte[] dest = [0x00, 0x07];
+        byte[] code = Prepare.EvmCode
+            .PushData((byte)0x00)
+            .Op(Instruction.ISZERO)
+            .PushData(dest)
+            .Op(Instruction.JUMP)
+            .Op(Instruction.JUMPDEST)
+            .PushData((byte)0x00)
+            .Op(Instruction.SSTORE)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput r = Execute(code);
+        AssertStorage(0, (UInt256)1);
+        AssertGas(r, 41021);
+    }
+
+    [Test]
+    public void ISZERO_before_a_truncated_PUSH2_keeps_the_implicit_stop()
+    {
+        // The JUMPI the lookahead needs is past the end of the code, so nothing fuses and the
+        // trailing PUSH2 falls into the implicit STOP that ends a frame on incomplete data.
+        //   [0] PUSH1 0x42
+        //   [2] PUSH1 0x00
+        //   [4] SSTORE
+        //   [5] PUSH1 0x00
+        //   [7] ISZERO
+        //   [8] PUSH2 0x0000     (code ends after the immediate)
+        byte[] truncated = [0x00, 0x00];
+        byte[] code = Prepare.EvmCode
+            .PushData((byte)0x42)
+            .PushData((byte)0x00)
+            .Op(Instruction.SSTORE)
+            .PushData((byte)0x00)
+            .Op(Instruction.ISZERO)
+            .PushData(truncated)
+            .Done;
+
+        TestAllTracerWithOutput r = Execute(code);
+        AssertStorage(0, (UInt256)0x42);
+        AssertGas(r, 41015);
+    }
+
+    [Test]
+    public void ISZERO_on_an_empty_stack_underflows()
+    {
+        byte[] code = Prepare.EvmCode
+            .Op(Instruction.ISZERO)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput r = Execute(code);
+        AssertGas(r, 100000);
+    }
+
+    [Test]
+    public void A_full_stack_overflows_at_the_fused_PUSH2()
+    {
+        // The fused sequence is one word shorter on the way out than on the way in, but the
+        // PUSH2 it swallows still runs against a full stack and has to fault there.
+        byte[] dest = [0x00, 0x00];
+        Prepare prepare = Prepare.EvmCode;
+        for (int i = 0; i < EvmStack.MaxStackSize - 1; i++)
+            prepare = prepare.PushData((byte)0x00);
+
+        byte[] code = prepare
+            .Op(Instruction.ISZERO)
+            .PushData(dest)
+            .Op(Instruction.JUMPI)
+            .Op(Instruction.JUMPDEST)
+            .Op(Instruction.STOP)
+            .Done;
+
+        TestAllTracerWithOutput r = Execute(code);
+        // StackOverflow consumes all remaining gas, as every EVM fault but a revert does.
+        AssertGas(r, 100000);
+    }
+}

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math1Param.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Math1Param.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using Nethermind.Core;
@@ -105,6 +106,75 @@ public static partial class EvmInstructions
 
         return EvmExceptionType.None;
         // Label for error handling when the stack does not have the required element.
+    StackUnderflow:
+        return EvmExceptionType.StackUnderflow;
+    }
+
+    /// <summary>
+    /// Executes ISZERO, fusing it with a following <c>PUSH2; JUMPI</c> when the bytecode has that shape.
+    /// </summary>
+    /// <remarks>
+    /// The conditional jump only asks whether the word ISZERO wrote is non-zero, which is the same question
+    /// as whether ISZERO's operand is zero. A fused sequence therefore branches on the operand in place and
+    /// skips both the boolean the stack slot would have carried and the dispatch into <c>PUSH2</c>, which
+    /// already fuses the jump itself. Gas, the stack limit, and the pop stay in bytecode order, so a
+    /// sequence that faults faults for the same reason and at the same counter as the three opcodes do.
+    /// </remarks>
+    [SkipLocalsInit]
+    public static EvmExceptionType InstructionIsZero<TGasPolicy>(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter)
+        where TGasPolicy : struct, IGasPolicy<TGasPolicy>
+    {
+        const int Push2Size = sizeof(ushort);
+        // ISZERO's own cost and operand, whether or not the sequence fuses.
+        if (!TGasPolicy.UpdateGas<OpIsZero>(ref gas)) return EvmExceptionType.OutOfGas;
+        if (!stack.EnsureDepth(1)) goto StackUnderflow;
+
+        ref byte code = ref stack.Code;
+        nint pc = programCounter;
+        // The PUSH2 opcode, its two immediate bytes, and the JUMPI all have to be present to be read.
+        if (stack.CodeLength - pc < Push2Size + 2 ||
+            (Instruction)Add(ref code, pc) != Instruction.PUSH2 ||
+            (Instruction)Add(ref code, pc + 1 + Push2Size) != Instruction.JUMPI)
+        {
+            return Math1ParamCore<OpIsZero, OffFlag>(ref stack);
+        }
+
+        // PUSH2 is counted and charged before the jump, and its stack limit still applies even though the
+        // fused sequence leaves the stack one word shorter than it found it.
+        vm.OpCodeCount++;
+        if (!TGasPolicy.UpdateGas<VeryLowGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
+        if (stack.Head >= EvmStack.MaxStackSize - 1)
+        {
+            programCounter = pc + 1 + Push2Size;
+            return EvmExceptionType.StackOverflow;
+        }
+
+        vm.OpCodeCount++;
+        if (!TGasPolicy.UpdateGas<JumpIGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
+
+        // The depth check above covers the condition as well: ISZERO neither grows nor shrinks the stack.
+        // The branch is taken exactly when the operand is zero, which is when ISZERO would have written one.
+        if (!EvmStack.IsSlotZero(ref stack.PopBytesByRefUnchecked()))
+        {
+            // Move past the two immediate bytes and the JUMPI.
+            programCounter = pc + 1 + Push2Size + 1;
+            goto Success;
+        }
+
+        ushort destination = BinaryPrimitives.ReverseEndianness(As<byte, ushort>(ref Add(ref code, pc + 1)));
+        nint jumpTarget = JumpDestination(destination, ref stack);
+        if (jumpTarget < 0) goto InvalidJumpDestination;
+        // Skip the JUMPDEST byte we just validated, charging its gas and count here.
+        programCounter = jumpTarget + 1;
+        PrefetchCodeAtDestination(ref stack, programCounter);
+        vm.OpCodeCount++;
+        if (!TGasPolicy.UpdateGas<JumpDestGasCost>(ref gas)) return EvmExceptionType.OutOfGas;
+
+    Success:
+        return EvmExceptionType.None;
+        // Jump forward to be unpredicted by the branch predictor.
+    InvalidJumpDestination:
+        return EvmExceptionType.InvalidJumpDestination;
     StackUnderflow:
         return EvmExceptionType.StackUnderflow;
     }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.OpcodeHandlers.cs
@@ -96,7 +96,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         lookup[(int)Instruction.SLT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpSLt, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.SGT] = OpcodeHandler<Math2Opcode<EvmInstructions.OpSGt, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.EQ] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseEq, TTracingInst>, TTracingInst, TCancelable>();
-        lookup[(int)Instruction.ISZERO] = OpcodeHandler<Math1Opcode<EvmInstructions.OpIsZero, TTracingInst>, TTracingInst, TCancelable>();
+        lookup[(int)Instruction.ISZERO] = OpcodeHandler<IsZeroOpcode<TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.AND] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseAnd, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.OR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseOr, TTracingInst>, TTracingInst, TCancelable>();
         lookup[(int)Instruction.XOR] = OpcodeHandler<BitwiseOpcode<EvmInstructions.OpBitwiseXor, TTracingInst>, TTracingInst, TCancelable>();
@@ -574,6 +574,25 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
             return EvmInstructions.Math1ParamCore<TOpMath, OffFlag>(ref stack);
         }
+    }
+
+    /// <summary>
+    /// ISZERO, which reads the bytecode after it to fuse with a following <c>PUSH2; JUMPI</c>.
+    /// </summary>
+    /// <remarks>
+    /// The body owns its gas and depth guards rather than taking the checked path: a fused sequence can
+    /// still fault on PUSH2's stack limit or an invalid destination, which dispatch discards for a checked
+    /// body. A traced run keeps the plain operation, since the fused form would hide two opcodes.
+    /// </remarks>
+    [SkipLocalsInit]
+    private readonly struct IsZeroOpcode<TTracingInst> : IOpcodeBody where TTracingInst : struct, IFlag
+    {
+        public static bool UsesVm => true;
+
+        public static EvmExceptionType Execute(ref EvmStack stack, ref TGasPolicy gas, VirtualMachine<TGasPolicy> vm, ref nint programCounter) =>
+            TTracingInst.IsActive
+                ? EvmInstructions.InstructionMath1Param<TGasPolicy, EvmInstructions.OpIsZero>(ref stack, ref gas, vm)
+                : EvmInstructions.InstructionIsZero(ref stack, ref gas, vm, ref programCounter);
     }
 
     [SkipLocalsInit]


### PR DESCRIPTION
## Changes

- Branch an untraced `ISZERO; PUSH2; JUMPI` sequence on ISZERO's operand directly, so the boolean the jump would have read back is never written to the stack slot and the dispatch into `PUSH2` is skipped. `PUSH2` already fuses the jump itself, so this removes one indirect dispatch, not two.
- Keep gas, opcode counts, the `PUSH2` stack limit, and the condition pop in bytecode order, so a fused sequence faults for the same reason and at the same program counter as the three separate opcodes.
- Leave every other shape alone: a traced run, an `ISZERO` with no `PUSH2` after it, an `ISZERO; PUSH2; JUMP`, and a `PUSH2` truncated by the end of the code all keep their current paths.
- Move ISZERO off the checked dispatch body, which discards a handler's status, since a fused sequence can still report `StackOverflow` or `InvalidJumpDestination`.
- Add regression cases for both branch outcomes, the two sequences that must not fuse, the truncated lookahead, and the underflow, invalid-destination, and full-stack faults.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- Release build of Nethermind.Evm and Nethermind.Evm.Test succeeded with zero warnings and errors.
- Full Nethermind.Evm.Test suite run locally on ARM64: 12333 total, 0 failed, 8 skipped.
- The new cases were checked against a deliberately inverted fused condition and 4 of the 9 went red, so the fused path is the one under test rather than the unfused fallback.
- Gas totals are pinned exactly in every case, which is what would catch a JUMPDEST charged twice or not at all.
- **No speedup is claimed yet.** Matched candidate/master A/B benchmarking is pending. The lookahead adds two bytecode loads and two comparisons to every `ISZERO` that does not fuse, which can pay against the saved store and dispatch; only a matched A/B settles it.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Targets the normal EVM only. Base commit: `127706c5c4b9c43141693b1984d15730bfb11496`.

The candidate was picked from the pinned `multicall-high-gas-1` workload: its dominant callee has 123 predicate-then-`PUSH2`-then-`JUMPI` sites in its deployed bytecode, 94 of them `ISZERO`. Those are static counts from a decode of the deployed code, not execution frequency, so they identify a shape worth trying rather than a gain to expect. If the A/B pays, `EQ` and `LT` are the same shape and would follow separately.
