### PR TITLE
EIP-8141: address the P3 review threads on the frame-tx stack

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -863,9 +863,10 @@ public class FrameTxProcessorTests
 
         TransactionResult result = Process(tx);
 
+        Assert.That(result.TransactionExecuted, Is.True);
+
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result.TransactionExecuted, Is.True);
             AssertStorage(Observer, 0, TxFrameSignature.SchemeArbitrary);
             AssertStorage(Observer, 1, UInt256.Zero);
             AssertStorage(Observer, 2, 3);
@@ -941,9 +942,10 @@ public class FrameTxProcessorTests
 
         TransactionResult result = Process(tx);
 
+        Assert.That(result.TransactionExecuted, Is.True);
+
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result.TransactionExecuted, Is.True);
             AssertStorage(Observer, 0, AddressAsWord(Eip8141Constants.EntryPointAddress));
             AssertStorage(Recipient, 0, AddressAsWord(Sender));
         }
@@ -966,11 +968,8 @@ public class FrameTxProcessorTests
 
         TransactionResult result = Process(tx);
 
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.TransactionExecuted, Is.True);
-            AssertStorage(Observer, 0, UInt256.Zero);
-        }
+        Assert.That(result.TransactionExecuted, Is.True);
+        AssertStorage(Observer, 0, UInt256.Zero);
     }
 
     [Test]
@@ -991,13 +990,14 @@ public class FrameTxProcessorTests
 
         TransactionResult result = Process(tx);
 
+        Assert.That(result.TransactionExecuted, Is.True, "payer set by frame 0 outside the batch");
+
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(result.TransactionExecuted, Is.True, "payer set by frame 0 outside the batch");
             Assert.That(tx.Frames![1].IsAtomicBatch, Is.True);
+            AssertStorage(Observer, 0, UInt256.Zero, "batch frame 1 write rolled back");
+            AssertStorage(TestItem.AddressD, 0, UInt256.Zero, "terminal frame skipped, never wrote");
         }
-        AssertStorage(Observer, 0, UInt256.Zero, "batch frame 1 write rolled back");
-        AssertStorage(TestItem.AddressD, 0, UInt256.Zero, "terminal frame skipped, never wrote");
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -658,11 +658,7 @@ public class FrameTxProcessorTests
     [TestCase((byte)0x0C, DefaultFrameStateGasLimit, TestName = "Execute_TxParam_StateGasLeft")]
     public void Execute_TxParamIntrospection_ExposesTransactionField(byte param, ulong expected)
     {
-        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
-        DeployContract(Observer, Prepare.EvmCode
-            .PushData(param).Op(Instruction.TXPARAM).PushData(0).Op(Instruction.SSTORE)
-            .Op(Instruction.STOP).Done);
-        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        Transaction tx = TxParamObserverTx(param);
 
         TransactionResult result = Process(tx);
 
@@ -673,11 +669,7 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_TxParamSender_ExposesSenderAddress()
     {
-        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
-        DeployContract(Observer, Prepare.EvmCode
-            .PushData(0x02).Op(Instruction.TXPARAM).PushData(0).Op(Instruction.SSTORE)
-            .Op(Instruction.STOP).Done);
-        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        Transaction tx = TxParamObserverTx(0x02);
 
         TransactionResult result = Process(tx);
 
@@ -688,16 +680,22 @@ public class FrameTxProcessorTests
     [Test]
     public void Execute_TxParamSigHash_ExposesCanonicalHash()
     {
-        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
-        DeployContract(Observer, Prepare.EvmCode
-            .PushData(0x08).Op(Instruction.TXPARAM).PushData(0).Op(Instruction.SSTORE)
-            .Op(Instruction.STOP).Done);
-        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
+        Transaction tx = TxParamObserverTx(0x08);
 
         TransactionResult result = Process(tx);
 
         Assert.That(result.TransactionExecuted, Is.True);
         AssertStorage(Observer, 0, new UInt256(FrameTxSigHash.ComputeValue(tx).Bytes, isBigEndian: true));
+    }
+
+    /// <summary>Builds the transaction whose body frame stores <c>TXPARAM param</c> into the observer's slot 0.</summary>
+    private Transaction TxParamObserverTx(byte param)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, Prepare.EvmCode
+            .PushData(param).Op(Instruction.TXPARAM).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        return FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Observer));
     }
 
     [TestCase((byte)0x01, 200_000UL, TestName = "Execute_FrameParam_GasLimit")]
@@ -865,10 +863,13 @@ public class FrameTxProcessorTests
 
         TransactionResult result = Process(tx);
 
-        Assert.That(result.TransactionExecuted, Is.True);
-        AssertStorage(Observer, 0, TxFrameSignature.SchemeArbitrary);
-        AssertStorage(Observer, 1, UInt256.Zero);
-        AssertStorage(Observer, 2, 3);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            AssertStorage(Observer, 0, TxFrameSignature.SchemeArbitrary);
+            AssertStorage(Observer, 1, UInt256.Zero);
+            AssertStorage(Observer, 2, 3);
+        }
     }
 
     [Test]
@@ -940,9 +941,12 @@ public class FrameTxProcessorTests
 
         TransactionResult result = Process(tx);
 
-        Assert.That(result.TransactionExecuted, Is.True);
-        AssertStorage(Observer, 0, AddressAsWord(Eip8141Constants.EntryPointAddress));
-        AssertStorage(Recipient, 0, AddressAsWord(Sender));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            AssertStorage(Observer, 0, AddressAsWord(Eip8141Constants.EntryPointAddress));
+            AssertStorage(Recipient, 0, AddressAsWord(Sender));
+        }
     }
 
     [Test]
@@ -962,8 +966,11 @@ public class FrameTxProcessorTests
 
         TransactionResult result = Process(tx);
 
-        Assert.That(result.TransactionExecuted, Is.True);
-        AssertStorage(Observer, 0, UInt256.Zero);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.TransactionExecuted, Is.True);
+            AssertStorage(Observer, 0, UInt256.Zero);
+        }
     }
 
     [Test]
@@ -3088,8 +3095,12 @@ public class FrameTxProcessorTests
         Transaction tx = FrameTx(nonce: Eip8250Constants.MaxNonceSeq, SelfVerifyFrame());
 
         Assert.That(Process(tx).TransactionExecuted, Is.False, "no payer approved");
-        Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(Eip8250Constants.MaxNonceSeq));
-        Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(balanceBefore), "max cost was not collected");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(Eip8250Constants.MaxNonceSeq));
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(balanceBefore), "max cost was not collected");
+        }
 
         Transaction keyed = FrameTx(nonce: Eip8250Constants.MaxNonceSeq, SelfVerifyFrame());
         keyed.NonceKeys = [UInt256.Zero];
@@ -4170,10 +4181,12 @@ public class FrameTxProcessorTests
         (_, CallOutputTracer tracer) = CallSimulated(
             FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModePostTx, target: Recipient)), out _, out EthereumVirtualMachine vm);
 
+        Assert.That(vm.TxExecutionContext.FrameTxContext, Is.Not.Null,
+            "the view is only released, so the context still proves the assertion ran");
+
         using (Assert.EnterMultipleScope())
         {
             Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success));
-            Assert.That(vm.TxExecutionContext.FrameTxContext, Is.Not.Null, "the view is only released, so the context still proves the assertion ran");
             Assert.That(vm.TxExecutionContext.FrameTxContext!.PostTxDiffView, Is.Null);
         }
     }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxValidationPrefixSimulationTests.cs
@@ -199,10 +199,15 @@ public class FrameTxValidationPrefixSimulationTests
         AssertPrefixVerdictParity(tx, expectedValid);
     }
 
-    [Test]
-    public void Simulate_PrefixNeverSetsPayer_Rejected()
+    // The prefix leaves no payer either way: one halts without approving, the other reverts.
+    [TestCase(false, TestName = "Simulate_PrefixNeverSetsPayer_Rejected")]
+    [TestCase(true, TestName = "Simulate_PrefixReverts_Rejected")]
+    public void Simulate_PrefixResolvingNoPayer_Rejected(bool reverts)
     {
-        DeployContract(Sender, Prepare.EvmCode.Op(Instruction.STOP).Done, 1.Ether);
+        byte[] prefix = reverts
+            ? Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done
+            : Prepare.EvmCode.Op(Instruction.STOP).Done;
+        DeployContract(Sender, prefix, 1.Ether);
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
 
         (TransactionResult result, FrameTxValidationTracer tracer) = Simulate(tx);
@@ -215,24 +220,8 @@ public class FrameTxValidationPrefixSimulationTests
     }
 
     [Test]
-    public void Simulate_PrefixReverts_Rejected()
-    {
-        DeployContract(Sender, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done, 1.Ether);
-        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
-
-        (TransactionResult result, FrameTxValidationTracer tracer) = Simulate(tx);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.TransactionExecuted, Is.False);
-            Assert.That(tracer.Payer, Is.Null);
-        }
-    }
-
-    [TestCase(Instruction.ORIGIN)]
-    [TestCase(Instruction.BLOBHASH)]
-    [TestCase(Instruction.TLOAD)]
-    public void Simulate_PrefixUsesRelaxedOpcode_ResolvesPayer(Instruction opcode)
+    public void Simulate_PrefixUsesRelaxedOpcode_ResolvesPayer(
+        [Values(Instruction.ORIGIN, Instruction.BLOBHASH, Instruction.TLOAD)] Instruction opcode)
     {
         // Each reads the frame or transaction payload, not the block environment, so none makes the
         // prefix depend on state that could differ between simulation and inclusion.

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -67,7 +67,7 @@ namespace Nethermind.Evm.TransactionProcessing
         }
     }
 
-    public abstract partial class TransactionProcessorBase
+    public abstract class TransactionProcessorBase
     {
         internal static bool ForceSimpleTransferDisabled;
 
@@ -92,6 +92,21 @@ namespace Nethermind.Evm.TransactionProcessing
             {
                 worldState.CreateAccount(toBeDestroyed, balance);
             }
+        }
+
+        /// <summary>Bounds a prefix frame's execution gas by what is left of <c>MAX_VERIFY_GAS</c>.</summary>
+        /// <remarks>An opaque prefix's declared gas_limits are not structurally bounded, so this cap is what
+        /// keeps cumulative validation work under the budget.</remarks>
+        /// <param name="frame">The validation-prefix frame about to run.</param>
+        /// <param name="remainingVerifyGas">What is left of <c>MAX_VERIFY_GAS</c>, in gas.</param>
+        /// <param name="capped">Whether the frame's declared execution gas exceeded that remainder.</param>
+        /// <returns><paramref name="frame"/> itself when it fits, otherwise a copy bounded to the remainder.</returns>
+        private protected static TxFrame CapFrameGas(TxFrame frame, ulong remainingVerifyGas, out bool capped)
+        {
+            capped = frame.ExecutionGasLimit > remainingVerifyGas;
+            return capped
+                ? new TxFrame(frame.Mode, frame.Flags, frame.Target, remainingVerifyGas, frame.StateGasLimit, frame.Value, frame.Data)
+                : frame;
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -67,7 +67,7 @@ namespace Nethermind.Evm.TransactionProcessing
         }
     }
 
-    public abstract class TransactionProcessorBase
+    public abstract partial class TransactionProcessorBase
     {
         internal static bool ForceSimpleTransferDisabled;
 

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -734,17 +734,6 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             : TransactionResult.ErrorType.MalformedTransaction.WithDetail("recent root reference is not committed or out of range");
     }
 
-    /// <summary>Bounds a prefix frame's execution gas by what is left of <c>MAX_VERIFY_GAS</c>.</summary>
-    /// <remarks>An opaque prefix's declared gas_limits are not structurally bounded, so this cap is what
-    /// keeps cumulative validation work under the budget.</remarks>
-    private static TxFrame CapFrameGas(TxFrame frame, ulong remainingVerifyGas, out bool capped)
-    {
-        capped = frame.ExecutionGasLimit > remainingVerifyGas;
-        return capped
-            ? new TxFrame(frame.Mode, frame.Flags, frame.Target, remainingVerifyGas, frame.StateGasLimit, frame.Value, frame.Data)
-            : frame;
-    }
-
     /// <summary>Whether frame <paramref name="i"/> is a <c>deploy</c> frame opening the validation prefix.</summary>
     /// <remarks>Positional, as RecognizedPrefixLength reaches index 1 only past an expiry-verify frame at index 0.
     /// Spells the same prologue rule as <see cref="FrameTxValidation.ApprovalSearchStart"/>; a grammar change touches both.</remarks>
@@ -971,4 +960,22 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
     private static TransactionSubstate DefaultCodeSuccess() =>
         new(ReadOnlyMemory<byte>.Empty, refund: 0, destroyList: null, logs: null, shouldRevert: false);
+}
+
+public abstract partial class TransactionProcessorBase
+{
+    /// <summary>Bounds a prefix frame's execution gas by what is left of <c>MAX_VERIFY_GAS</c>.</summary>
+    /// <remarks>An opaque prefix's declared gas_limits are not structurally bounded, so this cap is what
+    /// keeps cumulative validation work under the budget.</remarks>
+    /// <param name="frame">The validation-prefix frame about to run.</param>
+    /// <param name="remainingVerifyGas">What is left of <c>MAX_VERIFY_GAS</c>, in gas.</param>
+    /// <param name="capped">Whether the frame's declared execution gas exceeded that remainder.</param>
+    /// <returns><paramref name="frame"/> itself when it fits, otherwise a copy bounded to the remainder.</returns>
+    private protected static TxFrame CapFrameGas(TxFrame frame, ulong remainingVerifyGas, out bool capped)
+    {
+        capped = frame.ExecutionGasLimit > remainingVerifyGas;
+        return capped
+            ? new TxFrame(frame.Mode, frame.Flags, frame.Target, remainingVerifyGas, frame.StateGasLimit, frame.Value, frame.Data)
+            : frame;
+    }
 }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -961,21 +961,3 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
     private static TransactionSubstate DefaultCodeSuccess() =>
         new(ReadOnlyMemory<byte>.Empty, refund: 0, destroyList: null, logs: null, shouldRevert: false);
 }
-
-public abstract partial class TransactionProcessorBase
-{
-    /// <summary>Bounds a prefix frame's execution gas by what is left of <c>MAX_VERIFY_GAS</c>.</summary>
-    /// <remarks>An opaque prefix's declared gas_limits are not structurally bounded, so this cap is what
-    /// keeps cumulative validation work under the budget.</remarks>
-    /// <param name="frame">The validation-prefix frame about to run.</param>
-    /// <param name="remainingVerifyGas">What is left of <c>MAX_VERIFY_GAS</c>, in gas.</param>
-    /// <param name="capped">Whether the frame's declared execution gas exceeded that remainder.</param>
-    /// <returns><paramref name="frame"/> itself when it fits, otherwise a copy bounded to the remainder.</returns>
-    private protected static TxFrame CapFrameGas(TxFrame frame, ulong remainingVerifyGas, out bool capped)
-    {
-        capped = frame.ExecutionGasLimit > remainingVerifyGas;
-        return capped
-            ? new TxFrame(frame.Mode, frame.Flags, frame.Target, remainingVerifyGas, frame.StateGasLimit, frame.Value, frame.Data)
-            : frame;
-    }
-}

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameForRpc.cs
@@ -11,12 +11,31 @@ namespace Nethermind.Facade.Eth.RpcTransaction;
 /// where <c>limits = [execution, state]</c>.</summary>
 public class FrameForRpc
 {
+    /// <summary>The frame's kind, one of the <see cref="TxFrame"/> <c>Mode*</c> values: <c>0</c> default,
+    /// <c>1</c> verify, <c>2</c> sender, <c>3</c> post-tx.</summary>
+    /// <remarks>It fixes both the caller the frame runs as and where the frame may appear in the transaction.</remarks>
     public byte Mode { get; set; }
+
+    /// <summary>The frame's flag byte: bits 0-1 carry the approval scope
+    /// (<see cref="TxFrame.ApprovePayment"/> | <see cref="TxFrame.ApproveExecution"/>), bit 2 is
+    /// <see cref="TxFrame.AtomicBatchFlag"/>.</summary>
     public byte Flags { get; set; }
+
+    /// <summary>The frame's target address; omitted from the response, and accepted as absent in a request,
+    /// when the frame targets the transaction sender.</summary>
     public Address? Target { get; set; }
+
+    /// <summary>EIP-8141 <c>limits.execution</c>: the frame's execution-gas budget, in gas.</summary>
     public ulong ExecutionGasLimit { get; set; }
+
+    /// <summary>EIP-8141 <c>limits.state</c>: the frame's EIP-8037 state-gas budget, in gas.</summary>
+    /// <remarks>The payer reserves the two budgets summed; neither is spendable as the other.</remarks>
     public ulong StateGasLimit { get; set; }
+
+    /// <summary>Wei the frame moves from its caller to <see cref="Target"/>.</summary>
     public UInt256 Value { get; set; }
+
+    /// <summary>The frame's calldata.</summary>
     public byte[] Data { get; set; } = [];
 
     [JsonConstructor]

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameSignatureForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameSignatureForRpc.cs
@@ -10,9 +10,19 @@ namespace Nethermind.Facade.Eth.RpcTransaction;
 /// <remarks>Raw signature bytes are surfaced here deliberately: the EIP-8141 introspection limits bind the EVM, not RPC.</remarks>
 public class FrameSignatureForRpc
 {
+    /// <summary>Which of the <see cref="TxFrameSignature"/> <c>Scheme*</c> values governs how
+    /// <see cref="Signature"/> is read and verified: <c>0</c> arbitrary, <c>1</c> secp256k1, <c>2</c> P-256.</summary>
     public byte Scheme { get; set; }
+
+    /// <summary>The address the entry is verified against; omitted from the response, and accepted as absent in
+    /// a request, when the signer is the transaction sender. Always absent for the arbitrary scheme.</summary>
     public Address? Signer { get; set; }
+
+    /// <summary>The 32-byte digest signed, or empty when the entry signs the transaction's canonical
+    /// signature hash.</summary>
     public byte[] Msg { get; set; } = [];
+
+    /// <summary>The raw signature bytes, whose layout and required length are fixed by <see cref="Scheme"/>.</summary>
     public byte[] Signature { get; set; } = [];
 
     [JsonConstructor]

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameSignatureForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameSignatureForRpc.cs
@@ -18,8 +18,11 @@ public class FrameSignatureForRpc
     /// a request, when the signer is the transaction sender. Always absent for the arbitrary scheme.</summary>
     public Address? Signer { get; set; }
 
-    /// <summary>The 32-byte digest signed, or empty when the entry signs the transaction's canonical
+    /// <summary>The digest a protocol-verified entry signs, or empty when it signs the transaction's canonical
     /// signature hash.</summary>
+    /// <remarks>Accepted only as empty or exactly 32 non-zero bytes — an all-zero 32-byte value is rejected
+    /// rather than read as a synonym for empty. The arbitrary scheme is held to that same rule although
+    /// nothing verifies the value.</remarks>
     public byte[] Msg { get; set; } = [];
 
     /// <summary>The raw signature bytes, whose layout and required length are fixed by <see cref="Scheme"/>.</summary>

--- a/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
+++ b/src/Nethermind/Nethermind.Facade/Eth/RpcTransaction/FrameTransactionForRpc.cs
@@ -19,9 +19,14 @@ public class FrameTransactionForRpc : EIP1559TransactionForRpc, IFromTransaction
     /// <remarks>Absent for an envelope nonce, which is a different signing payload from the key set <c>[0]</c>.</remarks>
     public UInt256[]? NonceKeys { get; set; }
 
+    /// <summary>EIP-8141 <c>frames</c>, in execution order; the field that discriminates this envelope.</summary>
+    /// <remarks>The transaction's <c>gas</c> is their summed limits, so a frame's own budget is read here
+    /// rather than from that total.</remarks>
     [JsonDiscriminator]
     public FrameForRpc[]? Frames { get; set; }
 
+    /// <summary>EIP-8141 <c>signatures</c>: the entries hoisted out of the frames, verified before any frame
+    /// runs and read by frame code through <c>SIGPARAM</c> by index into this list.</summary>
     public FrameSignatureForRpc[]? Signatures { get; set; }
 
     /// <summary><c>max_fee_per_blob_gas</c>, an unconditional field of the signed payload.</summary>

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BlobTxDecoder.cs
@@ -41,7 +41,7 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
 
                 if ((rlpBehaviors & RlpBehaviors.ExcludeHashes) == 0)
                 {
-                    transaction.Hash = CalculateHashForNetworkPayloadForm(transactionSequence);
+                    transaction.Hash = NetworkPayloadFormHash.Calculate(TxType.Blob, transactionSequence);
                 }
             }
             else if ((rlpBehaviors & RlpBehaviors.ExcludeHashes) == 0)
@@ -91,15 +91,6 @@ public sealed class BlobTxDecoder<T>(Func<T>? transactionFactory = null)
 
     private static void DecodeShardBlobNetworkWrapper(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors) =>
         transaction.NetworkWrapper = ShardBlobNetworkWrapperRlp.Decode(ref decoderContext, rlpBehaviors);
-
-    private static Hash256 CalculateHashForNetworkPayloadForm(ReadOnlySpan<byte> transactionSequence)
-    {
-        KeccakHash hash = KeccakHash.Create();
-        Span<byte> txType = [(byte)TxType.Blob];
-        hash.Update(txType);
-        hash.Update(transactionSequence);
-        return new Hash256(hash.GenerateValueHash());
-    }
 
     protected override int GetContentLength(Transaction transaction, RlpBehaviors rlpBehaviors, bool forSigning,
         bool isEip155Enabled = false, ulong chainId = 0)

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/FrameTxDecoder.cs
@@ -94,18 +94,9 @@ public sealed class FrameTxDecoder<T>(Func<T>? transactionFactory = null)
 
             if ((rlpBehaviors & RlpBehaviors.ExcludeHashes) == 0)
             {
-                transaction.Hash = CalculateHashForNetworkPayloadForm(transactionSequence);
+                transaction.Hash = NetworkPayloadFormHash.Calculate(TxType.FrameTx, transactionSequence);
             }
         }
-    }
-
-    private static Hash256 CalculateHashForNetworkPayloadForm(ReadOnlySpan<byte> transactionSequence)
-    {
-        KeccakHash hash = KeccakHash.Create();
-        Span<byte> txType = [(byte)TxType.FrameTx];
-        hash.Update(txType);
-        hash.Update(transactionSequence);
-        return new Hash256(hash.GenerateValueHash());
     }
 
     /// <inheritdoc/>

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/NetworkPayloadFormHash.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/NetworkPayloadFormHash.cs
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+
+namespace Nethermind.Serialization.Rlp.TxDecoders;
+
+/// <summary>Hashes the inner payload of a transaction that travels the network inside a wrapper.</summary>
+/// <remarks>Non-generic so the decoders' closed generic types share one JIT instantiation of it.</remarks>
+internal static class NetworkPayloadFormHash
+{
+    /// <summary>Computes <c>keccak(txType || transactionSequence)</c>, the canonical hash of the wrapped
+    /// transaction rather than of the wrapper carrying it.</summary>
+    /// <param name="txType">The transaction's envelope type byte.</param>
+    /// <param name="transactionSequence">The inner payload sequence, without that type byte.</param>
+    public static Hash256 Calculate(TxType txType, ReadOnlySpan<byte> transactionSequence)
+    {
+        KeccakHash hash = KeccakHash.Create();
+        Span<byte> typeByte = [(byte)txType];
+        hash.Update(typeByte);
+        hash.Update(transactionSequence);
+        return new Hash256(hash.GenerateValueHash());
+    }
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/NetworkPayloadFormHash.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/NetworkPayloadFormHash.cs
@@ -8,7 +8,7 @@ using Nethermind.Core.Crypto;
 namespace Nethermind.Serialization.Rlp.TxDecoders;
 
 /// <summary>Hashes the inner payload of a transaction that travels the network inside a wrapper.</summary>
-/// <remarks>Non-generic so the decoders' closed generic types share one JIT instantiation of it.</remarks>
+/// <remarks>Shared by the blob and frame decoders, which each held a byte-identical private copy.</remarks>
 internal static class NetworkPayloadFormHash
 {
     /// <summary>Computes <c>keccak(txType || transactionSequence)</c>, the canonical hash of the wrapped

--- a/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/GethGenesisConfigJson.cs
+++ b/src/Nethermind/Nethermind.Specs/ChainSpecStyle/Json/GethGenesisConfigJson.cs
@@ -65,8 +65,10 @@ public class GethGenesisConfigJson : IHasNamedForks
     public ulong? BogotaTime { get => GetTime(); set => SetTime(value); }
     /// <summary>Activation time for EIP-8141 frame transactions, in Unix timestamp seconds; <c>null</c> leaves them unscheduled.</summary>
     /// <remarks>
-    /// They schedule on their own rather than with Bogota: the expiry-verifier predeploy they install shifts
-    /// every block's EIP-7928 access list, which the Bogota consensus fixtures pin.
+    /// They schedule on their own rather than with Bogota: the expiry-verifier predeploy they install puts a
+    /// code change in the EIP-7928 access list of the first block processed under the fork, which the Bogota
+    /// consensus fixtures pin. Later blocks are unaffected, as the installer skips an install whose code is
+    /// already canonical.
     /// </remarks>
     public ulong? Eip8141PrototypeTime { get => GetTime(); set => SetTime(value); }
 

--- a/src/Nethermind/Nethermind.Specs/Forks/26_Bogota.cs
+++ b/src/Nethermind/Nethermind.Specs/Forks/26_Bogota.cs
@@ -8,9 +8,10 @@ namespace Nethermind.Specs.Forks;
 /// <summary>Fork enabling EIP-7805 inclusion lists on top of Amsterdam.</summary>
 /// <remarks>
 /// EIP-8141 frame transactions are deliberately not bundled here. Activating them installs the frame-tx
-/// expiry-verifier predeploy, which adds a code change to every block's EIP-7928 access list and so shifts
-/// the access-list hash the Bogota consensus fixtures pin. A chain wanting both schedules
-/// <c>eip8141TransitionTimestamp</c> alongside this fork.
+/// expiry-verifier predeploy, which puts a code change in the EIP-7928 access list of the first block
+/// processed under the fork and so shifts the access-list hash the Bogota consensus fixtures pin; later
+/// blocks are unaffected, as <c>PredeployInstaller.Install</c> skips an install whose code is already
+/// canonical. A chain wanting both schedules <c>eip8141TransitionTimestamp</c> alongside this fork.
 /// </remarks>
 public class Bogota() : NamedReleaseSpec<Bogota>(Amsterdam.Instance)
 {

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -340,12 +340,9 @@ namespace Nethermind.TxPool.Test
 
             _txPool = CreatePool(specProvider: provider);
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
-                Assert.That(_txPool.SubmitTx(followUpTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
-                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(2));
-            }
+            Assert.That(_txPool.SubmitTx(transaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(followUpTransaction, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(2));
 
             await AddEmptyBlock();
             AssertRevalidatedForHead();
@@ -1902,9 +1899,10 @@ namespace Nethermind.TxPool.Test
             Transaction dropped = null;
             _txPool.EvictedPending += (_, e) => dropped = e.Transaction;
 
+            Assert.That(_txPool.EvictTransaction(transaction), Is.True);
+
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(_txPool.EvictTransaction(transaction), Is.True);
                 Assert.That(dropped, Is.SameAs(transaction), "the drop is surfaced to EvictedPending subscribers");
                 Assert.That(_txPool.IsKnown(transaction.Hash), Is.False, "the long-term cache is cleared so the tx can re-enter");
             }
@@ -2981,21 +2979,7 @@ namespace Nethermind.TxPool.Test
             // MAX_VERIFY_GAS disabled: this covers payer resolution, not the verify-gas bound.
             _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance));
             // A default-code self_verify frame tx: the sender is its own payer, resolved natively.
-            Transaction frameTx = new()
-            {
-                Type = TxType.FrameTx,
-                ChainId = _specProvider.ChainId,
-                Nonce = 0,
-                SenderAddress = TestItem.PrivateKeyA.Address,
-                Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, Array.Empty<byte>())],
-                FrameSignatures = [],
-                GasLimit = 1_000_000,
-                GasPrice = 1.GWei,
-                DecodedMaxFeePerGas = 1.GWei,
-            };
-            frameTx.FrameSignatures = [FrameSignature(frameTx, FrameSignatureDefect.None)];
-            frameTx.Hash = frameTx.CalculateHash();
-            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+            Transaction frameTx = SelfVerifyFrameTx();
 
             AcceptTxResult result = _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
 
@@ -3011,28 +2995,11 @@ namespace Nethermind.TxPool.Test
         public void EvictTransaction_drops_a_frame_tx_on_the_first_failure_under_the_default_budget()
         {
             _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance));
-            Transaction frameTx = new()
-            {
-                Type = TxType.FrameTx,
-                ChainId = _specProvider.ChainId,
-                Nonce = 0,
-                SenderAddress = TestItem.PrivateKeyA.Address,
-                Frames = [new TxFrame(TxFrame.ModeVerify, TxFrame.ApproveExecutionAndPayment, target: null, gasLimit: 100_000, UInt256.Zero, Array.Empty<byte>())],
-                FrameSignatures = [],
-                GasLimit = 1_000_000,
-                GasPrice = 1.GWei,
-                DecodedMaxFeePerGas = 1.GWei,
-            };
-            frameTx.FrameSignatures = [FrameSignature(frameTx, FrameSignatureDefect.None)];
-            frameTx.Hash = frameTx.CalculateHash();
-            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+            Transaction frameTx = SelfVerifyFrameTx();
             _txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast);
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(_txPool.EvictTransaction(frameTx), Is.True, "the default budget evicts on the first failed attempt");
-                Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero, "the frame transaction leaves the pool at once");
-            }
+            Assert.That(_txPool.EvictTransaction(frameTx), Is.True, "the default budget evicts on the first failed attempt");
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero, "the frame transaction leaves the pool at once");
         }
 
         [Test]
@@ -3051,18 +3018,15 @@ namespace Nethermind.TxPool.Test
             int evicted = 0;
             _txPool.EvictedPending += (_, _) => evicted++;
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(_txPool.EvictTransaction(frameTx), Is.False, "the first production failure on a head is kept");
-                Assert.That(_txPool.EvictTransaction(frameTx), Is.False, "a second failure on the same head spends no further unit");
-                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1), "the frame transaction stays pending while its budget lasts");
-            }
+            Assert.That(_txPool.EvictTransaction(frameTx), Is.False, "the first production failure on a head is kept");
+            Assert.That(_txPool.EvictTransaction(frameTx), Is.False, "a second failure on the same head spends no further unit");
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1), "the frame transaction stays pending while its budget lasts");
 
             await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).TestObject);
+            Assert.That(_txPool.EvictTransaction(frameTx), Is.True, "failing on a second head spends the last unit and evicts");
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(_txPool.EvictTransaction(frameTx), Is.True, "failing on a second head spends the last unit and evicts");
                 Assert.That(evicted, Is.EqualTo(1), "eviction is surfaced exactly once");
                 Assert.That(_txPool.GetPendingTransactionsCount(), Is.Zero, "the frame transaction leaves the pool once its budget is spent");
             }
@@ -3245,11 +3209,8 @@ namespace Nethermind.TxPool.Test
             _headInfo.BlockGasLimit = long.MaxValue;
             Transaction frameTx = ForkGatedFrameTx(gate, preForkSpec, postForkSpec, revokedAtFork);
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(_txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
-                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
-            }
+            Assert.That(_txPool.SubmitTx(frameTx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(1));
 
             await AddEmptyBlock();
             AssertRevalidatedForHead();
@@ -3554,12 +3515,9 @@ namespace Nethermind.TxPool.Test
             // No deadline, so it is never itself a shed candidate: it is only here to fill the pool.
             Transaction staleNonce = BuildFrameTx(nonce: 0, TestItem.PrivateKeyB.Address, deadline: null);
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(_txPool.SubmitTx(nearlyExpired, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
-                Assert.That(_txPool.SubmitTx(staleNonce, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
-                Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(2), "the pool must be full, or nothing would be shed either way");
-            }
+            Assert.That(_txPool.SubmitTx(nearlyExpired, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(staleNonce, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.GetPendingTransactionsCount(), Is.EqualTo(2), "the pool must be full, or nothing would be shed either way");
 
             // The new head consumes B's nonce, so UpdateBuckets drops that transaction and the pool is
             // no longer full by the time shedding runs.
@@ -4099,30 +4057,20 @@ namespace Nethermind.TxPool.Test
             }
         }
 
-        [Test]
-        public void SubmitTx_SponsoredFrameTx_IsAdmittedWithAnUnfundedSender()
-        {
-            // The whole point of EIP-8141 sponsorship: the payer covers the fee, so pricing it against the
-            // sender turns every sponsored transaction away before the payer is resolved at all.
-            CreatePoolWithSimulator(FrameTxSimulationResult.Accept(TestItem.AddressD));
-            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.Zero);
-
-            Transaction tx = SponsoredFrameTx(TestItem.PrivateKeyA, TestItem.PrivateKeyD);
-            EnsureSenderBalance(TestItem.AddressD, MaxCostOf(tx));
-
-            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
-        }
-
-        [Test]
-        public void SubmitTx_UnfundedSender_WhoseSponsorCannotCoverTheMaxCost_IsRejected()
+        // The whole point of EIP-8141 sponsorship: the payer covers the fee, so pricing it against the
+        // sender turns every sponsored transaction away before the payer is resolved at all.
+        [TestCase(true, TestName = "SubmitTx_SponsoredFrameTx_IsAdmittedWithAnUnfundedSender")]
+        [TestCase(false, TestName = "SubmitTx_UnfundedSender_WhoseSponsorCannotCoverTheMaxCost_IsRejected")]
+        public void SubmitTx_UnfundedSender_IsPricedAgainstItsSponsor(bool sponsorCoversMaxCost)
         {
             CreatePoolWithSimulator(FrameTxSimulationResult.Accept(TestItem.AddressD));
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.Zero);
 
             Transaction tx = SponsoredFrameTx(TestItem.PrivateKeyA, TestItem.PrivateKeyD);
-            EnsureSenderBalance(TestItem.AddressD, MaxCostOf(tx) - 1);
+            EnsureSenderBalance(TestItem.AddressD, sponsorCoversMaxCost ? MaxCostOf(tx) : MaxCostOf(tx) - 1);
 
-            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.FrameTxPayerExposureExceeded));
+            Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.None),
+                Is.EqualTo(sponsorCoversMaxCost ? AcceptTxResult.Accepted : AcceptTxResult.FrameTxPayerExposureExceeded));
         }
 
         [Test]
@@ -4167,12 +4115,9 @@ namespace Nethermind.TxPool.Test
             UInt256 both = MaxCostOf(first) + MaxCostOf(second);
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, rejected ? both - 1 : both);
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(_txPool.SubmitTx(first, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
-                Assert.That(_txPool.SubmitTx(second, TxHandlingOptions.None),
-                    Is.EqualTo(rejected ? AcceptTxResult.InsufficientFunds : AcceptTxResult.Accepted));
-            }
+            Assert.That(_txPool.SubmitTx(first, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+            Assert.That(_txPool.SubmitTx(second, TxHandlingOptions.None),
+                Is.EqualTo(rejected ? AcceptTxResult.InsufficientFunds : AcceptTxResult.Accepted));
         }
 
         [TestCase(false, TestName = "the sender covers both")]
@@ -4194,13 +4139,10 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.SubmitTx(selfPaid, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
             SimulatesAs(simulator, FrameTxSimulationResult.Undecided("simulator unavailable"));
 
-            using (Assert.EnterMultipleScope())
-            {
-                Assert.That(selfPaid.PayerAddress, Is.EqualTo(TestItem.PrivateKeyA.Address),
-                    "the incumbent must be self-paid, or the walk sees it and the ledger is not what binds");
-                Assert.That(_txPool.SubmitTx(payerless, TxHandlingOptions.None),
-                    Is.EqualTo(rejected ? AcceptTxResult.InsufficientFunds : AcceptTxResult.Accepted));
-            }
+            Assert.That(selfPaid.PayerAddress, Is.EqualTo(TestItem.PrivateKeyA.Address),
+                "the incumbent must be self-paid, or the walk sees it and the ledger is not what binds");
+            Assert.That(_txPool.SubmitTx(payerless, TxHandlingOptions.None),
+                Is.EqualTo(rejected ? AcceptTxResult.InsufficientFunds : AcceptTxResult.Accepted));
         }
 
         [TestCase(false, TestName = "the sender still covers the priced cost")]


### PR DESCRIPTION
## Changes

Addresses the five P3 threads `benaadams` opened on #12526 on 2026-09-11. No behaviour change. Two other items from that review are out of scope here and are noted below rather than folded in: the two P2 findings, which are production changes belonging on #12526 itself, and a sixth P3 of the same day, which is a follow-up comment on the pre-existing test-DI thread and is declined again.

- **Test setup reuse and parameterization** (`TxPoolTests.cs`) — the two frame-tx tests that rebuilt the self-verify transaction inline now call the fixture's existing `SelfVerifyFrameTx()`, which produces the identical transaction. The equivalent case pairs are parameterized with their original names kept as `TestName=`: the funded/unfunded sponsor cases, the STOP/REVERT prefix cases in `FrameTxValidationPrefixSimulationTests`, and the relaxed-opcode cases now use `[Test]` plus `[Values]`. The repeated TXPARAM observer setup in `FrameTxProcessorTests` is extracted into one helper.
- **Measurement pairs in `FrameTxFloodMeasurement` — deliberately left alone.** The thread's fifth target is the three `..._with_shedding` arms, which differ from their partners only by `shedding: true`. Two arguments made earlier against folding them do not survive checking: each pair does share a signature (the `(ulong, int)` vs `(string, int)` clash blocks merging the *families*, not the pairs), and `CeilingRateCases`/`Groth16RateCases` feed nothing but these six arms, so the cross-product is one extra `foreach` per existing source and would be line-negative. Nor do the emitted rows depend on the arm names — `case=flood_delay` already carries `shedding=on|off`. What decides it is selection: the fixture is `[Explicit("measurement harness")]`, never runs in CI, and is driven by name filter, so `~_with_shedding` is how the mitigation half of the sweep gets priced on its own. A `shedding` case argument leaves only `,True)` to filter on, and each cell costs a 15 s fixture warm-up plus two 4 s warm-ups and two 3 s measured windows, so losing the half-sweep is a real cost for three one-line delegations.
- **Assertion-scope hygiene** — state-changing prerequisites (`EvictTransaction`, `SubmitTx`) are executed and asserted before entering a multiple-assertion scope, so a failed prerequisite stops the test instead of letting the next mutation run. Applied at the flagged site and at six more in the same stack. The null-check-then-dereference in `FrameTxProcessorTests` is fixed the same way, as is `result.TransactionExecuted` where it gates storage reads rather than standing beside them. In the other direction, runs of independent observations that were ungrouped are now grouped, including the two storage reads in `Execute_AtomicBatch_FrameFails_RollsBackBatchAndSkipsRemaining`.
- **RPC field documentation** (`FrameForRpc`, `FrameSignatureForRpc`, `FrameTransactionForRpc`) — mode and flag meaning, the target omission rule, and the execution/state gas limits with their units. `Msg` carries the whole structural rule a client can trip over: empty or exactly 32 non-zero bytes, with an all-zero 32-byte value rejected rather than read as a synonym for empty.
- **Non-generic helpers** — `CalculateHashForNetworkPayloadForm` becomes `NetworkPayloadFormHash.Calculate`, shared with `BlobTxDecoder`, which held a byte-identical copy; both decoders are constrained to reference types, so this is a duplication fix and not a JIT-instantiation one. `TransactionProcessorBase<TGasPolicy>.CapFrameGas` moves to the non-generic `TransactionProcessorBase`, immediately below `DestroyAccount` in `TransactionProcessor.cs` — that one does save an instantiation per gas policy, and keeping the non-generic base in one file means no `partial` keyword is needed anywhere.
- **Predeploy comment correction** (`26_Bogota.cs`, `GethGenesisConfigJson.cs`) — `PredeployInstaller.Install` skips an install whose existing code is already canonical, so enabling the frame-tx EIPs puts the code change in the EIP-7928 access list of the first block processed under the fork, not of every block.
- **Test DI wiring — declined again.** The day's sixth P3 is a follow-up on the earlier `FrameTxProcessorTests` thread, repeating the ask to resolve the VM/processor graph through production modules. The earlier round declined it because 27 of the 29 `Evm.Test` fixtures construct the same way and several of the cited sites deliberately build over a non-production code-info repository or state, which a module-resolved graph would have to override back out. That reasoning is unchanged, so this PR declines consistently rather than converting one fixture alone.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [x] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: <!-- Please describe -->

## Testing

Coverage is unchanged, verified rather than assumed: each test binary was listed before and after, in both configurations, and the generated display-name sets diffed.

| assembly | release before/after | release name-set diff | checked before/after | checked name-set diff |
| --- | --- | --- | --- | --- |
| `Nethermind.TxPool.Test` | 1229 / 1229 | 0 lines | 1229 / 1229 | 0 lines |
| `Nethermind.Core.Test` | 6514 / 6514 | 0 lines | 6515 / 6515 | 0 lines |
| `Nethermind.Evm.Test` | 10891 / 10891 | 0 lines | 10889 / 10889 | 0 lines |
| `Nethermind.JsonRpc.Test` | 2147 / 2147 | 0 lines | 2147 / 2147 | 0 lines |
| `Nethermind.Blockchain.Test` | 2034 / 2034 | 0 lines | 2034 / 2034 | 0 lines |

Three families randomise their display names (`Eip2565Tests` and `SecP256r1PrecompileTests` bare hex, `Simple_routine(<random int>)`), so the comparison normalises those and drops the runner's banner and `duration:` lines first. The normalisation is positive-controlled by listing the same unchanged binary twice: that yields 400 raw differing lines in `Nethermind.Evm.Test` in either configuration — exactly 200 bare-hex names and 200 `Simple_routine` names, nothing else — and 0 after normalisation, the same magnitude the before/after listing shows. The exact raw count varies run to run because the names are random.

All five suites pass in release and in checked (`-p:DefineConstants=TRACE%3BDEBUG`, `artifacts/bin` and `artifacts/obj` removed between configurations): 1205, 6378, 10872, 2125 and 1883 passing in release and 1205, 6378, 10870, 2125 and 1883 in checked, with no failures in either; the gap to the listed totals is explicit and skipped cases, `FrameTxFloodMeasurement` among them. Every build is 0 warnings, 0 errors with `-nodeReuse:false`. The code-lint invocation reports 0 IDE/CA warnings with its flags passed inline, positive-controlled by injecting an unused `using` and confirming IDE0005 fires. A second build with CS1570/1572/1573/1574/1584 re-enabled (the lint gate's `NoWarn` hides them) shows no new XML-doc or cref warnings from the added documentation.

### Requires testing

- [ ] Yes
- [x] No

## Documentation

Requires documentation update

- [ ] Yes
- [x] No

Requires explanation in Release Notes

- [ ] Yes
- [x] No
