### PR TITLE
chore(deps): bump Nethermind.Numerics.Int256 to 1.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,7 +65,7 @@
     <PackageVersion Include="Nethermind.Libp2p" Version="1.0.0-preview.45" />
     <PackageVersion Include="Nethermind.Libp2p.Protocols.PubsubPeerDiscovery" Version="1.0.0-preview.45" />
     <PackageVersion Include="Nethermind.MclBindings" Version="1.0.5" />
-    <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.8.0" />
+    <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.9.0" />
     <PackageVersion Include="Nethermind.RocksDbBindings" Version="[11.8.1-preview.92]" />
     <PackageVersion Include="Nethermind.TurboPForBindings" Version="1.0.0" />
     <PackageVersion Include="Nethermind.Zkvm.Abstractions" Version="1.0.0-preview.2" />

--- a/nix/nuget-deps.json
+++ b/nix/nuget-deps.json
@@ -801,8 +801,8 @@
   },
   {
     "pname": "Nethermind.Numerics.Int256",
-    "version": "1.8.0",
-    "hash": "sha256-GSOKuHxq1gj23uJgZ1UK09KHasgJkzPh6RY2qwDl5cs="
+    "version": "1.9.0",
+    "hash": "sha256-AlueeeeK61ptszw/pbyCzjbPEjGYdVNF+wKrzB/XuZw="
   },
   {
     "pname": "Nethermind.RocksDbBindings",

--- a/src/Nethermind/Nethermind.Runner/packages.lock.json
+++ b/src/Nethermind/Nethermind.Runner/packages.lock.json
@@ -705,7 +705,7 @@
           "Microsoft.IdentityModel.JsonWebTokens": "[8.22.0, )",
           "Nethermind.Crypto.SecP256k1": "[1.7.0, )",
           "Nethermind.Logging": "[1.40.0-unstable, )",
-          "Nethermind.Numerics.Int256": "[1.8.0, )",
+          "Nethermind.Numerics.Int256": "[1.9.0, )",
           "Nethermind.Serialization.Ssz": "[1.40.0-unstable, )",
           "NonBlocking": "[2.1.2, )",
           "Testably.Abstractions": "[10.3.0, )"
@@ -1107,7 +1107,7 @@
       "nethermind.serialization.ssz": {
         "type": "Project",
         "dependencies": {
-          "Nethermind.Numerics.Int256": "[1.8.0, )"
+          "Nethermind.Numerics.Int256": "[1.9.0, )"
         }
       },
       "nethermind.shutter": {
@@ -1587,9 +1587,9 @@
       },
       "Nethermind.Numerics.Int256": {
         "type": "CentralTransitive",
-        "requested": "[1.8.0, )",
-        "resolved": "1.8.0",
-        "contentHash": "Y+fQEFPsbfZsvzNEROU4ST86ocICVHDj6FImKxMRYfB1ka7wlQzEShLuxt50Vblo4AaLDlsUloYWyRFfSi+K6A==",
+        "requested": "[1.9.0, )",
+        "resolved": "1.9.0",
+        "contentHash": "MJyHqfo4yqDb7hX/PqxjRcOxUb8+/Zea34aJ5a2U8OXbnVaMx2TVjQWOH5oTfuHF5TNlA91eKjfECvzU2uB9Vw==",
         "dependencies": {
           "System.IO.Hashing": "10.0.10"
         }


### PR DESCRIPTION
## Changes

Bumps `Nethermind.Numerics.Int256` from 1.8.0 to [1.9.0](https://github.com/NethermindEth/int256/releases/tag/v1.9.0) (released today). Three files: the central package version, the regenerated `Nethermind.Runner` lock file, and the `nix/nuget-deps.json` entry (version plus the SRI hash of the published nupkg, so the flake build and the lockfile-sync check stay green).

1.9.0 contains a single PR since v1.8.0:

| PR | change |
|---|---|
| [#129](https://github.com/NethermindEth/int256/pull/129) | optimize UInt256 subtraction borrow propagation on AVX2 and zkEVM |

## Types of changes

- [x] Optimization

## Testing

Staged as `1.9.0-rc` on int.nugettest.org and benchmarked before this bump. Because master already pinned 1.8.0, the A/B isolates #129 by itself: both arms were master `aa5b2aab23` with only the package version changed, measured against master and against a second image built from identical master source, which sets the noise floor.

**Correctness: `eth_call` response parity 497/497 byte-identical to master** on both architectures, both rounds, with 0% request failures at 100 rps on each.

**`eth_call` corpus, 497 records, 20k requests per cell, two rounds, arms interleaved**

| metric | amd64 master → 1.9.0 | arm64 master → 1.9.0 |
|---|---|---|
| avg @100 rps | 20.23 → 20.07 ms (-0.8%, A/A spread 2.7%) | 15.13 → 15.07 ms (-0.4%, A/A spread 0.0%) |
| p99 @100 rps | 61.34 → 61.01 ms (-0.5%) | 44.12 → 43.97 ms (-0.3%) |
| CPU-ms/request | 21.60 → 21.42 (-0.9%) | 16.37 → 16.33 (-0.2%) |
| paired per-record replay | +0.1% (CI -0.1 .. +0.3) | -0.3% (CI -0.3 .. -0.2) |

Both architectures are neutral at the client level. The direction is mildly favourable throughout, and the arm64 cell had an unusually tight A/A spread (0.0-0.9%), so a genuine few-tenths-of-a-percent gain there is plausible, but it sits below what this rig can resolve.

That is what the upstream PR's own measurements predict rather than a contradiction of them: its gains are concentrated in *chained* subtraction (AVX2 FullOpts -7.8%, tiered -12.98%), while isolated callers range from -4% to +4.6%. Nethermind calls `UInt256.Subtract` in exactly one hot place, the `SUB` opcode handler in `EvmInstructions.Math2Param.cs`, where each result feeds a different opcode. That is the isolated shape, not a dependency chain.

Fusaka block-processing runs (999 mainnet blocks, three-dispatch Latin square per architecture, identical-code control in every batch) were still completing when this PR was opened; block processing is state- and I/O-bound, so a subtraction change is expected to be neutral there. I will add the numbers as a comment when they land, and flag anything unexpected before merge.

For reference, the same rig measured the previous bump (1.7.0 → 1.8.0, nine PRs) as a 1.2-1.7% arm64 `eth_call` improvement with everything else neutral: https://claude.ai/code/artifact/63a7b0ad-6be0-4b26-8997-25ee4cb0dff3

**Not covered here:** the zkEVM partial is the largest part of #129 (+40 lines), with upstream-reported RISC-V step counts down 7.3% and 20.9% and GPU proving down 6.1%. This benchmark rig does not exercise the zkVM guest, so that side is unverified by the numbers above.

## Documentation

Requires documentation update

- [ ] Yes
- [x] No
