### PR TITLE
Add opt-in historical debug trace prewarming

### DIFF
--- a/src/Nethermind/Nethermind.Consensus.Test/HistoricalTracePrewarmerTests.cs
+++ b/src/Nethermind/Nethermind.Consensus.Test/HistoricalTracePrewarmerTests.cs
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using Nethermind.Blockchain;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Tracing;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Logging;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Consensus.Test;
+
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+public class HistoricalTracePrewarmerTests
+{
+    private readonly IReadOnlyTxProcessingEnvFactory _factory = Substitute.For<IReadOnlyTxProcessingEnvFactory>();
+    private readonly IReadOnlyTxProcessorSource _environment = Substitute.For<IReadOnlyTxProcessorSource>();
+    private readonly IReadOnlyTxProcessingScope _scope = Substitute.For<IReadOnlyTxProcessingScope>();
+    private readonly ITransactionProcessor _processor = Substitute.For<ITransactionProcessor>();
+    private readonly TestBlockTree _blockTree = new() { Head = Build.A.Block.WithNumber(1_000).TestObject };
+    private readonly BlockHeader _parent = Build.A.BlockHeader.WithNumber(1).TestObject;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _factory.Create().Returns(_environment);
+        _environment.Build(_parent).Returns(_scope);
+        _scope.TransactionProcessor.Returns(_processor);
+    }
+
+    [TestCase(0, 2, true)]
+    [TestCase(1, 999, true)]
+    [TestCase(1, 1_001, true)]
+    [TestCase(1, 2, false)]
+    public void Prewarm_IneligibleBlock_DoesNotCreateWorkers(int concurrency, int number, bool canonical)
+    {
+        _blockTree.Canonical = canonical;
+        Create(concurrency).Prewarm(Block(number), _parent, CancellationToken.None);
+        _factory.DidNotReceive().Create();
+    }
+
+    [Test]
+    public void Prewarm_YoungChain_DoesNotUnderflowDistanceCheck()
+    {
+        _blockTree.Head = Build.A.Block.WithNumber(3).TestObject;
+        Create().Prewarm(Block(), _parent, CancellationToken.None);
+        _factory.DidNotReceive().Create();
+    }
+
+    [TestCase(TxType.Legacy)]
+    [TestCase(TxType.AccessList)]
+    [TestCase(TxType.EIP1559)]
+    public void Prewarm_SupportedTransaction_CopiesTransactionAndBoundsGas(TxType type)
+    {
+        Block block = Block();
+        Transaction source = block.Transactions[0];
+        source.Type = type;
+        source.GasLimit = 20_000_000;
+        Transaction warmed = null;
+        _processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
+            .Returns(call => { warmed = call.Arg<Transaction>(); return default; });
+
+        Create().Prewarm(block, _parent, CancellationToken.None);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(warmed, Is.Not.Null.And.Not.SameAs(source));
+            Assert.That(warmed!.GasLimit, Is.EqualTo(8_000_000));
+            Assert.That(source.GasLimit, Is.EqualTo(20_000_000));
+        }
+        _processor.Received(1).SetBlockExecutionContext(Arg.Is<BlockHeader>(h => !ReferenceEquals(h, block.Header) && h.Number == block.Number));
+        _processor.Received(1).Process(Arg.Any<Transaction>(), Arg.Is<ITxTracer>(t => t.IsCancelable && !t.IsTracingInstructions),
+            ExecutionOptions.Warmup | ExecutionOptions.SkipValidation);
+        _scope.Received(1).Dispose();
+        _environment.Received(1).Dispose();
+    }
+
+    [TestCase(TxType.Blob)]
+    [TestCase(TxType.SetCode)]
+    [TestCase(TxType.DepositTx)]
+    public void Prewarm_UnsupportedTransaction_DoesNotExecute(TxType type)
+    {
+        Block block = Block();
+        block.Transactions[0].Type = type;
+        Create().Prewarm(block, _parent, CancellationToken.None);
+        _environment.DidNotReceive().Build(Arg.Any<BlockHeader>());
+    }
+
+    [Test]
+    public void Prewarm_AuthorizationList_DoesNotExecute()
+    {
+        Block block = Block();
+        block.Transactions[0].AuthorizationList = [];
+        Create().Prewarm(block, _parent, CancellationToken.None);
+        _environment.DidNotReceive().Build(Arg.Any<BlockHeader>());
+    }
+
+    [Test]
+    public void Prewarm_Failure_DisposesWorkersAndReleasesAdmission()
+    {
+        _processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
+            .Returns(_ => throw new InvalidOperationException("speculative failure"));
+        HistoricalTracePrewarmer prewarmer = Create();
+
+        Assert.DoesNotThrow(() => prewarmer.Prewarm(Block(), _parent, CancellationToken.None));
+        Assert.DoesNotThrow(() => prewarmer.Prewarm(Block(), _parent, CancellationToken.None));
+
+        _scope.Received(2).Dispose();
+        _environment.Received(2).Dispose();
+        _factory.Received(2).Create();
+    }
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Prewarm_Cancellation_DisposesWorkersAndReleasesAdmission(bool throwAfterCancellation)
+    {
+        using CancellationTokenSource cancellation = new();
+        _processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
+            .Returns(_ =>
+            {
+                cancellation.Cancel();
+                if (throwAfterCancellation) throw new InvalidOperationException("speculative failure after cancellation");
+                return default;
+            });
+        HistoricalTracePrewarmer prewarmer = Create();
+
+        Assert.Throws<OperationCanceledException>(() => prewarmer.Prewarm(Block(), _parent, cancellation.Token));
+        prewarmer.Prewarm(Block(), _parent, CancellationToken.None);
+
+        _scope.Received(2).Dispose();
+        _environment.Received(2).Dispose();
+    }
+
+    [Test]
+    public void Prewarm_ConcurrentRequest_DoesNotCreateMoreWorkers()
+    {
+        HistoricalTracePrewarmer prewarmer = Create();
+        _processor.Process(Arg.Any<Transaction>(), Arg.Any<ITxTracer>(), Arg.Any<ExecutionOptions>())
+            .Returns(_ => { prewarmer.Prewarm(Block(), _parent, CancellationToken.None); return default; });
+
+        prewarmer.Prewarm(Block(), _parent, CancellationToken.None);
+
+        _factory.Received(1).Create();
+        _scope.Received(1).Dispose();
+    }
+
+    private HistoricalTracePrewarmer Create(int concurrency = 1) =>
+        new(_factory, _blockTree, new EthereumEcdsa(1), new(concurrency), LimboLogs.Instance);
+
+    private static Block Block(int number = 2) => Build.A.Block.WithNumber(number)
+        .WithTransactions(Build.A.Transaction.WithSenderAddress(TestItem.AddressA).TestObject).TestObject;
+
+    private sealed class TestBlockTree : BlockTreeTestDouble
+    {
+        public bool Canonical { get; set; } = true;
+        public override bool IsMainChain(Hash256 blockHash, bool throwOnMissingHash = true) => Canonical;
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/GethStyleTracer.cs
@@ -38,7 +38,8 @@ public class GethStyleTracer(
     ISpecProvider specProvider,
     ChangeableTransactionProcessorAdapter transactionProcessorAdapter,
     IFileSystem fileSystem,
-    IOverridableEnv<GethStyleTracer.BlockProcessingComponents> blockProcessingEnv
+    IOverridableEnv<GethStyleTracer.BlockProcessingComponents> blockProcessingEnv,
+    HistoricalTracePrewarmer? historicalTracePrewarmer = null
 ) : IGethStyleTracer
 {
     public GethLikeTxTrace? Trace(Hash256 blockHash, int txIndex, GethTraceOptions options, CancellationToken cancellationToken, Utf8JsonWriter? writer = null, PipeWriter? pipeWriter = null)
@@ -234,6 +235,7 @@ public class GethStyleTracer(
         ArgumentNullException.ThrowIfNull(block);
 
         BlockHeader parent = FindParent(block);
+        if (options.StateOverrides is null) historicalTracePrewarmer?.Prewarm(block, parent, cancellationToken);
         using Scope<BlockProcessingComponents> scope = blockProcessingEnv.BuildAndOverride(parent, options.StateOverrides);
 
         long destroyRefund = (long)specProvider.GetSpec(block.Header).GasCosts.DestroyRefund;

--- a/src/Nethermind/Nethermind.Consensus/Tracing/HistoricalTracePrewarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Tracing/HistoricalTracePrewarmer.cs
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Nethermind.Blockchain;
+using Nethermind.Consensus.Processing;
+using Nethermind.Core;
+using Nethermind.Core.Threading;
+using Nethermind.Crypto;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Logging;
+
+namespace Nethermind.Consensus.Tracing;
+
+public sealed record HistoricalTracePrewarmSettings(int Concurrency);
+
+public sealed class HistoricalTracePrewarmer(
+    IReadOnlyTxProcessingEnvFactory environmentFactory,
+    IBlockTree blockTree,
+    IEthereumEcdsa ecdsa,
+    HistoricalTracePrewarmSettings settings,
+    ILogManager logManager)
+{
+    private const int MinimumBlockDistance = 256;
+    private const int TimeoutMilliseconds = 5_000;
+    private const long MaximumTransactionGas = 8_000_000;
+    private readonly int _concurrency = Math.Clamp(settings.Concurrency, 0, Environment.ProcessorCount);
+    private readonly ILogger _logger = logManager.GetClassLogger<HistoricalTracePrewarmer>();
+    private int _active;
+
+    public void Prewarm(Block block, BlockHeader? parent, CancellationToken cancellationToken)
+    {
+        if (_concurrency == 0 || parent is null || block.Transactions.Length == 0
+            || blockTree.Head is not { } head || block.Number > head.Number
+            || head.Number - block.Number < MinimumBlockDistance
+            || block.Hash is null || !blockTree.IsMainChain(block.Hash, throwOnMissingHash: false))
+        {
+            return;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        if (Interlocked.CompareExchange(ref _active, 1, 0) != 0) return;
+
+        try
+        {
+            PrewarmCore(block, parent, cancellationToken);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            if (_logger.IsDebug) _logger.Debug($"Historical trace prewarming budget expired for block {block.Number}.");
+        }
+        catch (Exception exception)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_logger.IsDebug) _logger.Debug($"Historical trace prewarming skipped for block {block.Number}: {exception}");
+        }
+        finally
+        {
+            Volatile.Write(ref _active, 0);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+    }
+
+    private void PrewarmCore(Block block, BlockHeader parent, CancellationToken cancellationToken)
+    {
+        using CancellationTokenSource budget = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        budget.CancelAfter(TimeoutMilliseconds);
+        ParallelOptions options = new() { MaxDegreeOfParallelism = _concurrency, CancellationToken = budget.Token };
+        CancellationTxTracer tracer = new(NullTxTracer.Instance, budget.Token);
+
+        ParallelUnbalancedWork.For(0, block.Transactions.Length, options,
+            environmentFactory.Create,
+            (index, environment) =>
+            {
+                WarmTransaction(block.Transactions[index], block.Header, parent, environment, tracer);
+                return environment;
+            },
+            static environment => environment.Dispose());
+    }
+
+    private void WarmTransaction(Transaction source, BlockHeader header, BlockHeader parent,
+        IReadOnlyTxProcessorSource environment, ITxTracer tracer)
+    {
+        if (source.GetType() != typeof(Transaction)
+            || source.Type is not (TxType.Legacy or TxType.AccessList or TxType.EIP1559)
+            || source.AuthorizationList is not null || source.IsOPSystemTransaction || source.IsServiceTransaction)
+        {
+            return;
+        }
+
+        Transaction transaction = new();
+        source.CopyTo(transaction, copyHash: false);
+        transaction.SenderAddress ??= ecdsa.RecoverAddress(transaction);
+        if (transaction.SenderAddress is null) return;
+        transaction.GasLimit = Math.Min(transaction.GasLimit, MaximumTransactionGas);
+
+        using IReadOnlyTxProcessingScope scope = environment.Build(parent);
+        scope.TransactionProcessor.SetBlockExecutionContext(header.Clone());
+        scope.TransactionProcessor.Warmup(transaction, tracer);
+    }
+}

--- a/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
+++ b/src/Nethermind/Nethermind.Init/Modules/RpcModules.cs
@@ -49,6 +49,8 @@ public class RpcModules(IJsonRpcConfig jsonRpcConfig) : Module
         base.Load(builder);
 
         builder
+            .AddSingleton(new HistoricalTracePrewarmSettings(jsonRpcConfig.TraceBlockPrewarmConcurrency))
+            .AddSingleton<HistoricalTracePrewarmer>()
             .AddSingleton<IEthSyncingInfo, EthSyncingInfo>()
             .AddSingleton<IRpcModuleProvider, RpcModuleProvider>()
             .AddSingleton<IJsonRpcLocalStats, JsonRpcLocalStats>()

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.Prewarming.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.Prewarming.cs
@@ -26,9 +26,9 @@ public partial class DebugRpcModuleTests
 {
     [TestCase(false, "callTracer")]
     [TestCase(true, "callTracer")]
-    [TestCase(false, null)]
-    [TestCase(true, null)]
-    public async Task TraceBlock_Prewarming_PreservesResultsAndCanonicalState(bool flatDb, string? tracer)
+    [TestCase(false, "")]
+    [TestCase(true, "")]
+    public async Task TraceBlock_Prewarming_PreservesResultsAndCanonicalState(bool flatDb, string tracer)
     {
         HistoricalBlockView historyView = null!;
         CountingEnvironmentFactory environments = null!;

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.Prewarming.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.Prewarming.cs
@@ -34,8 +34,7 @@ public partial class DebugRpcModuleTests
         CountingEnvironmentFactory environments = null!;
         InterfaceLogger logger = Substitute.For<InterfaceLogger>();
         logger.IsDebug.Returns(true);
-        ILogManager logs = Substitute.For<ILogManager>();
-        logs.GetClassLogger<HistoricalTracePrewarmer>().Returns(new ILogger(logger));
+        ILogManager logs = new OneLoggerLogManager(new ILogger(logger));
         using TestRpcBlockchain blockchain = await TestRpcBlockchain.ForTest(SealEngineType.NethDev)
             .WithFlatDb(flatDb)
             .Build(builder => builder.AddSingleton<HistoricalTracePrewarmer>(context =>

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.Prewarming.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/DebugRpcModuleTests.Prewarming.cs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Autofac;
+using Nethermind.Blockchain;
+using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Consensus.Processing;
+using Nethermind.Consensus.Tracing;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Crypto;
+using Nethermind.Int256;
+using Nethermind.JsonRpc.Modules.DebugModule;
+using Nethermind.Logging;
+using Nethermind.State;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.JsonRpc.Test.Modules;
+
+public partial class DebugRpcModuleTests
+{
+    [TestCase(false, "callTracer")]
+    [TestCase(true, "callTracer")]
+    [TestCase(false, null)]
+    [TestCase(true, null)]
+    public async Task TraceBlock_Prewarming_PreservesResultsAndCanonicalState(bool flatDb, string? tracer)
+    {
+        HistoricalBlockView historyView = null!;
+        CountingEnvironmentFactory environments = null!;
+        InterfaceLogger logger = Substitute.For<InterfaceLogger>();
+        logger.IsDebug.Returns(true);
+        ILogManager logs = Substitute.For<ILogManager>();
+        logs.GetClassLogger<HistoricalTracePrewarmer>().Returns(new ILogger(logger));
+        using TestRpcBlockchain blockchain = await TestRpcBlockchain.ForTest(SealEngineType.NethDev)
+            .WithFlatDb(flatDb)
+            .Build(builder => builder.AddSingleton<HistoricalTracePrewarmer>(context =>
+            {
+                historyView = new(context.Resolve<IBlockTree>());
+                environments = new(context.Resolve<IReadOnlyTxProcessingEnvFactory>());
+                return new(environments, historyView, context.Resolve<IEthereumEcdsa>(), new(2), logs);
+            }));
+
+        Block block = await blockchain.AddBlock(CreateTraceBlockTransactions(blockchain));
+        Hash256? stateRoot = block.Header.StateRoot;
+        UInt256 balance = blockchain.StateReader.GetBalance(block.Header, TestItem.AddressA);
+        ulong nonce = blockchain.StateReader.GetNonce(block.Header, TestItem.AddressA);
+        GethTraceOptions options = new() { Tracer = tracer };
+        IDebugRpcModule module = blockchain.DebugRpcModule;
+        string baseline = await RpcTest.TestSerializedRequest(module, "debug_traceBlockByHash", block.Hash, options);
+        Assert.That(environments.Created, Is.Zero);
+
+        historyView.Enabled = true;
+        string warmed = await RpcTest.TestSerializedRequest(module, "debug_traceBlockByHash", block.Hash, options);
+
+        using JsonDocument expected = JsonDocument.Parse(baseline);
+        using JsonDocument actual = JsonDocument.Parse(warmed);
+        Assert.That(expected.RootElement.TryGetProperty("error", out _), Is.False);
+        Assert.That(JsonElement.DeepEquals(expected.RootElement, actual.RootElement), Is.True);
+        Assert.That(environments.Created, Is.InRange(1, 2));
+        Assert.That(blockchain.BlockTree.Head!.Header.StateRoot, Is.EqualTo(stateRoot));
+        Assert.That(blockchain.StateReader.GetBalance(block.Header, TestItem.AddressA), Is.EqualTo(balance));
+        Assert.That(blockchain.StateReader.GetNonce(block.Header, TestItem.AddressA), Is.EqualTo(nonce));
+        logger.DidNotReceive().Debug(Arg.Any<string>());
+
+        int createdBeforeOverride = environments.Created;
+        await RpcTest.TestSerializedRequest(module, "debug_traceBlockByHash", block.Hash,
+            new GethTraceOptions { Tracer = tracer, StateOverrides = [] });
+        Assert.That(environments.Created, Is.EqualTo(createdBeforeOverride));
+    }
+
+    private sealed class HistoricalBlockView(IBlockTree inner) : BlockTreeTestDouble(inner)
+    {
+        public bool Enabled { get; set; }
+        public override Block? Head { get => Build.A.Block.WithNumber(1_000).TestObject; set { } }
+        public override bool IsMainChain(Hash256 blockHash, bool throwOnMissingHash = true) =>
+            Enabled && base.IsMainChain(blockHash, throwOnMissingHash);
+    }
+
+    private sealed class CountingEnvironmentFactory(IReadOnlyTxProcessingEnvFactory inner) : IReadOnlyTxProcessingEnvFactory
+    {
+        private int _created;
+        public int Created => Volatile.Read(ref _created);
+
+        public IReadOnlyTxProcessorSource Create()
+        {
+            IReadOnlyTxProcessorSource environment = inner.Create();
+            Interlocked.Increment(ref _created);
+            return environment;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/IJsonRpcConfig.cs
@@ -143,6 +143,11 @@ public interface IJsonRpcConfig : IConfig
     public int? DebugModuleConcurrentInstances { get; set; }
 
     [ConfigItem(
+        Description = "Experimental parallel read prewarming for canonical full-block debug traces at least 256 blocks behind head. Zero disables it. At most one request prewarms at a time, for up to 5 seconds of cooperative work; other requests bypass it. Concurrency is capped at the logical processor count.",
+        DefaultValue = "0")]
+    public int TraceBlockPrewarmConcurrency { get; set; }
+
+    [ConfigItem(
         Description = """
             The number of concurrent instances for non-sharable calls:
 

--- a/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
+++ b/src/Nethermind/Nethermind.JsonRpc/JsonRpcConfig.cs
@@ -54,6 +54,7 @@ public class JsonRpcConfig : IJsonRpcConfig
     public bool EnableLogsStreamMode { get; set; } = false;
     public long? MaxLogsResponseBodySize { get; set; } = null;
     public int? DebugModuleConcurrentInstances { get; set; } = null;
+    public int TraceBlockPrewarmConcurrency { get; set; }
     public int? EthModuleConcurrentInstances { get; set; } = null;
     public string JwtSecretFile { get; set; } = null;
     public bool UnsecureDevNoRpcAuthentication { get; set; }


### PR DESCRIPTION
## Changes

- Add experimental, default-off read prewarming for canonical full-block debug traces at least 256 blocks behind head.
- Run bounded speculative transaction execution in independent resettable read-only environments before authoritative tracing. Only existing DB/page caches are warmed; speculative state and trace output are discarded.
- Admit one prewarming request globally, with configurable worker concurrency, a 5-second cooperative cancellation budget, and an 8M gas cap per speculative transaction. Requests that cannot enter bypass prewarming.
- Skip state overrides, custom transaction subclasses, authorization-bearing transactions, and unsupported transaction types.
- Enable with `JsonRpc.TraceBlockPrewarmConcurrency` (default `0`). No database format changes.

## Types of changes

- [x] Optimization

## Testing

### Requires testing

- [x] Yes

### Tests added

- [x] Coordinator eligibility, copying/gas cap, cancellation, cleanup, failure fallback, and global admission.
- [x] Production-environment full-block trace parity on flat/trie state, override bypass, and canonical account-state checks.

CI is the test verifier; local test suites were not run. Archive-node A/B measurement is pending. No performance improvement is claimed yet.

## Documentation

- Configuration is documented in the config metadata.
- Release-note decision deferred while this experimental PR is a draft.

## Remarks

This targets historical full-block debug traces only, not all debug/trace endpoints or near-tip requests. Prewarming adds CPU/I/O and may regress warm-cache latency or contend with other node work. Validation must include the entire prepass, concurrent RPC latency, and sync health, not only execution after warming.
