### PR TITLE
perf: reduce the MODEXP base before exponentiating

### DIFF
--- a/src/Nethermind/Nethermind.Benchmark/Precompiles/ModExpVectorBenchmark.cs
+++ b/src/Nethermind/Nethermind.Benchmark/Precompiles/ModExpVectorBenchmark.cs
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Nethermind.Core.Extensions;
+using Nethermind.Evm.Precompiles;
+using Nethermind.Specs.Forks;
+
+namespace Nethermind.Benchmarks.Precompiles;
+
+/// <summary>The MODEXP worst-case vectors from the execution-spec benchmark suite.</summary>
+/// <remarks>
+/// Each adversarial vector has a base that is either equal to the modulus or one above it, so the base
+/// reduces to 0 or 1 and the exponentiation is constant. <see cref="Ordinary1024"/> is the control: a base
+/// that reduces to neither, so the full ladder runs and the reduction is pure overhead.
+/// </remarks>
+[MemoryDiagnoser]
+public class ModExpVectorBenchmark
+{
+    private const string F8 = "ffffffffffffffff";
+    private const string F16 = F8 + F8;
+    private const string F24 = F16 + F8;
+    private const string F32 = F16 + F16;
+    private const string F64 = F32 + F32;
+    private const string F128 = F64 + F64;
+
+    private static string Repeat(string hex, int times)
+    {
+        StringBuilder builder = new(hex.Length * times);
+        for (int i = 0; i < times; i++)
+        {
+            builder.Append(hex);
+        }
+        return builder.ToString();
+    }
+
+    private static byte[] Encode(string @base, string exponent, string modulus)
+    {
+        byte[] baseBytes = Bytes.FromHexString(@base);
+        byte[] exponentBytes = Bytes.FromHexString(exponent);
+        byte[] modulusBytes = Bytes.FromHexString(modulus);
+
+        byte[] input = new byte[96 + baseBytes.Length + exponentBytes.Length + modulusBytes.Length];
+        input[31] = (byte)baseBytes.Length;
+        input[63] = (byte)exponentBytes.Length;
+        input[95] = (byte)modulusBytes.Length;
+        baseBytes.CopyTo(input, 96);
+        exponentBytes.CopyTo(input, 96 + baseBytes.Length);
+        modulusBytes.CopyTo(input, 96 + baseBytes.Length + exponentBytes.Length);
+        return input;
+    }
+
+    private byte[] _zkEvmWorstCase = null!;
+    private byte[] _pawel1 = null!;
+    private byte[] _pawel4 = null!;
+    private byte[] _ordinary1024 = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _zkEvmWorstCase = Encode(F32, F32, F32[..62] + "fe");
+        _pawel1 = Encode(F8, F64, F8);
+        _pawel4 = Encode(F32, F24, F32);
+        _ordinary1024 = Encode(Repeat("03", 128), F128, F128);
+    }
+
+    [Benchmark]
+    public int ZkEvmWorstCase() => ModExpPrecompile.Instance.Run(_zkEvmWorstCase, Osaka.Instance).Data!.Length;
+
+    [Benchmark]
+    public int Pawel1ExpHeavy() => ModExpPrecompile.Instance.Run(_pawel1, Osaka.Instance).Data!.Length;
+
+    [Benchmark]
+    public int Pawel4ExpHeavy() => ModExpPrecompile.Instance.Run(_pawel4, Osaka.Instance).Data!.Length;
+
+    [Benchmark]
+    public int Ordinary1024() => ModExpPrecompile.Instance.Run(_ordinary1024, Osaka.Instance).Data!.Length;
+}

--- a/src/Nethermind/Nethermind.Evm.Precompiles/std/ModExpPrecompile.cs
+++ b/src/Nethermind/Nethermind.Evm.Precompiles/std/ModExpPrecompile.cs
@@ -66,6 +66,20 @@ public unsafe partial class ModExpPrecompile
                 Gmp.mpz_import(expInt, expLength, 1, 1, 1, nuint.Zero, (nint)expData);
         }
 
+        // Reduce the base before exponentiating. EIP-198 leaves the result unchanged, but a base that
+        // falls to 0 or 1 makes the whole ladder constant, and the adversarial vectors in the execution-spec
+        // benchmark suite are exactly that shape: the base is either equal to the modulus or one above it.
+        Gmp.mpz_mod(baseInt, baseInt, modulusInt);
+
+        if (Gmp.mpz_cmp_ui(baseInt, 1) <= 0 && Gmp.mpz_sgn(expInt) != 0)
+        {
+            byte[] trivial = new byte[modulusLength];
+            // A reduced base of 1 raises to 1, which the modulus cannot be here since it would have reduced to 0.
+            if (Gmp.mpz_sgn(baseInt) != 0)
+                trivial[modulusLength - 1] = 1;
+            return trivial;
+        }
+
         Gmp.mpz_powm(powmResult, baseInt, expInt, modulusInt);
 
         nint powmResultLen = (nint)(Gmp.mpz_sizeinbase(powmResult, 2) + 7) / 8;

--- a/src/Nethermind/Nethermind.Evm.Test/ModExpPrecompileTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/ModExpPrecompileTests.cs
@@ -76,4 +76,81 @@ public class ModExpPrecompileTests : PrecompileTests<ModExpPrecompile, ModExpPre
             { TestName = "baseLen=uint32.MaxValue-68 (0xffffffbb): huge baseLength wraps exponent offset to header, must return zero (pre-EIP-7823)" };
         }
     }
+
+    [TestCaseSource(nameof(ReducibleBases))]
+    public void TestReducibleBase(string input, string expectedOutput, bool status)
+    {
+        RunTest(input, expectedOutput, status, Prague.Instance);
+        RunTest(input, expectedOutput, status, Osaka.Instance);
+    }
+
+    /// <summary>Bases that reduce to 0 or 1 modulo the modulus, which skip the exponentiation ladder.</summary>
+    public static IEnumerable<TestCaseData<string, string, bool>> ReducibleBases
+    {
+        get
+        {
+            yield return new(
+                "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001070507",
+                "00",
+                true
+            )
+            { TestName = "base equal to the modulus reduces to 0" };
+
+            yield return new(
+                "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001080507",
+                "01",
+                true
+            )
+            { TestName = "base one above the modulus reduces to 1" };
+
+            yield return new(
+                "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001080007",
+                "01",
+                true
+            )
+            { TestName = "a zero exponent is 1 even when the base reduces to 1" };
+
+            yield return new(
+                "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001070007",
+                "01",
+                true
+            )
+            { TestName = "0^0 is 1 when the base reduces to 0" };
+
+            yield return new(
+                "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001080501",
+                "00",
+                true
+            )
+            { TestName = "a modulus of 1 always yields 0" };
+
+            yield return new(
+                "000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000001",
+                "00",
+                true
+            )
+            { TestName = "0^0 modulo 1 is 0" };
+
+            yield return new(
+                "000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
+                "0000000000000000000000000000000000000000000000000000000000000001",
+                true
+            )
+            { TestName = "zkevm worst case: 2^256-1 modulo 2^256-2 reduces to 1" };
+
+            yield return new(
+                "000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000008ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "0000000000000000",
+                true
+            )
+            { TestName = "exp_heavy: base equal to the modulus reduces to 0" };
+
+            yield return new(
+                "000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000180000000000000000000000000000000000000000000000000000000000000020ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "0000000000000000000000000000000000000000000000000000000000000000",
+                true
+            )
+            { TestName = "exp_heavy: a 32-byte base equal to the modulus reduces to 0" };
+        }
+    }
 }


### PR DESCRIPTION
## Changes

The adversarial MODEXP vectors in the execution-spec benchmark suite all share one shape, and it is
not the one the name suggests. `mod_vul_pawel_1..4_exp_heavy` use a base **equal to the modulus**
(both all-`0xff`, same length), so the base reduces to 0. `mod_vul_zkevm_worst_case` uses
base = 2^256-1 against modulus = 2^256-2, so the base reduces to **1**. In every case the
exponentiation is constant regardless of the exponent — and GMP was running the full ladder anyway.

- Reduce the base modulo the modulus before `mpz_powm`, and short-circuit when it lands on 0 or 1.
  EIP-198 leaves the result unchanged.
- Adds `ModExpVectorBenchmark` covering three adversarial vectors plus an ordinary 1024-bit control.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

Nine cases in `ModExpPrecompileTests.ReducibleBases` covering both new branches and the edges around
them: base equal to the modulus, base one above it, a zero exponent over each (`0^0` is 1, not 0), a
modulus of 1, and the three real benchmark vectors.

**These pass on unpatched `master` as well.** That is the point of them — they encode EIP-198
behaviour rather than this optimization's behaviour, so they would catch a regression here rather than
merely agreeing with it. Verified by stashing the precompile change and running them against the
untouched implementation.

`Nethermind.Evm.Test` 12,356 passed / 0 failed, including the EF `modexp_eip2565.json` and
`modexp_eip7883.json` fixtures the suite already runs.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

**Measured**, `--job short --inProcess`, Osaka:

| vector | before | after | |
|---|---:|---:|---|
| `mod_vul_zkevm_worst_case` | 9.223 us | **546 ns** | 16.9x |
| `mod_vul_pawel_1_exp_heavy` | 4.085 us | **418 ns** | 9.8x |
| `mod_vul_pawel_4_exp_heavy` | 6.460 us | **480 ns** | 13.5x |
| ordinary 1024-bit base/exp/mod | 346.5 us | 293.9 us | no regression |

The control matters more than the wins: reducing the base is an extra division on **every** modexp,
including the ones that go on to run the full ladder. It does not cost anything measurable there —
GMP already reduces the base internally, so this mostly moves work rather than adding it. The
1024-bit row moved less than its own run-to-run spread, so read it as flat rather than as a 15% win.

**Why this is worth having beyond the benchmark.** These are the `vul` vectors — the shapes chosen to
maximise work per unit of gas. On the ethpandaops comparison runs ethrex was 12x ahead of Nethermind
on `zkevm_worst_case` and reth was slower still than both; the reduction is what ethrex was doing.
This narrows the worst case by an order of magnitude for any client that adopts it.

**How this was found.** Timing the precompile directly ruled out the obvious suspect first: at 10 us
per call Nethermind was allocating only 56 B, so the GMP interop overhead (4 `mpz_t` creations, ~12
P/Invokes) could not have been the story, and the cost had to be in the ladder itself. Reading the
vectors after that made the shared structure obvious.
