### PR TITLE
fix: skip blob transactions in the inclusion list satisfaction check

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Validators/InclusionListValidatorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Validators/InclusionListValidatorTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Collections.Generic;
+using Nethermind.Consensus.Decoders;
 using Nethermind.Consensus.Validators;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -10,6 +11,7 @@ using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
+using Nethermind.Serialization.Rlp;
 using Nethermind.Specs.Forks;
 using Nethermind.Specs.Test;
 using NSubstitute;
@@ -48,10 +50,13 @@ public class InclusionListValidatorTests
             yield return Case("Same-nonce replacement advances nonce", [_validTx], true, blockTxs: [BuildTx(value: UInt256.One, to: TestItem.AddressC)], senderNonce: 1);
             // EIP-1559 fee check uses MaxFeePerGas (cap), not the tip: cap above baseFee → appendable.
             yield return Case("EIP-1559 low tip but sufficient fee cap", [Build1559Tx()], false, baseFee: 5.GWei);
-            // The blob carve-out applies to building an IL, not to judging one.
-            yield return Case("Blob tx", [BuildBlobTx()], false);
-            // Blob gas is paid up front, so a blob fee beyond the balance makes the tx unappendable.
-            yield return Case("Blob tx cannot afford blob fee", [BuildBlobTx(maxFeePerBlobGas: 100_000.GWei)], true);
+            // No proposer can append a blob entry, so one must never count as appendable — otherwise a single
+            // non-conforming committee member makes every block in the slot unsatisfied.
+            yield return Case("Blob IL entry is never appendable", [BuildBlobTx()], true);
+            // The carve-out is categorical: affordability of the blob fee must not decide the outcome.
+            yield return Case("Blob IL entry with unaffordable blob fee", [BuildBlobTx(maxFeePerBlobGas: 100_000.GWei)], true);
+            // Only the blob entry is skipped; a genuinely appendable entry alongside it still fails the block.
+            yield return Case("Blob IL entry does not mask an appendable tx", [BuildBlobTx(), _validTx], false);
             // A tx normal execution rejects must not be reported appendable.
             yield return Case("Malformed 1559 tx (tip > fee cap)", [BuildMalformed1559Tx()], true);
             // A tx whose GasLimit is below the intrinsic cost cannot execute.
@@ -80,6 +85,20 @@ public class InclusionListValidatorTests
 
         IReadOnlyStateProvider state = StateWith(TestItem.AddressA, 10.Ether, senderNonce);
         Assert.That(InclusionListValidator.IsSatisfied(block, state, _specProvider.GetSpec(block.Header), _txValidator), Is.EqualTo(satisfied));
+    }
+
+    // The carve-out is only load-bearing while normal well-formedness accepts a blob entry. An entry is
+    // decoded sidecar-free, which the mempool blob checks skip rather than reject, so nothing else stops one.
+    [Test]
+    public void Blob_il_entry_passes_normal_well_formedness()
+    {
+        Transaction entry = TxsDecoder.DecodeTxs(InclusionListDecoder.Encode([BuildBlobTx()]), skipErrors: false).Transactions[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(entry.NetworkWrapper, Is.Null, "inclusion list entries carry no blob sidecar");
+            Assert.That(_txValidator.IsWellFormed(entry, _specProvider.GetSpec((ForkActivation)0), 30_000_000).AsBool(), Is.True);
+        }
     }
 
     // Withdrawals land after the block's transactions, so judging against the raw post-block balance

--- a/src/Nethermind/Nethermind.Consensus/Validators/InclusionListValidator.cs
+++ b/src/Nethermind/Nethermind.Consensus/Validators/InclusionListValidator.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Specs;
-using Nethermind.Evm;
 using Nethermind.Evm.State;
 using Nethermind.Int256;
 using Nethermind.TxPool;
@@ -74,6 +73,9 @@ public static class InclusionListValidator
 
     private static bool CouldIncludeTx(Transaction tx, Block block, IReadOnlyStateProvider state, IReleaseSpec spec, ITxValidator txValidator, ref Dictionary<AddressAsKey, AccountStruct>? senderCache)
     {
+        // engine_getInclusionListV1 forbids emitting a blob entry, and an entry carries no blob sidecar for
+        // getPayload, so no proposer can append one; judging it appendable would grief the whole slot.
+        if (tx.SupportsBlobs) return false;
         if (tx.SenderAddress is null) return false;
         // Subtract on the block side: GasUsed <= GasLimit is invariant, so this cannot underflow the
         // way GasLimit - tx.GasLimit would for an oversized tx.
@@ -93,12 +95,6 @@ public static class InclusionListValidator
         // Overflow-checked like TransactionProcessor.BuyGas: an adversarial MaxFeePerGas must not wrap the cost.
         if (UInt256.MultiplyOverflow((UInt256)tx.GasLimit, tx.MaxFeePerGas, out UInt256 txCost)
             || UInt256.AddOverflow(txCost, tx.Value, out txCost))
-            return false;
-
-        // A blob tx must also cover maxFeePerBlobGas × blob gas up front, or it could never have executed.
-        if (tx.SupportsBlobs
-            && (!BlobGasCalculator.TryCalculateBlobMaxFee(tx.BlobVersionedHashes?.Length ?? 0, tx.MaxFeePerBlobGas ?? UInt256.Zero, out UInt256 blobFee)
-                || UInt256.AddOverflow(txCost, blobFee, out txCost)))
             return false;
 
         return SpendableBalance(block, tx.SenderAddress, in account) >= txCost && account.Nonce == tx.Nonce;


### PR DESCRIPTION
## Changes

- `InclusionListValidator.CouldIncludeTx` now treats a blob transaction in an inclusion list as never appendable, so an omitted one no longer makes the block unsatisfied.
- Drops the now-unreachable blob-fee affordability branch.

Production already conforms to `engine_getInclusionListV1` rule 2 ("the transaction list MUST NOT include any blob transaction"): `InclusionListBuilder` reads only the non-blob pool and `InclusionListTxSource.FilterBlobs` strips them. Validation had no matching carve-out — it priced `maxFeePerBlobGas` into affordability and so judged a blob entry appendable. EIP-7805's Execution Layer algorithm has no blob step either, and the CL does no EL-side validation of inclusion list contents, so one committee member gossiping a single appendable blob transaction made every block in the slot unsatisfied and we withheld attestation from otherwise-valid blocks.

**This is consensus-visible attestation behaviour and the upstream spec has not resolved it.** Skipping is the safe direction — the block is valid either way, and skipping means voting for it — but it is a deliberate deviation from the algorithm as currently written. Spec change proposed in ethereum/EIPs#12319; this stays draft until that lands or is resolved otherwise.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Three parameterised cases in `InclusionListValidatorTests.SatisfactionCases` cover the carve-out, including one asserting it skips only the blob entry rather than the whole list. `Blob_il_entry_passes_normal_well_formedness` pins the reason the carve-out is needed: an entry decodes sidecar-free, which the mempool blob checks skip rather than reject, so nothing else stops one.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
