### PR TITLE
test(focil): pin the sender reservoir's headroom over the inclusion-list byte cap

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -151,28 +151,37 @@ public class InclusionListBuilderTests
         Assert.That(il.Sum(t => t.Count), Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
     }
 
-    // A too-small reservoir would leave the byte budget under-filled even at the smallest transactions the
-    // pool could offer, silently shrinking every inclusion list. 255 senders each with a minimal legacy tx
-    // (to=null, zero-valued fields — the ~74-75 byte floor the sample capacity is now sized against) must
-    // still saturate most of the byte cap.
-    [Test]
-    public void Reservoir_saturates_the_byte_budget_at_the_smallest_encoded_transaction_size()
+    /// <summary>The smallest transaction the pool could offer: a zero-valued legacy contract creation.</summary>
+    private static Transaction MinimalTx(PrivateKey sender) => Build.A.Transaction
+        .WithNonce(0)
+        .WithValue(0)
+        .WithGasPrice(0)
+        .WithGasLimit(0)
+        .WithTo(null)
+        .WithData([])
+        .SignedAndResolved(sender)
+        .TestObject;
+
+    // A reservoir holding only what the byte cap can emit under-fills every list, silently shrinking it: an
+    // entry skipped for size spends a draw without spending budget, leaving no spare sender to refill it.
+    [TestCase(0, TestName = "Reservoir_saturates_the_byte_budget_at_the_smallest_encoded_transaction_size")]
+    [TestCase(128, TestName = "Reservoir_saturates_the_byte_budget_when_half_the_senders_are_skipped_for_size")]
+    public void Reservoir_saturates_the_byte_budget(int sendersSkippedForSize)
     {
-        Transaction[] txs = [.. TestItem.PrivateKeys.Select(key => Build.A.Transaction
-            .WithNonce(0)
-            .WithValue(0)
-            .WithGasPrice(0)
-            .WithGasLimit(0)
-            .WithTo(null)
-            .WithData([])
-            .SignedAndResolved(key)
-            .TestObject)];
+        // Minimal legacy txs encode to 74-75 bytes, so 255 senders is barely enough to fill 8 KiB; the
+        // skipped ones are headed by a transaction larger than the whole list, so they can never contribute.
+        Transaction[] txs = [.. TestItem.PrivateKeys.Select((key, i) => i < sendersSkippedForSize
+            ? TxOfSize(Eip7805Constants.MaxBytesPerInclusionList, 0, key)
+            : MinimalTx(key))];
 
         using InclusionListBytes il = BuildBuilder(PoolOf(txs)).GetInclusionList();
         int totalBytes = il.Sum(t => t.Count);
 
-        Assert.That(totalBytes, Is.GreaterThan(Eip7805Constants.MaxBytesPerInclusionList - 200));
-        Assert.That(totalBytes, Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(totalBytes, Is.GreaterThan(Eip7805Constants.MaxBytesPerInclusionList - 200));
+            Assert.That(totalBytes, Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -151,6 +151,30 @@ public class InclusionListBuilderTests
         Assert.That(il.Sum(t => t.Count), Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
     }
 
+    // A too-small reservoir would leave the byte budget under-filled even at the smallest transactions the
+    // pool could offer, silently shrinking every inclusion list. 255 senders each with a minimal legacy tx
+    // (to=null, zero-valued fields — the ~74-75 byte floor the sample capacity is now sized against) must
+    // still saturate most of the byte cap.
+    [Test]
+    public void Reservoir_saturates_the_byte_budget_at_the_smallest_encoded_transaction_size()
+    {
+        Transaction[] txs = [.. TestItem.PrivateKeys.Select(key => Build.A.Transaction
+            .WithNonce(0)
+            .WithValue(0)
+            .WithGasPrice(0)
+            .WithGasLimit(0)
+            .WithTo(null)
+            .WithData([])
+            .SignedAndResolved(key)
+            .TestObject)];
+
+        using InclusionListBytes il = BuildBuilder(PoolOf(txs)).GetInclusionList();
+        int totalBytes = il.Sum(t => t.Count);
+
+        Assert.That(totalBytes, Is.GreaterThan(Eip7805Constants.MaxBytesPerInclusionList - 200));
+        Assert.That(totalBytes, Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
+    }
+
     [Test]
     public void Returned_bytes_are_valid_RLP_decoding_back_to_originals()
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -60,6 +60,18 @@ public class InclusionListBuilderTests
         return TxDecoder.Instance.DecodeCompleteNotNull(ref ctx, RlpBehaviors.SkipTypedWrapping);
     }
 
+    /// <summary>A synthetic floor: a zero-valued legacy contract creation, smaller than any pool-admissible
+    /// transaction, since gasLimit 0 is below the 21000 intrinsic floor a real one must clear.</summary>
+    private static Transaction MinimalTx(PrivateKey sender) => Build.A.Transaction
+        .WithNonce(0)
+        .WithValue(0)
+        .WithGasPrice(0)
+        .WithGasLimit(0)
+        .WithTo(null)
+        .WithData([])
+        .SignedAndResolved(sender)
+        .TestObject;
+
     [Test]
     public void Empty_pool_yields_empty_inclusion_list() =>
         Assert.That(BuildBuilder(PoolOf()).GetInclusionList(), Is.Empty);
@@ -139,8 +151,10 @@ public class InclusionListBuilderTests
         Assert.That(il.Select(b => senderByHash[Decode(b).Hash!]).Distinct().Count(), Is.EqualTo(senderCount));
     }
 
+    // 255 signers is below the sample capacity, so the cap is reached through second nonces rather than
+    // through reservoir eviction, which no fixture here exercises.
     [Test]
-    public void Handles_more_senders_than_the_sample_capacity()
+    public void Handles_more_transactions_than_the_sample_capacity()
     {
         Transaction[] txs = [.. Enumerable.Range(0, TestItem.PrivateKeys.Length)
             .SelectMany(i => new[] { TxOfSize(0, 0, TestItem.PrivateKeys[i]), TxOfSize(0, 1, TestItem.PrivateKeys[i]) })];
@@ -151,25 +165,20 @@ public class InclusionListBuilderTests
         Assert.That(il.Sum(t => t.Count), Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
     }
 
-    /// <summary>The smallest transaction the pool could offer: a zero-valued legacy contract creation.</summary>
-    private static Transaction MinimalTx(PrivateKey sender) => Build.A.Transaction
-        .WithNonce(0)
-        .WithValue(0)
-        .WithGasPrice(0)
-        .WithGasLimit(0)
-        .WithTo(null)
-        .WithData([])
-        .SignedAndResolved(sender)
-        .TestObject;
+    private static IEnumerable<TestCaseData> ReservoirCases()
+    {
+        yield return new TestCaseData(0).SetName("Reservoir_saturates_the_byte_budget_at_the_smallest_encoded_transaction_size");
+        yield return new TestCaseData(TestItem.PrivateKeys.Length / 2).SetName("Reservoir_saturates_the_byte_budget_when_half_the_senders_are_skipped_for_size");
+    }
 
     // A reservoir holding only what the byte cap can emit under-fills every list, silently shrinking it: an
     // entry skipped for size spends a draw without spending budget, leaving no spare sender to refill it.
-    [TestCase(0, TestName = "Reservoir_saturates_the_byte_budget_at_the_smallest_encoded_transaction_size")]
-    [TestCase(128, TestName = "Reservoir_saturates_the_byte_budget_when_half_the_senders_are_skipped_for_size")]
+    [TestCaseSource(nameof(ReservoirCases))]
     public void Reservoir_saturates_the_byte_budget(int sendersSkippedForSize)
     {
         // Minimal legacy txs encode to 74-75 bytes, so 255 senders is barely enough to fill 8 KiB; the
         // skipped ones are headed by a transaction larger than the whole list, so they can never contribute.
+        // The fixture tops out below the sample capacity, so reservoir eviction is not exercised here.
         Transaction[] txs = [.. TestItem.PrivateKeys.Select((key, i) => i < sendersSkippedForSize
             ? TxOfSize(Eip7805Constants.MaxBytesPerInclusionList, 0, key)
             : MinimalTx(key))];
@@ -179,7 +188,8 @@ public class InclusionListBuilderTests
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(totalBytes, Is.GreaterThan(Eip7805Constants.MaxBytesPerInclusionList - 200));
+            // The encode loop only stops once nothing could fit, so a saturated list has under one entry of slack.
+            Assert.That(totalBytes, Is.GreaterThan(Eip7805Constants.MaxBytesPerInclusionList - 100));
             Assert.That(totalBytes, Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
         }
     }

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -17,11 +17,9 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     // Deliberately below any real minimum, so the encode loop's early-break check below never skips a
     // smaller tx that could still fit.
     private const int MinTransactionSizeBytes = 32;
-    // The measured floor for a signable tx. Sizing the reservoir off this, not the early-break bound above,
-    // avoids drawing senders the byte cap could never emit.
-    private const int MinSampledTransactionSizeBytes = 74;
-    // Senders drawn per list. The byte cap, not this, decides how many of them reach the wire.
-    private const int SenderSampleCapacity = Eip7805Constants.MaxBytesPerInclusionList / MinSampledTransactionSizeBytes;
+    // Senders drawn per list, deliberately over twice the entries the byte cap can emit: an entry skipped
+    // for size spends a draw without spending budget, and the spare senders are what refill it.
+    private const int SenderSampleCapacity = Eip7805Constants.MaxBytesPerInclusionList / MinTransactionSizeBytes;
 
     /// <summary>Draws pending transactions for an inclusion list, up to the per-list byte cap.</summary>
     /// <param name="parent">Header the next-block base fee is derived from; the head when null.</param>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -14,10 +14,14 @@ namespace Nethermind.Merge.Plugin.Handlers;
 
 public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecProvider specProvider)
 {
-    // Conservative lower bound for an encoded transaction's size.
+    // Deliberately below any real minimum, so the encode loop's early-break check below never skips a
+    // smaller tx that could still fit.
     private const int MinTransactionSizeBytes = 32;
+    // The measured floor for a signable tx. Sizing the reservoir off this, not the early-break bound above,
+    // avoids drawing senders the byte cap could never emit.
+    private const int MinSampledTransactionSizeBytes = 74;
     // Senders drawn per list. The byte cap, not this, decides how many of them reach the wire.
-    private const int SenderSampleCapacity = Eip7805Constants.MaxBytesPerInclusionList / MinTransactionSizeBytes;
+    private const int SenderSampleCapacity = Eip7805Constants.MaxBytesPerInclusionList / MinSampledTransactionSizeBytes;
 
     /// <summary>Draws pending transactions for an inclusion list, up to the per-list byte cap.</summary>
     /// <param name="parent">Header the next-block base fee is derived from; the head when null.</param>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -17,9 +17,12 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     // Deliberately below any real minimum, so the encode loop's early-break check below never skips a
     // smaller tx that could still fit.
     private const int MinTransactionSizeBytes = 32;
-    // Senders drawn per list, deliberately over twice the entries the byte cap can emit: an entry skipped
-    // for size spends a draw without spending budget, and the spare senders are what refill it.
-    private const int SenderSampleCapacity = Eip7805Constants.MaxBytesPerInclusionList / MinTransactionSizeBytes;
+    // Upper bound on the entries the byte cap can emit: 64 is under the smallest encoding seen in practice
+    // (73 bytes over a 300k-key scan), so this over-counts rather than under-counts.
+    private const int MaxEmittableEntries = Eip7805Constants.MaxBytesPerInclusionList / 64;
+    // Senders drawn per list, at twice the emittable entries: an entry skipped for size spends a draw
+    // without spending budget, and the spare senders are what refill it.
+    private const int SenderSampleCapacity = 2 * MaxEmittableEntries;
 
     /// <summary>Draws pending transactions for an inclusion list, up to the per-list byte cap.</summary>
     /// <param name="parent">Header the next-block base fee is derived from; the head when null.</param>


### PR DESCRIPTION
## Changes

- Keep `SenderSampleCapacity` at the conservative `MaxBytesPerInclusionList / MinTransactionSizeBytes` (256) and document the headroom as deliberate. The first revision of this PR sized the reservoir off the smallest transaction that can actually be encoded (`MinSampledTransactionSizeBytes = 74`, capacity 110); measurement showed that shrinks every inclusion list near the size floor, so that constant is dropped.
- Document both constants: the 32-byte bound is deliberately below any real minimum so the encode loop's early break never skips a transaction that would still fit; the reservoir is deliberately over twice the entries the byte cap can emit, because an entry skipped for size spends a draw without spending budget and the spare senders are what refill it.
- Add the regression test `Reservoir_saturates_the_byte_budget`, parameterised over 0 and 128 of the 255 senders being headed by a transaction larger than the whole list.

**Net production change against `master` is comments only.** The behaviour is `master`'s; what this PR adds is the invariant, written down and pinned by a test.

## Why

Sizing the reservoir to exactly what the byte cap can emit leaves nothing to absorb entries the encode loop skips, so the 8 KiB budget goes under-filled. Measured average bytes emitted out of 8192, 20 draws per cell, 255 senders each holding one minimal legacy transaction unless stated, a share of them headed by a 9 KB transaction no list could ever hold:

| pool shape | `master` | #13382 | capacity 110 | #13382 + capacity 110 |
| --- | --- | --- | --- | --- |
| 50% of senders oversized | 8175 | 8175 | 4233 | 4106 |
| 20% oversized | 8174 | 8174 | 6622 | 6577 |
| 10% oversized | 8174 | 8174 | 7417 | 7357 |
| none oversized | 8174 | 8174 | 8174 | 8174 |
| 40 senders x 20-nonce runs, 50% oversized | 8174 | 8173 | 6750 | 4117 |

Two things worth calling out:

- The reduction under-fills the budget **on its own**, without #13382 — column 3. When every sender holds a single ready transaction the reservoir is exhausted in round 0, so a skipped entry is simply a wasted draw and no later nonce replaces it.
- It also does not pay for itself here. Nothing in `SampleAppendableTxs` costs per *drawn* sender on this base beyond the round-robin iteration; the per-sender run computation the first revision cited belongs to #13383, which is not merged.

The headroom is finite, not a guarantee. At capacity 256 with 1024 senders, saturation holds while the skipped share stays under roughly `1 - 110/256`: 8174 at 50% skipped, 7709 at 60%, 5830 at 70%. Past that the pool itself has too few live senders for any reservoir size to help.

This only bites near the encoding floor. At realistic ~225-byte transactions the byte cap admits ~36 entries, so both capacities saturate.

## Interaction with #13382

#13382 ends a sender's run at a transaction skipped for size, which turns one skipped entry into a dead sender for the rest of the list. That is correct on its own and costs nothing at this capacity (column 2 matches `master`), but it compounds the shortfall once the headroom is gone — clearest in the last row, 6750 -> 4117. **Either PR can land first; neither should land alongside a reservoir sized to the emittable entry count.** `Reservoir_saturates_the_byte_budget` is what holds that line.

## On the 74-byte figure

74 was an observation, not a bound. A minimal legacy transaction (`to=null`, zero-valued fields) encodes via `InclusionListDecoder.EncodePooled` to 75 bytes for 252 of the 255 `TestItem.PrivateKeys` signers and 74 for the other 3, but a scan of 300,000 random keys reaches 73 bytes (~1 in 10,000) whenever both `r` and `s` lose a leading zero byte, and nothing rules out 72 or less. Rather than lower the constant to another observation, the code no longer claims a bound it does not have.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [x] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`InclusionListBuilderTests` 11/11 pass. `Reservoir_saturates_the_byte_budget_when_half_the_senders_are_skipped_for_size` was positive-controlled against the capacity-110 constant: it fails there (3900 bytes against a 7992 floor) and passes at the conservative capacity. The 0-skipped case passes on both. Both cases assert on the byte total, not on ordering, since the sample is shuffled. `dotnet format whitespace src/Nethermind/ --folder` reports no changes.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
