### PR TITLE
perf: remove fixed block prewarming and trie concurrency caps

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -101,7 +101,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         IHasAccessList[]? systemAccessLists = null)
     {
         _systemAccessLists = systemAccessLists ?? [];
-        _concurrencyLevel = concurrency == 0 ? Math.Min(Environment.ProcessorCount - 1, 16) : concurrency;
+        _concurrencyLevel = concurrency == 0 ? Environment.ProcessorCount - 1 : concurrency;
         _speculativeConcurrencyLevel = speculativeConcurrency == 0 ? Math.Max(1, _concurrencyLevel / 2) : speculativeConcurrency;
         _parallelExecutionBatchRead = parallelExecutionBatchRead;
         // minPoolSize is a floor: the address warmer, transaction warmup, and storage discovery rent

--- a/src/Nethermind/Nethermind.Core/Cpu/RuntimeInformation.cs
+++ b/src/Nethermind/Nethermind.Core/Cpu/RuntimeInformation.cs
@@ -52,6 +52,5 @@ public static class RuntimeInformation
     public static bool IsSingleProcessor => ProcessorCount <= 1;
     public static int PhysicalCoreCount { get; } = GetCpuInfo()?.PhysicalCoreCount ?? ProcessorCount;
     public static ParallelOptions ParallelOptionsLogicalCores { get; } = new() { MaxDegreeOfParallelism = ProcessorCount };
-    public static ParallelOptions ParallelOptionsPhysicalCoresUpTo16 { get; } = new() { MaxDegreeOfParallelism = Math.Min(ProcessorCount, 16) };
     public static bool Is64BitPlatform() => IntPtr.Size == 8;
 }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.std.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.std.cs
@@ -52,7 +52,7 @@ internal sealed partial class PersistentStorageProvider
         ParallelUnbalancedWork.For(
             0,
             storages.Count,
-            RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+            RuntimeInformation.ParallelOptionsLogicalCores,
             (storages, toUpdateRoots: _toUpdateRoots, writes: 0, skips: 0),
             static (i, state) =>
             {

--- a/src/Nethermind/Nethermind.State/Proofs/IndexedTrieRoot.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/IndexedTrieRoot.cs
@@ -51,7 +51,7 @@ internal static class IndexedTrieRoot
             TEncoder leafEncoder = encoder;
             try
             {
-                Parallel.For(0, (_items.Length - 1) / LeafBatchSize + 1, RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16, batch =>
+                Parallel.For(0, (_items.Length - 1) / LeafBatchSize + 1, RuntimeInformation.ParallelOptionsLogicalCores, batch =>
                 {
                     Calculator<T, TEncoder> calculator = new(inputs.AsSpan(), leafEncoder);
                     int start = batch * LeafBatchSize;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -933,7 +933,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         ParallelUnbalancedWork.For(
             0,
             _dirtyNodes.Length,
-            RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+            RuntimeInformation.ParallelOptionsLogicalCores,
             (prunePersisted, forceRemovePersistedNodes, dirtyNodes: _dirtyNodes, persistedHashes: _persistedHashes, nodeStorage),
             static (index, state) =>
             {
@@ -977,7 +977,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             ParallelUnbalancedWork.For(
                 0,
                 shardCountToPrune,
-                RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+                RuntimeInformation.ParallelOptionsLogicalCores,
                 (dirtyNodes: _dirtyNodes, shardedCount: _shardedDirtyNodeCount, startShardIdx),
                 static (i, state) =>
                 {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -346,7 +346,7 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchNonRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
-                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
                     (local: 0, item, tree, bufferPool, rootPath, canBeParallel),
                     static (i, state) =>
                     {
@@ -432,7 +432,7 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
-                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
                     (local: 0, item, tree, bufferPool, rootPath, canBeParallel),
                     static (i, state) =>
                     {


### PR DESCRIPTION
## Changes

- Remove the fixed 16-worker ceiling from automatic block prewarming. The default remains logical processor count minus one, and explicit `Blocks.PreWarmStateConcurrency` overrides still apply. Speculative mempool prewarming retains its half-concurrency adjustment.
- Use the existing `ParallelOptionsLogicalCores` for storage-root updates, indexed trie-root calculation, trie-node encoding and dirty trie-cache pruning. Remove the unused `ParallelOptionsPhysicalCoresUpTo16` property.
- With 20 logical processors available, automatic block prewarming can use 19 workers instead of 16, and the affected trie/storage operations can use up to 20 instead of 16. Work size still bounds concurrency, including the 16 children of a trie branch.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

Existing suites built and run in Release on a host reporting 32 logical processors:

- `BlockCachePreWarmerTests`: 65 passed.
- `Nethermind.State.Test`: 1,309 passed, 4 skipped.
- `Nethermind.Trie.Test`: 600 passed, 7 skipped.
- Whitespace formatting for changed files and `git diff --check` passed.

No new tests: this change adjusts existing concurrency limits and reuses the existing logical-CPU parallel options.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Higher allowed concurrency has not yet been benchmarked for block latency or throughput. It may increase CPU/memory contention on busy or heterogeneous-core hosts. This change does not add CPU affinity or P-core/E-core scheduling. Removing the public `ParallelOptionsPhysicalCoresUpTo16` helper requires any external source consumers to use `ParallelOptionsLogicalCores` instead.
