### PR TITLE
fix(eip7805): anchor the inclusion-list run at the account nonce

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -226,7 +226,9 @@ public class InclusionListBuilderTests
     }
 
     // Every drawn sender costs one account-nonce read, so the reservoir must bound the reads whatever the pool size.
-    private static (ITxPool Pool, IReadOnlyStateProvider HeadState, InclusionListBuilder Builder) KeyedHeadSetup(int senderCount)
+    // The frame transaction no longer decides whether that read happens; it keeps each bucket on the copying
+    // branch of WithoutFrameTxs, which is what still makes this the worst case per drawn sender.
+    private static (ITxPool Pool, IReadOnlyStateProvider HeadState, InclusionListBuilder Builder) WorstCaseReadSetup(int senderCount)
     {
         Transaction[] txs = new Transaction[senderCount * 2];
         for (int i = 0; i < senderCount; i++)
@@ -259,7 +261,7 @@ public class InclusionListBuilderTests
     public void State_reads_are_bounded_by_the_sender_sample_capacity()
     {
         const int senderCount = 1024;
-        (_, IReadOnlyStateProvider headState, InclusionListBuilder builder) = KeyedHeadSetup(senderCount);
+        (_, IReadOnlyStateProvider headState, InclusionListBuilder builder) = WorstCaseReadSetup(senderCount);
 
         builder.GetInclusionList().Dispose();
 
@@ -275,7 +277,7 @@ public class InclusionListBuilderTests
     {
         const int senderCount = 1024;
         const int iterations = 50;
-        (_, IReadOnlyStateProvider headState, InclusionListBuilder builder) = KeyedHeadSetup(senderCount);
+        (_, IReadOnlyStateProvider headState, InclusionListBuilder builder) = WorstCaseReadSetup(senderCount);
 
         builder.GetInclusionList().Dispose();  // warm
         long before = headState.ReceivedCalls().Count();

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -130,8 +130,8 @@ public class InclusionListBuilderTests
         Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(new[] { nonce0.Hash, nonce1.Hash }));
     }
 
-    // The pool admits a whole bucket on its first entry's readiness alone, so a frame transaction at the
-    // head is what vouched for the run; once dropped, what remains need not sit at the next account nonce.
+    // The pool admits a bucket on any one entry being ready, so a frame transaction can be what vouched for
+    // the run; once dropped, what remains need not sit at the next account nonce.
     [Test]
     public void Drops_a_sender_run_the_removed_frame_transaction_was_vouching_for()
     {
@@ -165,8 +165,38 @@ public class InclusionListBuilderTests
         Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(new[] { atAccountNonce.Hash, next.Hash }));
     }
 
-    // The pool checks CanPayBaseFee on the bucket's first entry alone, so a transaction behind a paying head can
-    // sit below the next block's base fee. The validator excuses omitting it, so listing it burns the cap.
+    private static IEnumerable<TestCaseData> BucketsAdmittedByANonFrontEntry()
+    {
+        // The pool reads a bucket entry under the account nonce as spent rather than blocking, so it admits this
+        // bucket on nonce 5 alone while nonce 4 heads it. Only nonce 5 is appendable.
+        Transaction spent = TxOfSize(50, 4);
+        Transaction atAccountNonce = TxOfSize(50, 5);
+        yield return new TestCaseData(new[] { spent, atAccountNonce }, 5UL, new[] { atAccountNonce })
+            .SetName("Skips_a_spent_nonce_heading_the_bucket");
+
+        // A keyed frame transaction is judged on its own sequence however the account-nonce entries sit, so it can
+        // admit a bucket whose only ordinary entry is four nonces ahead. Stripping it leaves nothing appendable.
+        Transaction gapped = TxOfSize(50, 9);
+        Transaction keyedFrame = FrameTx(TestItem.AddressA, nonce: 100, nonceKeys: [1]);
+        yield return new TestCaseData(new[] { gapped, keyedFrame }, 5UL, Array.Empty<Transaction>())
+            .SetName("Drops_a_gapped_run_admitted_by_a_keyed_frame_transaction");
+    }
+
+    // The bucket's lowest entry is not the account's next nonce: the pool admits a bucket on any one entry being
+    // ready, so only a state read names the anchor.
+    [TestCaseSource(nameof(BucketsAdmittedByANonFrontEntry))]
+    public void Anchors_a_sender_run_at_the_account_nonce_not_at_the_bucket_front(
+        Transaction[] bucket, ulong accountNonce, Transaction[] expected)
+    {
+        using InclusionListBytes il = BuildBuilder(
+            PoolOf(bucket),
+            accountNonces: [(TestItem.AddressA, accountNonce)]).GetInclusionList();
+
+        Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(expected.Select(tx => tx.Hash)));
+    }
+
+    // The pool admits a bucket once one entry both pays and is nonce-ready, so a transaction behind a paying head
+    // can sit below the next block's base fee. The validator excuses omitting it, so listing it burns the cap.
     [Test]
     public void Truncates_a_sender_run_at_the_first_transaction_below_the_next_base_fee()
     {
@@ -195,8 +225,7 @@ public class InclusionListBuilderTests
         Assert.That(il, Is.Empty);
     }
 
-    // Worst case for the state read: every sender's bucket is headed by a keyed frame transaction, so the cheap
-    // anchor comparison never decides. The reservoir must bound the reads whatever the pool size.
+    // Every drawn sender costs one account-nonce read, so the reservoir must bound the reads whatever the pool size.
     private static (ITxPool Pool, IReadOnlyStateProvider HeadState, InclusionListBuilder Builder) KeyedHeadSetup(int senderCount)
     {
         Transaction[] txs = new Transaction[senderCount * 2];

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetInclusionListTransactionsHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetInclusionListTransactionsHandler.cs
@@ -17,8 +17,8 @@ namespace Nethermind.Merge.Plugin.Handlers;
 /// <param name="blockTree">Supplies the head header the next block's base fee is derived from.</param>
 /// <param name="specProvider">Resolves the fork gate and the base-fee parameters.</param>
 /// <param name="chainHeadInfo">
-/// Supplies head state. An EIP-8250 keyed transaction heading a sender's pool bucket names a per-key sequence
-/// rather than an account nonce, so only the account itself says where that sender's appendable run starts.
+/// Supplies head state. The pool admits a sender's bucket on any one entry being ready, so only the account
+/// itself says where that sender's appendable run starts.
 /// </param>
 public class GetInclusionListTransactionsHandler(
     ITxPool? txPool,

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -115,7 +115,9 @@ internal class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecP
             length++;
         }
 
-        return start == 0 && length == bySender.Length ? bySender : bySender[start..(start + length)];
+        // The loop bounds length by bySender.Length - start, so a full-length run had nothing skipped and
+        // start is 0: the whole array is the run and needs no copy.
+        return length == bySender.Length ? bySender : bySender[start..(start + length)];
     }
 
     /// <summary>The sender's pending run with its EIP-8141 frame transactions removed.</summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -8,7 +8,6 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
-using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.TxPool;
 
@@ -90,26 +89,33 @@ internal class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecP
         }
     }
 
-    /// <summary>The leading transactions of <paramref name="pending"/> the next block could append, in order.</summary>
-    /// <remarks>The pool vouches for its first entry alone, so the rest is re-checked here: frame transactions
-    /// removed, anchored at the account's next nonce, cut at the first nonce gap or unpayable base fee.</remarks>
+    /// <summary>The transactions of <paramref name="pending"/> the next block could append, in order.</summary>
+    /// <remarks>The pool vouches only that some bucket entry is ready, so the run is rebuilt here against the
+    /// account: frame transactions removed, spent nonces skipped, anchored at the account's next nonce, cut at the
+    /// first nonce gap or unpayable base fee.</remarks>
     private Transaction[] AppendableRun(Transaction[] pending, in UInt256 baseFee)
     {
         Transaction[] bySender = WithoutFrameTxs(pending);
-        if (bySender.Length == 0 || !IsAnchoredAtNextAccountNonce(pending, bySender)) return [];
+        if (bySender.Length == 0) return [];
 
-        ulong anchor = bySender[0].Nonce;
+        ulong anchor = headState.GetNonce(bySender[0].SenderAddress!);
+        int start = 0;
+        // The pool reads an entry under the account nonce as spent rather than blocking, so one can head the
+        // bucket while a later entry is what got it admitted.
+        while (start < bySender.Length && bySender[start].Nonce < anchor) start++;
+        if (start == bySender.Length || bySender[start].Nonce != anchor) return [];
+
         int length = 0;
         // Buckets are nonce-ordered, so a broken offset can never realign: nothing behind a gap is appendable,
         // and nothing behind an entry the next block would price out is worth the byte cap either.
-        while (length < bySender.Length
-            && bySender[length].Nonce == anchor + (ulong)length
-            && bySender[length].CanPayBaseFee(baseFee))
+        while (start + length < bySender.Length
+            && bySender[start + length].Nonce == anchor + (ulong)length
+            && bySender[start + length].CanPayBaseFee(baseFee))
         {
             length++;
         }
 
-        return length == bySender.Length ? bySender : bySender[..length];
+        return start == 0 && length == bySender.Length ? bySender : bySender[start..(start + length)];
     }
 
     /// <summary>The sender's pending run with its EIP-8141 frame transactions removed.</summary>
@@ -130,16 +136,6 @@ internal class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecP
             if (!tx.SupportsFrames) result[j++] = tx;
         return result;
     }
-
-    /// <summary>Whether <paramref name="bySender"/> still begins at the sender's next account nonce.</summary>
-    /// <remarks>
-    /// The pool admits a whole bucket on <paramref name="pending"/>[0] being ready, so that entry alone names the
-    /// next account nonce — unless it is an EIP-8250 keyed one, which names a per-key sequence and so needs a read.
-    /// </remarks>
-    private bool IsAnchoredAtNextAccountNonce(Transaction[] pending, Transaction[] bySender) =>
-        KeyedNonceManager.UsesKeyedNonce(pending[0])
-            ? bySender[0].Nonce == headState.GetNonce(bySender[0].SenderAddress!)
-            : bySender[0].Nonce == pending[0].Nonce;
 
     /// <summary>The base fee the next block will charge.</summary>
     /// <remarks>Approximate at a fork boundary: the next timestamp is not derivable here, so the parent's


### PR DESCRIPTION
## Changes

`InclusionListBuilder` anchored each sender's run at the bucket's lowest entry, on the premise that the pool admits a bucket only when that entry is ready. Since #13283 the pool admits a bucket when *any* entry is ready: an entry under the account nonce is read as spent rather than blocking, and a keyed (EIP-8250) entry is judged all the way down. The lowest entry can therefore be a spent nonce or sit behind a gap, and the builder listed transactions no block could include — wasting the 8 KiB per-list budget EIP-7805 exists to allocate. Not a consensus issue: `InclusionListValidator.CouldIncludeTx` already excuses such entries.

- `AppendableRun` now reads the account nonce for every drawn sender, skips the spent prefix and requires the first remaining entry to sit exactly at that nonce; `IsAnchoredAtNextAccountNonce` is removed
- Corrected the stale comments in the builder, its tests, and `GetInclusionListTransactionsHandler`'s `chainHeadInfo` doc, which all asserted the old admission premise as fact

Anchoring unconditionally on the account nonce was the minimum fix, but it drops a whole bucket whose front is merely spent — the transient after a head change the pool has not finished processing, and precisely when censorship-resistance coverage matters. Skipping the spent prefix costs two extra lines and keeps that sender covered.

### Read budget

This changes the read budget in kind, not just in degree, and that is worth stating plainly:

- Before, `IsAnchoredAtNextAccountNonce` read state only when `pending[0]` was keyed. On a chain with no EIP-8250 traffic an `engine_getInclusionListV1` call did **zero** account reads.
- Now every drawn sender costs one, bounded by the reservoir at `SenderSampleCapacity` = 256 per call.
- Those reads go through `chainHeadInfo.ReadOnlyStateProvider` — a `ChainHeadReadOnlyStateProvider`, i.e. `IStateReader.TryGetAccount` against the head's state root — **not** the `AccountCache` the pool wraps the same provider in for `HasReadyTransaction`. So they are real trie reads, on the engine-API thread, inside a call the CL puts on a per-slot deadline.

256 reads is small in absolute terms, but it is a new per-call cost on that thread rather than a widening of an existing one. #13384 sits on top of this and removes a much larger read budget from the same call.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other:

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Anchors_a_sender_run_at_the_account_nonce_not_at_the_bucket_front` covers both shapes: `Skips_a_spent_nonce_heading_the_bucket` (account at 5, bucket `[#4, #5]` — only `#5` listed) and `Drops_a_gapped_run_admitted_by_a_keyed_frame_transaction` (account at 5, bucket `[#9, keyed frame]` — nothing listed). Both fail on the previous logic and pass with the fix.

Full suites, release and checked (`-p:DefineConstants=TRACE;DEBUG`, artifacts cleaned between configurations) — identical counts in both:

| suite | passed | skipped |
| --- | ---: | ---: |
| `Nethermind.TxPool.Test` | 1205 | 24 |
| `Nethermind.Merge.Plugin.Test` | 1889 | 3 |
| `Nethermind.JsonRpc.Test` | 2125 | 22 |
| `Nethermind.Blockchain.Test` | 1883 | 151 |

Known gap: `InclusionListBuilderTests.PoolOf` substitutes `ITxPool` and hands back hand-built buckets, so the real `HasReadyTransaction` predicate is never exercised alongside the builder — which is why this regression slipped through. No end-to-end test was added: the spent-front window is driven by `TxPool.ResetAddress`, which is `internal` to `Nethermind.TxPool` and not visible from `Nethermind.Merge.Plugin.Test`, so reproducing it there would need new `InternalsVisibleTo` plumbing or a full `TestBlockchain` fixture. Both bucket shapes are already pinned pool-side by `TxPoolTests.Stale_ordinary_tx_does_not_hide_the_next_one_at_the_account_nonce` and `TxPoolTests.Keyed_frame_tx_heads_the_bucket_ahead_of_an_ordinary_tx_at_the_account_nonce`, so the two suites cover both halves of the seam even though no single test crosses it.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
