### PR TITLE
fix(focil): end a sender's inclusion-list run at the first priced-out nonce

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -22,13 +22,15 @@ namespace Nethermind.Merge.Plugin.Test;
 
 public class InclusionListBuilderTests
 {
-    private static Transaction TxOfSize(int payloadBytes, int nonce = 0, PrivateKey? sender = null)
+    private static Transaction TxOfSize(int payloadBytes, int nonce = 0, PrivateKey? sender = null, uint maxFeePerGas = 1)
     {
         byte[] data = new byte[payloadBytes];
         return Build.A.Transaction
             .WithNonce((ulong)nonce)
             .WithTo(TestItem.AddressA)
             .WithData(data)
+            // Legacy txs price off GasPrice, which is what MaxFeePerGas reads back for them.
+            .WithGasPrice(maxFeePerGas)
             .SignedAndResolved(sender ?? TestItem.PrivateKeyA)
             .TestObject;
     }
@@ -120,6 +122,34 @@ public class InclusionListBuilderTests
 
         Assert.That(il.Count, Is.EqualTo(2));
         Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(new[] { nonce0.Hash, nonce1.Hash }));
+    }
+
+    // A run also ends at the first transaction the next block's base fee prices out: that one could not be
+    // appended, so nothing behind it could either, and listing them only spends the byte cap.
+    [TestCase(1u, 1)]
+    [TestCase(10u, 3)]
+    [TestCase(11u, 3)]
+    public void Stops_a_sender_run_at_a_transaction_the_next_base_fee_prices_out(uint middleMaxFeePerGas, int expectedCount)
+    {
+        Transaction nonce0 = TxOfSize(50, 0, maxFeePerGas: 100);
+        Transaction nonce1 = TxOfSize(50, 1, maxFeePerGas: middleMaxFeePerGas);
+        Transaction nonce2 = TxOfSize(50, 2, maxFeePerGas: 100);
+
+        using InclusionListBytes il = BuildBuilder(PoolOf(nonce0, nonce1, nonce2), baseFee: 10).GetInclusionList();
+
+        Assert.That(il.Count, Is.EqualTo(expectedCount));
+    }
+
+    // One sender's run being priced out must not cost the other drawn senders their place in the list.
+    [Test]
+    public void Keeps_other_senders_when_one_run_is_priced_out()
+    {
+        Transaction pricedOut = TxOfSize(50, 0, TestItem.PrivateKeyA, maxFeePerGas: 1);
+        Transaction payable = TxOfSize(50, 0, TestItem.PrivateKeyB, maxFeePerGas: 100);
+
+        using InclusionListBytes il = BuildBuilder(PoolOf(pricedOut, payable), baseFee: 10).GetInclusionList();
+
+        Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(new[] { payable.Hash }));
     }
 
     // Every drawn sender must reach the list before any one of them gets a second nonce, or an account

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -66,6 +66,23 @@ public class InclusionListBuilderTests
     public void Empty_pool_yields_empty_inclusion_list() =>
         Assert.That(BuildBuilder(PoolOf()).GetInclusionList(), Is.Empty);
 
+    // ITxPool's contract doesn't guarantee GetPendingTransactionsBySender omits empty buckets.
+    [Test]
+    public void Tolerates_an_empty_bucket_from_the_pool()
+    {
+        Dictionary<AddressAsKey, Transaction[]> bySender = new()
+        {
+            [new AddressAsKey(TestItem.AddressA)] = [],
+            [new AddressAsKey(TestItem.AddressB)] = [TxOfSize(50, 0, TestItem.PrivateKeyB)]
+        };
+        ITxPool pool = Substitute.For<ITxPool>();
+        pool.GetPendingTransactionsBySender(Arg.Any<bool>(), Arg.Any<UInt256>()).Returns(bySender);
+
+        using InclusionListBytes il = BuildBuilder(pool).GetInclusionList();
+
+        Assert.That(il.Count, Is.EqualTo(1));
+    }
+
     [Test]
     public void Caps_at_max_bytes_per_inclusion_list()
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -29,17 +29,18 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     }
 
     /// <summary>Draws candidate transactions for the list, round-robin across the drawn senders.</summary>
-    /// <remarks>Restricted to each sender's gapless run from its next nonce, since nothing else could be
+    /// <remarks>Restricted to each sender's appendable run from its next nonce, since nothing else could be
     /// appended. Drawn uniformly, not by fee: a fee-ordered draw drops what a builder passes over.</remarks>
     private ArrayPoolListRef<Transaction> SampleAppendableTxs(BlockHeader? parent)
     {
         const int capacity = SenderSampleCapacity;
         Random rnd = Random.Shared;
+        UInt256 baseFee = NextBlockBaseFee(parent);
 
         using ArrayPoolListRef<Transaction[]> senders = new(capacity);
         int seen = 0;
         // Blob txs cannot appear here: TxPool routes them to a separate pool this snapshot does not read.
-        foreach (Transaction[] bySender in txPool.GetPendingTransactionsBySender(filterToReadyTx: true, NextBlockBaseFee(parent)).Values)
+        foreach (Transaction[] bySender in txPool.GetPendingTransactionsBySender(filterToReadyTx: true, baseFee).Values)
         {
             if (senders.Count < capacity)
             {
@@ -60,26 +61,43 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
             (senders[i], senders[j]) = (senders[j], senders[i]);
         }
 
+        using ArrayPoolListRef<int> runLengths = new(capacity);
+        foreach (Transaction[] bySender in senders) runLengths.Add(AppendableRunLength(bySender, in baseFee));
+
         // Take one nonce per sender per round rather than draining each run in turn, so a single account
         // with a long ready run cannot spend the byte cap before the other drawn senders are represented.
         ArrayPoolListRef<Transaction> sample = new(capacity);
         for (int round = 0; ; round++)
         {
             bool advanced = false;
-            foreach (Transaction[] bySender in senders)
+            for (int i = 0; i < senders.Count; i++)
             {
-                if (round >= bySender.Length) continue;
-                Transaction tx = bySender[round];
-                // Buckets are nonce-ordered, so once a gap breaks this offset it can never realign: the
-                // run ends there, because nothing behind a gap can be appended either.
-                if (tx.Nonce != bySender[0].Nonce + (ulong)round) continue;
+                if (round >= runLengths[i]) continue;
 
-                sample.Add(tx);
+                sample.Add(senders[i][round]);
                 advanced = true;
                 if (sample.Count == capacity) return sample;
             }
             if (!advanced) return sample;
         }
+    }
+
+    /// <summary>How many leading transactions of <paramref name="bySender"/> the next block could append.</summary>
+    /// <remarks>Buckets are nonce-ordered, so a broken offset can never realign: nothing behind a nonce gap is
+    /// appendable, and nothing behind an entry the next block would price out is worth the byte cap either.
+    /// The pool vouches for the first entry alone, so both are re-checked from there.</remarks>
+    private static int AppendableRunLength(Transaction[] bySender, in UInt256 baseFee)
+    {
+        ulong anchor = bySender[0].Nonce;
+        int length = 0;
+        while (length < bySender.Length
+            && bySender[length].Nonce == anchor + (ulong)length
+            && bySender[length].CanPayBaseFee(baseFee))
+        {
+            length++;
+        }
+
+        return length;
     }
 
     /// <summary>The base fee the next block will charge.</summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -87,8 +87,9 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     /// appendable, and nothing behind an entry the next block would price out is worth the byte cap either.
     /// The pool vouches for the first entry alone, so both are re-checked from there.
     /// Deliberately doesn't check gas limit or spendable balance like <see cref="Nethermind.Consensus.Validators.InclusionListValidator"/>
-    /// does: the pool already maintains both invariants (<c>GasLimitTxFilter</c> plus EIP-7825's cap; <c>BalanceTooLowFilter</c>
-    /// plus bottleneck eviction), so re-checking here would be redundant.</remarks>
+    /// does: the pool already evicts a run past the nonce its sender cannot fund (<c>BalanceTooLowFilter</c> plus the
+    /// cumulative-cost eviction in <c>UpdateGasBottleneckAndMarkForEviction</c>), and the validator's gas-limit check is
+    /// against the built block's remaining gas, which is not knowable here.</remarks>
     private static int AppendableRunLength(Transaction[] bySender, in UInt256 baseFee)
     {
         // GetBucketSnapshot only prunes empty buckets when a predicate is supplied (SortedPool.cs); ITxPool's

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -85,12 +85,22 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     /// <summary>How many leading transactions of <paramref name="bySender"/> the next block could append.</summary>
     /// <remarks>Buckets are nonce-ordered, so a broken offset can never realign: nothing behind a nonce gap is
     /// appendable, and nothing behind an entry the next block would price out is worth the byte cap either.
-    /// The pool vouches for the first entry alone, so both are re-checked from there.</remarks>
+    /// The pool vouches for the first entry alone, so both are re-checked from there.
+    /// Deliberately doesn't check gas limit or spendable balance like <see cref="Nethermind.Consensus.Validators.InclusionListValidator"/>
+    /// does: the pool already maintains both invariants (<c>GasLimitTxFilter</c> plus EIP-7825's cap; <c>BalanceTooLowFilter</c>
+    /// plus bottleneck eviction), so re-checking here would be redundant.</remarks>
     private static int AppendableRunLength(Transaction[] bySender, in UInt256 baseFee)
     {
+        // GetBucketSnapshot only prunes empty buckets when a predicate is supplied (SortedPool.cs); ITxPool's
+        // contract doesn't guarantee it otherwise, so guard rather than rely on the current caller's filter.
+        if (bySender.Length == 0) return 0;
+
         ulong anchor = bySender[0].Nonce;
         int length = 0;
-        while (length < bySender.Length
+        // The caller only ever consults round < SenderSampleCapacity, so a run longer than that is
+        // indistinguishable from one capped here — scanning further would just waste work.
+        int limit = Math.Min(bySender.Length, SenderSampleCapacity);
+        while (length < limit
             && bySender[length].Nonce == anchor + (ulong)length
             && bySender[length].CanPayBaseFee(baseFee))
         {


### PR DESCRIPTION
## Changes

- End a sender's inclusion-list run at the first transaction the next block's base fee prices out. `TxPool`'s readiness filter vouches for a bucket's first transaction only (`data.first.CanPayBaseFee(baseFee)`), and nothing evicts a later nonce whose `maxFeePerGas` drops below the next base fee — `UpdateGasBottleneckAndMarkForEviction` only lowers its `GasBottleneck`. Such an entry cannot be included, and neither can anything behind it, so both were spending the 8 KiB cap on nothing.
- Mirrors `InclusionListValidator.CouldIncludeTx`'s `tx.MaxFeePerGas < block.BaseFeePerGas` on the build side. No state reads, no new dependencies.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`InclusionListBuilderTests` extended with a parameterised case over the priced-out nonce and one covering the other drawn senders. Verified red before the fix (only the two new behaviours fail), green after.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Second-and-later nonces only reach the list when fewer senders are ready than the byte cap allows, so this bites on quiet chains and is a no-op on a busy mempool.
