### PR TITLE
test(eip8141): say what the frame-tx pool fixtures measure, and share the pool helper

### DIFF
--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPoolRetentionMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPoolRetentionMeasurement.cs
@@ -27,12 +27,15 @@ using static Nethermind.Core.Test.Builders.FrameTxTestFrames;
 
 namespace Nethermind.TxPool.Test;
 
-/// <summary>Measures how long an unincludable frame transaction stays pending, and therefore how many times a
-/// block producer re-executes its validation prefix without ever collecting a fee for it.</summary>
-/// <remarks>Results go to <c>FRAME_RETRY_OUT</c> (default <c>frame-prefix-retry.txt</c> under the temp
+/// <summary>Measures how many chain heads a pending frame transaction survives in the pool, and how an expiry
+/// deadline bounds that.</summary>
+/// <remarks>Retention only: nothing here produces a block or reaches the eviction path, and the pool is built
+/// without a validation-prefix simulator, so revalidation reaches no verdict on an opaque prefix either.
+/// <c>FrameTxProducerRetryMeasurement</c> is where production attempts are run and the gas each one burns is
+/// counted. Results go to <c>FRAME_RETRY_OUT</c> (default <c>frame-prefix-retry.txt</c> under the temp
 /// directory), because the test runner swallows console writers.</remarks>
 [Explicit("measurement harness")]
-public class FrameTxPrefixRetryMeasurement
+public class FrameTxPoolRetentionMeasurement
 {
     private const int HeadAdvances = 20;
     private const ulong SampleFrameGas = 50_000;
@@ -89,7 +92,7 @@ public class FrameTxPrefixRetryMeasurement
     }
 
     [Test]
-    public async Task Unincludable_frame_transaction_survives_every_head()
+    public async Task Pending_frame_transaction_survives_every_head()
     {
         Transaction tx = BuildFrameTx(nonce: 0, deadline: null);
         Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
@@ -103,15 +106,18 @@ public class FrameTxPrefixRetryMeasurement
             if (Array.IndexOf(_txPool.GetPendingTransactions(), tx) >= 0) survived++;
         }
 
-        ulong prefixGas = FrameTxValidation.ValidationWorkGas(tx);
-        Emit($"case=no_deadline heads={HeadAdvances} survived_heads={survived} prefix_gas={prefixGas} "
-             + $"unpaid_gas_over_window={prefixGas * (ulong)survived}");
-        Assert.That(survived, Is.EqualTo(HeadAdvances), "the pool dropped an unincludable frame transaction on its own");
+        // Both gas figures are ceilings, not observations: ValidationWorkGas is the declared bound rather than
+        // a burn, and the default eviction budget drops a frame transaction on its first failed production.
+        ulong declaredPrefixGas = FrameTxValidation.ValidationWorkGas(tx);
+        Emit($"case=retention_no_deadline heads={HeadAdvances} survived_heads={survived} "
+             + $"declared_prefix_gas={declaredPrefixGas} production_attempts=0 "
+             + $"hypothetical_gas_if_every_head_retried={declaredPrefixGas * (ulong)survived}");
+        Assert.That(survived, Is.EqualTo(HeadAdvances), "the pool dropped a pending frame transaction on its own");
     }
 
-    /// <summary>An expiry deadline bounds the same exposure in blocks rather than in gas.</summary>
+    /// <summary>An expiry deadline is the one thing that ends that retention without a producer.</summary>
     [Test]
-    public async Task Expiry_deadline_bounds_the_number_of_attempts()
+    public async Task Expiry_deadline_bounds_how_long_it_is_retained()
     {
         ulong deadline = _headTimestamp + SlotSeconds * 3;
         Transaction tx = BuildFrameTx(nonce: 0, deadline);
@@ -125,7 +131,7 @@ public class FrameTxPrefixRetryMeasurement
             survived++;
         }
 
-        Emit($"case=with_deadline deadline_slots=3 heads={HeadAdvances} survived_heads={survived}");
+        Emit($"case=retention_with_deadline deadline_slots=3 heads={HeadAdvances} survived_heads={survived}");
         Assert.That(survived, Is.LessThan(HeadAdvances), "an expired frame transaction was never evicted");
     }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPoolRetentionMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPoolRetentionMeasurement.cs
@@ -29,8 +29,9 @@ namespace Nethermind.TxPool.Test;
 
 /// <summary>Measures how many chain heads a pending frame transaction survives in the pool, and how an expiry
 /// deadline bounds that.</summary>
-/// <remarks>Retention only: nothing here produces a block or reaches the eviction path, and the pool is built
-/// without a validation-prefix simulator, so revalidation reaches no verdict on an opaque prefix either.
+/// <remarks>Retention only: nothing here produces a block or calls <c>ITxPool.EvictTransaction</c> — the expiry
+/// sweep is the one eviction reached — and the pool is built without a validation-prefix simulator, so
+/// revalidation reaches no verdict on an opaque prefix either.
 /// <c>FrameTxProducerRetryMeasurement</c> is where production attempts are run and the gas each one burns is
 /// counted. Results go to <c>FRAME_RETRY_OUT</c> (default <c>frame-prefix-retry.txt</c> under the temp
 /// directory), because the test runner swallows console writers.</remarks>
@@ -38,6 +39,7 @@ namespace Nethermind.TxPool.Test;
 public class FrameTxPoolRetentionMeasurement
 {
     private const int HeadAdvances = 20;
+    private const int DeadlineSlots = 3;
     private const ulong SampleFrameGas = 50_000;
     private const ulong FirstHeadNumber = 10_000_000;
     private const ulong SlotSeconds = 12;
@@ -101,9 +103,7 @@ public class FrameTxPoolRetentionMeasurement
         for (int i = 0; i < HeadAdvances; i++)
         {
             await AdvanceHead(includedTx: null);
-            // Membership in the pending set is what a producer actually reads, so assert that rather
-            // than mere presence in the pool's hash index.
-            if (Array.IndexOf(_txPool.GetPendingTransactions(), tx) >= 0) survived++;
+            if (IsPending(tx)) survived++;
         }
 
         // Both gas figures are ceilings, not observations: ValidationWorkGas is the declared bound rather than
@@ -115,11 +115,15 @@ public class FrameTxPoolRetentionMeasurement
         Assert.That(survived, Is.EqualTo(HeadAdvances), "the pool dropped a pending frame transaction on its own");
     }
 
-    /// <summary>An expiry deadline is the one thing that ends that retention without a producer.</summary>
+    /// <summary>An expiry deadline ends the retention measured above, and is the only producer-free drop this
+    /// fixture reaches.</summary>
+    /// <remarks><c>ShedNearlyExpiredFrameTransactions</c> and <c>RevalidateFrameTransactions</c> also drop pending
+    /// frame transactions on a head change with no producer involved, but need a full pool or a changed tracked
+    /// dependency, and one unchanging sample gives neither.</remarks>
     [Test]
     public async Task Expiry_deadline_bounds_how_long_it_is_retained()
     {
-        ulong deadline = _headTimestamp + SlotSeconds * 3;
+        ulong deadline = _headTimestamp + SlotSeconds * DeadlineSlots;
         Transaction tx = BuildFrameTx(nonce: 0, deadline);
         Assert.That(_txPool.SubmitTx(tx, TxHandlingOptions.PersistentBroadcast), Is.EqualTo(AcceptTxResult.Accepted));
 
@@ -127,13 +131,19 @@ public class FrameTxPoolRetentionMeasurement
         for (int i = 0; i < HeadAdvances; i++)
         {
             await AdvanceHead(includedTx: null);
-            if (!_txPool.TryGetPendingTransaction(tx.Hash!, out _)) break;
+            if (!IsPending(tx)) break;
             survived++;
         }
 
-        Emit($"case=retention_with_deadline deadline_slots=3 heads={HeadAdvances} survived_heads={survived}");
-        Assert.That(survived, Is.LessThan(HeadAdvances), "an expired frame transaction was never evicted");
+        Emit($"case=retention_with_deadline deadline_slots={DeadlineSlots} heads={HeadAdvances} survived_heads={survived}");
+        // The sweep compares strictly and runs before the awaited TxPoolHeadChanged, so the head landing on the
+        // deadline still survives and the next one drops the sample — an exact count, not just "fewer".
+        Assert.That(survived, Is.EqualTo(DeadlineSlots), "the deadline did not bound retention at its own slots");
     }
+
+    /// <summary>Membership in the pending set — what a producer reads, and the one predicate both cases count
+    /// with, so the two emitted <c>survived_heads</c> are comparable.</summary>
+    private bool IsPending(Transaction tx) => Array.IndexOf(_txPool.GetPendingTransactions(), tx) >= 0;
 
     private async Task AdvanceHead(Transaction? includedTx)
     {

--- a/src/Nethermind/Nethermind.TxPool.Test/FrameTxPoolRetentionMeasurement.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/FrameTxPoolRetentionMeasurement.cs
@@ -33,8 +33,9 @@ namespace Nethermind.TxPool.Test;
 /// sweep is the one eviction reached — and the pool is built without a validation-prefix simulator, so
 /// revalidation reaches no verdict on an opaque prefix either.
 /// <c>FrameTxProducerRetryMeasurement</c> is where production attempts are run and the gas each one burns is
-/// counted. Results go to <c>FRAME_RETRY_OUT</c> (default <c>frame-prefix-retry.txt</c> under the temp
-/// directory), because the test runner swallows console writers.</remarks>
+/// counted. Results go to <c>FRAME_POOL_RETENTION_OUT</c>, then <c>FRAME_RETRY_OUT</c>, or
+/// <c>frame-pool-retention.txt</c> in the temp directory, because the test runner swallows console
+/// writers.</remarks>
 [Explicit("measurement harness")]
 public class FrameTxPoolRetentionMeasurement
 {
@@ -143,6 +144,7 @@ public class FrameTxPoolRetentionMeasurement
 
     /// <summary>Membership in the pending set — what a producer reads, and the one predicate both cases count
     /// with, so the two emitted <c>survived_heads</c> are comparable.</summary>
+    /// <remarks>The standard pool only, so a sample carrying blobs would never register as pending here.</remarks>
     private bool IsPending(Transaction tx) => Array.IndexOf(_txPool.GetPendingTransactions(), tx) >= 0;
 
     private async Task AdvanceHead(Transaction? includedTx)
@@ -218,8 +220,9 @@ public class FrameTxPoolRetentionMeasurement
 
     private static void Emit(string line)
     {
-        string path = Environment.GetEnvironmentVariable("FRAME_RETRY_OUT")
-                      ?? Path.Combine(Path.GetTempPath(), "frame-prefix-retry.txt");
+        string path = Environment.GetEnvironmentVariable("FRAME_POOL_RETENTION_OUT")
+                      ?? Environment.GetEnvironmentVariable("FRAME_RETRY_OUT")
+                      ?? Path.Combine(Path.GetTempPath(), "frame-pool-retention.txt");
         File.AppendAllText(path, $"RESULT {line}{Environment.NewLine}");
     }
 }

--- a/src/Nethermind/Nethermind.TxPool.Test/KeyedNonceFilterTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/KeyedNonceFilterTests.cs
@@ -4,24 +4,18 @@
 #nullable enable
 
 using System.Buffers.Binary;
-using System.Collections.Generic;
-using Nethermind.Blockchain;
-using Nethermind.Consensus.Comparers;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
-using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
-using Nethermind.Logging;
-using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.TxPool.Collections;
 using Nethermind.TxPool.Filters;
-using NSubstitute;
 using NUnit.Framework;
+using static Nethermind.TxPool.Test.FrameTxFilterTestPools;
 
 namespace Nethermind.TxPool.Test;
 
@@ -63,25 +57,6 @@ internal class KeyedNonceFilterTests
         KeyedNonceFilter filter = new(state, config ?? new TxPoolConfig(), standard, blob);
         TxFilteringState filteringState = new(tx, state, Eip8141Prototype.Instance);
         return filter.Accept(tx, ref filteringState, TxHandlingOptions.None);
-    }
-
-    private static TxDistinctSortedPool Pool(bool blobs, params Transaction[] pending)
-    {
-        ISpecProvider specProvider = Substitute.For<ISpecProvider>();
-        specProvider.GetSpec(Arg.Any<ForkActivation>()).Returns(new ReleaseSpec { IsEip1559Enabled = false });
-        IBlockTree blockTree = Substitute.For<IBlockTree>();
-        blockTree.Head.Returns(Build.A.Block.WithNumber(0).TestObject);
-
-        IComparer<Transaction> comparer = new TransactionComparerProvider(specProvider, blockTree).GetDefaultComparer();
-        TxDistinctSortedPool pool = blobs
-            ? new BlobTxDistinctSortedPool(pending.Length + 1, comparer, LimboLogs.Instance)
-            : new TxDistinctSortedPool(pending.Length + 1, comparer, LimboLogs.Instance);
-        foreach (Transaction tx in pending)
-        {
-            pool.TryInsert(tx.Hash!, tx);
-        }
-
-        return pool;
     }
 
     /// <remarks>The sender's account nonce is <see cref="AccountNonce"/> throughout, so every accepted case here


### PR DESCRIPTION
Addresses two P3 review threads on #12526.

## Changes

- **`FrameTxPrefixRetryMeasurement` → `FrameTxPoolRetentionMeasurement`.** The harness advanced empty heads and checked pool membership; it never produced a block and never reached the eviction path, so `unpaid_gas_over_window = prefix_gas * survived_heads` named a producer cost it never observed. It now says what it runs — pool retention across heads, and the expiry deadline that bounds it — and the derived gas value is reported as an explicit hypothetical next to `production_attempts=0`.
- Production attempts are not re-measured here because `Nethermind.Blockchain.Test/FrameTxProducerRetryMeasurement` already runs them through `BlockProcessor.BlockProductionTransactionsExecutor` and reports `execution_attempts`, `burn_first_attempt` and `burn_total` over a `K_retry` sweep.
- **`KeyedNonceFilterTests.Pool`** duplicated `FrameTxFilterTestPools.Pool` byte for byte apart from its accessibility modifier. Deleted in favour of the shared helper, matching the paymaster and payer-exposure fixtures; those two were the only copies in `Nethermind.TxPool.Test`.

Emitted line, before and after:

```
RESULT case=no_deadline heads=20 survived_heads=20 prefix_gas=50000 unpaid_gas_over_window=1000000
RESULT case=retention_no_deadline heads=20 survived_heads=20 declared_prefix_gas=50000 production_attempts=0 hypothetical_gas_if_every_head_retried=1000000
```

## Types of changes

#### What types of changes does your code introduce?

- [x] Refactoring

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

`Nethermind.TxPool.Test` run in full in release and checked (`-p:DefineConstants=TRACE;DEBUG`, artifacts cleared between configs): 1209 passed, 0 failed, 24 skipped in both. The measurement harness is `[Explicit]`, so it was also run directly to confirm it still emits.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
