### PR TITLE
feat(focil): allow reserving part of the inclusion-list draw for the oldest senders

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/GetInclusionListTransactionsHandlerTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/GetInclusionListTransactionsHandlerTests.cs
@@ -32,7 +32,7 @@ public class GetInclusionListTransactionsHandlerTests
         specProvider.GetSpec(Arg.Any<ForkActivation>())
             .Returns(ci => focilScheduled && ci.ArgAt<ForkActivation>(0).Timestamp >= BogotaTimestamp ? bogota : preBogota);
 
-        return new GetInclusionListTransactionsHandler(pool, Substitute.For<IBlockTree>(), specProvider);
+        return new GetInclusionListTransactionsHandler(pool, Substitute.For<IBlockTree>(), specProvider, new MergeConfig());
     }
 
     // The list is built before its block exists and a missed slot moves the timestamp, so only whether

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -36,13 +36,19 @@ public class InclusionListBuilderTests
     }
 
     // Frontier leaves the parent's base fee unchanged, so the head header fixes the fee the builder asks for.
-    private static InclusionListBuilder BuildBuilder(ITxPool pool, UInt256 baseFee = default)
+    // The age tier defaults to MergeConfig's, so an unnamed tier is the shipped one: off.
+    private static InclusionListBuilder BuildBuilder(ITxPool pool, UInt256 baseFee = default, double oldestShare = 0, int oldestCount = 200)
     {
         IBlockTree blockTree = Substitute.For<IBlockTree>();
         blockTree.Head.Returns(Build.A.Block.WithBaseFeePerGas(baseFee).TestObject);
         ISpecProvider specProvider = Substitute.For<ISpecProvider>();
         specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(Frontier.Instance);
-        return new InclusionListBuilder(pool, blockTree, specProvider);
+        MergeConfig mergeConfig = new()
+        {
+            InclusionListOldestSenderShare = oldestShare,
+            InclusionListOldestSenderCount = oldestCount
+        };
+        return new InclusionListBuilder(pool, blockTree, specProvider, mergeConfig);
     }
 
     /// <summary>A pool whose ready buckets are the given transactions, grouped by sender and nonce-ordered.</summary>
@@ -169,16 +175,100 @@ public class InclusionListBuilderTests
         Assert.That(il.Select(b => senderByHash[Decode(b).Hash!]).Distinct().Count(), Is.EqualTo(senderCount));
     }
 
+    // Both draws answer to the transport's caps, whether or not part of one is reserved by age.
     [Test]
-    public void Handles_more_senders_than_the_sample_capacity()
+    public void Handles_more_senders_than_the_sample_capacity([Values(0.0, 0.5)] double oldestShare)
     {
         Transaction[] txs = [.. Enumerable.Range(0, TestItem.PrivateKeys.Length)
             .SelectMany(i => new[] { TxOfSize(0, 0, TestItem.PrivateKeys[i]), TxOfSize(0, 1, TestItem.PrivateKeys[i]) })];
 
-        using InclusionListBytes il = BuildBuilder(PoolOf(txs)).GetInclusionList();
+        using InclusionListBytes il = BuildBuilder(PoolOf(txs), oldestShare: oldestShare).GetInclusionList();
 
         Assert.That(il.Count, Is.LessThanOrEqualTo(Eip7805Constants.MaxTransactionsPerInclusionList));
         Assert.That(il.Sum(t => t.Count), Is.LessThanOrEqualTo(Eip7805Constants.MaxBytesPerInclusionList));
+    }
+
+    /// <summary>A one-transaction sender, its pool index standing in for how long it has been pending.</summary>
+    private static Transaction SenderTx(int index, ulong poolIndex)
+    {
+        // A nonce per sender keeps every transaction distinct and every appendable run one entry long.
+        Transaction tx = TxOfSize(50, index);
+        // The pool holds far more senders than there are test keys, and only the address is read here.
+        tx.SenderAddress = Address.FromNumber((UInt256)(index + 1));
+        tx.PoolIndex = poolIndex;
+        return tx;
+    }
+
+    private const int TierPoolSenders = 800;
+    private const int TierCohortSize = 160;
+
+    /// <summary>The share of the listed transactions that came from the oldest cohort, over many lists.</summary>
+    /// <param name="step">Pool indices apart between consecutive senders; <c>0</c> stamps them all alike.</param>
+    private static double ListedOldestShare(double oldestShare, int oldestCount, ulong firstPoolIndex, ulong step)
+    {
+        Transaction[] txs = new Transaction[TierPoolSenders];
+        HashSet<Hash256> cohort = [];
+        for (int i = 0; i < TierPoolSenders; i++)
+        {
+            txs[i] = SenderTx(i, firstPoolIndex + (ulong)i * step);
+            if (i < TierCohortSize) cohort.Add(txs[i].Hash!);
+        }
+
+        InclusionListBuilder builder = BuildBuilder(PoolOf(txs), oldestShare: oldestShare, oldestCount: oldestCount);
+        int listed = 0;
+        int fromCohort = 0;
+        // One list is a single draw; a share only means anything across many of them.
+        for (int round = 0; round < 60; round++)
+        {
+            using InclusionListBytes il = builder.GetInclusionList();
+            foreach (ArrayPoolList<byte> bytes in il)
+            {
+                listed++;
+                if (cohort.Contains(Decode(bytes).Hash!)) fromCohort++;
+            }
+        }
+
+        return (double)fromCohort / listed;
+    }
+
+    // Off, the draw is uniform and the oldest cohort is listed at its share of the pool, 160 of 800. On, the
+    // share reserved out of the 256-sender draw is the share of the list the cohort gets, since the byte cap
+    // keeps a random prefix of that draw. Both are what the model of a censored transaction's odds rests on.
+    [TestCase(0.0, TierCohortSize, 0ul, 1ul, 0.20)]
+    [TestCase(0.25, TierCohortSize, 0ul, 1ul, 0.25)]
+    [TestCase(0.5, TierCohortSize, 0ul, 1ul, 0.50)]
+    // The cohort is the pool's oldest by rank, not by an index threshold, so the same share holds wherever the
+    // pool's sequence happens to start — which is what survives it restarting with the process.
+    [TestCase(0.5, TierCohortSize, ulong.MaxValue - 10_000ul, 1ul, 0.50)]
+    // Nothing to rank by leaves the whole pool tied for oldest, which is the uniform draw again.
+    [TestCase(0.5, TierCohortSize, 0ul, 0ul, 0.20)]
+    // So does a cohort as wide as the pool: there is nothing left to reserve the draw against.
+    [TestCase(0.5, TierPoolSenders, 0ul, 1ul, 0.20)]
+    public void Reserved_share_of_the_draw_is_what_the_oldest_cohort_gets(double oldestShare, int oldestCount, ulong firstPoolIndex, ulong step, double expected) =>
+        Assert.That(ListedOldestShare(oldestShare, oldestCount, firstPoolIndex, step), Is.EqualTo(expected).Within(0.04));
+
+    /// <summary>Entries one draw fits in the byte cap, asserting no sender reached the list twice.</summary>
+    private static int ListedCount(Transaction[] txs, double oldestShare, int oldestCount)
+    {
+        using InclusionListBytes il = BuildBuilder(PoolOf(txs), oldestShare: oldestShare, oldestCount: oldestCount).GetInclusionList();
+
+        Assert.That(il.Select(b => Decode(b).Hash).Distinct().Count(), Is.EqualTo(il.Count),
+            "a sender drawn into both tiers would be listed twice");
+        return il.Count;
+    }
+
+    // Neither tier running short may cost the list entries: each spends what the other leaves.
+    [TestCase(0.05, 28)] // a cohort wider than its reserved draw, with too few senders behind it to fill the rest
+    [TestCase(0.5, 5)]   // a cohort too narrow to fill its reserved draw
+    public void A_short_tier_does_not_shrink_the_draw(double oldestShare, int oldestCount)
+    {
+        const int senderCount = 30;
+        Transaction[] txs = new Transaction[senderCount];
+        for (int i = 0; i < txs.Length; i++) txs[i] = SenderTx(i, (ulong)i);
+
+        // The premise: this pool fits the byte cap whole, so a narrowed draw would cost the list entries.
+        Assert.That(ListedCount(txs, 0, oldestCount), Is.EqualTo(senderCount));
+        Assert.That(ListedCount(txs, oldestShare, oldestCount), Is.EqualTo(senderCount));
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nethermind.Blockchain;
@@ -189,10 +190,10 @@ public class InclusionListBuilderTests
     }
 
     /// <summary>A one-transaction sender, its pool index standing in for how long it has been pending.</summary>
-    private static Transaction SenderTx(int index, ulong poolIndex)
+    private static Transaction SenderTx(int index, ulong poolIndex, int payloadBytes = 50)
     {
         // A nonce per sender keeps every transaction distinct and every appendable run one entry long.
-        Transaction tx = TxOfSize(50, index);
+        Transaction tx = TxOfSize(payloadBytes, index);
         // The pool holds far more senders than there are test keys, and only the address is read here.
         tx.SenderAddress = Address.FromNumber((UInt256)(index + 1));
         tx.PoolIndex = poolIndex;
@@ -251,6 +252,29 @@ public class InclusionListBuilderTests
     [TestCase(0.5, TierPoolSenders, 0ul, 1ul, 0.20)]
     public void Reserved_share_is_a_floor_under_what_the_oldest_cohort_gets(double oldestShare, int oldestCount, ulong firstPoolIndex, ulong step, double expected) =>
         Assert.That(ListedOldestShare(oldestShare, oldestCount, firstPoolIndex, step), Is.EqualTo(expected).Within(0.04));
+
+    // A share worth less than one of the draw's slots must still reserve one: truncating it away would leave
+    // the tier off, and the shipped default running, on a knob an operator is calibrating.
+    [Test]
+    public void Reserves_a_slot_for_a_share_below_one_slot()
+    {
+        Transaction[] txs = new Transaction[TierPoolSenders];
+        txs[0] = SenderTx(0, 0);
+        // Nothing behind the cohort can be listed, so the list is non-empty exactly when the cohort is drawn.
+        for (int i = 1; i < txs.Length; i++) txs[i] = SenderTx(i, (ulong)i, Eip7805Constants.MaxBytesPerInclusionList);
+
+        using InclusionListBytes il = BuildBuilder(PoolOf(txs), oldestShare: 0.003, oldestCount: 1).GetInclusionList();
+
+        Assert.That(il.Select(b => Decode(b).Hash), Is.EqualTo(new[] { txs[0].Hash }));
+    }
+
+    // A misconfigured share must fail loudly: clamping or truncating it hands back the shipped default.
+    [TestCase(double.NaN)]
+    [TestCase(double.PositiveInfinity)]
+    [TestCase(-0.1)]
+    [TestCase(1.5)]
+    public void Rejects_a_share_that_is_not_a_fraction(double oldestShare) =>
+        Assert.That(() => BuildBuilder(PoolOf(), oldestShare: oldestShare), Throws.InstanceOf<ArgumentOutOfRangeException>());
 
     /// <summary>Entries one draw fits in the byte cap, asserting no sender reached the list twice.</summary>
     private static int ListedCount(Transaction[] txs, double oldestShare, int oldestCount)

--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/InclusionListBuilderTests.cs
@@ -237,6 +237,11 @@ public class InclusionListBuilderTests
     [TestCase(0.0, TierCohortSize, 0ul, 1ul, 0.20)]
     [TestCase(0.25, TierCohortSize, 0ul, 1ul, 0.25)]
     [TestCase(0.5, TierCohortSize, 0ul, 1ul, 0.50)]
+    // A share under the cohort's own 0.20 of the pool is a floor that does not bind, not a ceiling that demotes
+    // it: reserving a sliver of the draw for the oldest senders must never list fewer of them than drawing
+    // uniformly would have. Reserving by share alone inverts here, worst at the smallest non-zero shares.
+    [TestCase(0.02, TierCohortSize, 0ul, 1ul, 0.20)]
+    [TestCase(0.05, TierCohortSize, 0ul, 1ul, 0.20)]
     // The cohort is the pool's oldest by rank, not by an index threshold, so the same share holds wherever the
     // pool's sequence happens to start — which is what survives it restarting with the process.
     [TestCase(0.5, TierCohortSize, ulong.MaxValue - 10_000ul, 1ul, 0.50)]
@@ -244,7 +249,7 @@ public class InclusionListBuilderTests
     [TestCase(0.5, TierCohortSize, 0ul, 0ul, 0.20)]
     // So does a cohort as wide as the pool: there is nothing left to reserve the draw against.
     [TestCase(0.5, TierPoolSenders, 0ul, 1ul, 0.20)]
-    public void Reserved_share_of_the_draw_is_what_the_oldest_cohort_gets(double oldestShare, int oldestCount, ulong firstPoolIndex, ulong step, double expected) =>
+    public void Reserved_share_is_a_floor_under_what_the_oldest_cohort_gets(double oldestShare, int oldestCount, ulong firstPoolIndex, ulong step, double expected) =>
         Assert.That(ListedOldestShare(oldestShare, oldestCount, firstPoolIndex, step), Is.EqualTo(expected).Within(0.04));
 
     /// <summary>Entries one draw fits in the byte cap, asserting no sender reached the list twice.</summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetInclusionListTransactionsHandler.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/GetInclusionListTransactionsHandler.cs
@@ -16,9 +16,10 @@ namespace Nethermind.Merge.Plugin.Handlers;
 public class GetInclusionListTransactionsHandler(
     ITxPool? txPool,
     IBlockTree blockTree,
-    ISpecProvider specProvider) : IHandler<Hash256?, InclusionListBytes>
+    ISpecProvider specProvider,
+    IMergeConfig mergeConfig) : IHandler<Hash256?, InclusionListBytes>
 {
-    private readonly InclusionListBuilder? _inclusionListBuilder = txPool is null ? null : new(txPool, blockTree, specProvider);
+    private readonly InclusionListBuilder? _inclusionListBuilder = txPool is null ? null : new(txPool, blockTree, specProvider, mergeConfig);
 
     /// <inheritdoc/>
     /// <param name="parentBlockHash">Block whose header fixes the next-block base fee the candidates are

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -104,8 +104,8 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
             Random.Shared.Shuffle(rest.AsSpan());
 
             ArrayPoolListRef<Transaction[]> senders = new(SenderSampleCapacity);
-            // Floored at the slots a uniform draw would have given the cohort, so a share below its weight in
-            // the pool leaves it where the tier off would: reserving cannot demote what it is meant to promote.
+            // Floored at the slots a uniform draw would have given the cohort, so reserving cannot demote what it
+            // is meant to promote. Both operands are pre-reservoir: capped counts would leak `rest`'s compression in.
             int uniformDraw = (int)((long)SenderSampleCapacity * oldestSeen / pending.Count);
             int reserved = int.Min(int.Max(_oldestSenderDraw, uniformDraw), oldest.Count);
             Take(ref senders, oldest.AsSpan()[..reserved]);

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -71,11 +71,13 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     /// <summary>Draws up to <see cref="SenderSampleCapacity"/> of the pending senders, in random order.</summary>
     /// <remarks>
     /// Uniform over the pool unless <see cref="IMergeConfig.InclusionListOldestSenderShare"/> reserves part of
-    /// the draw for a uniform sample of the longest-pending senders. Since the byte cap keeps only a random
-    /// prefix of the draw, that share is also the share of the list the cohort gets, which is what lifts the
-    /// odds of a transaction a builder keeps passing over. EIP-7805 leaves the strategy to the implementer and
-    /// names pending time as one; it is off by default because age is cheap to manufacture, so the tier costs
-    /// the honest sender its share of the draw exactly when the pool is being flooded.
+    /// the draw for a uniform sample of the longest-pending senders. The reservation is a floor, not a quota:
+    /// the cohort takes the larger of that share and the share a uniform draw would have given it, so raising
+    /// the share can never leave it worse represented than leaving the tier off. Since the byte cap keeps only
+    /// a random prefix of the draw, the cohort's share of the draw is its share of the list, which is what
+    /// lifts the odds of a transaction a builder keeps passing over. EIP-7805 leaves the strategy to the
+    /// implementer and names pending time as one; it is off by default because age is cheap to manufacture, so
+    /// the tier costs the honest sender its share of the draw exactly when the pool is being flooded.
     /// </remarks>
     private ArrayPoolListRef<Transaction[]> DrawSenders(IDictionary<AddressAsKey, Transaction[]> pending)
     {
@@ -102,7 +104,10 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
             Random.Shared.Shuffle(rest.AsSpan());
 
             ArrayPoolListRef<Transaction[]> senders = new(SenderSampleCapacity);
-            int reserved = int.Min(_oldestSenderDraw, oldest.Count);
+            // Floored at the slots a uniform draw would have given the cohort, so a share below its weight in
+            // the pool leaves it where the tier off would: reserving cannot demote what it is meant to promote.
+            int uniformDraw = (int)((long)SenderSampleCapacity * oldestSeen / pending.Count);
+            int reserved = int.Min(int.Max(_oldestSenderDraw, uniformDraw), oldest.Count);
             Take(ref senders, oldest.AsSpan()[..reserved]);
             Take(ref senders, rest.AsSpan());
             // Either tier spends what the other leaves rather than shrinking the draw.

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -23,8 +23,23 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     // Orders the age cohort newest first, so its head is the member an older sender displaces.
     private static readonly IComparer<ulong> NewestFirst = Comparer<ulong>.Create(static (a, b) => b.CompareTo(a));
 
-    private readonly int _oldestSenderDraw = (int)(double.Clamp(mergeConfig.InclusionListOldestSenderShare, 0, 1) * SenderSampleCapacity);
+    private readonly int _oldestSenderDraw = OldestSenderDraw(mergeConfig.InclusionListOldestSenderShare);
     private readonly int _oldestSenderCount = int.Max(0, mergeConfig.InclusionListOldestSenderCount);
+
+    /// <summary>Slots of the draw <see cref="IMergeConfig.InclusionListOldestSenderShare"/> reserves.</summary>
+    /// <remarks>Rounded up, so a share worth less than a whole slot still turns the tier on: truncating it to
+    /// zero would silently ship the default on a knob an operator is calibrating.</remarks>
+    /// <exception cref="ArgumentOutOfRangeException">The share is not a number between 0 and 1.</exception>
+    private static int OldestSenderDraw(double share)
+    {
+        if (!double.IsFinite(share) || share is < 0 or > 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(IMergeConfig.InclusionListOldestSenderShare), share,
+                $"{nameof(IMergeConfig.InclusionListOldestSenderShare)} must be between 0 and 1.");
+        }
+
+        return (int)double.Ceiling(share * SenderSampleCapacity);
+    }
 
     /// <summary>Draws pending transactions for an inclusion list, up to the per-list byte cap.</summary>
     /// <param name="parent">Header the next-block base fee is derived from; the head when null.</param>
@@ -162,10 +177,11 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
     /// whose next pending nonce reached this pool first.</summary>
     /// <remarks>
     /// A queue bounded to the cohort, so selecting it costs one pass and no sort of the pool. Selecting by rank
-    /// rather than against an absolute index keeps the cohort meaningful across the two ways the sequence lies:
+    /// rather than against an absolute index keeps the cohort well defined across the two ways the sequence lies:
     /// it restarts from zero with the process, and a reorg re-admits its transactions, re-stamping them as the
-    /// newest in the pool. Either only costs a transaction its place in the cohort, so neither can pass a new
-    /// arrival off as old.
+    /// newest in the pool. Neither can pass a new arrival off as old: a reorg costs its transactions their place
+    /// in the cohort, and a restart, since nothing persists the non-blob pool, ranks every sender by arrival
+    /// since startup until the pool turns over.
     /// </remarks>
     private static ulong OldestSenderBound(IDictionary<AddressAsKey, Transaction[]> pending, int cohortSize)
     {

--- a/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/Handlers/InclusionListBuilder.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Collections.Generic;
 using Nethermind.Blockchain;
 using Nethermind.Consensus.Decoders;
 using Nethermind.Core;
@@ -12,12 +13,18 @@ using Nethermind.TxPool;
 
 namespace Nethermind.Merge.Plugin.Handlers;
 
-public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecProvider specProvider)
+public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecProvider specProvider, IMergeConfig mergeConfig)
 {
     // Conservative lower bound for an encoded transaction's size.
     private const int MinTransactionSizeBytes = 32;
     // Senders drawn per list. The byte cap, not this, decides how many of them reach the wire.
     private const int SenderSampleCapacity = Eip7805Constants.MaxBytesPerInclusionList / MinTransactionSizeBytes;
+
+    // Orders the age cohort newest first, so its head is the member an older sender displaces.
+    private static readonly IComparer<ulong> NewestFirst = Comparer<ulong>.Create(static (a, b) => b.CompareTo(a));
+
+    private readonly int _oldestSenderDraw = (int)(double.Clamp(mergeConfig.InclusionListOldestSenderShare, 0, 1) * SenderSampleCapacity);
+    private readonly int _oldestSenderCount = int.Max(0, mergeConfig.InclusionListOldestSenderCount);
 
     /// <summary>Draws pending transactions for an inclusion list, up to the per-list byte cap.</summary>
     /// <param name="parent">Header the next-block base fee is derived from; the head when null.</param>
@@ -30,36 +37,15 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
 
     /// <summary>Draws candidate transactions for the list, round-robin across the drawn senders.</summary>
     /// <remarks>Restricted to each sender's appendable run from its next nonce, since nothing else could be
-    /// appended. Drawn uniformly, not by fee: a fee-ordered draw drops what a builder passes over.</remarks>
+    /// appended. Never drawn by fee: a fee-ordered draw drops what a builder passes over. See
+    /// <see cref="DrawSenders"/> for how the senders themselves are picked.</remarks>
     private ArrayPoolListRef<Transaction> SampleAppendableTxs(BlockHeader? parent)
     {
         const int capacity = SenderSampleCapacity;
-        Random rnd = Random.Shared;
         UInt256 baseFee = NextBlockBaseFee(parent);
 
-        using ArrayPoolListRef<Transaction[]> senders = new(capacity);
-        int seen = 0;
         // Blob txs cannot appear here: TxPool routes them to a separate pool this snapshot does not read.
-        foreach (Transaction[] bySender in txPool.GetPendingTransactionsBySender(filterToReadyTx: true, baseFee).Values)
-        {
-            if (senders.Count < capacity)
-            {
-                senders.Add(bySender);
-            }
-            else
-            {
-                int j = rnd.Next(seen + 1);
-                if (j < capacity) senders[j] = bySender;
-            }
-            seen++;
-        }
-
-        // The byte-cap loop below treats position as priority, so shuffle: membership alone isn't enough.
-        for (int i = senders.Count - 1; i > 0; i--)
-        {
-            int j = rnd.Next(i + 1);
-            (senders[i], senders[j]) = (senders[j], senders[i]);
-        }
+        using ArrayPoolListRef<Transaction[]> senders = DrawSenders(txPool.GetPendingTransactionsBySender(filterToReadyTx: true, baseFee));
 
         using ArrayPoolListRef<int> runLengths = new(capacity);
         foreach (Transaction[] bySender in senders) runLengths.Add(AppendableRunLength(bySender, in baseFee));
@@ -80,6 +66,114 @@ public class InclusionListBuilder(ITxPool txPool, IBlockTree blockTree, ISpecPro
             }
             if (!advanced) return sample;
         }
+    }
+
+    /// <summary>Draws up to <see cref="SenderSampleCapacity"/> of the pending senders, in random order.</summary>
+    /// <remarks>
+    /// Uniform over the pool unless <see cref="IMergeConfig.InclusionListOldestSenderShare"/> reserves part of
+    /// the draw for a uniform sample of the longest-pending senders. Since the byte cap keeps only a random
+    /// prefix of the draw, that share is also the share of the list the cohort gets, which is what lifts the
+    /// odds of a transaction a builder keeps passing over. EIP-7805 leaves the strategy to the implementer and
+    /// names pending time as one; it is off by default because age is cheap to manufacture, so the tier costs
+    /// the honest sender its share of the draw exactly when the pool is being flooded.
+    /// </remarks>
+    private ArrayPoolListRef<Transaction[]> DrawSenders(IDictionary<AddressAsKey, Transaction[]> pending)
+    {
+        // Nothing to reserve when the cohort is the whole pool, which also leaves the bound below defined.
+        if (_oldestSenderDraw == 0 || _oldestSenderCount == 0 || pending.Count <= _oldestSenderCount)
+            return SampleUniformly(pending);
+
+        ulong bound = OldestSenderBound(pending, _oldestSenderCount);
+        // Not `using`: a reservoir is offered to by reference, which a using variable cannot be.
+        ArrayPoolListRef<Transaction[]> oldest = new(SenderSampleCapacity);
+        ArrayPoolListRef<Transaction[]> rest = new(SenderSampleCapacity);
+        try
+        {
+            int oldestSeen = 0;
+            int restSeen = 0;
+            foreach (Transaction[] bySender in pending.Values)
+            {
+                if (bySender[0].PoolIndex <= bound) Offer(ref oldest, ref oldestSeen, bySender);
+                else Offer(ref rest, ref restSeen, bySender);
+            }
+
+            // Both tiers are read as a prefix below, so each has to be shuffled to sample it.
+            Random.Shared.Shuffle(oldest.AsSpan());
+            Random.Shared.Shuffle(rest.AsSpan());
+
+            ArrayPoolListRef<Transaction[]> senders = new(SenderSampleCapacity);
+            int reserved = int.Min(_oldestSenderDraw, oldest.Count);
+            Take(ref senders, oldest.AsSpan()[..reserved]);
+            Take(ref senders, rest.AsSpan());
+            // Either tier spends what the other leaves rather than shrinking the draw.
+            Take(ref senders, oldest.AsSpan()[reserved..]);
+
+            // The tier is a share of the draw, not of its order: the byte cap keeps only a prefix of it.
+            Random.Shared.Shuffle(senders.AsSpan());
+            return senders;
+        }
+        finally
+        {
+            oldest.Dispose();
+            rest.Dispose();
+        }
+
+        static void Take(ref ArrayPoolListRef<Transaction[]> draw, ReadOnlySpan<Transaction[]> tier) =>
+            draw.AddRange(tier[..int.Min(tier.Length, SenderSampleCapacity - draw.Count)]);
+    }
+
+    /// <summary>Reservoir-samples the pending senders, uniformly and in uniformly random order.</summary>
+    /// <remarks>Over senders rather than over their runs, so the pool's size costs no allocation: only the
+    /// drawn senders pay for a slot. Shuffled because the byte-cap loop treats position as priority, so
+    /// membership alone would not spread the draw.</remarks>
+    private static ArrayPoolListRef<Transaction[]> SampleUniformly(IDictionary<AddressAsKey, Transaction[]> pending)
+    {
+        ArrayPoolListRef<Transaction[]> senders = new(SenderSampleCapacity);
+        int seen = 0;
+        foreach (Transaction[] bySender in pending.Values) Offer(ref senders, ref seen, bySender);
+
+        Random.Shared.Shuffle(senders.AsSpan());
+        return senders;
+    }
+
+    /// <summary>Offers one sender to a reservoir holding a uniform sample of what it has been offered.</summary>
+    /// <param name="seen">Senders offered to this reservoir so far; advanced by the call.</param>
+    private static void Offer(ref ArrayPoolListRef<Transaction[]> reservoir, ref int seen, Transaction[] bySender)
+    {
+        if (reservoir.Count < SenderSampleCapacity)
+        {
+            reservoir.Add(bySender);
+        }
+        else
+        {
+            int j = Random.Shared.Next(seen + 1);
+            if (j < SenderSampleCapacity) reservoir[j] = bySender;
+        }
+
+        seen++;
+    }
+
+    /// <summary>The highest <see cref="Transaction.PoolIndex"/> among the <paramref name="cohortSize"/> senders
+    /// whose next pending nonce reached this pool first.</summary>
+    /// <remarks>
+    /// A queue bounded to the cohort, so selecting it costs one pass and no sort of the pool. Selecting by rank
+    /// rather than against an absolute index keeps the cohort meaningful across the two ways the sequence lies:
+    /// it restarts from zero with the process, and a reorg re-admits its transactions, re-stamping them as the
+    /// newest in the pool. Either only costs a transaction its place in the cohort, so neither can pass a new
+    /// arrival off as old.
+    /// </remarks>
+    private static ulong OldestSenderBound(IDictionary<AddressAsKey, Transaction[]> pending, int cohortSize)
+    {
+        PriorityQueue<ulong, ulong> cohort = new(cohortSize, NewestFirst);
+        foreach (Transaction[] bySender in pending.Values)
+        {
+            ulong poolIndex = bySender[0].PoolIndex;
+            if (cohort.Count < cohortSize) cohort.Enqueue(poolIndex, poolIndex);
+            else if (poolIndex < cohort.Peek()) cohort.EnqueueDequeue(poolIndex, poolIndex);
+        }
+
+        // The caller only asks for a cohort smaller than the pool, so the queue is never empty here.
+        return cohort.Peek();
     }
 
     /// <summary>How many leading transactions of <paramref name="bySender"/> the next block could append.</summary>

--- a/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
@@ -79,10 +79,16 @@ public interface IMergeConfig : IConfig
     [ConfigItem(Description = """
             [EXPERIMENTAL] The share, from `0` to `1`, of an EIP-7805 inclusion list drawn from the longest-pending senders. `0` draws the whole list uniformly over the transaction pool.
 
-            A non-zero share raises the odds that a transaction a builder keeps passing over reaches a list, but it also weakens the list against a flooded pool, since pending age costs an attacker nothing but time. Measure before enabling it on a live network.
+            A floor rather than a quota: the cohort gets this share or the share a uniform draw would have given it, whichever is larger, so a share below `InclusionListOldestSenderCount` divided by the pool size changes nothing.
+
+            A non-zero share raises the odds that a transaction a builder keeps passing over reaches a list, but it also weakens the list against a flooded pool, since pending age costs an attacker nothing but time. Age is measured from when the pool accepted the sender's next pending transaction, so replacing it — a fee bump, for instance — restamps it as newly arrived and drops the sender out of the cohort. Measure before enabling it on a live network.
             """, DefaultValue = "0", HiddenFromDocs = true)]
     double InclusionListOldestSenderShare { get; set; }
 
-    [ConfigItem(Description = "[EXPERIMENTAL] How many of the longest-pending senders `InclusionListOldestSenderShare` samples from. Ignored when that share is `0`, and pools no larger than this are drawn uniformly. Keep it well above the share's part of the 256 senders a list draws, or every committee member samples the same fixed set of senders.", DefaultValue = "200", HiddenFromDocs = true)]
+    [ConfigItem(Description = """
+            [EXPERIMENTAL] How many of the longest-pending senders `InclusionListOldestSenderShare` samples from. Ignored when that share is `0`, and pools no larger than this are drawn uniformly.
+
+            It sets both sides of the trade at once: it is what an attacker must outbid to crowd the cohort out, and it is the cohort's weight in the pool, which is the share below which the knob does nothing. Keep it well above the share's part of the 256 senders a list draws, or every committee member samples the same fixed set of senders.
+            """, DefaultValue = "200", HiddenFromDocs = true)]
     int InclusionListOldestSenderCount { get; set; }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
@@ -75,4 +75,14 @@ public interface IMergeConfig : IConfig
 
     [ConfigItem(Description = "Delay, in milliseconds, between `newPayload` and GC trigger. If not set, defaults to 1/8th of `Blocks.SecondsPerSlot`.", DefaultValue = null, HiddenFromDocs = true)]
     int? PostBlockGcDelayMs { get; set; }
+
+    [ConfigItem(Description = """
+            [EXPERIMENTAL] The share, from `0` to `1`, of an EIP-7805 inclusion list drawn from the longest-pending senders. `0` draws the whole list uniformly over the transaction pool.
+
+            A non-zero share raises the odds that a transaction a builder keeps passing over reaches a list, but it also weakens the list against a flooded pool, since pending age costs an attacker nothing but time. Measure before enabling it on a live network.
+            """, DefaultValue = "0", HiddenFromDocs = true)]
+    double InclusionListOldestSenderShare { get; set; }
+
+    [ConfigItem(Description = "[EXPERIMENTAL] How many of the longest-pending senders `InclusionListOldestSenderShare` samples from. Ignored when that share is `0`, and pools no larger than this are drawn uniformly. Keep it well above the share's part of the 256 senders a list draws, or every committee member samples the same fixed set of senders.", DefaultValue = "200", HiddenFromDocs = true)]
+    int InclusionListOldestSenderCount { get; set; }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/IMergeConfig.cs
@@ -77,7 +77,7 @@ public interface IMergeConfig : IConfig
     int? PostBlockGcDelayMs { get; set; }
 
     [ConfigItem(Description = """
-            [EXPERIMENTAL] The share, from `0` to `1`, of an EIP-7805 inclusion list drawn from the longest-pending senders. `0` draws the whole list uniformly over the transaction pool.
+            [EXPERIMENTAL] The share, from `0` to `1`, of an EIP-7805 inclusion list drawn from the longest-pending senders. `0` draws the whole list uniformly over the transaction pool; anything outside that range is rejected at startup.
 
             A floor rather than a quota: the cohort gets this share or the share a uniform draw would have given it, whichever is larger, so a share below `InclusionListOldestSenderCount` divided by the pool size changes nothing.
 
@@ -88,7 +88,7 @@ public interface IMergeConfig : IConfig
     [ConfigItem(Description = """
             [EXPERIMENTAL] How many of the longest-pending senders `InclusionListOldestSenderShare` samples from. Ignored when that share is `0`, and pools no larger than this are drawn uniformly.
 
-            It sets both sides of the trade at once: it is what an attacker must outbid to crowd the cohort out, and it is the cohort's weight in the pool, which is the share below which the knob does nothing. Keep it well above the share's part of the 256 senders a list draws, or every committee member samples the same fixed set of senders.
+            It sets both sides of the trade at once: it is what an attacker must outbid to crowd the cohort out, and it is the cohort's weight in the pool, which is the share below which the knob does nothing. Keep it well above the share's part of the senders a list draws, or every committee member samples the same fixed set of senders.
             """, DefaultValue = "200", HiddenFromDocs = true)]
     int InclusionListOldestSenderCount { get; set; }
 }

--- a/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin/MergeConfig.cs
@@ -38,5 +38,8 @@ namespace Nethermind.Merge.Plugin
 
         public bool SimulateBlockProduction { get; set; } = false;
         public int? PostBlockGcDelayMs { get; set; } = null;
+
+        public double InclusionListOldestSenderShare { get; set; } = 0;
+        public int InclusionListOldestSenderCount { get; set; } = 200;
     }
 }


### PR DESCRIPTION
Stacked on #13383 — its commit is the first of the three here, so review the second and third (or rebase this onto that branch once it merges).

## Changes

- `InclusionListBuilder` can reserve a share of its 256-sender draw for a uniform sample of the longest-pending senders, ranked by `Transaction.PoolIndex`. The byte cap keeps a random prefix of the shuffled draw, so that share is also the share of a list's entries the cohort gets.
- The reservation is a **floor, not a quota**: the cohort takes the larger of the configured share and the share a uniform draw would have given it. Without that floor, a share below the cohort's weight in the pool *demoted* the senders the knob exists to promote — with a 160-of-800 cohort, a `0.02` share listed them at 0.019 and `0.05` at 0.051, against the 0.20 a uniform draw gives. Shares above the crossover are unchanged.
- Two new hidden `Merge` settings, both **experimental** and the feature **off by default**: `InclusionListOldestSenderShare` (`0`, i.e. today's uniform draw) and `InclusionListOldestSenderCount` (`200`, the cohort the sample is taken from).
- The uniform draw is unchanged when the share is `0`; the cohort selection costs one extra pass and a bounded queue, never a sort of the pool.

## Types of changes

- [x] New feature (a non-breaking change that adds functionality)

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`InclusionListBuilderTests` — distributions, not orderings, since the draw is shuffled: the share of listed transactions coming from the oldest cohort across 60 draws, the caps under both settings, and that neither tier running short narrows the draw. Red/green checked by removing the spill fill, the final shuffle, and the tier branch in turn.

`Reserved_share_is_a_floor_under_what_the_oldest_cohort_gets` pins the floor at `0.02` and `0.05`, the sub-crossover shares where the inversion was worst. Red/green control: with the floor removed the two cases measure 0.019 and 0.051 and the other six are unaffected, so the fix is confined to the region it is meant to change. Eight repeat runs of the case list are green at the existing ±0.04 tolerance, which is wide enough for the sampling variance without being widened for this change.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Why it ships off. EIP-7805 leaves list building to the implementer and names pending time as a legitimate input, and a uniform draw leaves a censored transaction's odds at a list's entries over the ready pool. But age is free to manufacture: uniform sampling scales an attacker's share with funded accounts, age bias scales it with accounts × time. Modelled at 20–32 entries per list (from real RLP sizes: 117 B legacy transfer, 129 B EIP-1559, 198 B ERC-20, 520 B router swap) and 2000 ready senders, reserving half the draw for the oldest 200 lifts P(listed by ≥1 of 16) from 15–23% to 56–74%, but an attacker owning that cohort drops it to 9–13%, below uniform. "Ready" also only means the next base fee is payable, so the honest old cohort is dominated by transactions being outbid rather than censored. Worth measuring on a devnet; not worth defaulting on.

### Known limitation — do not calibrate off the model above

The 2000-ready-sender figure in that model is not what mainnet looks like. Sampling `txpool_content` (n=1046, indicative rather than solid) puts the **ready sender count at ~103 on average, range 12–241**, with **~27–30 entries per list** — the entry count matches the model, the pool size does not, by a factor of 20.

At that pool size an absolute `InclusionListOldestSenderCount` cannot do its job. The default of `200` puts the whole pool inside the cohort almost always, and even `100` does so about half the time; whenever the pool is no larger than the cohort every sender is "oldest", the non-cohort tier is empty, and the draw is the uniform one — the feature is **inert**. The floor above makes that degradation graceful (inert, not distorting), but inert is still inert.

The suggested fix is to express the cohort as a **fraction of the ready set** rather than an absolute count, so it has a stable weight for the share to be measured against. That is a design change and is deliberately **not** implemented here; it needs sign-off before the knob is worth calibrating on a devnet.

### Sender age is reset by replacement

Age is `PoolIndex` on the sender's next pending transaction, and the pool stamps a fresh index on every accepted transaction. Replacing that transaction — a fee bump, most commonly — therefore restamps the sender as newly arrived and drops it out of the cohort. This is documented rather than fixed: `PoolIndex` is also the arrival-order tie-break in `TransactionComparerProvider`, so carrying it forward across a replacement would change block-production ordering pool-wide, well outside the scope of an off-by-default list-building knob.

`PoolIndex` over `Timestamp`: no clock dependency, and the reorg re-add path leaves `Timestamp` at zero. The cohort is selected by rank rather than against an absolute index, so a pool whose sequence restarted with the process still yields one, and a reorg-re-stamped transaction only loses its place in it — neither failure can pass a new arrival off as old.
