### PR TITLE
fix: end an inclusion-list sender run at a tx skipped for size

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -77,8 +77,8 @@ public class InclusionListBuilderTests
     }
 
     // An entry too big for the remaining budget is skipped rather than ending the encoding, so another
-    // sender's smaller transaction can still take the space. The skipped sender's own later nonces cannot:
-    // their predecessor is missing, so they would spend the scarce byte budget on an unappendable entry.
+    // sender's smaller transaction can still take the space. The skipped sender's own later nonces are
+    // excused whenever it is absent, so listing them spends the scarce byte budget for no extra coverage.
     [TestCase(true, TestName = "Sender_run_ends_at_a_tx_skipped_for_size")]
     [TestCase(false, TestName = "Tx_skipped_for_size_leaves_other_senders_alone")]
     public void Skips_txs_that_would_overflow_but_keeps_smaller_ones_that_fit(bool sameSender)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -76,12 +76,27 @@ public class InclusionListBuilderTests
         Assert.That(il, Is.Not.Empty);
     }
 
-    [Test]
-    public void Skips_txs_that_would_overflow_but_keeps_smaller_ones_that_fit()
+    // An entry too big for the remaining budget is skipped rather than ending the encoding, so another
+    // sender's smaller transaction can still take the space. The skipped sender's own later nonces cannot:
+    // their predecessor is missing, so they would spend the scarce byte budget on an unappendable entry.
+    [TestCase(true, TestName = "Sender_run_ends_at_a_tx_skipped_for_size")]
+    [TestCase(false, TestName = "Tx_skipped_for_size_leaves_other_senders_alone")]
+    public void Skips_txs_that_would_overflow_but_keeps_smaller_ones_that_fit(bool sameSender)
     {
-        using InclusionListBytes il = BuildBuilder(PoolOf(TxOfSize(8000), TxOfSize(50, 1))).GetInclusionList();
+        // Larger than the whole list, so it is skipped whichever order the sample draws it in.
+        Transaction oversized = TxOfSize(Eip7805Constants.MaxBytesPerInclusionList, 0, TestItem.PrivateKeyA);
+        Transaction small = sameSender
+            ? TxOfSize(50, 1, TestItem.PrivateKeyA)
+            : TxOfSize(50, 0, TestItem.PrivateKeyB);
 
-        Assert.That(il.Sum(t => t.Count), Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
+        using InclusionListBytes il = BuildBuilder(PoolOf(oversized, small)).GetInclusionList();
+
+        Hash256?[] expected = sameSender ? [] : [small.Hash];
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(expected));
+            Assert.That(il.Sum(t => t.Count), Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
+        }
     }
 
     // Only what the next block could append belongs in the list, so the pool must do the readiness and

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -79,22 +79,22 @@ public class InclusionListBuilderTests
     // An entry too big for the remaining budget is skipped rather than ending the encoding, so another
     // sender's smaller transaction can still take the space. The skipped sender's own later nonces are
     // excused whenever it is absent, so listing them spends the scarce byte budget for no extra coverage.
-    [TestCase(true, TestName = "Sender_run_ends_at_a_tx_skipped_for_size")]
-    [TestCase(false, TestName = "Tx_skipped_for_size_leaves_other_senders_alone")]
-    public void Skips_txs_that_would_overflow_but_keeps_smaller_ones_that_fit(bool sameSender)
+    [Test]
+    public void Sender_run_ends_at_a_tx_skipped_for_the_remaining_budget()
     {
-        // Larger than the whole list, so it is skipped whichever order the sample draws it in.
-        Transaction oversized = TxOfSize(Eip7805Constants.MaxBytesPerInclusionList, 0, TestItem.PrivateKeyA);
-        Transaction small = sameSender
-            ? TxOfSize(50, 1, TestItem.PrivateKeyA)
-            : TxOfSize(50, 0, TestItem.PrivateKeyB);
+        Transaction head = TxOfSize(5 * 1024, 0, TestItem.PrivateKeyA);
+        Transaction skipped = TxOfSize(4 * 1024, 1, TestItem.PrivateKeyA);
+        Transaction afterSkipped = TxOfSize(50, 2, TestItem.PrivateKeyA);
+        Transaction otherSender = TxOfSize(50, 0, TestItem.PrivateKeyB);
 
-        using InclusionListBytes il = BuildBuilder(PoolOf(oversized, small)).GetInclusionList();
+        using InclusionListBytes il = BuildBuilder(PoolOf(head, skipped, afterSkipped, otherSender)).GetInclusionList();
 
-        Hash256?[] expected = sameSender ? [] : [small.Hash];
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(expected));
+            // The scenario is a short remaining budget, not a transaction too big for any list.
+            Assert.That(TxDecoder.Instance.GetLength(skipped, RlpBehaviors.SkipTypedWrapping),
+                Is.LessThan(Eip7805Constants.MaxBytesPerInclusionList));
+            Assert.That(il.Select(b => Decode(b).Hash), Is.EquivalentTo(new[] { head.Hash, otherSender.Hash }));
             Assert.That(il.Sum(t => t.Count), Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
         }
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -98,8 +98,8 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
         try
         {
             int size = 0;
-            // The sample orders each sender's run by ascending nonce, so once one entry is dropped for size
-            // the rest of that sender's run is unappendable and would only waste the list's scarce budget.
+            // The sample orders each sender's run by ascending nonce, so once one entry is skipped the rest
+            // of that run is excused whenever the skipped one is absent: budget spent for no extra coverage.
             HashSet<AddressAsKey>? droppedSenders = null;
             foreach (Transaction tx in txs)
             {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Decoders;
 using Nethermind.Core;
@@ -97,13 +98,19 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
         try
         {
             int size = 0;
+            // The sample orders each sender's run by ascending nonce, so once one entry is dropped for size
+            // the rest of that sender's run is unappendable and would only waste the list's scarce budget.
+            HashSet<AddressAsKey>? droppedSenders = null;
             foreach (Transaction tx in txs)
             {
+                if (droppedSenders is not null && droppedSenders.Contains(tx.SenderAddress!)) continue;
+
                 ArrayPoolList<byte> txBytes = InclusionListDecoder.EncodePooled(tx);
 
                 if (size + txBytes.Count > Eip7805Constants.MaxBytesPerInclusionList)
                 {
                     txBytes.Dispose();
+                    (droppedSenders ??= []).Add(tx.SenderAddress!);
                     continue;
                 }
 


### PR DESCRIPTION
## Changes

- `InclusionListBuilder.EncodeTransactionsUpToLimit` now ends a sender's run once one of its transactions is skipped for size. The sample is round-robin over senders, so a sender's nonce-`k` transaction always precedes its nonce-`k+1`; skipping the former while admitting the latter puts an entry on the list that buys no censorship resistance, because the inclusion-list validator excuses it whenever the skipped predecessor is absent. It only spends the scarce 8 KiB budget EIP-7805 exists to allocate.
- Skipping still leaves other senders' transactions free to take the remaining space — that behaviour is unchanged.
- Parameterised `Skips_txs_that_would_overflow_but_keeps_smaller_ones_that_fit` over the same-sender and cross-sender cases.

## Why

The reason is the byte budget, not appendability. The drop is keyed on a **remaining-budget skip, not on unappendability**: a transaction skipped because the list is nearly full is still block-appendable, so its successors do become enforceable if a builder includes it voluntarily. What those successors are not is extra coverage — the validator excuses them whenever the skipped entry is absent, so listing them reads as satisfied either way. No builder was ever blocked by the old behaviour; the cost was weaker censorship detection per byte spent. The comments have been reworded to say that rather than call the successors unappendable.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`InclusionListBuilderTests` 10/10 pass. The same-sender case was positive-controlled: it fails on the unfixed code, the cross-sender case passes on both.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Not a consensus issue — the inclusion-list validator already excuses an entry whose nonce does not match the account. Only reachable near the byte cap.

**Interaction with #13392.** Ending the run makes a size-skipped sender dead for the rest of the list, which only stays free as long as the sender reservoir holds more senders than the byte cap can emit entries. #13392 originally shrank `SenderSampleCapacity` from 256 to 110 (`8192/74`), removing exactly that headroom; combined, the two drop the emitted list from 8175/8192 bytes to 4106/8192 over 255 senders each holding one minimal legacy transaction with half of them headed by a 9 KB transaction, and from 8174 to 4117 for 40 senders with 20-nonce runs. This PR is measurably free at the current capacity (8175 and 8173 in those two shapes, matching `master`). #13392 has been amended to keep the headroom and now carries `Reservoir_saturates_the_byte_budget`, which pins it. Either PR can land first; neither should land alongside a reservoir sized to the emittable entry count.
