### PR TITLE
Document why the FOCIL inclusion list is not revalidation-gated

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -30,7 +30,9 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
 
     /// <summary>Draws candidate transactions for the list, round-robin across the drawn senders.</summary>
     /// <remarks>Restricted to each sender's gapless run from its next nonce, since nothing else could be
-    /// appended. Drawn uniformly, not by fee: a fee-ordered draw drops what a builder passes over.</remarks>
+    /// appended. Drawn uniformly, not by fee: a fee-ordered draw drops what a builder passes over.
+    /// Deliberately not gated on pool revalidation: the target timestamp is not derivable here, so a fork
+    /// boundary can draw entries the new spec rejects, which appendability excuses at the cost of list bytes.</remarks>
     private ArrayPoolListRef<Transaction> SampleAppendableTxs(BlockHeader? parent)
     {
         const int capacity = SenderSampleCapacity;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -32,8 +32,10 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     /// <remarks>Restricted to each sender's gapless run from its next nonce, since nothing else could be
     /// appended. Drawn uniformly, not by fee: a fee-ordered draw drops what a builder passes over.
     /// Deliberately not gated on pool revalidation: this reads the pool's ready-tx snapshot directly, which
-    /// applies no per-transaction spec check, so a fork boundary can draw entries the pool's background
-    /// revalidation hasn't caught up to yet — appendability excuses the cost in list bytes.</remarks>
+    /// applies no per-transaction spec check, so around a fork it can draw entries the new spec rejects —
+    /// whether the pool's background revalidation is still catching up, or the target block is the activation
+    /// slot itself, whose spec is not derivable from a parent hash alone. Appendability excuses the cost in
+    /// list bytes.</remarks>
     private ArrayPoolListRef<Transaction> SampleAppendableTxs(BlockHeader? parent)
     {
         const int capacity = SenderSampleCapacity;

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -31,8 +31,9 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     /// <summary>Draws candidate transactions for the list, round-robin across the drawn senders.</summary>
     /// <remarks>Restricted to each sender's gapless run from its next nonce, since nothing else could be
     /// appended. Drawn uniformly, not by fee: a fee-ordered draw drops what a builder passes over.
-    /// Deliberately not gated on pool revalidation: the target timestamp is not derivable here, so a fork
-    /// boundary can draw entries the new spec rejects, which appendability excuses at the cost of list bytes.</remarks>
+    /// Deliberately not gated on pool revalidation: this reads the pool's ready-tx snapshot directly, which
+    /// applies no per-transaction spec check, so a fork boundary can draw entries the pool's background
+    /// revalidation hasn't caught up to yet — appendability excuses the cost in list bytes.</remarks>
     private ArrayPoolListRef<Transaction> SampleAppendableTxs(BlockHeader? parent)
     {
         const int capacity = SenderSampleCapacity;


### PR DESCRIPTION
## Changes

Document why `InclusionListBuilder` samples the pool directly rather than via `ITxPool.GetPendingForProduction`, the only snapshot path reporting revalidation state against the target spec.

Investigated as a possible bug; it is not one. `engine_getInclusionListV1` carries only a parent hash, so the target timestamp — and thus its spec — is not derivable in the builder, and a revalidation gate could not cover the fork-activation slot anyway. A stale entry is excused downstream: `InclusionListValidator.CouldIncludeTx` runs the full `ITxValidator.IsWellFormed` against the block's own spec, so it is never counted as appendable and cannot make an honest proposer look like a censor. Cost is bounded to wasted bytes in the 8 KiB per-list budget, for roughly one slot per hard fork.

No behavioural change.

## Types of changes

#### What types of changes does your code introduce?

- [x] Documentation update

## Testing

#### Requires testing

- [ ] Yes
- [x] No

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
