### PR TITLE
Charge warm SELFDESTRUCT beneficiary access under EIP-8038

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/Eip8038Tests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Eip8038Tests.cs
@@ -134,11 +134,13 @@ public class Eip8038Tests(bool eip8038Enabled, bool tracing = true, bool cancela
     }
 
     [Test]
-    public void Selfdestruct_charges_beneficiary_access_and_creation([Values] bool newBeneficiary)
+    public void Selfdestruct_charges_beneficiary_access_and_creation([Values] bool newBeneficiary, [Values] bool warm)
     {
         Address beneficiary = newBeneficiary ? TestItem.AddressE : Target;
-        byte[] code = Prepare.EvmCode.SELFDESTRUCT(beneficiary).Done;
-        ulong expected = GasCostOf.Transaction + GasCostOf.VeryLow + GasCostOf.SelfDestructEip150 + ColdAccountAccess;
+        byte[] warmup = warm ? Prepare.EvmCode.PushData(beneficiary).Op(Instruction.BALANCE).Op(Instruction.POP).Done : [];
+        byte[] code = [.. warmup, .. Prepare.EvmCode.SELFDESTRUCT(beneficiary).Done];
+        ulong expected = GasCostOf.Transaction + GasCostOf.VeryLow + GasCostOf.SelfDestructEip150 + ColdAccountAccess
+            + (warm ? GasCostOf.VeryLow + GasCostOf.Base + ExtraWarmAccess : 0);
         if (newBeneficiary)
             expected += GasCostOf.NewAccount + (eip8038Enabled ? Eip8038Constants.AccountWrite : 0);
 
@@ -149,6 +151,23 @@ public class Eip8038Tests(bool eip8038Enabled, bool tracing = true, bool cancela
             Assert.That(result.StatusCode, Is.EqualTo(StatusCode.Success));
             Assert.That(result.GasSpent, Is.EqualTo(expected));
             Assert.That(TestState.GetBalance(beneficiary), Is.GreaterThan(UInt256.Zero));
+        }
+    }
+
+    [Test]
+    public void Selfdestruct_to_self_obeys_exact_gas_boundary([Values(-1, 0, 1)] int gasDelta)
+    {
+        byte[] code = Prepare.EvmCode.SELFDESTRUCT(Recipient).Done;
+        ulong expected = GasCostOf.Transaction + GasCostOf.VeryLow + GasCostOf.SelfDestructEip150 + ExtraWarmAccess;
+        ulong gasLimit = (ulong)((long)expected + gasDelta);
+
+        TestAllTracerWithOutput result = Execute(Activation, gasLimit, code);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.StatusCode, Is.EqualTo(gasDelta < 0 ? StatusCode.Failure : StatusCode.Success));
+            Assert.That(result.GasSpent, Is.EqualTo(gasDelta < 0 ? gasLimit : expected));
+            Assert.That(TestState.GetBalance(Recipient), Is.EqualTo(gasDelta < 0 ? 100.Ether : 100.Ether + 1));
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/AccountAccessKind.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/AccountAccessKind.cs
@@ -18,7 +18,7 @@ public enum AccountAccessKind : byte
     /// <summary>
     /// SELFDESTRUCT beneficiary access.
     /// Cold access charges full cost to StorageAccess (no Computation split);
-    /// warm access charges nothing.
+    /// warm access charges nothing before EIP-8038 and WARM_ACCESS after activation.
     /// </summary>
     SelfDestructBeneficiary = 1
 }

--- a/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
+++ b/src/Nethermind/Nethermind.Evm/GasPolicy/EthereumGasPolicy.cs
@@ -247,7 +247,7 @@ public struct EthereumGasPolicy : IGasPolicy<EthereumGasPolicy>
         return (accessTracker.WarmUp(address) && !spec.IsPrecompile(address)) switch
         {
             true => UpdateGas(ref gas, TColdCost.GasCost(spec)),
-            false when kind == AccountAccessKind.SelfDestructBeneficiary => true,
+            false when kind == AccountAccessKind.SelfDestructBeneficiary && !TMode.IsEip8038Enabled(spec) => true,
             false => UpdateGas(ref gas, GasCostOf.WarmStateRead)
         };
     }


### PR DESCRIPTION
## Changes

- Charge `WARM_ACCESS` (100 gas) for a warm SELFDESTRUCT beneficiary when EIP-8038 is enabled. Keep the pre-EIP-8038 exemption and cold-access charges unchanged.
- Extend beneficiary tests to warm existing/new accounts and cover self-beneficiary execution one gas below, at, and above the required gas across fork and tracer specializations.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

The added regression cases fail against the original implementation: warm beneficiaries are undercharged by 100 gas, and insufficient-gas self-beneficiary execution incorrectly succeeds. After the fix, all 920 focused EIP-8038/gas-policy tests pass. The full EVM suite passes: 12,356 passed, 8 skipped, 0 failed. All 19 repository solutions build with warnings treated as errors (zero warnings/errors). Changed-file whitespace and diff checks pass. Three independent reviews found no actionable issues.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

This follows the current [EIP-8038 access-cost table](https://eips.ethereum.org/EIPS/eip-8038#overview). The [July 29 clarification](https://github.com/ethereum/EIPs/commit/b7491982cec3657684e3047f9647b4c60fc23d4d) explicitly includes SELFDESTRUCT among warm-access operations.

Upstream discrepancy: [execution-specs tests at 622620d](https://github.com/ethereum/execution-specs/blob/622620d84a70efe1337abdafaecd7bdfeb254b92/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_selfdestruct_gas.py#L5-L18) and [Geth at 101035a](https://github.com/ethereum/go-ethereum/blob/101035a1049c7dc468bfe973478b579d9883d7b6/core/vm/gas_table.go#L648-L664) still use zero for warm beneficiaries. This PR aligns with the EIP; it does not claim agreement with those implementations.
