### PR TITLE
fix(xdc): encode sign-transaction receipts as legacy in the receipts trie

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -288,7 +288,7 @@ public partial class BlockProcessor(
         return blockBloom;
     }
 
-    private static Hash256 CalculateReceiptsRoot(TxReceipt[] receipts, IReleaseSpec spec, Block block)
+    protected virtual Hash256 CalculateReceiptsRoot(TxReceipt[] receipts, IReleaseSpec spec, Block block)
     {
         using MetricsTimer<ReceiptsRootTimeSink> _ = new();
         return ReceiptsRootCalculator.Instance.GetReceiptsRoot(receipts, spec, block.ReceiptsRoot);

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcReceiptsTrieTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcReceiptsTrieTests.cs
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm;
+using Nethermind.Serialization.Rlp;
+using Nethermind.State.Proofs;
+using Nethermind.Xdc.Spec;
+using NUnit.Framework;
+
+namespace Nethermind.Xdc.Test;
+
+internal class XdcReceiptsTrieTests
+{
+    private static readonly Address BlockSigner = TestItem.AddressE;
+
+    private static XdcReleaseSpec Spec => new() { BlockSignerContract = BlockSigner, RandomizeSMCBinary = TestItem.AddressC };
+
+    private static TxReceipt Receipt(Address recipient, TxType type) => new()
+    {
+        TxType = type,
+        Recipient = recipient,
+        StatusCode = StatusCode.Success,
+        GasUsedTotal = 0,
+        Logs = [new LogEntry(recipient, [], [])],
+        Bloom = Bloom.Empty,
+    };
+
+    private static Hash256 Root(params TxReceipt[] receipts) =>
+        ReceiptTrie.CalculateRoot(Spec, receipts, Rlp.GetDecoderOrThrow<TxReceipt>(RlpDecoderKey.Trie));
+
+    [TestCase(TxType.EIP1559)]
+    [TestCase(TxType.AccessList)]
+    public void SignTransactionReceipt_IsEncodedAsLegacy(TxType txType)
+    {
+        TxReceipt typed = Receipt(BlockSigner, txType);
+
+        Hash256 asEncoded = Root(XdcBlockProcessor.AsEncodedForTrie([typed], Spec));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(asEncoded, Is.EqualTo(Root(Receipt(BlockSigner, TxType.Legacy))));
+            Assert.That(asEncoded, Is.Not.EqualTo(Root(typed)));
+        });
+    }
+
+    [TestCase(TxType.EIP1559)]
+    [TestCase(TxType.AccessList)]
+    public void OtherRecipientReceipt_KeepsItsType(TxType txType)
+    {
+        TxReceipt randomize = Receipt(TestItem.AddressC, txType);
+        TxReceipt ordinary = Receipt(TestItem.AddressD, txType);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Root(XdcBlockProcessor.AsEncodedForTrie([randomize], Spec)), Is.EqualTo(Root(randomize)));
+            Assert.That(Root(XdcBlockProcessor.AsEncodedForTrie([ordinary], Spec)), Is.EqualTo(Root(ordinary)));
+        });
+    }
+
+    [Test]
+    public void StoredReceiptKeepsItsType()
+    {
+        TxReceipt typed = Receipt(BlockSigner, TxType.EIP1559);
+
+        XdcBlockProcessor.AsEncodedForTrie([typed], Spec);
+
+        Assert.That(typed.TxType, Is.EqualTo(TxType.EIP1559));
+    }
+}

--- a/src/Nethermind/Nethermind.Xdc.Test/XdcReceiptsTrieTests.cs
+++ b/src/Nethermind/Nethermind.Xdc.Test/XdcReceiptsTrieTests.cs
@@ -60,13 +60,33 @@ internal class XdcReceiptsTrieTests
         });
     }
 
+    // The caller keeps using these receipts after the root is taken — they are what gets stored and
+    // served over RPC — so the trie encoding must not reach back into the array or the receipts in it.
     [Test]
-    public void StoredReceiptKeepsItsType()
+    public void OriginalReceipts_AreNotTouched()
     {
-        TxReceipt typed = Receipt(BlockSigner, TxType.EIP1559);
+        TxReceipt signReceipt = Receipt(BlockSigner, TxType.EIP1559);
+        TxReceipt[] receipts = [signReceipt, Receipt(TestItem.AddressD, TxType.EIP1559)];
+        TxReceipt[] before = (TxReceipt[])receipts.Clone();
 
-        XdcBlockProcessor.AsEncodedForTrie([typed], Spec);
+        TxReceipt[] forTrie = XdcBlockProcessor.AsEncodedForTrie(receipts, Spec);
 
-        Assert.That(typed.TxType, Is.EqualTo(TxType.EIP1559));
+        Assert.Multiple(() =>
+        {
+            Assert.That(forTrie, Is.Not.SameAs(receipts));
+            for (int i = 0; i < receipts.Length; i++)
+            {
+                Assert.That(receipts[i], Is.SameAs(before[i]));
+                Assert.That(receipts[i].TxType, Is.EqualTo(TxType.EIP1559));
+            }
+        });
+    }
+
+    [Test]
+    public void NothingToAdjust_ReturnsTheSameArray()
+    {
+        TxReceipt[] receipts = [Receipt(TestItem.AddressD, TxType.EIP1559), Receipt(BlockSigner, TxType.Legacy)];
+
+        Assert.That(XdcBlockProcessor.AsEncodedForTrie(receipts, Spec), Is.SameAs(receipts));
     }
 }

--- a/src/Nethermind/Nethermind.Xdc/XdcBlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Xdc/XdcBlockProcessor.cs
@@ -16,6 +16,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Logging;
+using Nethermind.Xdc.Spec;
 using Nethermind.Int256;
 
 namespace Nethermind.Xdc;
@@ -34,6 +35,37 @@ internal class XdcBlockProcessor(
     IExecutionRequestsProcessor executionRequestsProcessor,
     IBlockAccessListManager balManager) : BlockProcessor(specProvider, blockValidator, rewardCalculator, blockTransactionsExecutor, stateProvider, receiptStorage, beaconBlockRootHandler, blockHashStore, logManager, withdrawalProcessor, executionRequestsProcessor, balManager), IBlockProcessor
 {
+    protected override Hash256 CalculateReceiptsRoot(TxReceipt[] receipts, IReleaseSpec spec, Block block) =>
+        base.CalculateReceiptsRoot(AsEncodedForTrie(receipts, spec), spec, block);
+
+    /// <summary>
+    /// Returns the receipts as the receipts trie must encode them, which is not always how they are stored.
+    /// </summary>
+    /// <remarks>
+    /// A sign transaction's receipt enters the trie as a legacy receipt whatever the transaction's type,
+    /// because the reference client builds it with <c>types.NewReceipt</c> and never assigns
+    /// <c>receipt.Type</c> — see XinFinOrg/XDPoSChain
+    /// https://github.com/XinFinOrg/XDPoSChain/blob/5d080472c84a92a46f5fd0d343c09cca9f1b1356/core/state_processor.go#L426
+    /// It still reports the real type over RPC, as the reference does by filling it in from the
+    /// transaction when the receipt is read back, so only the encoding fed to the trie is adjusted here.
+    /// </remarks>
+    internal static TxReceipt[] AsEncodedForTrie(TxReceipt[] receipts, IReleaseSpec spec)
+    {
+        if (spec is not IXdcReleaseSpec { BlockSignerContract: not null } xdcSpec) return receipts;
+
+        TxReceipt[]? forTrie = null;
+        for (int i = 0; i < receipts.Length; i++)
+        {
+            TxReceipt receipt = receipts[i];
+            if (receipt.TxType == TxType.Legacy || receipt.Recipient != xdcSpec.BlockSignerContract) continue;
+
+            forTrie ??= (TxReceipt[])receipts.Clone();
+            forTrie[i] = new TxReceipt(receipt) { TxType = TxType.Legacy };
+        }
+
+        return forTrie ?? receipts;
+    }
+
     protected override void PostValidation(Block suggestedBlock, Block processedBlock, TxReceipt[] receipts, ProcessingOptions options)
     {
         base.PostValidation(suggestedBlock, processedBlock, receipts, options);


### PR DESCRIPTION
## Changes

A type-1 (EIP-2930) or type-2 (EIP-1559) transaction to the XDC block-signer contract
`0x0000000000000000000000000000000000000089` produced a different `receiptsRoot` from the reference
client, so the block hash differed and a mixed-client network forked. The state root always agreed —
only the receipt encoding was wrong. Legacy transactions to that contract, and transactions of any type
to the randomize contract, were already fine.

The reference builds that receipt with `types.NewReceipt` and never assigns `receipt.Type`:

https://github.com/XinFinOrg/XDPoSChain/blob/5d080472c84a92a46f5fd0d343c09cca9f1b1356/core/state_processor.go#L426

`types.NewReceipt` leaves `Type` at `LegacyTxType`, and there is no `receipt.Type` assignment anywhere
in that file, so the receipt enters the trie as **legacy** whatever the transaction type. It still
reports the real type over RPC, because `DeriveFields` fills it in from the transaction when the
receipt is read back.

So only the receipts handed to the trie are adjusted; the stored receipt and its RPC output are left
alone, which keeps both consensus and `eth_getTransactionReceipt` in step with the reference.
`BlockProcessor.CalculateReceiptsRoot` becomes `virtual` (it was `private static`) so the plugin can
override it.

**Consensus-affecting for XDC**, though only for a transaction shape the consensus engine never
produces itself — it builds signing transactions as legacy. It needs a masternode-candidate sender, but
modern wallets default to type-2, so a candidate signing through an ordinary wallet would hit it.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`XdcReceiptsTrieTests` asserts that a type-1 and a type-2 sign-transaction receipt produce the root of
the equivalent legacy receipt and not of a typed one, that receipts for any other recipient keep their
type, and that the stored receipt is not mutated. `Nethermind.Xdc.Test` 719/719.

Verified on a mixed-client network — two Nethermind masternodes and two `XDPoSChain v2.9.0-devnet`
(commit `5d080472`), all four validators. Before, for a type-2 signing transaction:

```
stateRoot          same
transactionsRoot   same
gasUsed            same
logsBloom          same
receiptsRoot       DIFFER   nm=0xd32f0c94…  go=0x366edb13…
```

After, for both a type-1 and a type-2 signing transaction, every header field matches and both clients
stay on the same block, while `eth_getTransactionReceipt` still reports `type=0x1`/`0x2` on both sides.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

Fixes a consensus divergence on XDC for typed transactions to the block-signer contract.

## Remarks

`ApplyEmptyTransaction`, used for the trading and lending contracts under `IsTIPXDCXReceiver`, builds
its receipt the same way and is likely affected too. I have not reproduced that, so it is deliberately
left out of this PR rather than fixed blind.

Independent of #13359, which changes the randomize path and does not touch sign transactions.
