### PR TITLE
test(il): measure EIP-7805 inclusion-list transaction count (K)

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListSizeMeasurement.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListSizeMeasurement.cs
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using Nethermind.Blockchain;
+using Nethermind.Consensus.Decoders;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Extensions;
+using Nethermind.Core.Specs;
+using Nethermind.Int256;
+using Nethermind.Merge.Plugin.Handlers;
+using Nethermind.Serialization.Rlp;
+using Nethermind.TxPool;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Nethermind.Merge.Plugin.Test;
+
+/// <summary>
+/// Measures how many real transactions fit in one EIP-7805 inclusion list, against a corpus of transactions
+/// captured from a live mempool.
+/// </summary>
+/// <remarks>
+/// The corpus is a text file of one canonical EIP-2718 <c>TransactionType || TransactionPayload</c> hex string
+/// per line — the form <c>eth_getRawTransactionByHash</c> returns — named by the <c>NETHERMIND_IL_TX_CORPUS</c>
+/// environment variable. Each entry is re-encoded through <see cref="InclusionListDecoder.EncodePooled"/> and
+/// checked byte-for-byte against the captured bytes, so the reported sizes are the builder's own units rather
+/// than a second encoder's.
+///
+/// The list count comes from running <see cref="InclusionListBuilder"/> itself over a pool of one transaction
+/// per sender, which is the shape a live pool's ready set overwhelmingly takes. The builder draws senders
+/// uniformly, so the count varies run to run and the harness reports its distribution rather than a mean alone.
+/// </remarks>
+[TestFixture]
+[Explicit("measurement harness; needs a captured mempool corpus")]
+public class InclusionListSizeMeasurement
+{
+    private const string CorpusVariable = "NETHERMIND_IL_TX_CORPUS";
+    private const int Draws = 2000;
+    private const int SszOffsetBytes = 4;
+
+    [Test]
+    public void Measure()
+    {
+        Transaction[] txs = LoadCorpus();
+        int[] sizes = new int[txs.Length];
+        for (int i = 0; i < txs.Length; i++)
+        {
+            using ArrayPoolList<byte> encoded = InclusionListDecoder.EncodePooled(txs[i]);
+            sizes[i] = encoded.Count;
+        }
+
+        Array.Sort(sizes);
+        long total = 0;
+        foreach (int size in sizes) total += size;
+
+        TestContext.Out.WriteLine($"RESULT corpus transactions={sizes.Length} mean={(double)total / sizes.Length:F1}B");
+        foreach (double q in new[] { 0.01, 0.1, 0.25, 0.5, 0.75, 0.9, 0.99 })
+        {
+            TestContext.Out.WriteLine($"RESULT size p{q * 100:0.##}={sizes[(int)(q * (sizes.Length - 1))]}B");
+        }
+        TestContext.Out.WriteLine($"RESULT size min={sizes[0]}B max={sizes[^1]}B");
+
+        MeasureListCounts(txs);
+    }
+
+    /// <summary>Runs the real builder repeatedly over the corpus and reports the entries per list.</summary>
+    private static void MeasureListCounts(Transaction[] txs)
+    {
+        InclusionListBuilder builder = BuildBuilder(PoolOfOneTxPerSender(txs));
+        int[] counts = new int[Draws];
+        long totalBytes = 0;
+        for (int i = 0; i < Draws; i++)
+        {
+            using InclusionListBytes list = builder.GetInclusionList();
+            counts[i] = list.Count;
+            foreach (ArrayPoolList<byte> entry in list) totalBytes += entry.Count;
+        }
+
+        Array.Sort(counts);
+        long sum = 0;
+        foreach (int count in counts) sum += count;
+        double mean = (double)sum / Draws;
+
+        TestContext.Out.WriteLine($"RESULT list entries mean={mean:F1} min={counts[0]} p10={counts[Draws / 10]} " +
+                                  $"p50={counts[Draws / 2]} p90={counts[Draws * 9 / 10]} max={counts[^1]}");
+        TestContext.Out.WriteLine($"RESULT list bytes mean={(double)totalBytes / Draws:F0} of " +
+                                  $"{Eip7805Constants.MaxBytesPerInclusionList}, " +
+                                  $"with SSZ offsets {(double)(totalBytes + (long)SszOffsetBytes * sum) / Draws:F0}");
+    }
+
+    private static Transaction[] LoadCorpus()
+    {
+        string? path = Environment.GetEnvironmentVariable(CorpusVariable);
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+        {
+            Assert.Ignore($"Set {CorpusVariable} to a file of raw transaction hex, one per line.");
+        }
+
+        string[] lines = File.ReadAllLines(path!);
+        List<byte[]> raw = new(lines.Length);
+        foreach (string line in lines)
+        {
+            string trimmed = line.Trim();
+            if (trimmed.Length > 0) raw.Add(Bytes.FromHexString(trimmed));
+        }
+
+        byte[][] entries = raw.ToArray();
+        TransactionDecodingResult decoded = TxsDecoder.DecodeTxs(entries, skipErrors: false);
+        Assert.That(decoded.Error, Is.Null, "corpus entry is not a valid EIP-2718 transaction");
+
+        Transaction[] txs = decoded.Transactions;
+        for (int i = 0; i < txs.Length; i++)
+        {
+            using ArrayPoolList<byte> reEncoded = InclusionListDecoder.EncodePooled(txs[i]);
+            Assert.That(reEncoded.AsSpan().ToArray(), Is.EqualTo(entries[i]),
+                $"entry {i} does not re-encode to the bytes it was captured as");
+        }
+
+        return txs;
+    }
+
+    /// <summary>A pool whose ready set is one transaction per sender, as the corpus was captured.</summary>
+    private static ITxPool PoolOfOneTxPerSender(Transaction[] txs)
+    {
+        Dictionary<AddressAsKey, Transaction[]> bySender = new(txs.Length);
+        for (int i = 0; i < txs.Length; i++)
+        {
+            // Captured entries carry no recovered sender, and recovering one would only re-derive a key the
+            // bucket layout already fixes: one transaction each, so no two share a bucket.
+            byte[] address = new byte[Address.Size];
+            BinaryPrimitives.WriteInt32BigEndian(address.AsSpan(Address.Size - sizeof(int)), i);
+            bySender[new AddressAsKey(new Address(address))] = [txs[i]];
+        }
+
+        ITxPool pool = Substitute.For<ITxPool>();
+        pool.GetPendingTransactionsBySender(Arg.Any<bool>(), Arg.Any<UInt256>()).Returns(bySender);
+        return pool;
+    }
+
+    private static InclusionListBuilder BuildBuilder(ITxPool pool) =>
+        new(pool, Substitute.For<IBlockTree>(), Substitute.For<ISpecProvider>());
+}

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListSizeMeasurement.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListSizeMeasurement.cs
@@ -11,9 +11,11 @@ using Nethermind.Core;
 using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
+using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
 using Nethermind.Merge.Plugin.Handlers;
 using Nethermind.Serialization.Rlp;
+using Nethermind.Specs.Forks;
 using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
@@ -29,7 +31,8 @@ namespace Nethermind.Merge.Plugin.Test;
 /// per line — the form <c>eth_getRawTransactionByHash</c> returns — named by the <c>NETHERMIND_IL_TX_CORPUS</c>
 /// environment variable. Each entry is re-encoded through <see cref="InclusionListDecoder.EncodePooled"/> and
 /// checked byte-for-byte against the captured bytes, so the reported sizes are the builder's own units rather
-/// than a second encoder's.
+/// than a second encoder's. Blob transactions are dropped and their count reported, since the builder's
+/// snapshot cannot reach them.
 ///
 /// The list count comes from running <see cref="InclusionListBuilder"/> itself over a pool of one transaction
 /// per sender, which is the shape a live pool's ready set overwhelmingly takes. The builder draws senders
@@ -43,7 +46,7 @@ public class InclusionListSizeMeasurement
     private const int Draws = 2000;
     private const int SszOffsetBytes = 4;
 
-    // Below this fraction of the cap, a draw is corpus-bound rather than cap-bound and proves nothing.
+    // Below this fraction of the cap, the average draw is corpus-bound rather than cap-bound and proves nothing.
     private const double MinSaturationFraction = 0.95;
 
     [Test]
@@ -84,15 +87,11 @@ public class InclusionListSizeMeasurement
         InclusionListBuilder builder = BuildBuilder(PoolOfOneTxPerSender(txs));
         int[] counts = new int[Draws];
         long totalBytes = 0;
-        long maxBytes = 0;
         for (int i = 0; i < Draws; i++)
         {
             using InclusionListBytes list = builder.GetInclusionList();
             counts[i] = list.Count;
-            long listBytes = 0;
-            foreach (ArrayPoolList<byte> entry in list) listBytes += entry.Count;
-            totalBytes += listBytes;
-            if (listBytes > maxBytes) maxBytes = listBytes;
+            foreach (ArrayPoolList<byte> entry in list) totalBytes += entry.Count;
         }
 
         Array.Sort(counts);
@@ -106,10 +105,12 @@ public class InclusionListSizeMeasurement
                                   $"{Eip7805Constants.MaxBytesPerInclusionList}, " +
                                   $"with SSZ offsets {(double)(totalBytes + (long)SszOffsetBytes * sum) / Draws:F0}");
 
-        long saturationThreshold = (long)(Eip7805Constants.MaxBytesPerInclusionList * MinSaturationFraction);
-        if (maxBytes < saturationThreshold)
+        // On the mean, not the best draw: the statistics above describe the typical draw, so one lucky draw
+        // reaching the cap must not vouch for them.
+        long meanBytes = totalBytes / Draws;
+        if (meanBytes < (long)(Eip7805Constants.MaxBytesPerInclusionList * MinSaturationFraction))
         {
-            Assert.Inconclusive($"No draw exceeded {maxBytes}B of the {Eip7805Constants.MaxBytesPerInclusionList}B cap " +
+            Assert.Inconclusive($"Draws average {meanBytes}B of the {Eip7805Constants.MaxBytesPerInclusionList}B cap " +
                                  $"({MinSaturationFraction:P0} threshold) — draws are corpus-bound, not cap-bound. Supply a larger corpus.");
         }
     }
@@ -152,7 +153,13 @@ public class InclusionListSizeMeasurement
                 $"entry {i} does not re-encode to the bytes it was captured as");
         }
 
-        return txs;
+        // The builder draws from the pool's non-blob snapshot alone, so blob txs are outside its input domain.
+        // A mined-block capture carries them, so drop them here rather than reject the capture.
+        Transaction[] appendable = Array.FindAll(txs, static tx => !tx.SupportsBlobs);
+        TestContext.Out.WriteLine($"RESULT corpus blob transactions excluded={txs.Length - appendable.Length}");
+        Assert.That(appendable, Is.Not.Empty, $"{CorpusVariable} file '{path}' holds only blob transactions.");
+
+        return appendable;
     }
 
     /// <summary>A pool whose ready set is one transaction per sender, as the corpus was captured.</summary>
@@ -173,6 +180,13 @@ public class InclusionListSizeMeasurement
         return pool;
     }
 
-    private static InclusionListBuilder BuildBuilder(ITxPool pool) =>
-        new(pool, Substitute.For<IBlockTree>(), Substitute.For<ISpecProvider>());
+    /// <summary>A builder over a zero-base-fee head, so the corpus is priced in rather than filtered out.</summary>
+    private static InclusionListBuilder BuildBuilder(ITxPool pool)
+    {
+        IBlockTree blockTree = Substitute.For<IBlockTree>();
+        blockTree.Head.Returns(Build.A.Block.WithBaseFeePerGas(UInt256.Zero).TestObject);
+        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
+        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(Frontier.Instance);
+        return new InclusionListBuilder(pool, blockTree, specProvider);
+    }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListSizeMeasurement.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListSizeMeasurement.cs
@@ -43,6 +43,9 @@ public class InclusionListSizeMeasurement
     private const int Draws = 2000;
     private const int SszOffsetBytes = 4;
 
+    // Below this fraction of the cap, a draw is corpus-bound rather than cap-bound and proves nothing.
+    private const double MinSaturationFraction = 0.95;
+
     [Test]
     public void Measure()
     {
@@ -65,6 +68,13 @@ public class InclusionListSizeMeasurement
         }
         TestContext.Out.WriteLine($"RESULT size min={sizes[0]}B max={sizes[^1]}B");
 
+        // Even one list containing every corpus transaction couldn't reach the cap, so no draw ever will.
+        if (total < Eip7805Constants.MaxBytesPerInclusionList)
+        {
+            Assert.Inconclusive($"Corpus totals {total}B, below the {Eip7805Constants.MaxBytesPerInclusionList}B cap — " +
+                                 "not even the whole corpus fills one list. Supply a larger corpus.");
+        }
+
         MeasureListCounts(txs);
     }
 
@@ -74,11 +84,15 @@ public class InclusionListSizeMeasurement
         InclusionListBuilder builder = BuildBuilder(PoolOfOneTxPerSender(txs));
         int[] counts = new int[Draws];
         long totalBytes = 0;
+        long maxBytes = 0;
         for (int i = 0; i < Draws; i++)
         {
             using InclusionListBytes list = builder.GetInclusionList();
             counts[i] = list.Count;
-            foreach (ArrayPoolList<byte> entry in list) totalBytes += entry.Count;
+            long listBytes = 0;
+            foreach (ArrayPoolList<byte> entry in list) listBytes += entry.Count;
+            totalBytes += listBytes;
+            if (listBytes > maxBytes) maxBytes = listBytes;
         }
 
         Array.Sort(counts);
@@ -91,14 +105,26 @@ public class InclusionListSizeMeasurement
         TestContext.Out.WriteLine($"RESULT list bytes mean={(double)totalBytes / Draws:F0} of " +
                                   $"{Eip7805Constants.MaxBytesPerInclusionList}, " +
                                   $"with SSZ offsets {(double)(totalBytes + (long)SszOffsetBytes * sum) / Draws:F0}");
+
+        long saturationThreshold = (long)(Eip7805Constants.MaxBytesPerInclusionList * MinSaturationFraction);
+        if (maxBytes < saturationThreshold)
+        {
+            Assert.Inconclusive($"No draw exceeded {maxBytes}B of the {Eip7805Constants.MaxBytesPerInclusionList}B cap " +
+                                 $"({MinSaturationFraction:P0} threshold) — draws are corpus-bound, not cap-bound. Supply a larger corpus.");
+        }
     }
 
     private static Transaction[] LoadCorpus()
     {
         string? path = Environment.GetEnvironmentVariable(CorpusVariable);
-        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+        if (string.IsNullOrEmpty(path))
         {
             Assert.Ignore($"Set {CorpusVariable} to a file of raw transaction hex, one per line.");
+        }
+
+        if (!File.Exists(path))
+        {
+            Assert.Fail($"{CorpusVariable} is set to '{path}', but no such file exists.");
         }
 
         string[] lines = File.ReadAllLines(path!);
@@ -107,6 +133,11 @@ public class InclusionListSizeMeasurement
         {
             string trimmed = line.Trim();
             if (trimmed.Length > 0) raw.Add(Bytes.FromHexString(trimmed));
+        }
+
+        if (raw.Count == 0)
+        {
+            Assert.Fail($"{CorpusVariable} file '{path}' contains no transaction lines.");
         }
 
         byte[][] entries = raw.ToArray();


### PR DESCRIPTION
## Changes

- Add `InclusionListSizeMeasurement` (`src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListSizeMeasurement.cs`), an `[Explicit]` NUnit harness that runs the real `InclusionListDecoder.EncodePooled` and `InclusionListBuilder` over a captured mempool corpus (raw EIP-2718 hex, one transaction per line, path from `NETHERMIND_IL_TX_CORPUS`) and reports the encoded-size distribution and the resulting entries-per-8-KiB-list distribution. Every corpus entry is byte-for-byte re-validated against `EncodePooled`'s own output before use, so results reflect the builder's exact encoding, not a second implementation of it.
- No production code changes.

### Measurements (not checked in — see PR description)

Run against ~1100 real ready-mempool transactions (mainnet and Hoodi, sampled via public RPC `txpool_content`, readiness matching `TxPool.GetPendingTransactionsBySender(filterToReadyTx: true, baseFee)`) and ~9000 recently-mined mainnet transactions:

| Corpus | n | K mean | K p10 | K p50 | K p90 |
|---|---|---|---|---|---|
| Mainnet, live ready mempool | 1046 | 28.1 | 17 | 28 | 39 |
| Hoodi, live ready mempool | 77 | 30.9 | 20 | 30 | 41 |
| Mainnet, mined (biased proxy) | 8934 | 27.0 | 16 | 27 | 37 |

K (entries per 8 KiB inclusion list) medians around **27-30**, corroborating an RLP-layout estimate of K≈20-32 and correcting an earlier working assumption of K≈60. Byte utilisation is near-total (>99%) in every run, so K is essentially the mempool's tx-size mix divided into 8192 bytes, not bounded by anything else in the builder.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: measurement/investigation tooling only

## Testing

#### Requires testing

- [ ] Yes
- [x] No

#### Notes on testing

The harness itself is the deliverable; it is `[Explicit]` so it never runs in CI (it needs a corpus file it cannot ship with, since real mempool data isn't a repo fixture). Verified: builds clean (`dotnet build -c release`), positive-controlled with no corpus set (correctly skips rather than a false green), then run against three independent real corpora as described above.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Opened as an investigation deliverable — the corpus files, capture scripts, and full findings (N/ready-sender counts, caveats on the public RPC's load-balanced backends, day-window limitations) are not part of this PR; they were reported separately. This PR is just the reusable harness.