### PR TITLE
perf(il): skip the keyed nonce scan when drawing an inclusion list

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/GetInclusionListTransactionsHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/GetInclusionListTransactionsHandlerTests.cs
@@ -22,7 +22,7 @@ public class GetInclusionListTransactionsHandlerTests
     private static GetInclusionListTransactionsHandler BuildHandler(bool focilScheduled)
     {
         ITxPool pool = Substitute.For<ITxPool>();
-        pool.GetPendingTransactionsBySender(Arg.Any<bool>(), Arg.Any<UInt256>()).Returns(new Dictionary<AddressAsKey, Transaction[]>());
+        pool.GetPendingTransactionsBySenderWithReadyNonFrameTx(Arg.Any<UInt256>()).Returns(new Dictionary<AddressAsKey, Transaction[]>());
 
         IReleaseSpec preBogota = Substitute.For<IReleaseSpec>();
         preBogota.IsEip7805Enabled.Returns(false);

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -58,7 +58,7 @@ public class InclusionListBuilderTests
             .GroupBy(tx => new AddressAsKey(tx.SenderAddress!))
             .ToDictionary(g => g.Key, g => g.OrderBy(tx => tx.Nonce).ToArray());
         ITxPool pool = Substitute.For<ITxPool>();
-        pool.GetPendingTransactionsBySender(Arg.Any<bool>(), Arg.Any<UInt256>()).Returns(bySender);
+        pool.GetPendingTransactionsBySenderWithReadyNonFrameTx(Arg.Any<UInt256>()).Returns(bySender);
         return pool;
     }
 
@@ -101,7 +101,7 @@ public class InclusionListBuilderTests
 
         BuildBuilder(pool, baseFee: 17).GetInclusionList().Dispose();
 
-        pool.Received().GetPendingTransactionsBySender(true, (UInt256)17);
+        pool.Received().GetPendingTransactionsBySenderWithReadyNonFrameTx((UInt256)17);
     }
 
     // The named parent, not the head, fixes the fee the candidates are filtered against.
@@ -113,7 +113,7 @@ public class InclusionListBuilderTests
 
         BuildBuilder(pool, baseFee: 17).GetInclusionList(parent).Dispose();
 
-        pool.Received().GetPendingTransactionsBySender(true, (UInt256)23);
+        pool.Received().GetPendingTransactionsBySenderWithReadyNonFrameTx((UInt256)23);
     }
 
     // Listing a frame transaction spends the byte cap for nothing, and its per-key nonce would break the
@@ -173,6 +173,12 @@ public class InclusionListBuilderTests
         Transaction atAccountNonce = TxOfSize(50, 5);
         yield return new TestCaseData(new[] { spent, atAccountNonce }, 5UL, new[] { atAccountNonce })
             .SetName("Skips_a_spent_nonce_heading_the_bucket");
+
+        // The non-frame snapshot vouches for the same bucket by walking past the spent entry, and it need not be
+        // contiguous with the anchor: a gap below the account nonce is as spent as the nonce beneath it.
+        Transaction spentBehindAGap = TxOfSize(50, 3);
+        yield return new TestCaseData(new[] { spentBehindAGap, atAccountNonce }, 5UL, new[] { atAccountNonce })
+            .SetName("Skips_a_spent_nonce_a_gap_below_the_anchor");
 
         // A keyed frame transaction is judged on its own sequence however the account-nonce entries sit, so it can
         // admit a bucket whose only ordinary entry is four nonces ahead. Stripping it leaves nothing appendable.

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -130,8 +130,8 @@ public class InclusionListBuilderTests
         Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(new[] { nonce0.Hash, nonce1.Hash }));
     }
 
-    // The pool admits a whole bucket on its first entry's readiness alone, so a frame transaction at the
-    // head is what vouched for the run; once dropped, what remains need not sit at the next account nonce.
+    // The pool admits a bucket on any one entry being ready, so a frame transaction can be what vouched for
+    // the run; once dropped, what remains need not sit at the next account nonce.
     [Test]
     public void Drops_a_sender_run_the_removed_frame_transaction_was_vouching_for()
     {
@@ -165,8 +165,38 @@ public class InclusionListBuilderTests
         Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(new[] { atAccountNonce.Hash, next.Hash }));
     }
 
-    // The pool checks CanPayBaseFee on the bucket's first entry alone, so a transaction behind a paying head can
-    // sit below the next block's base fee. The validator excuses omitting it, so listing it burns the cap.
+    private static IEnumerable<TestCaseData> BucketsAdmittedByANonFrontEntry()
+    {
+        // The pool reads a bucket entry under the account nonce as spent rather than blocking, so it admits this
+        // bucket on nonce 5 alone while nonce 4 heads it. Only nonce 5 is appendable.
+        Transaction spent = TxOfSize(50, 4);
+        Transaction atAccountNonce = TxOfSize(50, 5);
+        yield return new TestCaseData(new[] { spent, atAccountNonce }, 5UL, new[] { atAccountNonce })
+            .SetName("Skips_a_spent_nonce_heading_the_bucket");
+
+        // A keyed frame transaction is judged on its own sequence however the account-nonce entries sit, so it can
+        // admit a bucket whose only ordinary entry is four nonces ahead. Stripping it leaves nothing appendable.
+        Transaction gapped = TxOfSize(50, 9);
+        Transaction keyedFrame = FrameTx(TestItem.AddressA, nonce: 100, nonceKeys: [1]);
+        yield return new TestCaseData(new[] { gapped, keyedFrame }, 5UL, Array.Empty<Transaction>())
+            .SetName("Drops_a_gapped_run_admitted_by_a_keyed_frame_transaction");
+    }
+
+    // The bucket's lowest entry is not the account's next nonce: the pool admits a bucket on any one entry being
+    // ready, so only a state read names the anchor.
+    [TestCaseSource(nameof(BucketsAdmittedByANonFrontEntry))]
+    public void Anchors_a_sender_run_at_the_account_nonce_not_at_the_bucket_front(
+        Transaction[] bucket, ulong accountNonce, Transaction[] expected)
+    {
+        using InclusionListBytes il = BuildBuilder(
+            PoolOf(bucket),
+            accountNonces: [(TestItem.AddressA, accountNonce)]).GetInclusionList();
+
+        Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(expected.Select(tx => tx.Hash)));
+    }
+
+    // The pool admits a bucket once one entry both pays and is nonce-ready, so a transaction behind a paying head
+    // can sit below the next block's base fee. The validator excuses omitting it, so listing it burns the cap.
     [Test]
     public void Truncates_a_sender_run_at_the_first_transaction_below_the_next_base_fee()
     {
@@ -195,8 +225,7 @@ public class InclusionListBuilderTests
         Assert.That(il, Is.Empty);
     }
 
-    // Worst case for the state read: every sender's bucket is headed by a keyed frame transaction, so the cheap
-    // anchor comparison never decides. The reservoir must bound the reads whatever the pool size.
+    // Every drawn sender costs one account-nonce read, so the reservoir must bound the reads whatever the pool size.
     private static (ITxPool Pool, IReadOnlyStateProvider HeadState, InclusionListBuilder Builder) KeyedHeadSetup(int senderCount)
     {
         Transaction[] txs = new Transaction[senderCount * 2];

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListPoolSeamTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListPoolSeamTests.cs
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Spec;
+using Nethermind.Consensus.Comparers;
+using Nethermind.Consensus.Validators;
+using Nethermind.Core;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
+using Nethermind.TxPool;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+/// <summary>
+/// Pins the seam between the pool's non-frame readiness filter and the run the inclusion list builder rebuilds
+/// from a vouched-for bucket: the two judge the same bucket by the same rule, in different code.
+/// </summary>
+/// <remarks>
+/// Both sides are the production ones — a real <see cref="TxPool"/> admitting real transactions and a real
+/// <see cref="InclusionListBuilder"/> — so a readiness dimension gained by one and not the other turns one of
+/// the two assertions red instead of silently shortening the list.
+/// </remarks>
+public class InclusionListPoolSeamTests
+{
+    /// <summary>What the sender's bucket holds; the account nonce is always 0.</summary>
+    public enum Bucket
+    {
+        KeyedFrameOnly,
+        OrdinaryAtTheNonce,
+        KeyedFrameAndOrdinaryAtTheNonce,
+        KeyedFrameAndOrdinaryAhead,
+        OrdinaryAhead,
+        OrdinaryAtTheNonceButPricedOut,
+    }
+
+    private static readonly ISpecProvider PoolSpecProvider =
+        new TestSpecProvider(new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = true });
+
+    [TestCase(Bucket.KeyedFrameOnly, false)]
+    [TestCase(Bucket.OrdinaryAtTheNonce, true)]
+    [TestCase(Bucket.KeyedFrameAndOrdinaryAtTheNonce, true)]
+    [TestCase(Bucket.KeyedFrameAndOrdinaryAhead, false)]
+    [TestCase(Bucket.OrdinaryAhead, false)]
+    [TestCase(Bucket.OrdinaryAtTheNonceButPricedOut, false)]
+    public async Task Pool_vouches_for_exactly_the_buckets_the_builder_can_draw_from(Bucket bucket, bool expectedReady)
+    {
+        UInt256 nextBaseFee = bucket == Bucket.OrdinaryAtTheNonceButPricedOut ? 2 : UInt256.Zero;
+        TestReadOnlyStateProvider state = new();
+        Address sender = TestItem.PrivateKeyA.Address;
+        state.CreateAccount(sender, 100.Ether);
+
+        BlockHeader head = Build.A.BlockHeader.WithNumber(1).WithBaseFee(UInt256.Zero).TestObject;
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(Build.A.Block.WithHeader(head).TestObject);
+        blockTree.BestSuggestedHeader.Returns(head);
+        blockTree.FindBestSuggestedHeader().Returns(head);
+        EthereumEcdsa ecdsa = new(PoolSpecProvider.ChainId);
+
+        await using Nethermind.TxPool.TxPool txPool = new(
+            ecdsa,
+            new BlobTxStorage(),
+            new ChainHeadInfoProvider(new ChainHeadSpecProvider(PoolSpecProvider, blockTree), blockTree, state),
+            new TxPoolConfig { BlobsSupport = BlobsSupportMode.Disabled },
+            new TxValidator(PoolSpecProvider.ChainId),
+            new SpecChangeTxValidator(PoolSpecProvider.ChainId),
+            LimboLogs.Instance,
+            new TransactionComparerProvider(PoolSpecProvider, blockTree).GetDefaultComparer());
+
+        foreach (Transaction tx in TransactionsOf(bucket, ecdsa))
+        {
+            Assert.That(txPool.SubmitTx(tx, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted));
+        }
+
+        // Frontier leaves the parent's base fee alone, so this header fixes the fee both sides are judged at.
+        BlockHeader parent = Build.A.BlockHeader.WithNumber(1).WithBaseFee(nextBaseFee).TestObject;
+        bool vouched = txPool.GetPendingTransactionsBySenderWithReadyNonFrameTx(nextBaseFee).ContainsKey(sender);
+
+        using InclusionListBytes drawn = BuildBuilder(txPool, blockTree, state).GetInclusionList(parent);
+        using InclusionListBytes drawnIfVouchedForAnyway =
+            BuildBuilder(VouchingFor(txPool.GetPendingTransactionsBySender()), blockTree, state).GetInclusionList(parent);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(vouched, Is.EqualTo(expectedReady));
+            Assert.That(drawnIfVouchedForAnyway.Count > 0, Is.EqualTo(vouched),
+                "the pool vouches for a bucket the builder draws nothing from, or drops one it could have used");
+            Assert.That(drawn.Count > 0, Is.EqualTo(vouched), "the list holds what the pool vouched for");
+        });
+    }
+
+    private static IEnumerable<Transaction> TransactionsOf(Bucket bucket, EthereumEcdsa ecdsa)
+    {
+        if (bucket is Bucket.KeyedFrameOnly or Bucket.KeyedFrameAndOrdinaryAtTheNonce or Bucket.KeyedFrameAndOrdinaryAhead)
+        {
+            yield return KeyedFrameTx();
+        }
+
+        switch (bucket)
+        {
+            case Bucket.OrdinaryAtTheNonce or Bucket.KeyedFrameAndOrdinaryAtTheNonce:
+                yield return OrdinaryTx(ecdsa, nonce: 0, maxFee: 1.GWei);
+                break;
+            case Bucket.KeyedFrameAndOrdinaryAhead or Bucket.OrdinaryAhead:
+                yield return OrdinaryTx(ecdsa, nonce: 2, maxFee: 1.GWei);
+                break;
+            case Bucket.OrdinaryAtTheNonceButPricedOut:
+                yield return OrdinaryTx(ecdsa, nonce: 0, maxFee: 1);
+                break;
+        }
+    }
+
+    private static Transaction OrdinaryTx(EthereumEcdsa ecdsa, ulong nonce, UInt256 maxFee) =>
+        Build.A.Transaction
+            .WithType(TxType.EIP1559)
+            .WithNonce(nonce)
+            .WithChainId(PoolSpecProvider.ChainId)
+            .WithGasLimit(21_000)
+            .WithMaxFeePerGas(maxFee)
+            .WithMaxPriorityFeePerGas(maxFee)
+            .SignedAndResolved(ecdsa, TestItem.PrivateKeyA).TestObject;
+
+    /// <remarks>A frame transaction authenticates by its frame signatures, so it carries a sender rather than an
+    /// outer signature.</remarks>
+    private static Transaction KeyedFrameTx()
+    {
+        Transaction tx = FrameTxTestFrames.FrameTx(
+            TestItem.PrivateKeyA.Address, [], FrameTxTestFrames.SelfVerify(FrameTxTestFrames.PrefixFrameGas));
+        tx.ChainId = PoolSpecProvider.ChainId;
+        tx.Nonce = 0;
+        tx.NonceKeys = [1];
+        tx.GasLimit = 1_000_000;
+        tx.GasPrice = 1.GWei;
+        tx.DecodedMaxFeePerGas = 1.GWei;
+        tx.Hash = tx.CalculateHash();
+        return tx;
+    }
+
+    /// <summary>A pool that vouches for every bucket, to show what the builder would have drawn from one.</summary>
+    private static ITxPool VouchingFor(IDictionary<AddressAsKey, Transaction[]> buckets)
+    {
+        ITxPool pool = Substitute.For<ITxPool>();
+        pool.GetPendingTransactionsBySenderWithReadyNonFrameTx(Arg.Any<UInt256>()).Returns(buckets);
+        return pool;
+    }
+
+    private static InclusionListBuilder BuildBuilder(ITxPool pool, IBlockTree blockTree, TestReadOnlyStateProvider state) =>
+        new(pool, blockTree, new TestSpecProvider(Frontier.Instance), state);
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetInclusionListTransactionsHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetInclusionListTransactionsHandler.cs
@@ -17,8 +17,8 @@ namespace Nethermind.Merge.Plugin.Handlers;
 /// <param name="blockTree">Supplies the head header the next block's base fee is derived from.</param>
 /// <param name="specProvider">Resolves the fork gate and the base-fee parameters.</param>
 /// <param name="chainHeadInfo">
-/// Supplies head state. An EIP-8250 keyed transaction heading a sender's pool bucket names a per-key sequence
-/// rather than an account nonce, so only the account itself says where that sender's appendable run starts.
+/// Supplies head state. The pool admits a sender's bucket on any one entry being ready, so only the account
+/// itself says where that sender's appendable run starts.
 /// </param>
 public class GetInclusionListTransactionsHandler(
     ITxPool? txPool,

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -8,7 +8,6 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
-using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.TxPool;
 
@@ -90,26 +89,33 @@ internal class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecP
         }
     }
 
-    /// <summary>The leading transactions of <paramref name="pending"/> the next block could append, in order.</summary>
-    /// <remarks>The pool vouches for its first entry alone, so the rest is re-checked here: frame transactions
-    /// removed, anchored at the account's next nonce, cut at the first nonce gap or unpayable base fee.</remarks>
+    /// <summary>The transactions of <paramref name="pending"/> the next block could append, in order.</summary>
+    /// <remarks>The pool vouches only that some bucket entry is ready, so the run is rebuilt here against the
+    /// account: frame transactions removed, spent nonces skipped, anchored at the account's next nonce, cut at the
+    /// first nonce gap or unpayable base fee.</remarks>
     private Transaction[] AppendableRun(Transaction[] pending, in UInt256 baseFee)
     {
         Transaction[] bySender = WithoutFrameTxs(pending);
-        if (bySender.Length == 0 || !IsAnchoredAtNextAccountNonce(pending, bySender)) return [];
+        if (bySender.Length == 0) return [];
 
-        ulong anchor = bySender[0].Nonce;
+        ulong anchor = headState.GetNonce(bySender[0].SenderAddress!);
+        int start = 0;
+        // The pool reads an entry under the account nonce as spent rather than blocking, so one can head the
+        // bucket while a later entry is what got it admitted.
+        while (start < bySender.Length && bySender[start].Nonce < anchor) start++;
+        if (start == bySender.Length || bySender[start].Nonce != anchor) return [];
+
         int length = 0;
         // Buckets are nonce-ordered, so a broken offset can never realign: nothing behind a gap is appendable,
         // and nothing behind an entry the next block would price out is worth the byte cap either.
-        while (length < bySender.Length
-            && bySender[length].Nonce == anchor + (ulong)length
-            && bySender[length].CanPayBaseFee(baseFee))
+        while (start + length < bySender.Length
+            && bySender[start + length].Nonce == anchor + (ulong)length
+            && bySender[start + length].CanPayBaseFee(baseFee))
         {
             length++;
         }
 
-        return length == bySender.Length ? bySender : bySender[..length];
+        return start == 0 && length == bySender.Length ? bySender : bySender[start..(start + length)];
     }
 
     /// <summary>The sender's pending run with its EIP-8141 frame transactions removed.</summary>
@@ -130,16 +136,6 @@ internal class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecP
             if (!tx.SupportsFrames) result[j++] = tx;
         return result;
     }
-
-    /// <summary>Whether <paramref name="bySender"/> still begins at the sender's next account nonce.</summary>
-    /// <remarks>
-    /// The pool admits a whole bucket on <paramref name="pending"/>[0] being ready, so that entry alone names the
-    /// next account nonce — unless it is an EIP-8250 keyed one, which names a per-key sequence and so needs a read.
-    /// </remarks>
-    private bool IsAnchoredAtNextAccountNonce(Transaction[] pending, Transaction[] bySender) =>
-        KeyedNonceManager.UsesKeyedNonce(pending[0])
-            ? bySender[0].Nonce == headState.GetNonce(bySender[0].SenderAddress!)
-            : bySender[0].Nonce == pending[0].Nonce;
 
     /// <summary>The base fee the next block will charge.</summary>
     /// <remarks>Approximate at a fork boundary: the next timestamp is not derivable here, so the parent's

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -42,8 +42,9 @@ internal class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecP
         // state read: only the drawn senders below pay for one.
         using ArrayPoolListRef<Transaction[]> drawn = new(capacity);
         int seen = 0;
-        // Blob txs cannot appear here: TxPool routes them to a separate pool this snapshot does not read.
-        foreach (Transaction[] pending in txPool.GetPendingTransactionsBySender(filterToReadyTx: true, baseFee).Values)
+        // Blob txs cannot appear here: TxPool routes them to a separate pool this snapshot does not read. Frame
+        // txs still can, inside a mixed bucket; only buckets holding nothing else are left out.
+        foreach (Transaction[] pending in txPool.GetPendingTransactionsBySenderWithReadyNonFrameTx(baseFee).Values)
         {
             if (drawn.Count < capacity)
             {

--- a/src/Nethermind/Nethermind.TxPool.Test/CountingReadOnlyStateProvider.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/CountingReadOnlyStateProvider.cs
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Evm.State;
+
+namespace Nethermind.TxPool.Test;
+
+/// <summary>Counts per-address account reads, so a test can assert which reads a pool actually makes.</summary>
+/// <remarks><see cref="TxPool"/> caches accounts in front of this, so a count is only meaningful for an address
+/// evicted from that cache first — see <see cref="TxPool.ResetAddress"/>.</remarks>
+internal sealed class CountingReadOnlyStateProvider(IReadOnlyStateProvider inner) : IReadOnlyStateProvider
+{
+    private readonly ConcurrentDictionary<AddressAsKey, int> _reads = new();
+
+    public int AccountReads(Address address) => _reads.TryGetValue(address, out int count) ? count : 0;
+
+    public void ResetCounts() => _reads.Clear();
+
+    public bool TryGetAccount(Address address, out AccountStruct account)
+    {
+        _reads.AddOrUpdate(address, 1, static (_, count) => count + 1);
+        return inner.TryGetAccount(address, out account);
+    }
+
+    public Hash256 StateRoot => inner.StateRoot;
+
+    public byte[]? GetCode(Address address) => inner.GetCode(address);
+
+    public byte[]? GetCode(in ValueHash256 codeHash) => inner.GetCode(in codeHash);
+
+    public bool IsContract(Address address) => inner.IsContract(address);
+
+    public bool AccountExists(Address address) => inner.AccountExists(address);
+
+    public bool IsDeadAccount(Address address) => inner.IsDeadAccount(address);
+
+    public ReadOnlySpan<byte> Get(in StorageCell storageCell) => inner.Get(in storageCell);
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/InclusionListSnapshotMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/InclusionListSnapshotMeasurement.cs
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Spec;
+using Nethermind.Consensus.Comparers;
+using Nethermind.Consensus.Validators;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Core.Test;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Evm.State;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Int256;
+using Nethermind.Logging;
+using Nethermind.Specs;
+using Nethermind.Specs.Forks;
+using Nethermind.State;
+using Nethermind.TxPool.Collections;
+using NUnit.Framework;
+
+namespace Nethermind.TxPool.Test;
+
+/// <summary>
+/// Times the pool snapshot behind <c>engine_getInclusionListV1</c> against a trie-backed state reader, for a pool
+/// of ordinary transactions and for one filled with EIP-8250 keyed transactions at the maximum key count.
+/// </summary>
+/// <remarks>
+/// Reports <c>RESULT</c> lines for three snapshots of the same pool: <c>filtered</c> is the full readiness filter,
+/// <c>nonframe</c> the inclusion list's, and <c>unfiltered</c> the bucket copy alone, which separates the copy
+/// from the readiness reads. The whole snapshot runs under the pool's exclusive lock.
+///
+/// The state lives in a <c>MemDb</c>, so every read here is a warm in-process trie traversal — a floor for what
+/// the same scan costs against RocksDB.
+/// </remarks>
+[TestFixture]
+[Explicit("measurement harness")]
+[NonParallelizable]
+public class InclusionListSnapshotMeasurement
+{
+    private const int Warmup = 5;
+    private const int Samples = 30;
+    private const ulong KeyedSeq = 1;
+
+    private static readonly ISpecProvider SpecProvider = MainnetSpecProvider.Instance;
+
+    [TestCase(2048, false, TestName = "ordinary transactions at the default pool size")]
+    [TestCase(2048, true, TestName = "keyed transactions at the default pool size")]
+    [TestCase(8192, true, TestName = "keyed transactions at four times the default pool size")]
+    [TestCase(20000, true, TestName = "keyed transactions at ten times the default pool size")]
+    public async Task Measure(int senders, bool keyed)
+    {
+        (IWorldState world, IStateReader stateReader) = TestWorldStateFactory.CreateForTestWithStateReader();
+        Address[] addresses = new Address[senders];
+        Hash256 stateRoot;
+
+        using (world.BeginScope(null))
+        {
+            for (int i = 0; i < senders; i++)
+            {
+                addresses[i] = AddressOf(i);
+                world.CreateAccount(addresses[i], 1.Ether);
+            }
+
+            if (keyed)
+            {
+                // Non-empty, or the commit prunes NONCE_MANAGER and takes the slots below with it.
+                world.CreateAccount(Eip8250Constants.NonceManagerAddress, 1, 1);
+                foreach (Address sender in addresses)
+                {
+                    for (int k = 0; k < Eip8250Constants.MaxNonceKeys; k++)
+                    {
+                        world.Set(KeyedNonceManager.StorageSlot(sender, KeyOf(sender, k)), [(byte)KeyedSeq]);
+                    }
+                }
+            }
+
+            world.Commit(Cancun.Instance);
+            world.CommitTree(0);
+            stateRoot = world.StateRoot;
+        }
+
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).WithStateRoot(stateRoot).WithBaseFee(0).TestObject;
+        TestBlockTree blockTree = new() { Head = Build.A.Block.WithHeader(header).TestObject, BestSuggestedHeader = header };
+        ChainHeadInfoProvider headInfo = new(
+            new ChainHeadSpecProvider(SpecProvider, blockTree),
+            blockTree,
+            new SpecificBlockReadOnlyStateProvider(stateReader, header));
+
+        await using TxPool txPool = new(
+            new EthereumEcdsa(SpecProvider.ChainId),
+            new BlobTxStorage(),
+            headInfo,
+            new TxPoolConfig { Size = senders, BlobsSupport = BlobsSupportMode.Disabled },
+            new TxValidator(SpecProvider.ChainId),
+            new SpecChangeTxValidator(SpecProvider.ChainId),
+            LimboLogs.Instance,
+            new TransactionComparerProvider(SpecProvider, blockTree).GetDefaultComparer());
+
+        // Admission is not what is being measured, and a keyed frame transaction cannot clear it without an EVM.
+        TxDistinctSortedPool pool = txPool._transactions;
+        for (int i = 0; i < senders; i++)
+        {
+            Transaction tx = BuildTx(i, addresses[i], keyed);
+            Assert.That(pool.TryInsert(tx.Hash!, tx), Is.True, $"transaction {i} was not inserted");
+        }
+
+        // The readiness filter must reach every bucket's expensive branch, or the numbers below mean nothing.
+        Assert.That(txPool.GetPendingTransactionsBySender(true, UInt256.Zero), Has.Count.EqualTo(senders));
+
+        Report("filtered", () => txPool.GetPendingTransactionsBySender(true, UInt256.Zero), senders, keyed);
+        Report("nonframe", () => txPool.GetPendingTransactionsBySenderWithReadyNonFrameTx(UInt256.Zero), senders, keyed);
+        Report("unfiltered", () => txPool.GetPendingTransactionsBySender(), senders, keyed);
+    }
+
+    private static void Report(string label, Func<IDictionary<AddressAsKey, Transaction[]>> snapshot, int senders, bool keyed)
+    {
+        for (int i = 0; i < Warmup; i++) snapshot();
+
+        double[] ms = new double[Samples];
+        for (int i = 0; i < Samples; i++)
+        {
+            long start = Stopwatch.GetTimestamp();
+            GC.KeepAlive(snapshot());
+            ms[i] = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+        }
+
+        Array.Sort(ms);
+        TestContext.Out.WriteLine(
+            $"RESULT {label} senders={senders} keyed={keyed} min={ms[0]:F3}ms p50={ms[Samples / 2]:F3}ms p90={ms[Samples * 9 / 10]:F3}ms max={ms[^1]:F3}ms");
+    }
+
+    /// <remarks>Big-endian, so distinct senders differ in the last byte: the pool's account cache shards on it.</remarks>
+    private static Address AddressOf(int index)
+    {
+        Span<byte> bytes = stackalloc byte[Address.Size];
+        bytes.Clear();
+        BinaryPrimitives.WriteInt32BigEndian(bytes[(Address.Size - sizeof(int))..], index);
+        return new Address(bytes);
+    }
+
+    private static UInt256 KeyOf(Address sender, int k)
+    {
+        UInt256 baseKey = new(Keccak.Compute(sender.Bytes).Bytes, isBigEndian: true);
+        return baseKey + (UInt256)(k + 1);
+    }
+
+    private static UInt256[] KeysOf(Address sender)
+    {
+        UInt256[] keys = new UInt256[Eip8250Constants.MaxNonceKeys];
+        for (int k = 0; k < keys.Length; k++) keys[k] = KeyOf(sender, k);
+        return keys;
+    }
+
+    private static Transaction BuildTx(int index, Address sender, bool keyed)
+    {
+        TransactionBuilder<Transaction> builder = Build.A.Transaction
+            .WithSenderAddress(sender)
+            .WithGasLimit(21_000)
+            .WithMaxFeePerGas(1.GWei)
+            .WithMaxPriorityFeePerGas(1.GWei)
+            .WithHash(Keccak.Compute(((UInt256)index).ToBigEndian()));
+
+        return keyed
+            ? builder.WithType(TxType.FrameTx).WithNonce(KeyedSeq).WithNonceKeys(KeysOf(sender)).TestObject
+            : builder.WithType(TxType.EIP1559).WithNonce(0).TestObject;
+    }
+}

--- a/src/Nethermind/Nethermind.TxPool.Test/InclusionListSnapshotMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/InclusionListSnapshotMeasurement.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -25,8 +24,8 @@ using Nethermind.Int256;
 using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
+using Nethermind.Specs.Test;
 using Nethermind.State;
-using Nethermind.TxPool.Collections;
 using NUnit.Framework;
 
 namespace Nethermind.TxPool.Test;
@@ -51,8 +50,10 @@ public class InclusionListSnapshotMeasurement
     private const int Warmup = 5;
     private const int Samples = 30;
     private const ulong KeyedSeq = 1;
+    private const ulong FrameTxGasLimit = 1_000_000;
 
-    private static readonly ISpecProvider SpecProvider = MainnetSpecProvider.Instance;
+    private static readonly ISpecProvider SpecProvider =
+        new TestSpecProvider(new OverridableReleaseSpec(Eip8141Prototype.Instance) { IsEip8250Enabled = true });
 
     [TestCase(2048, false, TestName = "ordinary transactions at the default pool size")]
     [TestCase(2048, true, TestName = "keyed transactions at the default pool size")]
@@ -60,27 +61,28 @@ public class InclusionListSnapshotMeasurement
     [TestCase(20000, true, TestName = "keyed transactions at ten times the default pool size")]
     public async Task Measure(int senders, bool keyed)
     {
+        EthereumEcdsa ecdsa = new(SpecProvider.ChainId);
         (IWorldState world, IStateReader stateReader) = TestWorldStateFactory.CreateForTestWithStateReader();
-        Address[] addresses = new Address[senders];
+        PrivateKey[] keys = new PrivateKey[senders];
         Hash256 stateRoot;
 
         using (world.BeginScope(null))
         {
             for (int i = 0; i < senders; i++)
             {
-                addresses[i] = AddressOf(i);
-                world.CreateAccount(addresses[i], 1.Ether);
+                keys[i] = KeyOfSender(i);
+                world.CreateAccount(keys[i].Address, 1.Ether);
             }
 
             if (keyed)
             {
                 // Non-empty, or the commit prunes NONCE_MANAGER and takes the slots below with it.
                 world.CreateAccount(Eip8250Constants.NonceManagerAddress, 1, 1);
-                foreach (Address sender in addresses)
+                foreach (PrivateKey key in keys)
                 {
                     for (int k = 0; k < Eip8250Constants.MaxNonceKeys; k++)
                     {
-                        world.Set(KeyedNonceManager.StorageSlot(sender, KeyOf(sender, k)), [(byte)KeyedSeq]);
+                        world.Set(KeyedNonceManager.StorageSlot(key.Address, KeyOf(key.Address, k)), [(byte)KeyedSeq]);
                     }
                 }
             }
@@ -90,7 +92,8 @@ public class InclusionListSnapshotMeasurement
             stateRoot = world.StateRoot;
         }
 
-        BlockHeader header = Build.A.BlockHeader.WithNumber(1).WithStateRoot(stateRoot).WithBaseFee(0).TestObject;
+        BlockHeader header = Build.A.BlockHeader.WithNumber(1).WithStateRoot(stateRoot).WithBaseFee(0)
+            .WithGasLimit(30_000_000).TestObject;
         TestBlockTree blockTree = new() { Head = Build.A.Block.WithHeader(header).TestObject, BestSuggestedHeader = header };
         ChainHeadInfoProvider headInfo = new(
             new ChainHeadSpecProvider(SpecProvider, blockTree),
@@ -98,7 +101,7 @@ public class InclusionListSnapshotMeasurement
             new SpecificBlockReadOnlyStateProvider(stateReader, header));
 
         await using TxPool txPool = new(
-            new EthereumEcdsa(SpecProvider.ChainId),
+            ecdsa,
             new BlobTxStorage(),
             headInfo,
             new TxPoolConfig { Size = senders, BlobsSupport = BlobsSupportMode.Disabled },
@@ -107,12 +110,10 @@ public class InclusionListSnapshotMeasurement
             LimboLogs.Instance,
             new TransactionComparerProvider(SpecProvider, blockTree).GetDefaultComparer());
 
-        // Admission is not what is being measured, and a keyed frame transaction cannot clear it without an EVM.
-        TxDistinctSortedPool pool = txPool._transactions;
         for (int i = 0; i < senders; i++)
         {
-            Transaction tx = BuildTx(i, addresses[i], keyed);
-            Assert.That(pool.TryInsert(tx.Hash!, tx), Is.True, $"transaction {i} was not inserted");
+            Transaction tx = BuildTx(ecdsa, keys[i], keyed);
+            Assert.That(txPool.SubmitTx(tx, TxHandlingOptions.None), Is.EqualTo(AcceptTxResult.Accepted), $"transaction {i}");
         }
 
         // The readiness filter must reach every bucket's expensive branch, or the numbers below mean nothing.
@@ -140,14 +141,7 @@ public class InclusionListSnapshotMeasurement
             $"RESULT {label} senders={senders} keyed={keyed} min={ms[0]:F3}ms p50={ms[Samples / 2]:F3}ms p90={ms[Samples * 9 / 10]:F3}ms max={ms[^1]:F3}ms");
     }
 
-    /// <remarks>Big-endian, so distinct senders differ in the last byte: the pool's account cache shards on it.</remarks>
-    private static Address AddressOf(int index)
-    {
-        Span<byte> bytes = stackalloc byte[Address.Size];
-        bytes.Clear();
-        BinaryPrimitives.WriteInt32BigEndian(bytes[(Address.Size - sizeof(int))..], index);
-        return new Address(bytes);
-    }
+    private static PrivateKey KeyOfSender(int index) => new(Keccak.Compute(((UInt256)(index + 1)).ToBigEndian()).BytesToArray());
 
     private static UInt256 KeyOf(Address sender, int k)
     {
@@ -162,17 +156,37 @@ public class InclusionListSnapshotMeasurement
         return keys;
     }
 
-    private static Transaction BuildTx(int index, Address sender, bool keyed)
+    /// <remarks>A frame transaction authenticates by its frame signatures, so it carries a sender rather than an
+    /// outer signature — the shape <see cref="TxPool"/> admission expects of one.</remarks>
+    private static Transaction BuildTx(EthereumEcdsa ecdsa, PrivateKey key, bool keyed)
     {
-        TransactionBuilder<Transaction> builder = Build.A.Transaction
-            .WithSenderAddress(sender)
-            .WithGasLimit(21_000)
-            .WithMaxFeePerGas(1.GWei)
-            .WithMaxPriorityFeePerGas(1.GWei)
-            .WithHash(Keccak.Compute(((UInt256)index).ToBigEndian()));
+        if (!keyed)
+        {
+            return Build.A.Transaction
+                .WithType(TxType.EIP1559)
+                .WithNonce(0)
+                .WithChainId(SpecProvider.ChainId)
+                .WithGasLimit(21_000)
+                .WithMaxFeePerGas(1.GWei)
+                .WithMaxPriorityFeePerGas(1.GWei)
+                .SignedAndResolved(ecdsa, key).TestObject;
+        }
 
-        return keyed
-            ? builder.WithType(TxType.FrameTx).WithNonce(KeyedSeq).WithNonceKeys(KeysOf(sender)).TestObject
-            : builder.WithType(TxType.EIP1559).WithNonce(0).TestObject;
+        Transaction tx = new()
+        {
+            Type = TxType.FrameTx,
+            ChainId = SpecProvider.ChainId,
+            Nonce = KeyedSeq,
+            SenderAddress = key.Address,
+            NonceKeys = KeysOf(key.Address),
+            Frames = [FrameTxTestFrames.SelfVerify(FrameTxTestFrames.PrefixFrameGas)],
+            FrameSignatures = [],
+            GasLimit = FrameTxGasLimit,
+            Value = UInt256.Zero,
+            GasPrice = 1.GWei,
+            DecodedMaxFeePerGas = 1.GWei,
+        };
+        tx.Hash = tx.CalculateHash();
+        return tx;
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -5189,6 +5189,44 @@ namespace Nethermind.TxPool.Test
             Assert.That(_txPool.GetLatestPendingNonce(sender), Is.EqualTo(expectedPendingNonce));
         }
 
+        /// <remarks>A keyed frame transaction makes its sender's bucket ready on its own, so a caller that drops
+        /// frame transactions would draw a bucket holding nothing it can use — and pay a NONCE_MANAGER read per
+        /// nonce key to be told so.</remarks>
+        [TestCase(false, TestName = "sender holding only a keyed frame transaction")]
+        [TestCase(true, TestName = "sender holding a keyed frame transaction and an ordinary one")]
+        public void Non_frame_snapshot_keeps_only_senders_with_an_ordinary_ready_transaction(bool hasOrdinaryTx)
+        {
+            const ulong accountNonce = 3;
+            _txPool = CreatePool(null, KeyedNonceSpecProvider());
+            Address sender = TestItem.PrivateKeyA.Address;
+            _stateProvider.CreateAccount(sender, 100.Ether, accountNonce);
+
+            Transaction keyed = BuildKeyedFrameTx(sender, nonceKey: 1, seq: 0, value: UInt256.Zero, maxFee: 1.GWei);
+            Assert.That(_txPool.SubmitTx(keyed, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            if (hasOrdinaryTx)
+            {
+                Transaction plain = Build.A.Transaction
+                    .WithNonce(accountNonce)
+                    .WithMaxFeePerGas(1.GWei)
+                    .WithMaxPriorityFeePerGas(1.GWei)
+                    .WithGasLimit(21_000)
+                    .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+                Assert.That(_txPool.SubmitTx(plain, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            }
+
+            Assert.That(_txPool.GetPendingTransactionsBySender(true, UInt256.Zero), Does.ContainKey(new AddressAsKey(sender)),
+                "the keyed head alone makes the bucket ready for the full filter");
+
+            IDictionary<AddressAsKey, Transaction[]> nonFrame = _txPool.GetPendingTransactionsBySenderWithReadyNonFrameTx(UInt256.Zero);
+
+            Assert.That(nonFrame.ContainsKey(sender), Is.EqualTo(hasOrdinaryTx));
+            if (hasOrdinaryTx)
+            {
+                Assert.That(nonFrame[sender], Has.Length.EqualTo(2), "a kept bucket comes back whole, frame transactions included");
+            }
+        }
+
         /// <remarks>Admission sums a sender's keyed and account-domain liabilities against one balance; the
         /// per-head sweep has to price them the same way, or a balance drop leaves both pending and announced.</remarks>
         [TestCase(true, 1, TestName = "the balance covers each alone but not both")]

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -5227,6 +5227,42 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        /// <remarks>The snapshot's whole saving is the account read a frame-only bucket does not make, so hoisting
+        /// that read to the head of the scan would be invisible everywhere but here.</remarks>
+        [TestCase(false, 0, TestName = "a frame-only bucket is judged without an account read")]
+        [TestCase(true, 1, TestName = "a bucket with an ordinary transaction pays for one")]
+        public void Non_frame_snapshot_reads_an_account_only_for_a_non_frame_entry(bool hasOrdinaryTx, int expectedReads)
+        {
+            ISpecProvider specProvider = KeyedNonceSpecProvider();
+            CountingReadOnlyStateProvider counting = new(_stateProvider);
+            _txPool = CreatePool(null, specProvider,
+                new ChainHeadInfoProvider(new ChainHeadSpecProvider(specProvider, _blockTree), _blockTree, counting));
+            Address sender = TestItem.PrivateKeyA.Address;
+            _stateProvider.CreateAccount(sender, 100.Ether);
+
+            Transaction keyed = BuildKeyedFrameTx(sender, nonceKey: 1, seq: 0, value: UInt256.Zero, maxFee: 1.GWei);
+            Assert.That(_txPool.SubmitTx(keyed, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+
+            if (hasOrdinaryTx)
+            {
+                Transaction plain = Build.A.Transaction
+                    .WithNonce(0)
+                    .WithMaxFeePerGas(1.GWei)
+                    .WithMaxPriorityFeePerGas(1.GWei)
+                    .WithGasLimit(21_000)
+                    .SignedAndResolved(_ethereumEcdsa, TestItem.PrivateKeyA).TestObject;
+                Assert.That(_txPool.SubmitTx(plain, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
+            }
+
+            // Admission cached the sender, which would serve a hoisted read and hide it from the count below.
+            _txPool.ResetAddress(sender);
+            counting.ResetCounts();
+
+            _txPool.GetPendingTransactionsBySenderWithReadyNonFrameTx(UInt256.Zero);
+
+            Assert.That(counting.AccountReads(sender), Is.EqualTo(expectedReads));
+        }
+
         /// <remarks>Admission sums a sender's keyed and account-domain liabilities against one balance; the
         /// per-head sweep has to price them the same way, or a balance drop leaves both pending and announced.</remarks>
         [TestCase(true, 1, TestName = "the balance covers each alone but not both")]

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -39,6 +39,17 @@ namespace Nethermind.TxPool
         IDictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySender(bool filterToReadyTx = false, UInt256 baseFee = default);
 
         /// <summary>
+        /// Non-blob txs grouped by sender address, limited to senders holding a non-frame transaction the next
+        /// block could include. Kept buckets come back whole, frame transactions included.
+        /// </summary>
+        /// <param name="baseFee">Base fee the next block will charge.</param>
+        /// <remarks>For a caller that discards EIP-8141 frame transactions anyway: judging a bucket's frames too
+        /// costs an EIP-8250 NONCE_MANAGER state read per nonce key they select, and hands back senders holding
+        /// nothing such a caller can use.</remarks>
+        IDictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySenderWithReadyNonFrameTx(UInt256 baseFee) =>
+            GetPendingTransactionsBySender(true, baseFee);
+
+        /// <summary>
         /// Blob txs light equivalences grouped by sender address, sorted by nonce and later tx pool sorting
         /// </summary>
         /// <returns></returns>

--- a/src/Nethermind/Nethermind.TxPool/ITxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/ITxPool.cs
@@ -45,9 +45,11 @@ namespace Nethermind.TxPool
         /// <param name="baseFee">Base fee the next block will charge.</param>
         /// <remarks>For a caller that discards EIP-8141 frame transactions anyway: judging a bucket's frames too
         /// costs an EIP-8250 NONCE_MANAGER state read per nonce key they select, and hands back senders holding
-        /// nothing such a caller can use.</remarks>
+        /// nothing such a caller can use.
+        /// <para>The default body only approximates that: it falls back to the full readiness filter, so an
+        /// implementation that does not override it pays those reads and may return frame-only senders.</para></remarks>
         IDictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySenderWithReadyNonFrameTx(UInt256 baseFee) =>
-            GetPendingTransactionsBySender(true, baseFee);
+            GetPendingTransactionsBySender(filterToReadyTx: true, baseFee);
 
         /// <summary>
         /// Blob txs light equivalences grouped by sender address, sorted by nonce and later tx pool sorting

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -51,7 +51,7 @@ namespace Nethermind.TxPool
         private readonly HashCache _hashCache = new();
         private readonly TxBroadcaster _broadcaster;
 
-        internal readonly TxDistinctSortedPool _transactions;
+        private readonly TxDistinctSortedPool _transactions;
         private readonly BlobTxDistinctSortedPool _blobTransactions;
 
         private readonly IChainHeadSpecProvider _specProvider;

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -51,7 +51,7 @@ namespace Nethermind.TxPool
         private readonly HashCache _hashCache = new();
         private readonly TxBroadcaster _broadcaster;
 
-        private readonly TxDistinctSortedPool _transactions;
+        internal readonly TxDistinctSortedPool _transactions;
         private readonly BlobTxDistinctSortedPool _blobTransactions;
 
         private readonly IChainHeadSpecProvider _specProvider;
@@ -340,6 +340,38 @@ namespace Nethermind.TxPool
             _transactions.GetBucketSnapshot(filterToReadyTx ?
                 (data => HasReadyTransaction(data.bucket, data.key, baseFee)) :
                 null);
+
+        /// <inheritdoc/>
+        public IDictionary<AddressAsKey, Transaction[]> GetPendingTransactionsBySenderWithReadyNonFrameTx(UInt256 baseFee) =>
+            _transactions.GetBucketSnapshot(data => HasReadyNonFrameTransaction(data.bucket, data.key, baseFee));
+
+        /// <summary>Whether a sender's bucket holds a non-frame transaction includable in the next block.</summary>
+        /// <remarks>The account-nonce half of <see cref="HasReadyTransaction"/>. Every EIP-8250 keyed transaction is
+        /// an EIP-8141 frame transaction, so skipping frames also skips every NONCE_MANAGER read the full scan
+        /// would make — the whole cost of that scan, and a caller that discards frame transactions buys nothing
+        /// with it.</remarks>
+        private bool HasReadyNonFrameTransaction(IReadOnlySortedSet<Transaction> bucket, Address sender, in UInt256 baseFee)
+        {
+            ulong accountNonce = 0;
+            bool accountNonceRead = false;
+            foreach (Transaction tx in bucket)
+            {
+                if (tx.SupportsFrames) continue;
+                // Deferred, so a frame-only bucket — what this filter exists to make cheap — pays no account read.
+                if (!accountNonceRead)
+                {
+                    accountNonce = _accounts.GetNonce(sender);
+                    accountNonceRead = true;
+                }
+
+                // An entry under the account nonce is stale rather than blocking: it awaits a head change the
+                // pool has not processed yet, and the next entry may sit exactly at the nonce.
+                if (tx.Nonce < accountNonce) continue;
+                return tx.Nonce == accountNonce && tx.CanPayBaseFee(baseFee);
+            }
+
+            return false;
+        }
 
         /// <summary>Whether <paramref name="tx"/> carries the nonce its sender can consume in the next block.</summary>
         /// <remarks>An EIP-8250 keyed set does not use the account nonce, so readiness is per-key currency instead.</remarks>


### PR DESCRIPTION
> **Stacked on #13381** — this PR targets `fix/focil-inclusion-list-anchor`, not the shared base, and is not correct without it. See [Why the dependency is load-bearing](#why-the-dependency-is-load-bearing) below.

## Changes

`engine_getInclusionListV1` sits on a per-slot deadline, but its single pool call took the full readiness snapshot: `HasReadyTransaction` judges each EIP-8250 keyed entry with a `NONCE_MANAGER` storage read per nonce key it selects (up to `MaxNonceKeys` = 16), and the whole scan runs under the pool's exclusive `McsLock` — blocking admission, broadcast and block production for its duration.

None of that work can reach the list. Every keyed transaction is an EIP-8141 frame transaction, and the builder drops frame transactions; frame-only buckets also displaced genuine senders from the 256-sender reservoir, shrinking the list the committee gossips.

- `ITxPool.GetPendingTransactionsBySenderWithReadyNonFrameTx` — a snapshot whose readiness is judged on a bucket's non-frame entries only. Kept buckets come back whole, so the builder's own frame handling is unchanged. The default interface implementation falls back to the existing filter.
- `InclusionListBuilder` draws from it.
- The account nonce is read lazily, at the first non-frame entry, so a frame-only bucket — the case this filter exists to make cheap — is a pure `SupportsFrames` walk with no state read at all. This is not a micro-optimisation; see the measurement below.

### Why the dependency is load-bearing

The new filter keeps a bucket on a non-frame entry that is *not* the bucket's first: it walks past entries under the account nonce, which the pool reads as spent rather than blocking. On the old builder, which anchored the run at `bySender[0].Nonce`, that combination is a live defect — account nonce 5, bucket `[legacy #3, legacy #5]` (head processed, pool not yet swept): the snapshot keeps the bucket on `#5`, the builder anchors at `#3`, cuts at the gap, and gossips a transaction no block can include while spending list cap to do it.

#13381 anchors the run at `headState.GetNonce` and skips the spent prefix, which makes the two filters agree entry-for-entry. This PR is rebased onto it rather than onto the shared base, and `InclusionListBuilderTests.Skips_a_spent_nonce_a_gap_below_the_anchor` pins exactly that bucket shape (`[#3, #5]`, account at 5 → only `#5` listed).

### Measured

`InclusionListSnapshotMeasurement`, an `[Explicit]` harness over a real trie-backed state reader. Pool filled one transaction per sender; `MemDb` state, so these are warm in-process traversals — a floor for RocksDB. Median of 30 after 5 warm-ups, p90 in brackets; three consecutive runs agreed within a few percent, and all rows below come from one release build on one machine.

`before` is the existing `GetPendingTransactionsBySender(filterToReadyTx: true, …)`; `after` is this PR's filter; `copy only` is the same snapshot with no readiness predicate at all, which separates the bucket copy from the readiness reads.

| senders | pool contents | before | after | copy only |
| --- | --- | ---: | ---: | ---: |
| 2,048 (default `TxPool.Size`) | ordinary | 0.83 ms (0.97) | 1.02 ms (1.11) | 0.33 ms (0.37) |
| 2,048 | keyed, 16 keys each | **26.0 ms** (27.3) | **0.14 ms** (0.19) | 0.11 ms (0.15) |
| 8,192 | keyed, 16 keys each | 138.7 ms (139.9) | 0.22 ms (0.69) | 0.39 ms (5.07) |
| 20,000 | keyed, 16 keys each | 417.3 ms (423.7) | 0.67 ms (1.21) | 1.36 ms (8.99) |

The ordinary row is the honest cost side: with no frame transactions in the pool the new filter is about 0.2 ms *slower* at 2,048 senders, since it does the same one account read per bucket plus a `SupportsFrames` check per entry. Every keyed row is two to three orders of magnitude cheaper.

The worst case is bounded by `TxPool.Size` × `MaxNonceKeys` reads — 32,768 at the default size. `MaxPendingTxsPerSender` defaults to 0 (no limit), so nothing caps how many keyed transactions one sender may hold; spreading them over more senders raises the bucket count rather than the total.

#### Where the lazy read matters

An earlier revision of this PR hoisted `_accounts.GetNonce(sender)` above the bucket scan, so a frame-only bucket still paid one account read. Measured on the same build and machine, that variant costs **12.4 ms and 13.7 ms** (median of 30, two runs) on the 20,000-sender keyed row, against **0.67 ms** for the lazy read shipped here. `AccountCache` is 16 shards × 1024 entries, so at 20,000 senders every shard thrashes and each `GetNonce` becomes a trie read. That residual was the whole of the 12.6 ms previously reported for that row.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`TxPoolTests.Non_frame_snapshot_keeps_only_senders_with_an_ordinary_ready_transaction` pins both halves pool-side: a sender holding only a keyed frame transaction is left out, and a mixed bucket comes back whole. `InclusionListBuilderTests.Skips_a_spent_nonce_a_gap_below_the_anchor` pins the builder half of the seam described above.

Mutation check — repointing `InclusionListBuilder` back at `GetPendingTransactionsBySender(filterToReadyTx: true, …)` fails 10 of the 18 `InclusionListBuilderTests`, so that suite genuinely discriminates on the new path. It does **not** fail `GetInclusionListTransactionsHandlerTests`: those two tests assert only the fork gate, and NSubstitute auto-substitutes the `IDictionary<,>` return either way, so the pool stub there is not load-bearing and never was. Its stub was still switched to the new method, because a dead stub naming a method the handler no longer reaches reads as coverage that does not exist.

`InclusionListSnapshotMeasurement` binds `TxPool._transactions` directly rather than through a reflected `"_transactions"` string; `Nethermind.TxPool` already grants `InternalsVisibleTo("Nethermind.TxPool.Test")`, so a rename now breaks the build instead of failing silently in an `[Explicit]` harness nobody runs.

Full suites, release and checked (`-p:DefineConstants=TRACE;DEBUG`, artifacts cleaned between configurations) — identical counts in both:

| suite | passed | skipped |
| --- | ---: | ---: |
| `Nethermind.TxPool.Test` | 1207 | 28 |
| `Nethermind.Merge.Plugin.Test` | 1890 | 3 |
| `Nethermind.JsonRpc.Test` | 2125 | 22 |
| `Nethermind.Blockchain.Test` | 1883 | 151 |

Code-lint job's exact invocation is clean on this branch, positive-controlled with an injected unused `using` (which does raise `IDE0005`).

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
