### PR TITLE
EIP-8141: keep every executed frame in callTracer output

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -23,11 +23,29 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     // attached to the current frame transaction's receipt; reset at the start of every tx trace.
     private Address? _frameTxPayer;
     private TxFrameReceipt[]? _frameTxReceipts;
+    private IFrameTxReceiptTracer? _currentFrameTxTracer;
 
     public void ReportFrameTxReceipt(Address payer, TxFrameReceipt[] frameReceipts)
     {
         _frameTxPayer = payer;
         _frameTxReceipts = frameReceipts;
+        _currentFrameTxTracer?.ReportFrameTxReceipt(payer, frameReceipts);
+    }
+
+    public void ReportFrameEnd(int frameIndex, EvmExceptionType? error) =>
+        _currentFrameTxTracer?.ReportFrameEnd(frameIndex, error);
+
+    /// <summary>The innermost tracer of <paramref name="tracer"/> that takes EIP-8141 frame reports.</summary>
+    /// <remarks>The tracing RPCs hand the processor a wrapped tracer, so the capability is reached through
+    /// the wrapper chain rather than on the outermost one.</remarks>
+    private static IFrameTxReceiptTracer? FrameTxTracerOf(ITxTracer tracer)
+    {
+        while (true)
+        {
+            if (tracer is IFrameTxReceiptTracer frameTxTracer) return frameTxTracer;
+            if (tracer is not ITxTracerWrapper wrapper) return null;
+            tracer = wrapper.InnerTracer;
+        }
     }
     protected Block Block = null!;
     public bool IsTracingReceipt => true;
@@ -352,6 +370,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         _currentIndex = 0;
         CurrentTx = null;
         _currentTxTracer = NullTxTracer.Instance;
+        _currentFrameTxTracer = null;
         int txCount = parallel ? 1 : block.Transactions.Length;
         _txReceipts.Clear();
         _txReceipts.EnsureCapacity(txCount);
@@ -391,6 +410,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     {
         _otherTracer = NullBlockTracer.Instance;
         _currentTxTracer = NullTxTracer.Instance;
+        _currentFrameTxTracer = null;
         Block = null!;
         CurrentTx = null;
         _currentIndex = 0;
@@ -409,6 +429,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
         _frameTxPayer = null;
         _frameTxReceipts = null;
         _currentTxTracer = _otherTracer.StartNewTxTrace(tx);
+        _currentFrameTxTracer = FrameTxTracerOf(_currentTxTracer);
         return _currentTxTracer;
     }
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -37,7 +37,8 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
 
     /// <summary>The innermost tracer of <paramref name="tracer"/> that takes EIP-8141 frame reports.</summary>
     /// <remarks>The tracing RPCs hand the processor a wrapped tracer, so the capability is reached through
-    /// the wrapper chain rather than on the outermost one.</remarks>
+    /// the wrapper chain rather than on the outermost one. A <see cref="CompositeTxTracer"/> is not a wrapper
+    /// and ends the walk; no tracing RPC builds one, and a chain that did would need this to fan out.</remarks>
     private static IFrameTxReceiptTracer? FrameTxTracerOf(ITxTracer tracer)
     {
         while (true)

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -10,6 +10,7 @@ using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Evm;
+using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.Serialization.Json;
@@ -25,17 +26,23 @@ namespace Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 // withLog (default = false): Logs emitted during each call will also be collected and included in the result.
 //
 // An EIP-8141 frame transaction runs every frame as its own top-level invocation, so it has no single
-// root call. Its trace is rooted in one synthetic transaction frame whose children are the executed
-// frames in order, which keeps the result a single CallFrame for consumers that walk `calls`.
-public sealed class NativeCallTracer : GethLikeNativeTxTracer
+// root call. Its trace is rooted in one synthetic transaction frame whose children are its frames, so
+// that `calls[i]` is `tx.Frames[i]` and the result stays a single CallFrame for consumers that walk
+// `calls`. Two deliberate divergences follow: onlyTopCall still returns that root with its frames as
+// children, and a frame that never entered the VM is rendered from the transaction's frame list.
+public sealed class NativeCallTracer : GethLikeNativeTxTracer, IFrameTxReceiptTracer
 {
     public const string CallTracer = "callTracer";
+
+    /// <summary>Error reported for a frame an unrolled atomic batch or a failed assertion never ran.</summary>
+    private const string SkippedFrameError = "frame skipped";
 
     private readonly ulong _gasLimit;
     private readonly Hash256? _txHash;
     private readonly bool _isEip8037Enabled;
     private readonly bool _isFrameTx;
     private readonly Address? _sender;
+    private readonly TxFrame[]? _frames;
     private readonly NativeCallTracerConfig _config;
     private readonly ArrayPoolList<NativeCallTracerCallFrame> _callStack = new(1024);
     private readonly CompositeDisposable _disposables = [];
@@ -44,6 +51,10 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
     private ulong _remainingGas;
     private bool _resultBuilt = false;
     private bool _framesCollapsed = false;
+    private NativeCallTracerCallFrame?[]? _frameRoots;
+    private EvmExceptionType?[]? _frameErrors;
+    private TxFrameReceipt[]? _frameReceipts;
+    private int _rootsClaimed;
 
     public NativeCallTracer(
         Transaction? tx,
@@ -56,6 +67,7 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         _isEip8037Enabled = spec.IsEip8037Enabled;
         _isFrameTx = tx.SupportsFrames;
         _sender = tx.SenderAddress;
+        _frames = _isFrameTx ? tx.Frames : null;
 
         _config = options.TracerConfig?.Deserialize<NativeCallTracerConfig>(EthereumJsonSerializer.JsonOptions) ?? new NativeCallTracerConfig();
 
@@ -225,7 +237,13 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         if (output is not null)
             firstCallFrame.Output = new ArrayPoolList<byte>(output);
 
-        if (_error is not null)
+        if (_isFrameTx)
+        {
+            // A frame transaction fails at the transaction level — a POST_TX frame failing before dispatch
+            // reports no EVM error at all — so the reason the processor gives is the root's.
+            firstCallFrame.Error = error ?? EvmExceptionType.Revert.GetEvmExceptionDescription();
+        }
+        else if (_error is not null)
         {
             EvmExceptionType errorType = _error.Value;
             MarkFrameFailed(firstCallFrame, errorType);
@@ -237,16 +255,48 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
 
         if (_config.WithLog)
         {
-            ClearFailedLogs(firstCallFrame, parentFailed: true);
+            // A frame transaction's committed frames keep their logs through a transaction-level failure,
+            // exactly as the receipt does; the frames that lost theirs were cleared against their receipt.
+            ClearFailedLogs(firstCallFrame, parentFailed: !_isFrameTx);
+        }
+    }
+
+    /// <inheritdoc/>
+    public void ReportFrameTxReceipt(Address payer, TxFrameReceipt[] frameReceipts)
+    {
+        // The validation-prefix simulation reports an empty set, which pins no frame's outcome.
+        if (frameReceipts.Length > 0)
+        {
+            _frameReceipts = frameReceipts;
+        }
+
+        CollapseFrameRoots();
+    }
+
+    /// <inheritdoc/>
+    public void ReportFrameEnd(int frameIndex, EvmExceptionType? error)
+    {
+        if (_frames is null || (uint)frameIndex >= (uint)_frames.Length) return;
+
+        _frameRoots ??= new NativeCallTracerCallFrame?[_frames.Length];
+        _frameErrors ??= new EvmExceptionType?[_frames.Length];
+        _frameErrors[frameIndex] = error;
+
+        // Only a frame that entered the VM pushed a root, and it pushed exactly one.
+        if (_callStack.Count > _rootsClaimed)
+        {
+            _frameRoots[frameIndex] = _callStack[_rootsClaimed++];
         }
     }
 
     /// <summary>Roots an EIP-8141 frame transaction's trace in one synthetic transaction frame whose
-    /// children are the executed frames, in execution order.</summary>
-    /// <remarks>A frame transaction has no single root call: each frame is its own top-level invocation,
-    /// so without this every frame after the first is dropped from the result. The synthetic root keeps the
-    /// trace a single <c>CallFrame</c>, and is the only frame carrying the transaction-wide gas figures.
-    /// Idempotent, because both the receipt callbacks and <see cref="BuildResult"/> reach it.</remarks>
+    /// children are its frames, in frame order.</summary>
+    /// <remarks>A frame transaction has no single root call: each frame is its own top-level invocation, so
+    /// without this every frame after the first is dropped from the result. Children come from the per-frame
+    /// receipts rather than from the VM roots, because a frame that fails before dispatch — and a
+    /// <c>VERIFY</c> frame running the default code — never enters the VM, and because only the receipt says
+    /// which frames kept their logs. The synthetic root is the only frame carrying the transaction-wide gas
+    /// figures. Idempotent, because both the receipt callbacks and <see cref="BuildResult"/> reach it.</remarks>
     private void CollapseFrameRoots()
     {
         if (!_isFrameTx || _framesCollapsed) return;
@@ -257,17 +307,65 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
             Type = Instruction.CALL,
             From = _sender,
             To = Eip8141Constants.EntryPointAddress,
-            Gas = _gasLimit
+            Gas = _gasLimit,
+            Value = UInt256.Zero
         };
 
-        foreach (NativeCallTracerCallFrame frameRoot in _callStack.AsSpan())
+        int rootsTaken = 0;
+        if (_frameReceipts is not null && _frames is not null && _frameRoots is not null)
         {
-            txCallFrame.Calls.Add(frameRoot);
+            rootsTaken = _rootsClaimed;
+            int frameCount = Math.Min(_frameReceipts.Length, _frames.Length);
+            for (int i = 0; i < frameCount; i++)
+            {
+                TxFrameReceipt frameReceipt = _frameReceipts[i];
+                NativeCallTracerCallFrame frameCallFrame = _frameRoots[i] ?? BuildUndispatchedFrame(i, frameReceipt);
+
+                if (_config.WithLog && frameReceipt.Logs.Length == 0)
+                {
+                    // The receipt is what the frame committed: an unrolled atomic batch and a POST_TX
+                    // rollback both keep the frame's success status while dropping its logs.
+                    ClearFailedLogs(frameCallFrame, parentFailed: true);
+                }
+
+                txCallFrame.Calls.Add(frameCallFrame);
+            }
+        }
+
+        // Everything left over, so no root is dropped on a path that reports no receipts.
+        for (int i = rootsTaken; i < _callStack.Count; i++)
+        {
+            txCallFrame.Calls.Add(_callStack[i]);
         }
 
         _callStack.Clear();
         _callStack.Add(txCallFrame);
     }
+
+    /// <summary>Renders a frame that never entered the VM from the transaction's own frame list.</summary>
+    private NativeCallTracerCallFrame BuildUndispatchedFrame(int frameIndex, TxFrameReceipt frameReceipt)
+    {
+        TxFrame frame = _frames![frameIndex];
+        bool isStatic = frame.Mode is TxFrame.ModeVerify or TxFrame.ModePostTx;
+        return new NativeCallTracerCallFrame
+        {
+            Type = isStatic ? Instruction.STATICCALL : Instruction.CALL,
+            From = frame.Mode == TxFrame.ModeSender ? _sender : Eip8141Constants.EntryPointAddress,
+            To = frame.Target ?? _sender,
+            Gas = frame.GasLimit,
+            GasUsed = frameReceipt.GasUsed,
+            Value = isStatic ? null : frame.Value,
+            Input = frame.Data.Span.ToPooledList(),
+            Error = UndispatchedFrameError(frameIndex, frameReceipt)
+        };
+    }
+
+    private string? UndispatchedFrameError(int frameIndex, TxFrameReceipt frameReceipt) => frameReceipt.Status switch
+    {
+        TxFrameReceipt.StatusSuccess => null,
+        TxFrameReceipt.StatusSkipped => SkippedFrameError,
+        _ => (_frameErrors?[frameIndex] ?? EvmExceptionType.Revert).GetEvmExceptionDescription()
+    };
 
     private void ApplyTwoDimensionalGas(NativeCallTracerCallFrame firstCallFrame, in GasConsumed gasSpent)
     {

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -29,7 +29,8 @@ namespace Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 // root call. Its trace is rooted in one synthetic transaction frame whose children are its frames, so
 // that `calls[i]` is `tx.Frames[i]` and the result stays a single CallFrame for consumers that walk
 // `calls`. Two deliberate divergences follow: onlyTopCall still returns that root with its frames as
-// children, and a frame that never entered the VM is rendered from the transaction's frame list.
+// children, and a frame that never entered the VM is rendered from the transaction's frame list. Every
+// frame's gas and gasUsed are its declared limit and its receipt's spend, so siblings read alike.
 public sealed class NativeCallTracer : GethLikeNativeTxTracer, IFrameTxReceiptTracer
 {
     public const string CallTracer = "callTracer";
@@ -255,21 +256,30 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer, IFrameTxReceiptTr
 
         if (_config.WithLog)
         {
-            // A frame transaction's committed frames keep their logs through a transaction-level failure,
-            // exactly as the receipt does; the frames that lost theirs were cleared against their receipt.
-            ClearFailedLogs(firstCallFrame, parentFailed: !_isFrameTx);
+            if (_isFrameTx)
+            {
+                // The synthetic root's error is transaction-level, so it must not propagate: the committed
+                // frames keep their logs as the receipt does, having been cleared against it already.
+                foreach (NativeCallTracerCallFrame frameCallFrame in firstCallFrame.Calls.AsSpan())
+                {
+                    ClearFailedLogs(frameCallFrame, parentFailed: false);
+                }
+            }
+            else
+            {
+                ClearFailedLogs(firstCallFrame, parentFailed: true);
+            }
         }
     }
 
     /// <inheritdoc/>
     public void ReportFrameTxReceipt(Address payer, TxFrameReceipt[] frameReceipts)
     {
-        // The validation-prefix simulation reports an empty set, which pins no frame's outcome.
-        if (frameReceipts.Length > 0)
-        {
-            _frameReceipts = frameReceipts;
-        }
+        // The validation-prefix simulation reports an empty set, which pins no frame's outcome and so
+        // must not collapse the result either.
+        if (frameReceipts.Length == 0) return;
 
+        _frameReceipts = frameReceipts;
         CollapseFrameRoots();
     }
 
@@ -321,6 +331,11 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer, IFrameTxReceiptTr
                 TxFrameReceipt frameReceipt = _frameReceipts[i];
                 NativeCallTracerCallFrame frameCallFrame = _frameRoots[i] ?? BuildUndispatchedFrame(i, frameReceipt);
 
+                // Uniform across dispatched and undispatched frames, where the VM's own figures would be the
+                // execution dimension net of the pre-dispatch charges.
+                frameCallFrame.Gas = _frames[i].GasLimit;
+                frameCallFrame.GasUsed = frameReceipt.GasUsed;
+
                 if (_config.WithLog && frameReceipt.Logs.Length == 0)
                 {
                     // The receipt is what the frame committed: an unrolled atomic batch and a POST_TX
@@ -352,8 +367,6 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer, IFrameTxReceiptTr
             Type = isStatic ? Instruction.STATICCALL : Instruction.CALL,
             From = frame.Mode == TxFrame.ModeSender ? _sender : Eip8141Constants.EntryPointAddress,
             To = frame.Target ?? _sender,
-            Gas = frame.GasLimit,
-            GasUsed = frameReceipt.GasUsed,
             Value = isStatic ? null : frame.Value,
             Input = frame.Data.Span.ToPooledList(),
             Error = UndispatchedFrameError(frameIndex, frameReceipt)

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -23,6 +23,10 @@ namespace Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 // TracerConfig options:
 // onlyTopCall (default = false): Only the main (top-level) call will be processed to avoid any extra processing if only the main call info is required.
 // withLog (default = false): Logs emitted during each call will also be collected and included in the result.
+//
+// An EIP-8141 frame transaction runs every frame as its own top-level invocation, so it has no single
+// root call. Its trace is rooted in one synthetic transaction frame whose children are the executed
+// frames in order, which keeps the result a single CallFrame for consumers that walk `calls`.
 public sealed class NativeCallTracer : GethLikeNativeTxTracer
 {
     public const string CallTracer = "callTracer";
@@ -30,6 +34,8 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
     private readonly ulong _gasLimit;
     private readonly Hash256? _txHash;
     private readonly bool _isEip8037Enabled;
+    private readonly bool _isFrameTx;
+    private readonly Address? _sender;
     private readonly NativeCallTracerConfig _config;
     private readonly ArrayPoolList<NativeCallTracerCallFrame> _callStack = new(1024);
     private readonly CompositeDisposable _disposables = [];
@@ -37,6 +43,7 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
     private EvmExceptionType? _error;
     private ulong _remainingGas;
     private bool _resultBuilt = false;
+    private bool _framesCollapsed = false;
 
     public NativeCallTracer(
         Transaction? tx,
@@ -47,6 +54,8 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         _gasLimit = tx!.GasLimit;
         _txHash = tx.Hash;
         _isEip8037Enabled = spec.IsEip8037Enabled;
+        _isFrameTx = tx.SupportsFrames;
+        _sender = tx.SenderAddress;
 
         _config = options.TracerConfig?.Deserialize<NativeCallTracerConfig>(EthereumJsonSerializer.JsonOptions) ?? new NativeCallTracerConfig();
 
@@ -61,6 +70,8 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
     public override GethLikeTxTrace BuildResult()
     {
         GethLikeTxTrace result = base.BuildResult();
+
+        CollapseFrameRoots();
 
         Debug.Assert(_callStack.Count <= 1, $"Unexpected frames on call stack, expected at most one master frame, found {_callStack.Count} frames.");
 
@@ -104,7 +115,9 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
             Type = callOpcode,
             From = from,
             To = to,
-            Gas = Depth == 0 ? _gasLimit : gas,
+            // A frame transaction's top-level invocations each carry their own limit; the whole
+            // transaction's belongs to the synthetic root CollapseFrameRoots builds.
+            Gas = Depth == 0 && !_isFrameTx ? _gasLimit : gas,
             Value = callOpcode == Instruction.STATICCALL ? null : value,
             Input = input.Span.ToPooledList()
         };
@@ -187,6 +200,7 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
     {
         base.MarkAsSuccess(recipient, gasSpent, output, logs, stateRoot);
 
+        CollapseFrameRoots();
         if (_callStack.Count == 0) return;
         NativeCallTracerCallFrame firstCallFrame = _callStack[0];
         firstCallFrame.GasUsed = gasSpent.SpentGas;
@@ -203,6 +217,7 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
     {
         base.MarkAsFailed(recipient, gasSpent, output, error, stateRoot);
 
+        CollapseFrameRoots();
         if (_callStack.Count == 0) return;
         NativeCallTracerCallFrame firstCallFrame = _callStack[0];
         firstCallFrame.GasUsed = gasSpent.SpentGas;
@@ -226,6 +241,34 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         }
     }
 
+    /// <summary>Roots an EIP-8141 frame transaction's trace in one synthetic transaction frame whose
+    /// children are the executed frames, in execution order.</summary>
+    /// <remarks>A frame transaction has no single root call: each frame is its own top-level invocation,
+    /// so without this every frame after the first is dropped from the result. The synthetic root keeps the
+    /// trace a single <c>CallFrame</c>, and is the only frame carrying the transaction-wide gas figures.
+    /// Idempotent, because both the receipt callbacks and <see cref="BuildResult"/> reach it.</remarks>
+    private void CollapseFrameRoots()
+    {
+        if (!_isFrameTx || _framesCollapsed) return;
+        _framesCollapsed = true;
+
+        NativeCallTracerCallFrame txCallFrame = new()
+        {
+            Type = Instruction.CALL,
+            From = _sender,
+            To = Eip8141Constants.EntryPointAddress,
+            Gas = _gasLimit
+        };
+
+        foreach (NativeCallTracerCallFrame frameRoot in _callStack.AsSpan())
+        {
+            txCallFrame.Calls.Add(frameRoot);
+        }
+
+        _callStack.Clear();
+        _callStack.Add(txCallFrame);
+    }
+
     private void ApplyTwoDimensionalGas(NativeCallTracerCallFrame firstCallFrame, in GasConsumed gasSpent)
     {
         if (!_isEip8037Enabled) return;
@@ -235,6 +278,20 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
 
     private void OnExit(ulong gas, ReadOnlyMemory<byte>? output, EvmExceptionType? error = null)
     {
+        if (Depth == 0)
+        {
+            // Only a frame transaction reaches this with more frames to come; every other transaction's
+            // root is finished by MarkAsSuccess/MarkAsFailed with the transaction-wide figures.
+            if (_isFrameTx && _callStack.Count > 0)
+            {
+                NativeCallTracerCallFrame frameRoot = _callStack[^1];
+                frameRoot.GasUsed = frameRoot.Gas - gas;
+                ProcessOutput(frameRoot, output, error);
+            }
+
+            return;
+        }
+
         if (!_config.OnlyTopCall && Depth > 0)
         {
             NativeCallTracerCallFrame callFrame = _callStack[^1];

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -4401,27 +4401,19 @@ public class FrameTxProcessorTests
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer));
         tx.GasLimit = FrameTxValidation.TotalGasLimit(tx.Frames);
 
-        GethTraceOptions options = GethTraceOptions.Default with
-        {
-            Tracer = NativeCallTracer.CallTracer,
-            TracerConfig = onlyTopCall ? JsonSerializer.Deserialize<JsonElement>("""{"onlyTopCall":true}""") : null
-        };
-        using NativeCallTracer tracer = new(tx, Spec, options);
-        Assert.That(ProcessTraced(tx, tracer).TransactionExecuted, Is.True);
-        using GethLikeTxTrace trace = tracer.BuildResult();
-
-        AssertStorage(Observer, 0, 42, "the SENDER frame must have run");
-
-        using JsonDocument document = JsonDocument.Parse(
-            JsonSerializer.Serialize(trace.CustomTracerResult?.Value, EthereumJsonSerializer.JsonOptions));
+        using JsonDocument document = TraceCall(tx, onlyTopCall).Trace;
         JsonElement root = document.RootElement;
         JsonElement frames = root.GetProperty("calls");
+
+        AssertStorage(Observer, 0, 42, "the SENDER frame must have run");
 
         using (Assert.EnterMultipleScope())
         {
             Assert.That(root.GetProperty("type").GetString(), Is.EqualTo("CALL"));
             Assert.That(root.GetProperty("from").GetString(), Is.EqualTo(Sender.ToString()));
             Assert.That(root.GetProperty("to").GetString(), Is.EqualTo(Eip8141Constants.EntryPointAddress.ToString()));
+            Assert.That(root.TryGetProperty("value", out JsonElement rootValue) ? rootValue.GetString() : null, Is.EqualTo("0x0"),
+                "the synthetic root must carry the same value field every other transaction's root does");
             Assert.That(Convert.ToUInt64(root.GetProperty("gas").GetString()![2..], 16), Is.EqualTo(tx.GasLimit),
                 "the transaction-wide limit belongs to the synthetic root, not to a frame");
             Assert.That(frames.GetArrayLength(), Is.EqualTo(2), "both executed frames belong in the trace");
@@ -4447,5 +4439,206 @@ public class FrameTxProcessorTests
                     Is.EqualTo(senderHelper.ToString()));
             }
         }
+    }
+
+    /// <summary>A <c>VERIFY</c> frame whose codeless target runs the EIP-8141 default code never enters the
+    /// VM, so a trace built from what the VM reported would show the transaction's second frame as its only
+    /// one.</summary>
+    [Test]
+    public void Execute_CodelessVerifyTargetTracedWithCallTracer_KeepsTheDefaultCodeFrame()
+    {
+        _stateProvider.CreateAccount(Sender, 1.Ether);
+        DeployContract(Observer, Prepare.EvmCode.PushData(42).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, new byte[TxFrameSignature.Secp256k1SignatureLength])];
+        SignCanonicalHash(tx, index: 0, TestItem.PrivateKeyA, signer: null);
+
+        using JsonDocument document = TraceCall(tx).Trace;
+        JsonElement frames = document.RootElement.GetProperty("calls");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(frames.GetArrayLength(), Is.EqualTo(2), "a default-code VERIFY frame is still a frame");
+            Assert.That(frames[0].GetProperty("type").GetString(), Is.EqualTo("STATICCALL"));
+            Assert.That(frames[0].GetProperty("to").GetString(), Is.EqualTo(Sender.ToString()));
+            Assert.That(frames[0].TryGetProperty("error", out _), Is.False, "the default code approved");
+            Assert.That(frames[1].GetProperty("to").GetString(), Is.EqualTo(Observer.ToString()));
+        }
+    }
+
+    /// <summary>Each of the pre-dispatch exits of <c>ExecuteFrame</c> ends a frame without the VM ever
+    /// reporting an action, and those are exactly the failed frames callTracer must render with an
+    /// <c>error</c>.</summary>
+    [TestCase(PreDispatchExit.EntryAccessCharge, "out of gas", TestName = "Execute_FrameFailingTheEntryAccessCharge_IsTracedWithItsError")]
+    [TestCase(PreDispatchExit.ValueTransfer, "execution reverted", TestName = "Execute_FrameFailingTheValueTransfer_IsTracedWithItsError")]
+    [TestCase(PreDispatchExit.EntryStateCharge, "out of gas", TestName = "Execute_FrameFailingTheEntryStateCharge_IsTracedWithItsError")]
+    [TestCase(PreDispatchExit.DelegationCharge, "out of gas", TestName = "Execute_FrameFailingTheDelegationCharge_IsTracedWithItsError")]
+    public void Execute_FrameFailingBeforeDispatch_IsTracedWithItsError(PreDispatchExit exit, string expectedError)
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        TxFrame failing = UndispatchedFrame(exit, out Address target);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), failing);
+
+        using JsonDocument document = TraceCall(tx).Trace;
+        JsonElement frames = document.RootElement.GetProperty("calls");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(frames.GetArrayLength(), Is.EqualTo(2), "a frame failing before dispatch is still a frame");
+            Assert.That(frames[1].GetProperty("to").GetString(), Is.EqualTo(target.ToString()));
+            Assert.That(frames[1].GetProperty("error").GetString(), Is.EqualTo(expectedError));
+            Assert.That(document.RootElement.TryGetProperty("error", out _), Is.False,
+                "one failed body frame does not fail the transaction");
+        }
+    }
+
+    /// <summary>A <c>POST_TX</c> frame failing before dispatch reverts the transaction without the VM
+    /// reporting any error, so the root's <c>error</c> has to come from the processor's reason.</summary>
+    [Test]
+    public void Execute_PostTxFrameFailingBeforeDispatch_TracesTheTransactionAsFailed()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        // Cold access costs more than the whole execution budget, so the frame halts before dispatch.
+        TxFrame postTx = new(TxFrame.ModePostTx, flags: 0, Recipient,
+            executionGasLimit: Eip8038Constants.ColdAccountAccess - 1, stateGasLimit: 0, UInt256.Zero, default);
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), postTx);
+
+        using JsonDocument document = TraceCall(tx).Trace;
+        JsonElement root = document.RootElement;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(root.TryGetProperty("error", out JsonElement rootError) ? rootError.GetString() : null,
+                Is.EqualTo("POST_TX frame reverted"), "a reverted frame transaction must not serialise as a clean root");
+            Assert.That(root.GetProperty("calls").GetArrayLength(), Is.EqualTo(2));
+            Assert.That(root.GetProperty("calls")[1].GetProperty("error").GetString(), Is.EqualTo("out of gas"));
+        }
+    }
+
+    /// <summary>An unrolled atomic batch keeps its frames' success status while dropping their logs, so a
+    /// trace that renders logs by frame status shows events that never reached the receipt.</summary>
+    [Test]
+    public void Execute_AtomicBatchUnrollsAFrameThatLogged_TracesOnlyTheCommittedLogs()
+    {
+        Address afterBatch = TestItem.AddressD;
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, LogEmitter(777));
+        DeployContract(Recipient, Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.REVERT).Done);
+        DeployContract(afterBatch, LogEmitter(888));
+
+        Transaction tx = FrameTx(nonce: 0,
+            SelfVerifyFrame(),
+            Frame(TxFrame.ModeSender, flags: TxFrame.AtomicBatchFlag, target: Observer),
+            Frame(TxFrame.ModeSender, target: Recipient),
+            Frame(TxFrame.ModeSender, target: afterBatch));
+
+        (JsonDocument trace, TxFrameReceipt[] receipts) = TraceCall(tx, withLog: true);
+        using JsonDocument document = trace;
+        JsonElement frames = document.RootElement.GetProperty("calls");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipts[1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess),
+                "the unroll keeps the frame's status, so status alone cannot identify it");
+            Assert.That(receipts[1].Logs, Is.Empty, "its log went back with its state");
+            Assert.That(frames[1].TryGetProperty("logs", out _), Is.False,
+                "an unrolled frame's logs must not survive in the trace either");
+            Assert.That(frames[3].GetProperty("logs").GetArrayLength(), Is.EqualTo(1),
+                "the frame after the batch committed its log");
+            Assert.That(CountLogs(document.RootElement), Is.EqualTo(TxFrameReceipt.ConcatLogs(receipts).Length),
+                "the trace's logs are the receipt's logs");
+        }
+    }
+
+
+    /// <summary>The pre-dispatch exits of <c>ExecuteFrame</c>, each of which ends a frame without entering the VM.</summary>
+    public enum PreDispatchExit
+    {
+        EntryAccessCharge,
+        ValueTransfer,
+        EntryStateCharge,
+        DelegationCharge
+    }
+
+    /// <summary>A <c>SENDER</c> frame taking <paramref name="exit"/>, with the state it needs deployed.</summary>
+    private TxFrame UndispatchedFrame(PreDispatchExit exit, out Address target)
+    {
+        target = exit == PreDispatchExit.EntryStateCharge ? TestItem.AddressF : Observer;
+        switch (exit)
+        {
+            case PreDispatchExit.EntryAccessCharge:
+                DeployContract(target, Prepare.EvmCode.Op(Instruction.STOP).Done);
+                return new TxFrame(TxFrame.ModeSender, flags: 0, target,
+                    executionGasLimit: Eip8038Constants.ColdAccountAccess - 1, stateGasLimit: 0, UInt256.Zero, default);
+            case PreDispatchExit.ValueTransfer:
+                DeployContract(target, Prepare.EvmCode.Op(Instruction.STOP).Done);
+                return Frame(TxFrame.ModeSender, target: target, value: 2.Ether);
+            case PreDispatchExit.EntryStateCharge:
+                // A value transfer to a dead account owes the new-account state cost, which the frame refuses to fund.
+                return Frame(TxFrame.ModeSender, target: target, value: 1, stateGasLimit: 0);
+            default:
+                DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+                DeployContract(target, [.. Eip7702Constants.DelegationHeader, .. Recipient.Bytes]);
+                return new TxFrame(TxFrame.ModeSender, flags: 0, target,
+                    gasLimit: Eip8038Constants.ColdAccountAccess, UInt256.Zero, default);
+        }
+    }
+
+    private static byte[] LogEmitter(UInt256 topic) => Prepare.EvmCode
+        .PushData(topic).PushData(0).PushData(0).Op(Instruction.LOG1)
+        .Op(Instruction.STOP).Done;
+
+    private static int CountLogs(JsonElement callFrame)
+    {
+        int count = callFrame.TryGetProperty("logs", out JsonElement logs) ? logs.GetArrayLength() : 0;
+        if (callFrame.TryGetProperty("calls", out JsonElement calls))
+        {
+            foreach (JsonElement child in calls.EnumerateArray())
+            {
+                count += CountLogs(child);
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>Runs <paramref name="tx"/> under <c>callTracer</c>, returning the serialized trace and the
+    /// per-frame receipts the processor reported alongside it.</summary>
+    private (JsonDocument Trace, TxFrameReceipt[] Receipts) TraceCall(Transaction tx, bool onlyTopCall = false, bool withLog = false)
+    {
+        string config = $$"""{"onlyTopCall":{{(onlyTopCall ? "true" : "false")}},"withLog":{{(withLog ? "true" : "false")}}}""";
+        GethTraceOptions options = GethTraceOptions.Default with
+        {
+            Tracer = NativeCallTracer.CallTracer,
+            TracerConfig = JsonSerializer.Deserialize<JsonElement>(config)
+        };
+
+        using NativeCallTracer callTracer = new(tx, Spec, options);
+        FrameCallTracer tracer = new(callTracer);
+        Assert.That(ProcessTraced(tx, tracer).TransactionExecuted, Is.True);
+
+        using GethLikeTxTrace trace = callTracer.BuildResult();
+        return (JsonDocument.Parse(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, EthereumJsonSerializer.JsonOptions)),
+            tracer.FrameReceipts);
+    }
+
+    /// <summary>A <c>callTracer</c> that also keeps the per-frame receipts, so a test can hold the trace
+    /// against what the receipt records.</summary>
+    private sealed class FrameCallTracer(NativeCallTracer callTracer) : CompositeTxTracer(callTracer), IFrameTxReceiptTracer
+    {
+        public TxFrameReceipt[] FrameReceipts { get; private set; } = [];
+
+        public void ReportFrameTxReceipt(Address payer, TxFrameReceipt[] frameReceipts)
+        {
+            FrameReceipts = frameReceipts;
+            callTracer.ReportFrameTxReceipt(payer, frameReceipts);
+        }
+
+        public void ReportFrameEnd(int frameIndex, EvmExceptionType? error) =>
+            callTracer.ReportFrameEnd(frameIndex, error);
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.BlockAccessLists;
@@ -23,6 +25,7 @@ using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Serialization.Json;
 using Nethermind.Serialization.Rlp;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
@@ -4372,6 +4375,77 @@ public class FrameTxProcessorTests
         {
             Assert.That(postTxResult.TransactionExecuted, Is.False);
             Assert.That(postTxResult.ErrorDescription, Does.Contain(FrameTxValidation.PostTxNotEnabled));
+        }
+    }
+
+    /// <summary>Every frame runs as its own top-level invocation, so a trace that kept only one root
+    /// reported one frame's call tree and silently dropped the rest.</summary>
+    [TestCase(false, TestName = "Execute_FrameTxTracedWithCallTracer_KeepsEveryExecutedFrame")]
+    [TestCase(true, TestName = "Execute_FrameTxTracedWithCallTracerOnlyTopCall_KeepsEveryExecutedFrame")]
+    public void Execute_FrameTxTracedWithCallTracer_KeepsEveryExecutedFrame(bool onlyTopCall)
+    {
+        Address verifyHelper = TestItem.AddressD;
+        Address senderHelper = Recipient;
+
+        // The VERIFY frame runs statically, so its nested call has to be a STATICCALL.
+        DeploySmartSender(Bytes.Concat(
+            Prepare.EvmCode.StaticCall(verifyHelper, 50_000).Op(Instruction.POP).Done,
+            ApproveCode(TxFrame.ApproveExecutionAndPayment)));
+        DeployContract(verifyHelper, Prepare.EvmCode.Op(Instruction.STOP).Done);
+        DeployContract(Observer, Prepare.EvmCode
+            .Call(senderHelper, 50_000).Op(Instruction.POP)
+            .PushData(42).PushData(0).Op(Instruction.SSTORE)
+            .Op(Instruction.STOP).Done);
+        DeployContract(senderHelper, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer));
+        tx.GasLimit = FrameTxValidation.TotalGasLimit(tx.Frames);
+
+        GethTraceOptions options = GethTraceOptions.Default with
+        {
+            Tracer = NativeCallTracer.CallTracer,
+            TracerConfig = onlyTopCall ? JsonSerializer.Deserialize<JsonElement>("""{"onlyTopCall":true}""") : null
+        };
+        using NativeCallTracer tracer = new(tx, Spec, options);
+        Assert.That(ProcessTraced(tx, tracer).TransactionExecuted, Is.True);
+        using GethLikeTxTrace trace = tracer.BuildResult();
+
+        AssertStorage(Observer, 0, 42, "the SENDER frame must have run");
+
+        using JsonDocument document = JsonDocument.Parse(
+            JsonSerializer.Serialize(trace.CustomTracerResult?.Value, EthereumJsonSerializer.JsonOptions));
+        JsonElement root = document.RootElement;
+        JsonElement frames = root.GetProperty("calls");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(root.GetProperty("type").GetString(), Is.EqualTo("CALL"));
+            Assert.That(root.GetProperty("from").GetString(), Is.EqualTo(Sender.ToString()));
+            Assert.That(root.GetProperty("to").GetString(), Is.EqualTo(Eip8141Constants.EntryPointAddress.ToString()));
+            Assert.That(Convert.ToUInt64(root.GetProperty("gas").GetString()![2..], 16), Is.EqualTo(tx.GasLimit),
+                "the transaction-wide limit belongs to the synthetic root, not to a frame");
+            Assert.That(frames.GetArrayLength(), Is.EqualTo(2), "both executed frames belong in the trace");
+
+            JsonElement verifyFrame = frames[0];
+            Assert.That(verifyFrame.GetProperty("type").GetString(), Is.EqualTo("STATICCALL"));
+            Assert.That(verifyFrame.GetProperty("to").GetString(), Is.EqualTo(Sender.ToString()));
+
+            JsonElement senderFrame = frames[1];
+            Assert.That(senderFrame.GetProperty("type").GetString(), Is.EqualTo("CALL"));
+            Assert.That(senderFrame.GetProperty("to").GetString(), Is.EqualTo(Observer.ToString()));
+
+            if (onlyTopCall)
+            {
+                Assert.That(verifyFrame.TryGetProperty("calls", out _), Is.False);
+                Assert.That(senderFrame.TryGetProperty("calls", out _), Is.False);
+            }
+            else
+            {
+                Assert.That(verifyFrame.GetProperty("calls")[0].GetProperty("to").GetString(),
+                    Is.EqualTo(verifyHelper.ToString()));
+                Assert.That(senderFrame.GetProperty("calls")[0].GetProperty("to").GetString(),
+                    Is.EqualTo(senderHelper.ToString()));
+            }
         }
     }
 }

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -4433,6 +4433,10 @@ public class FrameTxProcessorTests
             JsonElement senderFrame = frames[1];
             Assert.That(senderFrame.GetProperty("type").GetString(), Is.EqualTo("CALL"));
             Assert.That(senderFrame.GetProperty("to").GetString(), Is.EqualTo(Observer.ToString()));
+            Assert.That(HexValue(senderFrame, "gas"), Is.EqualTo(tx.Frames![1].GasLimit));
+            Assert.That(HexValue(senderFrame, "gasUsed"), Is.EqualTo(receipts[1].GasUsed)
+                .And.Not.EqualTo(HexValue(root, "gasUsed")),
+                "each frame spends its own gas; the transaction's total belongs to the synthetic root");
 
             if (onlyTopCall)
             {

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using Nethermind.Blockchain;
 using Nethermind.Blockchain.Tracing;
 using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native;
 using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 using Nethermind.Config;
 using Nethermind.Core;
@@ -4401,7 +4404,8 @@ public class FrameTxProcessorTests
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer));
         tx.GasLimit = FrameTxValidation.TotalGasLimit(tx.Frames);
 
-        using JsonDocument document = TraceCall(tx, onlyTopCall).Trace;
+        (JsonDocument trace, TxFrameReceipt[] receipts) = TraceCall(tx, onlyTopCall);
+        using JsonDocument document = trace;
         JsonElement root = document.RootElement;
         JsonElement frames = root.GetProperty("calls");
 
@@ -4414,13 +4418,17 @@ public class FrameTxProcessorTests
             Assert.That(root.GetProperty("to").GetString(), Is.EqualTo(Eip8141Constants.EntryPointAddress.ToString()));
             Assert.That(root.TryGetProperty("value", out JsonElement rootValue) ? rootValue.GetString() : null, Is.EqualTo("0x0"),
                 "the synthetic root must carry the same value field every other transaction's root does");
-            Assert.That(Convert.ToUInt64(root.GetProperty("gas").GetString()![2..], 16), Is.EqualTo(tx.GasLimit),
+            Assert.That(HexValue(root, "gas"), Is.EqualTo(tx.GasLimit),
                 "the transaction-wide limit belongs to the synthetic root, not to a frame");
             Assert.That(frames.GetArrayLength(), Is.EqualTo(2), "both executed frames belong in the trace");
 
             JsonElement verifyFrame = frames[0];
             Assert.That(verifyFrame.GetProperty("type").GetString(), Is.EqualTo("STATICCALL"));
             Assert.That(verifyFrame.GetProperty("to").GetString(), Is.EqualTo(Sender.ToString()));
+            Assert.That(HexValue(verifyFrame, "gas"), Is.EqualTo(tx.Frames![0].GasLimit),
+                "a dispatched frame's gas is the limit it declared, as an undispatched one's is");
+            Assert.That(HexValue(verifyFrame, "gasUsed"), Is.EqualTo(receipts[0].GasUsed),
+                "and its gasUsed is what its receipt records, across both dimensions");
 
             JsonElement senderFrame = frames[1];
             Assert.That(senderFrame.GetProperty("type").GetString(), Is.EqualTo("CALL"));
@@ -4555,6 +4563,82 @@ public class FrameTxProcessorTests
     }
 
 
+    /// <summary>EIP-7906 keeps everything up to the validation prefix when a <c>POST_TX</c> frame reverts, so
+    /// the prefix's logs stay in the receipt and a trace clearing the whole tree contradicts it.</summary>
+    [Test]
+    public void Execute_PostTxRevertsOverALoggingPrefix_TracesTheLogsTheReceiptKeeps()
+    {
+        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
+        DeployContract(Observer, LogEmitter(999));
+        DeployContract(Recipient, Prepare.EvmCode.Op(Instruction.STOP).Done);
+
+        // The deploy frame opening the prefix is the one prefix frame that is not static, so it can log.
+        TxFrame postTx = new(TxFrame.ModePostTx, flags: 0, Recipient,
+            executionGasLimit: Eip8038Constants.ColdAccountAccess - 1, stateGasLimit: 0, UInt256.Zero, default);
+        Transaction tx = FrameTx(nonce: 0, Frame(TxFrame.ModeDefault, target: Observer), SelfVerifyFrame(), postTx);
+
+        (JsonDocument trace, TxFrameReceipt[] receipts) = TraceCall(tx, withLog: true);
+        using JsonDocument document = trace;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(document.RootElement.GetProperty("error").GetString(), Is.EqualTo("POST_TX frame reverted"));
+            Assert.That(TxFrameReceipt.ConcatLogs(receipts), Has.Length.EqualTo(1),
+                "the prefix's log outlives the revert, so the receipt still carries it");
+            Assert.That(CountLogs(document.RootElement), Is.EqualTo(TxFrameReceipt.ConcatLogs(receipts).Length),
+                "the trace's logs are the receipt's logs through a transaction-level failure too");
+        }
+    }
+
+    /// <summary>The validation-prefix simulation reports an empty receipt set, which pins no frame's outcome
+    /// and so must not settle the result against a later real one.</summary>
+    [Test]
+    public void ReportFrameTxReceipt_AfterAnEmptyReport_StillBuildsFromTheRealOne()
+    {
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer));
+        GethTraceOptions options = GethTraceOptions.Default with { Tracer = NativeCallTracer.CallTracer };
+        using NativeCallTracer callTracer = new(tx, Spec, options);
+
+        callTracer.ReportFrameTxReceipt(Sender, []);
+        callTracer.ReportFrameEnd(0, null);
+        callTracer.ReportFrameEnd(1, null);
+        callTracer.ReportFrameTxReceipt(Sender, [
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, []),
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, [])]);
+
+        using GethLikeTxTrace trace = callTracer.BuildResult();
+        using JsonDocument document = JsonDocument.Parse(
+            JsonSerializer.Serialize(trace.CustomTracerResult?.Value, EthereumJsonSerializer.JsonOptions));
+
+        Assert.That(document.RootElement.GetProperty("calls").GetArrayLength(), Is.EqualTo(2),
+            "the empty report must not freeze the trace into the no-receipts shape");
+    }
+
+    /// <summary>The tracing RPCs reach the call tracer through the receipts tracer and the cancellation
+    /// wrapper, so that is the chain the per-frame reports have to survive.</summary>
+    [Test]
+    public void Execute_FrameTxTracedThroughTheReceiptsTracer_KeepsEveryFrame()
+    {
+        _stateProvider.CreateAccount(Sender, 1.Ether);
+        DeployContract(Observer, Prepare.EvmCode.PushData(42).PushData(0).Op(Instruction.SSTORE).Op(Instruction.STOP).Done);
+
+        // A codeless VERIFY target runs the default code without entering the VM, so only the frame
+        // reports can place it in the trace.
+        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeSender, target: Observer));
+        tx.FrameSignatures = [new TxFrameSignature(TxFrameSignature.SchemeSecp256k1, null, default, new byte[TxFrameSignature.Secp256k1SignatureLength])];
+        SignCanonicalHash(tx, index: 0, TestItem.PrivateKeyA, signer: null);
+
+        using JsonDocument document = TraceThroughReceiptsTracer(tx);
+        JsonElement frames = document.RootElement.GetProperty("calls");
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(frames.GetArrayLength(), Is.EqualTo(2), "the frame reports have to reach the call tracer");
+            Assert.That(frames[0].GetProperty("to").GetString(), Is.EqualTo(Sender.ToString()));
+            Assert.That(frames[1].GetProperty("to").GetString(), Is.EqualTo(Observer.ToString()));
+        }
+    }
+
     /// <summary>The pre-dispatch exits of <c>ExecuteFrame</c>, each of which ends a frame without entering the VM.</summary>
     public enum PreDispatchExit
     {
@@ -4592,6 +4676,9 @@ public class FrameTxProcessorTests
         .PushData(topic).PushData(0).PushData(0).Op(Instruction.LOG1)
         .Op(Instruction.STOP).Done;
 
+    private static ulong HexValue(JsonElement callFrame, string property) =>
+        Convert.ToUInt64(callFrame.GetProperty(property).GetString()![2..], 16);
+
     private static int CountLogs(JsonElement callFrame)
     {
         int count = callFrame.TryGetProperty("logs", out JsonElement logs) ? logs.GetArrayLength() : 0;
@@ -4624,6 +4711,32 @@ public class FrameTxProcessorTests
         using GethLikeTxTrace trace = callTracer.BuildResult();
         return (JsonDocument.Parse(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, EthereumJsonSerializer.JsonOptions)),
             tracer.FrameReceipts);
+    }
+
+    /// <summary>Runs <paramref name="tx"/> under <c>callTracer</c> through the chain the tracing RPCs build —
+    /// the receipts tracer over the cancellable native block tracer — and returns the serialized trace.</summary>
+    private JsonDocument TraceThroughReceiptsTracer(Transaction tx)
+    {
+        GethTraceOptions options = GethTraceOptions.Default with { Tracer = NativeCallTracer.CallTracer };
+        (EthereumTransactionProcessor tracedProcessor, TracedAccessWorldState tracedState) = TracedProcessor();
+        Block block = Build.A.Block.WithNumber(1)
+            .WithBaseFeePerGas(0)
+            .WithBeneficiary(Beneficiary)
+            .WithTransactions(tx)
+            .WithGasLimit(30_000_000).TestObject;
+
+        GethLikeBlockNativeTracer blockTracer = new(txHash: null,
+            (b, t) => GethLikeNativeTracerFactory.CreateTracer(options, b, t, tracedState, Spec));
+        BlockReceiptsTracer receiptsTracer = new();
+        receiptsTracer.SetOtherTracer(blockTracer.WithCancellation(CancellationToken.None));
+        receiptsTracer.StartNewBlockTrace(block);
+        receiptsTracer.StartNewTxTrace(tx);
+        Assert.That(tracedProcessor.Execute(tx, new BlockExecutionContext(block.Header, Spec), receiptsTracer).TransactionExecuted, Is.True);
+        receiptsTracer.EndTxTrace();
+        receiptsTracer.EndBlockTrace();
+
+        using GethLikeTxTrace trace = blockTracer.BuildResult().Single();
+        return JsonDocument.Parse(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, EthereumJsonSerializer.JsonOptions));
     }
 
     /// <summary>A <c>callTracer</c> that also keeps the per-frame receipts, so a test can hold the trace

--- a/src/Nethermind/Nethermind.Evm/Tracing/IFrameTxReceiptTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/IFrameTxReceiptTracer.cs
@@ -10,4 +10,11 @@ namespace Nethermind.Evm.Tracing;
 public interface IFrameTxReceiptTracer
 {
     void ReportFrameTxReceipt(Address payer, TxFrameReceipt[] frameReceipts);
+
+    /// <summary>Reports the frame at <paramref name="frameIndex"/> completing, so a tracer can align what it
+    /// observed with the per-frame receipts reported at the end of the transaction.</summary>
+    /// <remarks>A frame that fails before dispatch, and a <c>VERIFY</c> frame running the default code, never
+    /// enter the VM, so the action callbacks alone do not say which frame produced which observations.</remarks>
+    /// <param name="error">The EVM error that ended the frame, or <c>null</c> when it succeeded.</param>
+    void ReportFrameEnd(int frameIndex, EvmExceptionType? error) { }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/IFrameTxReceiptTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/IFrameTxReceiptTracer.cs
@@ -9,6 +9,10 @@ namespace Nethermind.Evm.Tracing;
 /// receipts before marking the transaction, for attaching to the built <see cref="TxReceipt"/>.</summary>
 public interface IFrameTxReceiptTracer
 {
+    /// <summary>Reports the transaction's payer and one receipt per frame, once every frame has run.</summary>
+    /// <param name="payer">The account the transaction's gas was charged to.</param>
+    /// <param name="frameReceipts">One receipt per <c>tx.Frames</c> entry, in frame order; empty from the
+    /// validation-prefix simulation, which pins no frame's outcome.</param>
     void ReportFrameTxReceipt(Address payer, TxFrameReceipt[] frameReceipts);
 
     /// <summary>Reports the frame at <paramref name="frameIndex"/> completing, so a tracer can align what it

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -245,6 +245,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
         // EIP-161: once any frame touches RIPEMD-160, the touch outlives every later rollback that
         // leaves the transaction valid, so it is tracked for the whole transaction rather than per frame.
         bool shouldRestoreRipemdTouch = false;
+        IFrameTxReceiptTracer? frameReceiptTracer = tracer as IFrameTxReceiptTracer;
 
         for (int i = 0; i < frames.Length; i++)
         {
@@ -294,6 +295,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             shouldRestoreRipemdTouch |= substate.ShouldRestoreRipemdTouch;
 
             bool frameSucceeded = !substate.ShouldRevert && !substate.IsError;
+            frameReceiptTracer?.ReportFrameEnd(i, frameSucceeded ? null : substate.EvmExceptionType);
 
             totalFrameGasUsed += frameGasUsed;
             if (frameSucceeded)
@@ -550,10 +552,7 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
 
         if (tracer.IsTracingReceipt)
         {
-            if (tracer is IFrameTxReceiptTracer frameReceiptTracer)
-            {
-                frameReceiptTracer.ReportFrameTxReceipt(payer, frameReceipts);
-            }
+            frameReceiptTracer?.ReportFrameTxReceipt(payer, frameReceipts);
 
             GasConsumed gasConsumed = new(spentGas, spentGas, blockRegularGas, blockStateGas, spentGas);
             if (postTxReverted)


### PR DESCRIPTION
## Changes

Addresses the **[P2] Preserve every executed frame in callTracer output** review thread on #12526.

Each frame of an EIP-8141 frame transaction runs as its own top-level VM invocation through the same
tracer. `NativeCallTracer` only pops a call frame off `_callStack` at depth > 0, so every frame's root
stayed on the stack and `BuildResult` returned `_callStack[0]` — the first frame's call tree, with the
rest silently dropped. The transaction-wide `gasUsed`/`gas`/EIP-8037 figures were grafted onto that
one frame as well.

A frame transaction has no single root call, so its trace is now rooted in one **synthetic transaction
frame** whose children are its frames:

```
CALL  from = sender  to = 0x…aa (entry point)  gas = tx gas limit  gasUsed = tx spent  value = 0x0
└─ calls[0]  STATICCALL → the VERIFY frame's tree
└─ calls[1]  CALL       → the SENDER frame's tree
```

`from`/`to` mirror what the processor already reports to the receipt (`MarkAsSuccess` is called with
the entry point as recipient). The alternative — returning an array of roots — was rejected because it
changes the top-level `debug_traceTransaction` schema from an object to an array and forces every
consumer to branch on transaction type; under a synthetic root, tooling that walks `calls` recursively
picks up all frames unchanged.

### The children come from the receipts, not from the VM

Reconstructing the children from what the VM reported is what the first revision of this PR did, and it
is wrong three ways, all with the same cause: the tracer was rebuilding state the processor already has.

* **A frame that never enters the VM reports no action.** `ExecuteFrame` short-circuits a `VERIFY`
  frame whose target is codeless and not a precompile into `ExecuteDefaultVerifyCode`, and returns
  before dispatch on four more paths — the entry-access charge exceeding `ExecutionGasLimit`, the
  value-transfer balance check, `TryConsumeStateAndExecutionGas`, and the delegation access charge.
  A plain EOA-sender frame transaction therefore traced with one child, not two, and the four
  pre-dispatch failures are exactly the frames callTracer should render with an `error`.
* **A failed transaction could trace clean.** `MarkAsFailed` is reached for a frame tx only via
  `postTxReverted`, and marked the root only when the VM had reported an error. A `POST_TX` frame
  failing a pre-dispatch check reports none, so a reverted transaction serialised a clean root.
* **Rolled-back frames rendered as ordinary successful calls.** An atomic-batch unroll and a `POST_TX`
  rollback both rewrite the frame receipt to drop its logs while **keeping its success status**, so no
  status-based rule can find them. With `withLog`, logs appeared in the trace that never appear in the
  receipt — a consumer reading logs from a trace saw events that did not happen.

So the children are built from `IFrameTxReceiptTracer.ReportFrameTxReceipt`, which the processor already
calls immediately before `MarkAsSuccess`/`MarkAsFailed`: **one child per frame receipt**, in frame order.
A frame that never entered the VM is rendered from `tx.Frames[i]` (mode → `CALL`/`STATICCALL`, target,
value, input, gas limits) and carries the EVM error that ended it. Each child's logs are then reconciled
against its receipt: a frame whose receipt committed no logs carries none in the trace either. The
transaction-level `error` comes from the reason the processor passes to `MarkAsFailed`.

Aligning VM roots with frame indices needs one fact the action callbacks do not carry — which frame
produced which root — so the processor now reports frame completion through the same
`IFrameTxReceiptTracer` (a default-implemented member; no existing implementer changes), and
`BlockReceiptsTracer` forwards both reports down the wrapper chain to the tracer it wraps, which is how
the tracing RPCs reach `NativeCallTracer` at all.

### Contract

* **`calls[i]` is `tx.Frames[i]`** — the child count equals the frame count. Frames an unrolled atomic
  batch or a failed assertion skipped are present too, with `error: "frame skipped"`; without them the
  correspondence would break in the middle, since a failed batch skips only to its terminal frame and
  execution continues after it.
* **`onlyTopCall` returns the synthetic root with its frames as children**, which it does for no other
  transaction. Each frame *is* a top-level call, so suppressing them would return a root describing
  nothing; the nested trees below each frame are still suppressed as usual. Stated on the class as a
  deliberate divergence.
* `value` on the synthetic root is an explicit `0x0`, so the field is present for frame transactions as
  it is for every other transaction rather than `undefined`.
* **Every frame's `gas` and `gasUsed` are its own** — `tx.Frames[i].GasLimit` and the frame receipt's
  spend across both dimensions — so siblings read alike whether or not the frame entered the VM. The VM's
  figures are the execution dimension net of the pre-dispatch charges, which would make `calls[0]` and
  `calls[1]` of one trace carry different quantities with nothing saying which.

### Other tracers

`GethLikeTxTracer` (struct logs), `4byteTracer`, `prestateTracer`, `stateGasTracer` and the JS custom
tracer all accumulate flat, transaction-scoped state and lose nothing structural.
`ParityLikeTxTracer` has the same class of defect but inverted — `PushAction` assigns
`_trace.Action = action` for every root, so the **last** frame wins while `_trace.VmTrace ??=` keeps the
**first** — and its fix is not the same shape (per-frame `TraceAddress` prefixes, plus its streaming
subclass). Left out of this PR and reported on the thread.

### No spec text covers this, and there is no cross-client convention

EIP-8141 defines the frame execution model and the per-frame receipt payload, but says nothing about
tracer output, and `debug_traceTransaction` has no specification at all — the `callTracer` shape is a de
facto convention, and it assumes one root call per transaction, which a frame transaction does not have.
Every decision above is therefore a convention this PR sets unilaterally: the synthetic root and its
`from`/`to`/`value`, the `calls[i]` ↔ `tx.Frames[i]` correspondence, the rendering of frames that never
entered the VM, `error: "frame skipped"`, and the `onlyTopCall` divergence. Divergence here is cheap to
create and expensive to undo — tooling pins to whatever ships first — so this is worth raising as a spec
discussion before the shape hardens. Nothing has been opened anywhere outside this repository; the
argument is recorded here for that decision to be made deliberately.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or a feature that would cause existing functionality not to work as expected)
- [ ] Documentation update
- [ ] Refactoring/Code style update
- [ ] Performance improvement
- [ ] Build-related changes
- [x] Other: adds one default-implemented member to `IFrameTxReceiptTracer`

## Testing

Requires testing

- [x] Yes
- [ ] No

If yes, did you write tests?

- [x] Yes
- [ ] No

### Notes on testing

Twelve tests in `FrameTxProcessorTests`, all asserted against the **serialized** callTracer JSON rather
than an internal collection, and each verified red against the revision it fixes and green after:

| test | what it pins |
|---|---|
| `Execute_FrameTxTracedWithCallTracer_KeepsEveryExecutedFrame` (×2, over `onlyTopCall`) | both frames and their nested calls under the synthetic root; root `gas` is the transaction's; root `value` is `0x0` |
| `Execute_CodelessVerifyTargetTracedWithCallTracer_KeepsTheDefaultCodeFrame` | a codeless EOA `VERIFY` target — the default-code path that never enters the VM — is still a child |
| `Execute_FrameFailingBeforeDispatch_IsTracedWithItsError` (×4) | each pre-dispatch exit: entry-access charge, value transfer, entry state charge, delegation charge |
| `Execute_PostTxFrameFailingBeforeDispatch_TracesTheTransactionAsFailed` | a `POST_TX` frame failing before dispatch gives the root `error: "POST_TX frame reverted"` |
| `Execute_AtomicBatchUnrollsAFrameThatLogged_TracesOnlyTheCommittedLogs` | an unrolled batch frame keeps status `1` with no logs, and the trace's logs equal the receipt's |
| `Execute_PostTxRevertsOverALoggingPrefix_TracesTheLogsTheReceiptKeeps` | EIP-7906 keeps the validation prefix, so its logs stay in both the receipt and the trace |
| `Execute_FrameTxTracedThroughTheReceiptsTracer_KeepsEveryFrame` | the chain the tracing RPCs build — receipts tracer over the cancellable native block tracer |
| `ReportFrameTxReceipt_AfterAnEmptyReport_StillBuildsFromTheRealOne` | the prefix simulation's empty report does not settle the result against a later real one |

Red on the previous revision: the frame counts come back `1` instead of `2`; `root.value` and
`root.error` are absent entirely (`KeyNotFoundException`, which is the `undefined`-vs-string complaint);
the unrolled frame's `logs` survive and the trace carries two logs where the receipt carries one.

Red on the revision each of the last three fixes: a `POST_TX`-reverted transaction serialises **zero**
logs where the receipt carries one; with the frame reports not reaching the tracer the root has **one**
child, the raw VM root, so `calls[0] != tx.Frames[0]`; and the empty report freezes the trace into the
no-receipts shape. The per-frame gas assertions are red on the un-normalised figures — a dispatched
frame's `gas` short by the warm-access charge, its `gasUsed` short by its state gas, and, with the roots
not collapsed before the transaction is marked, `calls[0].gasUsed` carrying the transaction's whole
spend.

Full `Nethermind.Evm.Test` (12800 release / 12798 checked), `Nethermind.JsonRpc.Test` (2147),
`Nethermind.Blockchain.Test` (2302) and `Nethermind.JsonRpc.TraceStore.Test` (22) pass in both `release` and `checked`
(`-p:DefineConstants=TRACE%3BDEBUG`, `artifacts/{bin,obj}` cleared between configs). The frame lanes
(`tests-frames-devnet@v0.3.0`, `--forkAlias Bogota=Eip8141Prototype`, chunk `1of1`) are 218/218 on both
`blockTest` and `engineTest` — a regression guard for the execution path this change touches, not
evidence about tracer shape: no fixture anywhere pins callTracer output for a frame transaction, which
is why the table above exists.

## Documentation

Requires documentation update

- [ ] Yes
- [x] No

Requires explanation in Release Notes

- [x] Yes
- [ ] No

`debug_traceTransaction` / `debug_traceBlock*` with `callTracer` now return every frame of an EIP-8141
frame transaction under a synthetic transaction root, with `calls[i]` corresponding to `tx.Frames[i]`,
frames that never entered the VM rendered from the transaction's frame list, and per-frame logs matching
the receipt. `onlyTopCall` returns that root with its frames as children.

