### PR TITLE
fix(evm): make the pooled-object leak detectors able to fire

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/PooledObjectLeakDetectionTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/PooledObjectLeakDetectionTests.cs
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#if DEBUG
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using Nethermind.Core;
+using Nethermind.Core.Test.Builders;
+using Nethermind.Evm.CodeAnalysis;
+using Nethermind.Evm.GasPolicy;
+using Nethermind.Evm.State;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test;
+
+/// <summary>
+/// The DEBUG-only finalizers on <see cref="ExecutionEnvironment"/> and <see cref="VmState{TGasPolicy}"/> report
+/// pooled instances that were rented and never returned.
+/// </summary>
+/// <remarks>
+/// Both checks were previously unable to fire: <see cref="GC.SuppressFinalize"/> in Dispose is permanent per
+/// object, so a recycled instance was never finalized again, and the environment's condition was inverted.
+/// The recycled cases below are the ones that regress if either returns.
+/// </remarks>
+[NonParallelizable]
+public class PooledObjectLeakDetectionTests
+{
+    // Warnings from other fixtures can land in the capture window, so every assertion keys off the frame of
+    // the helper that rented the instance under test rather than the buffer being empty.
+    private static string Probe(Action action, [CallerMemberName] string caller = "")
+    {
+        TextWriter original = Console.Error;
+        StringWriter captured = new();
+        Console.SetError(captured);
+        try
+        {
+            action();
+            for (int i = 0; i < 2; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+
+        return captured.ToString();
+    }
+
+    private static ExecutionEnvironment RentEnv(Address? executingAccount = null) =>
+        ExecutionEnvironment.Rent(CodeInfo.Empty, executingAccount!, TestItem.AddressB, null, 0, UInt256.Zero, default);
+
+    // Leaks must happen in a frame that has returned: a Debug build keeps locals alive to the end of their method.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void LeakFreshEnv() => RentEnv(TestItem.AddressA);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void LeakNullAccountEnv() => RentEnv();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void LeakRecycledEnv()
+    {
+        RentEnv(TestItem.AddressA).Dispose();
+        RentEnv(TestItem.AddressA);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DisposeEnv() => RentEnv(TestItem.AddressA).Dispose();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static VmState<EthereumGasPolicy> RentState(ExecutionEnvironment env) =>
+        VmState<EthereumGasPolicy>.RentTopLevel(
+            EthereumGasPolicy.FromULong(1000), ExecutionType.TRANSACTION, env, new StackAccessTracker(), Snapshot.Empty);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void LeakRecycledState()
+    {
+        // A top level env is caller-owned: VmState.Dispose only releases it when !IsTopLevel.
+        using ExecutionEnvironment first = RentEnv(TestItem.AddressA);
+        using ExecutionEnvironment second = RentEnv(TestItem.AddressA);
+        RentState(first).Dispose();
+        RentState(second);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DisposeState()
+    {
+        using ExecutionEnvironment env = RentEnv(TestItem.AddressA);
+        RentState(env).Dispose();
+    }
+
+    private static void AssertReported(Action leak, string type, string marker) =>
+        Assert.That(Probe(leak), Does.Contain($"{type} was not disposed").And.Contain(marker));
+
+    [Test]
+    public void Leaked_environment_is_reported() =>
+        AssertReported(LeakFreshEnv, nameof(ExecutionEnvironment), nameof(LeakFreshEnv));
+
+    [Test]
+    public void Leaked_environment_reused_from_the_pool_is_reported() =>
+        AssertReported(LeakRecycledEnv, nameof(ExecutionEnvironment), nameof(LeakRecycledEnv));
+
+    [Test]
+    public void Leaked_environment_rented_with_a_null_account_is_reported() =>
+        AssertReported(LeakNullAccountEnv, nameof(ExecutionEnvironment), nameof(LeakNullAccountEnv));
+
+    [Test]
+    public void Leaked_state_reused_from_the_pool_is_reported() =>
+        AssertReported(LeakRecycledState, "VmState", nameof(LeakRecycledState));
+
+    [Test]
+    public void Disposed_environment_is_not_reported() =>
+        Assert.That(Probe(DisposeEnv), Does.Not.Contain(nameof(DisposeEnv)));
+
+    [Test]
+    public void Disposed_state_is_not_reported() =>
+        Assert.That(Probe(DisposeState), Does.Not.Contain(nameof(DisposeState)));
+}
+#endif

--- a/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
+++ b/src/Nethermind/Nethermind.Evm/ExecutionEnvironment.cs
@@ -67,6 +67,10 @@ namespace Nethermind.Evm
             in ReadOnlyMemory<byte> inputData)
         {
             ExecutionEnvironment env = _pool.TryDequeue(out ExecutionEnvironment? pooled) ? pooled : new();
+#if DEBUG
+            env._isRented = true;
+            env._rentStackTrace = new System.Diagnostics.StackTrace();
+#endif
             env.CodeInfo = codeInfo;
             env.ExecutingAccount = executingAccount;
             env.Caller = caller;
@@ -82,6 +86,9 @@ namespace Nethermind.Evm
         /// </summary>
         public void Dispose()
         {
+#if DEBUG
+            _isRented = false;
+#endif
             if (ExecutingAccount is not null)
             {
                 CodeInfo = null!;
@@ -93,19 +100,22 @@ namespace Nethermind.Evm
                 InputData = default;
                 _pool.Enqueue(this);
             }
-#if DEBUG
-            GC.SuppressFinalize(this);
-#endif
         }
 
 #if DEBUG
-        private readonly System.Diagnostics.StackTrace _creationStackTrace = new();
+        private bool _isRented;
+        private System.Diagnostics.StackTrace? _rentStackTrace;
 
+        /// <remarks>
+        /// A leak is an instance still rented when collected; a disposed one the pool drops (dead thread tier,
+        /// shared overflow) stays silent. <see cref="GC.SuppressFinalize"/> must not be used in <see cref="Dispose"/>:
+        /// it is permanent per object, so it would blind this for every pooled instance after its first reuse.
+        /// </remarks>
         ~ExecutionEnvironment()
         {
-            if (ExecutingAccount is null)
+            if (_isRented)
             {
-                Console.Error.WriteLine($"Warning: {nameof(ExecutionEnvironment)} was not disposed. Created at: {_creationStackTrace}");
+                Console.Error.WriteLine($"Warning: {nameof(ExecutionEnvironment)} was not disposed. Rented at: {_rentStackTrace}");
             }
         }
 #endif

--- a/src/Nethermind/Nethermind.Evm/VmState.cs
+++ b/src/Nethermind/Nethermind.Evm/VmState.cs
@@ -228,16 +228,17 @@ public class VmState<TGasPolicy> : IDisposable
         StateGasRefundAdvanced = 0;
 
         _statePool.Enqueue(this);
-
-#if DEBUG
-        GC.SuppressFinalize(this);
-#endif
     }
 
 #if DEBUG
 
     private StackTrace? _creationStackTrace;
 
+    /// <remarks>
+    /// A leak is an instance still rented when collected; a disposed one the pool drops (dead thread tier,
+    /// shared overflow) stays silent. <see cref="GC.SuppressFinalize"/> must not be used in <see cref="Dispose"/>:
+    /// it is permanent per object, so it would blind this for every pooled instance after its first reuse.
+    /// </remarks>
     ~VmState()
     {
         if (!_isDisposed)


### PR DESCRIPTION
## Changes

The `#if DEBUG` finalizers on `ExecutionEnvironment` and `VmState<TGasPolicy>` are meant to report pooled instances that were rented and never returned. Neither could report a real leak.

- **`GC.SuppressFinalize` in `Dispose` blinded both.** It is permanent per object, so once an instance had been disposed and pooled it was never finalized again — and the pool only ever holds previously disposed instances, so every leak of a *recycled* instance was invisible. The suppression is also unneeded: a pooled instance that stays reachable is never collected in the first place. Removed from both.
- **`ExecutionEnvironment`'s condition was inverted.** It warned when `ExecutingAccount is null`, which is the *disposed* state, so a leak (account still set) never matched.
- **`ExecutingAccount` is not a sound sentinel either.** `Rent` may be given a null account, in which case `Dispose` does not pool the instance at all; such a leak would stay invisible, and a collected-but-disposed one would be reported. Replaced with an explicit DEBUG-only rented flag.
- **Stack trace captured at `Rent`, not construction**, so a recycled instance reports the site that leaked it rather than its first allocation.

`VmState`'s condition (`!_isDisposed`) was already correct and is unchanged; it only needed the `SuppressFinalize` removal.

All of this is inside `#if DEBUG` — no release-mode footprint.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`PooledObjectLeakDetectionTests` covers leaked/disposed instances of both types. It is red/green controlled: the three leak tests fail against the unfixed code and pass with the fix. The recycled-instance cases are the ones that regress if `SuppressFinalize` returns.

Two caveats worth knowing:

- The tests are `#if DEBUG` (the detector only exists there) and CI runs `-c release`, so **this is not guarded in CI**.
- Assertions key off the leaking helper's stack frame rather than an empty buffer, because the suite runs fixtures in parallel and unrelated finalizers land in the capture window.

Verified locally on `Nethermind.Evm.Test`: Debug 12359 tests / 0 failed, Release 12355 / 0 failed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Two things reviewers should weigh:

1. **The practical signal path is still weak.** Finalization is opportunistic and the warnings go to `Console.Error`, which the test runner hides for passing tests. In a plain Debug run of the suite I saw no warnings; with a forced collection and an explicit stderr tee, 95 genuine leaks appeared. So this fix makes the detector *able* to fire, but it will not reliably surface the next leak on its own. A deterministic end-of-run sweep (force a collection, fail the run on any warning) would be the version with real teeth — deliberately not included here to keep the change small.

2. **The pooling rework (#12905) changes the invariant.** With the per-thread free list and the `_maxShared` drop path, a properly disposed instance *can* become unreachable (a dead thread's tier, shared-queue overflow). That is why the check keys off the rented flag rather than reachability — the previous `ExecutingAccount is null` condition would have started firing on every such collection once the suppression was removed.

Of the 95 leaks the sweep surfaced, all were genuine and test-only. `VmStateTests` has since been fixed upstream via its `VmStateScope` helper; `EvmStackTests.CreateEvmState` still leaks its top-level env (a top-level `ExecutionEnvironment` is caller-owned, since `VmState.Dispose` releases `_env` only when `!IsTopLevel`). Not fixed here.
