### PR TITLE
Merge master into eip8141-frame-txs-devnet7

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -53,6 +53,29 @@ namespace Nethermind.Blockchain.Test;
 public class BlockProcessorTests
 {
     [Test]
+    public async Task Block_processing_preserves_receipt_logs_without_a_log_tracer()
+    {
+        using BasicTestBlockchain chain = await BasicTestBlockchain.Create(builder => builder
+            .AddSingleton<ISpecProvider>(new TestSpecProvider(Prague.Instance) { AllowTestChainOverride = false }));
+        Transaction tx = Build.A.Transaction.WithTo(null)
+            .WithCode(Prepare.EvmCode.Log(32, 0, [TestItem.KeccakA]).STOP().Done)
+            .WithGasLimit(100_000).SignedAndResolved(TestItem.PrivateKeyB).TestObject;
+
+        Block block = await chain.AddBlock(tx);
+
+        TxReceipt[] receipts = chain.ReceiptStorage.Get(block);
+        Assert.That(receipts, Has.Length.EqualTo(1));
+        Assert.That(receipts[0].Logs, Has.Length.EqualTo(1));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(receipts[0].StatusCode, Is.EqualTo(StatusCode.Success));
+            Assert.That(receipts[0].Logs[0].Topics, Is.EqualTo(new[] { TestItem.KeccakA }));
+            Assert.That(receipts[0].Bloom, Is.Not.EqualTo(Bloom.Empty));
+            Assert.That(block.Header.Bloom, Is.Not.EqualTo(Bloom.Empty));
+        }
+    }
+
+    [Test]
     public void ApplyStateChanges_uses_parent_state_without_prestate_sentinels()
     {
         ReadOnlyBlockAccessList bal = Build.A.BlockAccessList

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/AccessTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/AccessTxTracer.cs
@@ -14,6 +14,7 @@ namespace Nethermind.Blockchain.Tracing;
 public class AccessTxTracer(params Address[] addressesToOptimize) : TxTracer
 {
     public override bool IsTracingReceipt => true;
+    public override bool IsCollectingLogs => false;
     public override bool IsTracingAccess => true;
 
     public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs,

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -20,6 +20,7 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     private IBlockTracer _otherTracer = NullBlockTracer.Instance;
     protected Block Block = null!;
     public bool IsTracingReceipt => true;
+    public bool IsCollectingLogs => true;
     public bool IsTracingActions => _currentTxTracer.IsTracingActions;
     public bool IsTracingOpLevelStorage => _currentTxTracer.IsTracingOpLevelStorage;
     public bool IsTracingMemory => _currentTxTracer.IsTracingMemory;

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/CallOutputTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/CallOutputTracer.cs
@@ -11,6 +11,7 @@ namespace Nethermind.Blockchain.Tracing;
 public class CallOutputTracer : TxTracer
 {
     public override bool IsTracingReceipt => true;
+    public override bool IsCollectingLogs => false;
     public byte[]? ReturnValue { get; set; }
 
     public ulong GasSpent { get; set; }

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/EstimateGasTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/EstimateGasTracer.cs
@@ -19,6 +19,7 @@ public class EstimateGasTracer : TxTracer
     public EstimateGasTracer() => _currentGasAndNesting.Push(new GasAndNesting(0, -1));
 
     public override bool IsTracingReceipt => true;
+    public override bool IsCollectingLogs => false;
     public override bool IsTracingActions => true;
     public override bool IsTracingRefunds => true;
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/GethLikeTxTracer.cs
@@ -35,6 +35,7 @@ public abstract class GethLikeTxTracer : TxTracer, ITraceImplicitStop
 
     protected void ResetTrace() => _trace = null;
     public override bool IsTracingReceipt => true;
+    public override bool IsCollectingLogs => false;
     public sealed override bool IsTracingOpLevelStorage { get; protected set; }
     public sealed override bool IsTracingMemory { get; protected set; }
     public override bool IsTracingInstructions => true;

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/ParityLikeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/ParityStyle/ParityLikeTxTracer.cs
@@ -70,6 +70,7 @@ public class ParityLikeTxTracer : TxTracer
 
     public sealed override bool IsTracingActions { get; protected set; }
     public sealed override bool IsTracingReceipt { get; protected set; }
+    public override bool IsCollectingLogs => false;
     public sealed override bool IsTracingInstructions { get; protected set; }
     public sealed override bool IsTracingCode { get; protected set; }
     public sealed override bool IsTracingState { get; protected set; }

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockCachePreWarmer.cs
@@ -101,7 +101,7 @@ public sealed class BlockCachePreWarmer : IBlockCachePreWarmer
         IHasAccessList[]? systemAccessLists = null)
     {
         _systemAccessLists = systemAccessLists ?? [];
-        _concurrencyLevel = concurrency == 0 ? Math.Min(Environment.ProcessorCount - 1, 16) : concurrency;
+        _concurrencyLevel = concurrency == 0 ? Environment.ProcessorCount - 1 : concurrency;
         _speculativeConcurrencyLevel = speculativeConcurrency == 0 ? Math.Max(1, _concurrencyLevel / 2) : speculativeConcurrency;
         _parallelExecutionBatchRead = parallelExecutionBatchRead;
         // minPoolSize is a floor: the address warmer, transaction warmup, and storage discovery rent

--- a/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/RlpTests.cs
@@ -34,6 +34,151 @@ namespace Nethermind.Core.Test
             Assert.That(decoded, Is.EqualTo(value));
         }
 
+        [Test]
+        public void Cursor_decoders_chain_without_changing_the_input([Values(0, 3)] int start)
+        {
+            byte[] encoded = [0xc7, 0x01, 0x81, 0x80, 0x83, 0x61, 0x62, 0x63];
+            byte[] buffer = [.. new byte[start], .. encoded];
+            LiteRlpReader reader = new(buffer);
+
+            int position = start;
+            reader.ReadSequenceLength(ref position, out int contentLength);
+            int contentStart = position;
+            reader.DecodeULong(ref position, out ulong first);
+            reader.DecodeUInt256(ref position, out UInt256 second);
+            reader.DecodeByteArraySpan(ref position, out ReadOnlySpan<byte> third);
+            int rereadPosition = contentStart;
+            ulong reread = reader.DecodeULong(ref rereadPosition);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(contentLength, Is.EqualTo(7));
+                Assert.That(first, Is.EqualTo(1));
+                Assert.That(second, Is.EqualTo((UInt256)128));
+                Assert.That(third.ToArray(), Is.EqualTo(new byte[] { 0x61, 0x62, 0x63 }));
+                Assert.That(position, Is.EqualTo(start + encoded.Length));
+                Assert.That(rereadPosition, Is.EqualTo(start + 2));
+                Assert.That(reread, Is.EqualTo(first));
+                Assert.That(buffer.AsSpan(start).ToArray(), Is.EqualTo(encoded));
+            }
+        }
+
+        [Test]
+        public void Cursor_reader_distinguishes_null_from_empty_string()
+        {
+            byte[] nullValue = [Rlp.EmptyListByte, Rlp.EmptyByteArrayByte];
+            RlpReader nullContext = new(nullValue);
+            bool consumedNull = nullContext.TryConsumeNull(out LiteRlpReader nullReader, out int nullPosition);
+
+            byte[] emptyString = [Rlp.EmptyByteArrayByte];
+            RlpReader emptyContext = new(emptyString);
+            bool consumedEmptyString = emptyContext.TryConsumeNull(out LiteRlpReader emptyReader, out int emptyPosition);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(consumedNull, Is.True);
+                Assert.That(nullPosition, Is.Zero);
+                Assert.That(nullContext.Position, Is.EqualTo(1));
+                Assert.That(nullReader.Data.Length, Is.EqualTo(nullValue.Length));
+                Assert.That(nullReader.Data[0], Is.EqualTo(Rlp.EmptyListByte));
+                Assert.That(consumedEmptyString, Is.False);
+                Assert.That(emptyPosition, Is.Zero);
+                Assert.That(emptyContext.Position, Is.Zero);
+                Assert.That(emptyReader.Data[0], Is.EqualTo(Rlp.EmptyByteArrayByte));
+            }
+        }
+
+        [Test]
+        public void Lite_reader_forwards_the_remaining_cursor_decoders()
+        {
+            byte[] integer = [0x82, 0x01, 0x00];
+            LiteRlpReader reader = new(integer);
+            int position = 0;
+
+            reader.DecodeUShort(ref position, out ushort ushortValue);
+            Assert.That((ushortValue, position), Is.EqualTo(((ushort)256, integer.Length)));
+
+            position = 0;
+            reader.DecodePositiveLong(ref position, out long longValue);
+            Assert.That((longValue, position), Is.EqualTo((256L, integer.Length)));
+
+            position = 0;
+            reader.DecodeEvmWord(ref position, out EvmWord _);
+            Assert.That(position, Is.EqualTo(integer.Length));
+
+            byte[] byteValueRlp = [1];
+            reader = new(byteValueRlp);
+            position = 0;
+            reader.DecodeByte(ref position, out byte byteValue);
+            Assert.That((byteValue, position), Is.EqualTo(((byte)1, byteValueRlp.Length)));
+
+            byte[] hashRlp = [160, .. Keccak.EmptyTreeHash.Bytes];
+            reader = new(hashRlp);
+            position = 0;
+            reader.DecodeValueKeccakOrNull(ref position, out ValueHash256? nullableHash);
+            Assert.That((nullableHash, position), Is.EqualTo((Keccak.EmptyTreeHash.ValueHash256, hashRlp.Length)));
+
+            position = 0;
+            bool hasValue = reader.TryDecodeValueKeccak(ref position, out ValueHash256 valueHash);
+            Assert.That((hasValue, valueHash, position), Is.EqualTo((true, Keccak.EmptyTreeHash.ValueHash256, hashRlp.Length)));
+
+            byte[] zeroPrefixHashRlp = [1];
+            reader = new(zeroPrefixHashRlp);
+            position = 0;
+            reader.DecodeZeroPrefixKeccak(ref position, out Hash256? zeroPrefixHash);
+            byte[] expectedHashBytes = new byte[Hash256.Size];
+            expectedHashBytes[^1] = 1;
+            Assert.That((zeroPrefixHash, position), Is.EqualTo((new Hash256(expectedHashBytes), zeroPrefixHashRlp.Length)));
+
+            byte[] bloomRlp = ExpectedBloom(Bloom.Empty);
+            reader = new(bloomRlp);
+            position = 0;
+            reader.DecodeBloomSpan(ref position, out ReadOnlySpan<byte> bloomBytes);
+            Assert.That(bloomBytes.ToArray(), Is.EqualTo(Bloom.Empty.Bytes.ToArray()));
+            Assert.That(position, Is.EqualTo(bloomRlp.Length));
+
+            byte[] stringRlp = [0x83, 0x61, 0x62, 0x63];
+            reader = new(stringRlp);
+            position = 0;
+            reader.DecodeString(ref position, out string value);
+            Assert.That((value, position), Is.EqualTo(("abc", stringRlp.Length)));
+        }
+
+        [Test]
+        public void Cursor_span_decoder_keeps_the_failing_item_position()
+        {
+            byte[] buffer = [0x01, 0x81, 0x01];
+            int position = 0;
+
+            void Decode()
+            {
+                LiteRlpReader reader = new(buffer);
+                reader.DecodeByteArraySpan(ref position, out _);
+                reader.DecodeByteArraySpan(ref position, out _);
+            }
+
+            Assert.That(Decode, Throws.TypeOf<RlpException>());
+            Assert.That(position, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Cursor_decoder_keeps_the_failing_item_position([Values(0, 3)] int start, [Values] bool useOut)
+        {
+            byte[] buffer = [.. new byte[start], 0x01, 0x81, 0x01];
+            int position = start;
+
+            void Decode()
+            {
+                LiteRlpReader reader = new(buffer);
+                if (useOut) reader.DecodeULong(ref position, out _);
+                else reader.DecodeULong(ref position);
+            }
+
+            Decode();
+            Assert.That(Decode, Throws.TypeOf<RlpException>());
+            Assert.That(position, Is.EqualTo(start + 1));
+        }
+
         /// <summary>Builds a value whose canonical big-endian encoding is exactly that many bytes.</summary>
         private static UInt256 UInt256OfByteLength(int byteLength)
         {
@@ -1182,7 +1327,7 @@ namespace Nethermind.Core.Test
         {
             // These prefixes declare a multi-byte length field, but the data is truncated
             // before all length bytes are present. The bounds check should catch this.
-            Action act = () => RlpHelpers.PeekNextRlpLength(truncatedData, 0);
+            Action act = () => new LiteRlpReader(truncatedData).PeekNextRlpLength(0);
             Assert.That(act, Throws.TypeOf<RlpException>());
         }
     }

--- a/src/Nethermind/Nethermind.Core/Cpu/RuntimeInformation.cs
+++ b/src/Nethermind/Nethermind.Core/Cpu/RuntimeInformation.cs
@@ -52,6 +52,5 @@ public static class RuntimeInformation
     public static bool IsSingleProcessor => ProcessorCount <= 1;
     public static int PhysicalCoreCount { get; } = GetCpuInfo()?.PhysicalCoreCount ?? ProcessorCount;
     public static ParallelOptions ParallelOptionsLogicalCores { get; } = new() { MaxDegreeOfParallelism = ProcessorCount };
-    public static ParallelOptions ParallelOptionsPhysicalCoresUpTo16 { get; } = new() { MaxDegreeOfParallelism = Math.Min(ProcessorCount, 16) };
     public static bool Is64BitPlatform() => IntPtr.Size == 8;
 }

--- a/src/Nethermind/Nethermind.Evm.Benchmark/LogEmissionBenchmark.cs
+++ b/src/Nethermind/Nethermind.Evm.Benchmark/LogEmissionBenchmark.cs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Text.Json;
 using Autofac;
 using BenchmarkDotNet.Attributes;
+using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -12,6 +15,7 @@ using Nethermind.Core.Test.Modules;
 using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
+using Nethermind.Facade;
 using Nethermind.Specs.Forks;
 using Nethermind.State;
 
@@ -25,6 +29,7 @@ public class LogEmissionBenchmark
     private IDisposable _stateScope = null!;
     private IWorldState _state = null!;
     private ITransactionProcessor _processor = null!;
+    private IBlockchainBridge _bridge = null!;
     private Transaction _transaction = null!;
     private BlockHeader _header = null!;
     private Snapshot _snapshot;
@@ -32,8 +37,10 @@ public class LogEmissionBenchmark
     [Params(0, 100)]
     public int LogCount { get; set; }
 
-    [Params(false, true)]
-    public bool Warmup { get; set; }
+    private static readonly GethTraceOptions WithLogs = GethTraceOptions.Default with
+    {
+        TracerConfig = JsonSerializer.SerializeToElement(new { withLog = true })
+    };
 
     [GlobalSetup]
     public void Setup()
@@ -46,31 +53,59 @@ public class LogEmissionBenchmark
         _stateScope = _state.BeginScope(IWorldState.PreGenesis);
         _state.CreateAccount(TestItem.AddressA, 1.Ether);
         _state.CreateAccount(TestItem.AddressB, 0);
-        byte[] code = new byte[LogCount * 11 + 1];
+        byte[] code = new byte[LogCount * 11 + 4];
         for (int i = 0; i < LogCount; i++)
         {
             // Four zero topics, 1 KiB of data at offset 1 KiB.
             new byte[] { 0x5f, 0x5f, 0x5f, 0x5f, 0x61, 0x04, 0x00, 0x61, 0x04, 0x00, 0xa4 }
                 .CopyTo(code, i * 11);
         }
+        // Read one slot so access-list generation exercises convergence.
+        new byte[] { 0x5f, 0x54, 0x50 }.CopyTo(code, LogCount * 11);
         _state.InsertCode(TestItem.AddressB, Keccak.Compute(code), code, Osaka.Instance);
         _state.Commit(Osaka.Instance);
+        _state.CommitTree(1);
         _snapshot = _state.TakeSnapshot();
         _processor = _scope.Resolve<ITransactionProcessor>();
-        _header = Build.A.BlockHeader.WithNumber(1).WithGasLimit(30_000_000).WithBaseFee(0).TestObject;
+        _bridge = _scope.Resolve<IBlockchainBridge>();
+        _header = Build.A.BlockHeader.WithNumber(1).WithGasLimit(30_000_000).WithBaseFee(0)
+            .WithStateRoot(_state.StateRoot).TestObject;
         _processor.SetBlockExecutionContext(_header);
         _transaction = Build.A.Transaction.WithTo(TestItem.AddressB).WithGasLimit(10_000_000)
             .WithGasPrice(1).SignedAndResolved(TestItem.PrivateKeyA).TestObject;
-        if (!Execute().TransactionExecuted) throw new InvalidOperationException("Benchmark transaction did not execute.");
+        if (!Warmup().TransactionExecuted || Call().Error is not null || EstimateGas().Error is not null
+            || CreateAccessList().Error is not null)
+            throw new InvalidOperationException("Benchmark transaction did not execute.");
     }
 
     [Benchmark]
-    public TransactionResult Execute()
+    public CallOutput Call() => _bridge.Call(_header, _transaction);
+
+    [Benchmark]
+    public CallOutput EstimateGas() => _bridge.EstimateGas(_header, _transaction, 0);
+
+    [Benchmark]
+    public CallOutput CreateAccessList() => _bridge.CreateAccessList(_header, _transaction, null, false);
+
+    [Benchmark]
+    public void CallTrace() => Trace(GethTraceOptions.Default);
+
+    [Benchmark]
+    public void CallTraceWithLogs() => Trace(WithLogs);
+
+    private void Trace(GethTraceOptions options)
     {
         _header.GasUsed = 0;
-        TransactionResult result = Warmup
-            ? _processor.Warmup(_transaction, NullTxTracer.Instance)
-            : _processor.BuildUp(_transaction, NullTxTracer.Instance);
+        using NativeCallTracer tracer = new(_transaction, Osaka.Instance, options);
+        _processor.CallAndRestore(_transaction, tracer);
+        using GethLikeTxTrace result = tracer.BuildResult();
+    }
+
+    [Benchmark]
+    public TransactionResult Warmup()
+    {
+        _header.GasUsed = 0;
+        TransactionResult result = _processor.Warmup(_transaction, NullTxTracer.Instance);
         _state.Restore(_snapshot);
         return result;
     }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
@@ -15,6 +15,29 @@ namespace Nethermind.Evm.Test.Tracing;
 public class CompositeTxTracerTests
 {
     [Test]
+    public void Aggregates_receipt_log_requirements([Values] bool firstRequiresLogs, [Values] bool secondRequiresLogs)
+    {
+        ITxTracer first = Substitute.For<ITxTracer>();
+        first.IsCollectingLogs.Returns(firstRequiresLogs);
+        ITxTracer second = Substitute.For<ITxTracer>();
+        second.IsCollectingLogs.Returns(secondRequiresLogs);
+        using CompositeTxTracer tracer = new(first, second);
+
+        Assert.That(tracer.IsCollectingLogs, Is.EqualTo(firstRequiresLogs || secondRequiresLogs));
+    }
+
+    [Test]
+    public void Cancellation_preserves_receipt_log_requirements([Values] bool innerRequiresLogs, [Values] bool forceReceipts)
+    {
+        ITxTracer inner = Substitute.For<ITxTracer>();
+        inner.IsTracingReceipt.Returns(true);
+        inner.IsCollectingLogs.Returns(innerRequiresLogs);
+        using CancellationTxTracer tracer = new(inner) { IsTracingReceipt = forceReceipts };
+
+        Assert.That(tracer.IsCollectingLogs, Is.EqualTo(innerRequiresLogs || forceReceipts));
+    }
+
+    [Test]
     public void Aggregates_IsCancelable_from_children()
     {
         CompositeTxTracer nonCancelable = new(Substitute.For<ITxTracer>(), Substitute.For<ITxTracer>());

--- a/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorWarmupTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/TransactionProcessorWarmupTests.cs
@@ -3,7 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Tracing.GethStyle;
+using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Call;
+using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Prestate;
+using Nethermind.Blockchain.Tracing.ParityStyle;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Core.Extensions;
@@ -16,6 +21,7 @@ using Nethermind.Evm.Tracing;
 using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Int256;
 using Nethermind.Logging;
+using Nethermind.Serialization.Json;
 using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using NUnit.Framework;
@@ -27,6 +33,7 @@ public class TransactionProcessorWarmupTests
     private ISpecProvider _specProvider = null!;
     private IEthereumEcdsa _ethereumEcdsa = null!;
     private ITransactionProcessor _transactionProcessor = null!;
+    private EthereumVirtualMachine _virtualMachine = null!;
     private IWorldState _stateProvider = null!;
     private IDisposable _worldStateCloser = null!;
 
@@ -37,8 +44,8 @@ public class TransactionProcessorWarmupTests
         _stateProvider = TestWorldStateFactory.CreateForTest();
         _worldStateCloser = _stateProvider.BeginScope(IWorldState.PreGenesis);
         EthereumCodeInfoRepository codeInfoRepository = new(_stateProvider);
-        EthereumVirtualMachine virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
-        _transactionProcessor = new EthereumTransactionProcessor(BlobBaseFeeCalculator.Instance, _specProvider, _stateProvider, virtualMachine, codeInfoRepository, LimboLogs.Instance);
+        _virtualMachine = new(new TestBlockhashProvider(_specProvider), _specProvider, LimboLogs.Instance);
+        _transactionProcessor = new EthereumTransactionProcessor(BlobBaseFeeCalculator.Instance, _specProvider, _stateProvider, _virtualMachine, codeInfoRepository, LimboLogs.Instance);
         _ethereumEcdsa = new EthereumEcdsa(_specProvider.ChainId);
     }
 
@@ -46,16 +53,19 @@ public class TransactionProcessorWarmupTests
     public void TearDown() => _worldStateCloser?.Dispose();
 
     [Test]
-    public void Unobserved_logs_preserve_warmup_gas_and_memory([Range(0, 4)] int topicCount, [Values] bool receiptTracer)
+    public void Unobserved_logs_preserve_warmup_gas_and_memory(
+        [Range(0, 4)] int topicCount, [Values(0, 128)] int logSize, [Values] bool receiptTracer)
     {
         Hash256[] topics = new Hash256[topicCount];
         Array.Fill(topics, TestItem.KeccakA);
-        byte[] code = Prepare.EvmCode.Log(128, 1024, topics)
-            .Op(Instruction.MSIZE).PushData(0).Op(Instruction.SSTORE).Done;
+        byte[] code = Prepare.EvmCode.PushData(0x42).Log(logSize, 1024, topics)
+            .Op(Instruction.MSIZE).PushData(0).Op(Instruction.SSTORE)
+            .PushData(1).Op(Instruction.SSTORE).Done;
         (Transaction tx, Snapshot snapshot) = PrepareLogTransaction(code, 500_000);
         using LogCaptureTracer tracer = new(receiptTracer);
 
         _transactionProcessor.Warmup(tx, tracer);
+        Assert.That(_virtualMachine.TxExecutionContext.SuppressLogs, Is.False);
         UInt256 expectedBalance = _stateProvider.GetBalance(TestItem.AddressA);
         _stateProvider.Restore(snapshot);
         TransactionResult result = _transactionProcessor.Warmup(tx, NullTxTracer.Instance);
@@ -64,11 +74,13 @@ public class TransactionProcessorWarmupTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(result.TransactionExecuted, Is.True);
+            Assert.That(_virtualMachine.TxExecutionContext.SuppressLogs, Is.True);
             Assert.That(_stateProvider.GetBalance(TestItem.AddressA), Is.EqualTo(expectedBalance));
             Assert.That(_stateProvider.GetNonce(TestItem.AddressA), Is.EqualTo(1UL));
-            Assert.That(new UInt256(_stateProvider.Get(new StorageCell(TestItem.AddressB, 0)), isBigEndian: true), Is.EqualTo(new UInt256(1152)));
+            Assert.That(new UInt256(_stateProvider.Get(new StorageCell(TestItem.AddressB, 0)), isBigEndian: true), Is.EqualTo(new UInt256(logSize == 0 ? 0UL : 1152UL)));
+            Assert.That(new UInt256(_stateProvider.Get(new StorageCell(TestItem.AddressB, 1)), isBigEndian: true), Is.EqualTo(new UInt256(0x42)));
             Assert.That(tracer.Logs[0].Topics, Is.EqualTo(topics));
-            Assert.That(tracer.Logs[0].Data, Is.EqualTo(new byte[128]));
+            Assert.That(tracer.Logs[0].Data, Is.EqualTo(new byte[logSize]));
         }
     }
 
@@ -131,15 +143,66 @@ public class TransactionProcessorWarmupTests
     }
 
     [Test]
-    public void Warmup_preserves_memory_access_for_instruction_tracers()
+    public void Warmup_preserves_memory_access_for_instruction_tracers([Values(0x100800, 0x200000)] int offset)
     {
-        byte[] code = Prepare.EvmCode.Log(32, 0x100800).Op(Instruction.STOP).Done;
-        (Transaction tx, _) = PrepareLogTransaction(code, 5_000_000);
+        byte[] code = Prepare.EvmCode.Log(32, offset).Op(Instruction.STOP).Done;
+        (Transaction tx, _) = PrepareLogTransaction(code, 20_000_000);
         using MemoryWordTracer tracer = new();
 
         _transactionProcessor.Warmup(tx, tracer);
 
         Assert.That(tracer.LastWord, Is.EqualTo(new byte[32]));
+    }
+
+    [Test]
+    public void Tracing_collects_only_observed_logs(
+        [Values("call", "callLogs", "memory", "prestate", "parity", "parityVm")] string tracerName,
+        [Values] bool cancelable)
+    {
+        byte[] code = Prepare.EvmCode.Log(128, 1024, [TestItem.KeccakA])
+            .Op(Instruction.MSIZE).PushData(0).Op(Instruction.MSTORE)
+            .PushData(32).PushData(0).Op(Instruction.RETURN).Done;
+        (Transaction tx, _) = PrepareLogTransaction(code, 500_000);
+
+        (string baseline, ulong baselineGas, int baselineLogs) = TraceWithLogCollection(tx, tracerName, true, cancelable);
+        (string optimized, ulong optimizedGas, int optimizedLogs) = TraceWithLogCollection(tx, tracerName, false, cancelable);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(optimized, Is.EqualTo(baseline));
+            Assert.That(optimizedGas, Is.EqualTo(baselineGas));
+            Assert.That(baselineLogs, Is.EqualTo(1));
+            Assert.That(optimizedLogs, Is.EqualTo(tracerName == "callLogs" ? 1 : 0));
+        }
+    }
+
+    private (string, ulong, int) TraceWithLogCollection(Transaction tx, string tracerName, bool receiptLogs, bool cancelable)
+    {
+        using TxTracer tracer = tracerName switch
+        {
+            "call" or "callLogs" => new NativeCallTracer(tx, _specProvider.GenesisSpec, GethTraceOptions.Default with
+            {
+                TracerConfig = JsonSerializer.SerializeToElement(new { withLog = tracerName == "callLogs" })
+            }),
+            "memory" => new GethLikeTxMemoryTracer(tx, GethTraceOptions.Default with { EnableMemory = true }),
+            "prestate" => new NativePrestateTracer(_stateProvider, GethTraceOptions.Default, tx.Hash, tx.SenderAddress, tx.To),
+            _ => new ParityLikeTxTracer(Build.A.Block.WithTransactions(tx).TestObject, tx,
+                ParityTraceTypes.Trace | ParityTraceTypes.StateDiff | (tracerName == "parityVm" ? ParityTraceTypes.VmTrace : 0))
+        };
+        using LogCaptureTracer observer = new(receiptTracer: true, receiptLogs);
+        ITxTracer composite = new CompositeTxTracer(tracer, observer);
+        if (cancelable) composite = composite.WithCancellation(default);
+        TransactionResult result = _transactionProcessor.CallAndRestore(tx, composite);
+        Assert.That(result.TransactionExecuted, Is.True);
+        Assert.That(observer.Failed, Is.False);
+
+        if (tracer is GethLikeTxTracer gethTracer)
+        {
+            using GethLikeTxTrace trace = gethTracer.BuildResult();
+            return (JsonSerializer.Serialize(trace, EthereumJsonSerializer.JsonOptions), observer.GasSpent, observer.Logs.Count);
+        }
+
+        return (JsonSerializer.Serialize(((ParityLikeTxTracer)tracer).BuildResult(), EthereumJsonSerializer.JsonOptions), observer.GasSpent, observer.Logs.Count);
     }
 
     private sealed class MemoryWordTracer : TxTracer
@@ -163,17 +226,23 @@ public class TransactionProcessorWarmupTests
     {
         public List<LogEntry> Logs { get; } = [];
         public bool Failed { get; private set; }
+        public ulong GasSpent { get; private set; }
+        public override bool IsCollectingLogs { get; }
 
-        public LogCaptureTracer(bool receiptTracer)
+        public LogCaptureTracer(bool receiptTracer, bool? receiptLogs = null)
         {
             IsTracingReceipt = receiptTracer;
+            IsCollectingLogs = receiptLogs ?? receiptTracer;
             IsTracingLogs = !receiptTracer;
         }
 
         public override void ReportLog(LogEntry log) => Logs.Add(log);
 
         public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null)
-            => Logs.AddRange(logs);
+        {
+            GasSpent = gasSpent.SpentGas;
+            Logs.AddRange(logs);
+        }
 
         public override void MarkAsFailed(Address recipient, in GasConsumed gasSpent, byte[] output, string? error, Hash256? stateRoot = null)
             => Failed = true;

--- a/src/Nethermind/Nethermind.Evm.ZkEvm.Test/GuestDispatchFlagsTests.cs
+++ b/src/Nethermind/Nethermind.Evm.ZkEvm.Test/GuestDispatchFlagsTests.cs
@@ -30,7 +30,11 @@ public class GuestDispatchFlagsTests
     {
         using CapabilityTracer tracer = new(capability);
 
-        Assert.DoesNotThrow(() => DispatchFlags.Validate(tracer));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.DoesNotThrow(() => DispatchFlags.Validate(tracer));
+            Assert.That(tracer.IsCollectingLogs, Is.EqualTo(capability == nameof(ITxTracer.IsTracingReceipt)));
+        }
     }
 
     /// <remarks>Re-lists ITxTracer so Validate observes this IsCancelable implementation instead of the default interface value.</remarks>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Stack.cs
@@ -1152,6 +1152,9 @@ public static partial class EvmInstructions
 
         if (vm.TxExecutionContext.SuppressLogs)
         {
+            // Instruction tracers can inspect the expanded memory even when they do not collect logs.
+            if (DispatchFlags.ConstTracing && vm.TxExecutionContext.MaterializeLogMemory
+                && !vmState.Memory.TryLoad(in position, length, out _)) goto OutOfGas;
             for (int i = 0; i < TOpCount.Count; i++)
                 if (!stack.PopLimbo()) goto StackUnderflow;
             return EvmExceptionType.None;

--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -40,6 +40,8 @@ public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token
         init => _isTracingReceipt = value;
     }
 
+    public bool IsCollectingLogs => _isTracingReceipt || innerTracer.IsCollectingLogs;
+
     public bool IsTracingActions
     {
         get => _isTracingActions || innerTracer.IsTracingActions;

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -27,6 +27,7 @@ public class CompositeTxTracer : ITxTracer
             IsCancelable |= t.IsCancelable;
             IsTracingState |= t.IsTracingState;
             IsTracingReceipt |= t.IsTracingReceipt;
+            IsCollectingLogs |= t.IsCollectingLogs;
             IsTracingActions |= t.IsTracingActions;
             IsTracingOpLevelStorage |= t.IsTracingOpLevelStorage;
             IsTracingMemory |= t.IsTracingMemory;
@@ -61,6 +62,7 @@ public class CompositeTxTracer : ITxTracer
     public bool IsTracingState { get; }
     public bool IsTracingStorage { get; }
     public bool IsTracingReceipt { get; }
+    public bool IsCollectingLogs { get; }
     public bool IsTracingActions { get; }
     public bool IsTracingOpLevelStorage { get; }
     public bool IsTracingMemory { get; }

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -26,6 +26,16 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
     bool IsTracingReceipt { get; }
 
     /// <summary>
+    /// Whether receipt callbacks require the transaction's event logs.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to receipt tracing for compatibility. Tracers that only consume status, gas or output
+    /// can return false. Per-opcode log callbacks are controlled separately by <see cref="IsTracingLogs"/>.
+    /// Returning false permits an incomplete log array in receipt callbacks; it does not guarantee an empty array.
+    /// </remarks>
+    bool IsCollectingLogs => IsTracingReceipt;
+
+    /// <summary>
     /// High level calls with information on the target account
     /// </summary>
     /// <remarks>

--- a/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
@@ -34,6 +34,7 @@ public abstract class TxTracer : ITxTracer
 
     public virtual bool IsTracingState { get; protected set; }
     public virtual bool IsTracingReceipt { get; protected set; }
+    public virtual bool IsCollectingLogs => IsTracingReceipt;
     public virtual bool IsTracingActions { get; protected set; }
     public virtual bool IsTracingOpLevelStorage { get; protected set; }
     public virtual bool IsTracingMemory { get; protected set; }

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs
@@ -309,7 +309,8 @@ namespace Nethermind.Evm.TransactionProcessing
         {
             VirtualMachine.SetTxExecutionContext(new(tx.SenderAddress!, _codeInfoRepository, tx.BlobVersionedHashes, in opcodeGasPrice)
             {
-                SuppressLogs = opts.HasFlag(ExecutionOptions.Warmup) && ReferenceEquals(tracer, NullTxTracer.Instance)
+                SuppressLogs = !tracer.IsCollectingLogs && !tracer.IsTracingLogs,
+                MaterializeLogMemory = tracer.IsTracingInstructions || tracer.IsTracingMemory
             });
             // Top-level CREATE tx; the opcode-level CREATE/CREATE2 path bumps this counter from EvmInstructions.Create.
             if (tx.IsContractCreation) Metrics.IncrementCreates();

--- a/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
+++ b/src/Nethermind/Nethermind.Evm/TransactionProcessing/TransactionProcessorBase.FrameTx.cs
@@ -283,7 +283,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
             VirtualMachine.SetTxExecutionContext(new TxExecutionContext(
                 caller, _codeInfoRepository, tx.BlobVersionedHashes, in effectiveGasPrice, frameContext)
             {
-                SuppressLogs = ShouldSuppressLogs(opts, tracer)
+                SuppressLogs = ShouldSuppressLogs(opts, tracer),
+                MaterializeLogMemory = tracer.IsTracingInstructions || tracer.IsTracingMemory
             });
 
             // The shared journal accumulates logs across frames; this frame's own logs start here.
@@ -621,7 +622,8 @@ public abstract partial class TransactionProcessorBase<TGasPolicy>
                 VirtualMachine.SetTxExecutionContext(new TxExecutionContext(
                     caller, _codeInfoRepository, tx.BlobVersionedHashes, in effectiveGasPrice, frameContext)
                 {
-                    SuppressLogs = ShouldSuppressLogs(opts, tracer)
+                    SuppressLogs = ShouldSuppressLogs(opts, tracer),
+                    MaterializeLogMemory = tracer.IsTracingInstructions || tracer.IsTracingMemory
                 });
 
                 // The deploy-frame carve-outs are scoped to one frame and everything it calls, which the

--- a/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
+++ b/src/Nethermind/Nethermind.Evm/TxExecutionContext.cs
@@ -19,5 +19,6 @@ namespace Nethermind.Evm
         public readonly UInt256 GasPrice = gasPrice;
 
         internal bool SuppressLogs { get; init; }
+        internal bool MaterializeLogMemory { get; init; }
     }
 }

--- a/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
+++ b/src/Nethermind/Nethermind.JsonRpc.Test/Modules/Eth/EthRpcModuleTests.EthCall.cs
@@ -14,6 +14,8 @@ using Nethermind.Core.Test.Builders;
 using Nethermind.Core.Test.Container;
 using Nethermind.Evm;
 using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Facade.Eth.RpcTransaction;
 using Nethermind.Init;
 using Nethermind.Specs;
@@ -36,6 +38,97 @@ public partial class EthRpcModuleTests
         + GasCostOf.TxValueCostEip2780
         + (ulong)GasCostOf.NewAccountState;
     private const string FreshRecipientAddress = "0xc278000000000000000000000000000000000000";
+
+    [Test]
+    public async Task Rpc_discards_unobserved_logs(
+        [Values("eth_call", "eth_estimateGas", "eth_createAccessList")] string method,
+        [Range(0, 4)] int topicCount,
+        [Values(0, 128)] int logSize,
+        [Values] bool stateOverride)
+    {
+        Hash256[] topics = new Hash256[topicCount];
+        Array.Fill(topics, TestItem.KeccakA);
+        byte[] code = Prepare.EvmCode.PushData(7).Op(Instruction.SLOAD).Op(Instruction.POP)
+            .PushData(0x42).Log(logSize, 1024, topics)
+            .Op(Instruction.MSIZE).PushData(0).Op(Instruction.MSTORE)
+            .PushData(32).Op(Instruction.MSTORE)
+            .PushData(64).PushData(0).Op(Instruction.RETURN).Done;
+        await AssertRpcLogSuppression(method, code, stateOverride, expectLogs: true);
+    }
+
+    [Test]
+    public async Task Rpc_log_suppression_preserves_failures(
+        [Values("eth_call", "eth_estimateGas", "eth_createAccessList")] string method,
+        [ValueSource(nameof(FailingRpcLogCode))] byte[] code)
+        => await AssertRpcLogSuppression(method, code, stateOverride: true, expectLogs: false);
+
+    private static IEnumerable<byte[]> FailingRpcLogCode()
+    {
+        yield return Prepare.EvmCode.PushData(0).PushData(0).Op(Instruction.LOG4).Done;
+        yield return Prepare.EvmCode.PushData(1).PushData(UInt256.MaxValue).Op(Instruction.LOG0).Done;
+        yield return Prepare.EvmCode.Log(1_000_000, 0).Done;
+        yield return Prepare.EvmCode.Log(128, 1024).PushData(32).PushData(1024).Op(Instruction.REVERT).Done;
+    }
+
+    private static async Task AssertRpcLogSuppression(string method, byte[] code, bool stateOverride, bool expectLogs)
+    {
+        using RpcLogObserver observer = new();
+        using Context ctx = await Context.Create(new TestSpecProvider(Prague.Instance), configurer: builder =>
+            builder.AddDecorator<ITransactionProcessor>((_, processor) => new LogObservingProcessor(processor, observer)));
+        Transaction tx = Build.A.Transaction.WithGasLimit(500_000).WithGasPrice(0)
+            .WithTo(stateOverride ? TestItem.AddressB : null)
+            .WithData(stateOverride ? [] : code).SignedAndResolved(TestItem.PrivateKeyA).TestObject;
+        LegacyTransactionForRpc transaction = new(tx, new(BlockchainIds.Mainnet));
+        object[] parameters = stateOverride
+            ? [transaction, "latest", new Dictionary<Address, AccountOverride> { [TestItem.AddressB] = new() { Code = code } }]
+            : [transaction, "latest"];
+
+        TestRpcBlockchain test = ctx.Test;
+        observer.LogCount = 0;
+        string baseline = await test.TestEthRpc(method, parameters);
+        int baselineLogs = observer.LogCount;
+        observer.SuppressLogs = true;
+        observer.LogCount = 0;
+        observer.ExecutionCount = 0;
+        string optimized = await test.TestEthRpc(method, parameters);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(optimized, Is.EqualTo(baseline));
+            Assert.That(observer.ExecutionCount, Is.GreaterThan(0));
+            Assert.That(observer.LogCount, Is.Zero);
+            if (expectLogs)
+            {
+                Assert.That(baselineLogs, Is.GreaterThan(0));
+                if (method == "eth_createAccessList" && stateOverride)
+                    Assert.That(JToken.Parse(optimized)["result"]!["accessList"]!.HasValues, Is.True);
+            }
+        }
+    }
+
+    private sealed class RpcLogObserver : TxTracer
+    {
+        public override bool IsTracingReceipt => true;
+        public override bool IsCollectingLogs => !SuppressLogs;
+        public bool SuppressLogs { get; set; }
+        public int LogCount { get; set; }
+        public int ExecutionCount { get; set; }
+
+        public override void MarkAsSuccess(Address recipient, in GasConsumed gasSpent, byte[] output, LogEntry[] logs, Hash256? stateRoot = null)
+            => LogCount += logs.Length;
+    }
+
+    private sealed class LogObservingProcessor(ITransactionProcessor inner, RpcLogObserver observer) : ITransactionProcessor
+    {
+        public TransactionResult Process(Transaction transaction, ITxTracer txTracer, ExecutionOptions options)
+        {
+            observer.ExecutionCount++;
+            return inner.Process(transaction, new CompositeTxTracer(txTracer, observer), options);
+        }
+
+        public void SetBlockExecutionContext(BlockHeader blockHeader) => inner.SetBlockExecutionContext(blockHeader);
+        public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext) => inner.SetBlockExecutionContext(in blockExecutionContext);
+    }
 
     [Test]
     public async Task Eth_call_web3_sample()

--- a/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/AccountDecoder.cs
@@ -25,19 +25,19 @@ namespace Nethermind.Serialization.Rlp
 
         public (Hash256 CodeHash, Hash256 StorageRoot) DecodeHashesOnly(ref RlpReader context)
         {
-            ReadOnlySpan<byte> data = context.Data;
-            int position = SkipToHashes(data, context.Position);
+            LiteRlpReader reader = new(context.Data);
+            int position = SkipToHashes(reader, context.Position);
 
-            position = DecodeHash(data, position, Keccak.EmptyTreeHash, out Hash256 storageRoot);
-            context.Position = DecodeHash(data, position, Keccak.OfAnEmptyString, out Hash256 codeHash);
+            position = DecodeHash(reader, position, Keccak.EmptyTreeHash, out Hash256 storageRoot);
+            context.Position = DecodeHash(reader, position, Keccak.OfAnEmptyString, out Hash256 codeHash);
 
             return (codeHash, storageRoot);
         }
 
         public Hash256 DecodeStorageRootOnly(ref RlpReader context)
         {
-            ReadOnlySpan<byte> data = context.Data;
-            context.Position = DecodeHash(data, SkipToHashes(data, context.Position), Keccak.EmptyTreeHash, out Hash256 storageRoot);
+            LiteRlpReader reader = new(context.Data);
+            context.Position = DecodeHash(reader, SkipToHashes(reader, context.Position), Keccak.EmptyTreeHash, out Hash256 storageRoot);
             return storageRoot;
         }
 
@@ -49,24 +49,25 @@ namespace Nethermind.Serialization.Rlp
         /// </remarks>
         public Hash256 DecodeStorageRootOnly(ReadOnlySpan<byte> accountRlp)
         {
-            DecodeHash(accountRlp, SkipToHashes(accountRlp, 0), Keccak.EmptyTreeHash, out Hash256 storageRoot);
+            LiteRlpReader reader = new(accountRlp);
+            DecodeHash(reader, SkipToHashes(reader, 0), Keccak.EmptyTreeHash, out Hash256 storageRoot);
             return storageRoot;
         }
 
         /// <inheritdoc cref="TryDecodeStruct(ref RlpReader, out AccountStruct)"/>
         /// <remarks><inheritdoc cref="DecodeStorageRootOnly(ReadOnlySpan{byte})" path="/remarks"/></remarks>
         public bool TryDecodeStruct(ReadOnlySpan<byte> accountRlp, out AccountStruct account)
-            => TryDecodeStruct(accountRlp, position: 0, out _, out account);
+            => TryDecodeStruct(new(accountRlp), position: 0, out _, out account);
 
         /// <summary>The cursor-threaded core both public overloads run.</summary>
-        /// <param name="data">The buffer to decode from.</param>
-        /// <param name="position">Offset of the account sequence within <paramref name="data"/>.</param>
+        /// <param name="reader">The buffer to decode from.</param>
+        /// <param name="position">Offset of the account sequence within <paramref name="reader"/>.</param>
         /// <param name="endPosition">Offset just past the account, or just past the sequence prefix of a placeholder.</param>
         /// <param name="account">The decoded account, or <see cref="AccountStruct.TotallyEmpty"/> for a placeholder.</param>
         /// <returns><see langword="true"/> when an account was decoded; otherwise <see langword="false"/>.</returns>
-        private bool TryDecodeStruct(ReadOnlySpan<byte> data, int position, out int endPosition, out AccountStruct account)
+        private bool TryDecodeStruct(LiteRlpReader reader, int position, out int endPosition, out AccountStruct account)
         {
-            position = RlpHelpers.ReadSequenceLength(data, position, out int length);
+            reader.ReadSequenceLength(ref position, out int length);
             if (length == 1)
             {
                 account = AccountStruct.TotallyEmpty;
@@ -74,18 +75,22 @@ namespace Nethermind.Serialization.Rlp
                 return false;
             }
 
-            position = RlpHelpers.DecodeULong(data, position, out ulong nonce);
-            position = RlpHelpers.DecodeUInt256(data, position, out UInt256 balance);
-            position = DecodeValueHash(data, position, Keccak.EmptyTreeHash.ValueHash256, out ValueHash256 storageRoot);
-            endPosition = DecodeValueHash(data, position, Keccak.OfAnEmptyString.ValueHash256, out ValueHash256 codeHash);
+            reader.DecodeULong(ref position, out ulong nonce);
+            reader.DecodeUInt256(ref position, out UInt256 balance);
+            position = DecodeValueHash(reader, position, Keccak.EmptyTreeHash.ValueHash256, out ValueHash256 storageRoot);
+            endPosition = DecodeValueHash(reader, position, Keccak.OfAnEmptyString.ValueHash256, out ValueHash256 codeHash);
 
             account = new AccountStruct(nonce, balance, storageRoot, codeHash);
             return true;
         }
 
         /// <summary>Skips the sequence header, the nonce and the balance.</summary>
-        private static int SkipToHashes(ReadOnlySpan<byte> data, int position)
-            => RlpHelpers.SkipItems(data, RlpHelpers.SkipLength(data, position), 2);
+        private static int SkipToHashes(LiteRlpReader reader, int position)
+        {
+            reader.SkipLength(ref position);
+            reader.SkipItems(ref position, 2);
+            return position;
+        }
 
         public override void Encode<TWriter>(ref TWriter writer, Account? item, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
@@ -204,18 +209,19 @@ namespace Nethermind.Serialization.Rlp
 
         protected override Account? DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            ReadOnlySpan<byte> data = decoderContext.Data;
-            int position = RlpHelpers.ReadSequenceLength(data, decoderContext.Position, out int length);
+            LiteRlpReader reader = new(decoderContext.Data);
+            int position = decoderContext.Position;
+            reader.ReadSequenceLength(ref position, out int length);
             if (length == 1)
             {
                 decoderContext.Position = position;
                 return null;
             }
 
-            position = RlpHelpers.DecodeULong(data, position, out ulong nonce);
-            position = RlpHelpers.DecodeUInt256(data, position, out UInt256 balance);
-            position = DecodeHash(data, position, Keccak.EmptyTreeHash, out Hash256 storageRoot);
-            decoderContext.Position = DecodeHash(data, position, Keccak.OfAnEmptyString, out Hash256 codeHash);
+            reader.DecodeULong(ref position, out ulong nonce);
+            reader.DecodeUInt256(ref position, out UInt256 balance);
+            position = DecodeHash(reader, position, Keccak.EmptyTreeHash, out Hash256 storageRoot);
+            decoderContext.Position = DecodeHash(reader, position, Keccak.OfAnEmptyString, out Hash256 codeHash);
 
             if (ReferenceEquals(storageRoot, Keccak.EmptyTreeHash) && ReferenceEquals(codeHash, Keccak.OfAnEmptyString))
             {
@@ -232,32 +238,34 @@ namespace Nethermind.Serialization.Rlp
         /// </remarks>
         /// <returns>The position past the item.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int DecodeHash(ReadOnlySpan<byte> data, int position, Hash256 slimEmpty, out Hash256 hash)
+        private int DecodeHash(LiteRlpReader reader, int position, Hash256 slimEmpty, out Hash256 hash)
         {
-            if (IsSlimEmpty(data, position))
+            if (IsSlimEmpty(reader, position))
             {
                 hash = slimEmpty;
                 return position + 1;
             }
 
-            return RlpHelpers.DecodeKeccak(data, position, out hash);
+            reader.DecodeKeccak(ref position, out hash);
+            return position;
         }
 
         /// <inheritdoc cref="DecodeHash"/>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int DecodeValueHash(ReadOnlySpan<byte> data, int position, in ValueHash256 slimEmpty, out ValueHash256 hash)
+        private int DecodeValueHash(LiteRlpReader reader, int position, in ValueHash256 slimEmpty, out ValueHash256 hash)
         {
-            if (IsSlimEmpty(data, position))
+            if (IsSlimEmpty(reader, position))
             {
                 hash = slimEmpty;
                 return position + 1;
             }
 
-            return RlpHelpers.DecodeValueKeccakNonNull(data, position, out hash);
+            reader.DecodeValueKeccakNonNull(ref position, out hash);
+            return position;
         }
 
-        private bool IsSlimEmpty(ReadOnlySpan<byte> data, int position)
-            => _slimFormat && data[position] == Rlp.EmptyByteArrayByte;
+        private bool IsSlimEmpty(LiteRlpReader reader, int position)
+            => _slimFormat && reader.Data[position] == Rlp.EmptyByteArrayByte;
 
         /// <summary>Decodes an account payload into its allocation-free <see cref="AccountStruct"/> form.</summary>
         /// <remarks>
@@ -269,7 +277,7 @@ namespace Nethermind.Serialization.Rlp
         /// <returns><see langword="true"/> when an account was decoded; otherwise <see langword="false"/>.</returns>
         public bool TryDecodeStruct(ref RlpReader decoderContext, out AccountStruct account)
         {
-            bool decoded = TryDecodeStruct(decoderContext.Data, decoderContext.Position, out int endPosition, out account);
+            bool decoded = TryDecodeStruct(new(decoderContext.Data), decoderContext.Position, out int endPosition, out account);
             decoderContext.Position = endPosition;
             return decoded;
         }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockDecoder.cs
@@ -59,9 +59,9 @@ namespace Nethermind.Serialization.Rlp
 
         protected override Block? DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position)) return null;
+            if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int sequenceLength);
+            rlp.ReadSequenceLength(ref position, out int sequenceLength);
             int blockCheck = position + sequenceLength;
             decoderContext.Position = position;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/BlockInfoDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/BlockInfoDecoder.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
 using Nethermind.Int256;
@@ -55,20 +54,20 @@ namespace Nethermind.Serialization.Rlp
 
         protected override BlockInfo? DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position)) return null;
+            if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int sequenceLength);
+            rlp.ReadSequenceLength(ref position, out int sequenceLength);
             int lastCheck = position + sequenceLength;
 
-            position = RlpHelpers.DecodeKeccakOrNull(rlp, position, out Hash256? blockHash);
-            position = RlpHelpers.DecodeBool(rlp, position, out bool wasProcessed);
-            position = RlpHelpers.DecodeUInt256(rlp, position, out UInt256 totalDifficulty);
+            rlp.DecodeKeccakOrNull(ref position, out Hash256? blockHash);
+            rlp.DecodeBool(ref position, out bool wasProcessed);
+            rlp.DecodeUInt256(ref position, out UInt256 totalDifficulty);
 
             BlockMetadata metadata = BlockMetadata.None;
             // if we hadn't reached the end of the stream, assume we have metadata to decode
             if (position != lastCheck)
             {
-                position = RlpHelpers.DecodeUInt(rlp, position, out uint rawMetadata);
+                rlp.DecodeUInt(ref position, out uint rawMetadata);
                 metadata = (BlockMetadata)rawMetadata;
             }
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ChainLevelDecoder.cs
@@ -46,12 +46,12 @@ namespace Nethermind.Serialization.Rlp
 
         protected override ChainLevelInfo? DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position)) return null;
+            if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int sequenceLength);
+            rlp.ReadSequenceLength(ref position, out int sequenceLength);
             int lastCheck = position + sequenceLength;
-            position = RlpHelpers.DecodeBool(rlp, position, out bool hasMainChainBlock);
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out _);
+            rlp.DecodeBool(ref position, out bool hasMainChainBlock);
+            rlp.ReadSequenceLength(ref position, out _);
             decoderContext.Position = position;
 
             List<BlockInfo> blockInfos = [];

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactLogEntryDecoder.cs
@@ -18,22 +18,22 @@ namespace Nethermind.Serialization.Rlp
 
         protected override LogEntry? DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position)) return null;
+            if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int logEntryLength);
-            Rlp.GuardLimit(logEntryLength, rlp.Length - position, RlpLimit);
+            rlp.ReadSequenceLength(ref position, out int logEntryLength);
+            Rlp.GuardLimit(logEntryLength, rlp.Data.Length - position, RlpLimit);
             int logEntryCheck = position + logEntryLength;
 
-            position = RlpHelpers.DecodeAddress(rlp, position, out Address address);
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int topicsLength);
+            rlp.DecodeAddress(ref position, out Address address);
+            rlp.ReadSequenceLength(ref position, out int topicsLength);
             int topicCount = topicsLength / Rlp.LengthOfKeccakRlp;
-            Rlp.GuardLimit(topicCount, rlp.Length - position, RlpLimit.L4);
+            Rlp.GuardLimit(topicCount, rlp.Data.Length - position, RlpLimit.L4);
             int untilPosition = position + topicsLength;
 
             using ArrayPoolListRef<Hash256> topics = new(topicCount);
             while (position < untilPosition)
             {
-                position = RlpHelpers.DecodeZeroPrefixKeccakNonNull(rlp, position, out Hash256 topic);
+                rlp.DecodeZeroPrefixKeccakNonNull(ref position, out Hash256 topic);
                 topics.Add(topic);
             }
 
@@ -63,7 +63,7 @@ namespace Nethermind.Serialization.Rlp
             ReadOnlySpan<byte> topics = decoderContext.Data.Slice(decoderContext.Position, sequenceLength);
             decoderContext.SkipItem();
 
-            decoderContext.Position = DecodeCompactData(decoderContext.Data, decoderContext.Position, out byte[] data);
+            decoderContext.Position = DecodeCompactData(new(decoderContext.Data), decoderContext.Position, out byte[] data);
             decoderContext.Check(logEntryCheck);
 
             item = new LogEntryStructRef(address, data, topics);
@@ -120,10 +120,10 @@ namespace Nethermind.Serialization.Rlp
 
         /// <summary>Decodes the leading-zero-stripped log data.</summary>
         /// <returns>The position past the data.</returns>
-        private static int DecodeCompactData(ReadOnlySpan<byte> rlp, int position, out byte[] data)
+        private static int DecodeCompactData(LiteRlpReader rlp, int position, out byte[] data)
         {
-            position = RlpHelpers.DecodePositiveInt(rlp, position, out int zeroPrefix);
-            position = RlpHelpers.DecodeByteArraySpan(rlp, position, out ReadOnlySpan<byte> rlpData);
+            rlp.DecodePositiveInt(ref position, out int zeroPrefix);
+            rlp.DecodeByteArraySpan(ref position, out ReadOnlySpan<byte> rlpData);
 
             Rlp.GuardLimit(zeroPrefix, LogEntryDataRlpLimit.Limit - rlpData.Length, LogEntryDataRlpLimit);
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/CompactReceiptStorageDecoder.cs
@@ -21,13 +21,13 @@ namespace Nethermind.Serialization.Rlp
         protected override TxReceipt? DecodeInternal(ref RlpReader decoderContext,
             RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position)) return null;
+            if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
             TxReceipt txReceipt = new();
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int receiptLength);
+            rlp.ReadSequenceLength(ref position, out int receiptLength);
             int receiptEnd = position + receiptLength;
 
-            position = RlpHelpers.DecodeByteArray(rlp, position, out byte[] firstItem);
+            rlp.DecodeByteArray(ref position, out byte[] firstItem);
             if (firstItem.Length == 1)
             {
                 txReceipt.StatusCode = firstItem[0];
@@ -37,12 +37,12 @@ namespace Nethermind.Serialization.Rlp
                 txReceipt.PostTransactionState = firstItem.Length == 0 ? null : new Hash256(firstItem);
             }
 
-            (position, txReceipt.Sender) = RlpHelpers.DecodeAddressOrNull(rlp, position);
-            (position, txReceipt.GasUsedTotal) = RlpHelpers.DecodeULong(rlp, position);
+            txReceipt.Sender = rlp.DecodeAddressOrNull(ref position);
+            txReceipt.GasUsedTotal = rlp.DecodeULong(ref position);
 
-            int sequenceStart = RlpHelpers.ReadSequenceLength(rlp, position, out int sequenceLength);
-            int lastCheck = sequenceStart + sequenceLength;
-            decoderContext.Position = sequenceStart;
+            rlp.ReadSequenceLength(ref position, out int sequenceLength);
+            int lastCheck = position + sequenceLength;
+            decoderContext.Position = position;
 
             // Don't know the size exactly, I'll just assume its just an address and add some margin
             using ArrayPoolListRef<LogEntry> logEntries = new(sequenceLength * 2 / Rlp.LengthOfAddressRlp);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/HeaderDecoder.cs
@@ -20,25 +20,25 @@ namespace Nethermind.Serialization.Rlp
         protected override BlockHeader? DecodeInternal(ref RlpReader decoderContext,
             RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position)) return null;
+            if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
-            ReadOnlySpan<byte> headerRlp = rlp.Slice(position, RlpHelpers.PeekNextRlpLength(rlp, position));
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int headerSequenceLength);
+            ReadOnlySpan<byte> headerRlp = rlp.Data.Slice(position, rlp.PeekNextRlpLength(position));
+            rlp.ReadSequenceLength(ref position, out int headerSequenceLength);
             int headerCheck = position + headerSequenceLength;
 
-            position = RlpHelpers.DecodeKeccak(rlp, position, out Hash256 parentHash);
-            position = RlpHelpers.DecodeKeccak(rlp, position, out Hash256 unclesHash);
-            position = RlpHelpers.DecodeAddress(rlp, position, out Address beneficiary);
-            position = RlpHelpers.DecodeKeccak(rlp, position, out Hash256 stateRoot);
-            position = RlpHelpers.DecodeKeccak(rlp, position, out Hash256 transactionsRoot);
-            position = RlpHelpers.DecodeKeccak(rlp, position, out Hash256 receiptsRoot);
-            position = RlpHelpers.DecodeBloom(rlp, position, out Bloom bloom);
-            position = RlpHelpers.DecodeUInt256(rlp, position, out UInt256 difficulty);
-            position = RlpHelpers.DecodeULong(rlp, position, out ulong number);
-            position = RlpHelpers.DecodeULong(rlp, position, out ulong gasLimit);
-            position = RlpHelpers.DecodeULong(rlp, position, out ulong gasUsed);
-            position = RlpHelpers.DecodeULong(rlp, position, out ulong timestamp);
-            position = RlpHelpers.DecodeByteArray(rlp, position, out byte[] extraData);
+            rlp.DecodeKeccak(ref position, out Hash256 parentHash);
+            rlp.DecodeKeccak(ref position, out Hash256 unclesHash);
+            rlp.DecodeAddress(ref position, out Address beneficiary);
+            rlp.DecodeKeccak(ref position, out Hash256 stateRoot);
+            rlp.DecodeKeccak(ref position, out Hash256 transactionsRoot);
+            rlp.DecodeKeccak(ref position, out Hash256 receiptsRoot);
+            rlp.DecodeBloom(ref position, out Bloom bloom);
+            rlp.DecodeUInt256(ref position, out UInt256 difficulty);
+            rlp.DecodeULong(ref position, out ulong number);
+            rlp.DecodeULong(ref position, out ulong gasLimit);
+            rlp.DecodeULong(ref position, out ulong gasUsed);
+            rlp.DecodeULong(ref position, out ulong timestamp);
+            rlp.DecodeByteArray(ref position, out byte[] extraData);
 
             // The seal is a virtual extension point, so the cursor goes back to the reader once here.
             decoderContext.Position = position;
@@ -53,15 +53,15 @@ namespace Nethermind.Serialization.Rlp
 
             position = decoderContext.Position;
 
-            // BaseFeePerGas is a field, so it takes the `out` form; the rest are properties and take the pair form.
-            if (position != headerCheck) position = RlpHelpers.DecodeUInt256(rlp, position, out blockHeader.BaseFeePerGas);
-            if (position != headerCheck) (position, blockHeader.WithdrawalsRoot) = RlpHelpers.DecodeKeccak(rlp, position);
-            if (position != headerCheck) (position, blockHeader.BlobGasUsed) = RlpHelpers.DecodeULong(rlp, position);
-            if (position != headerCheck) (position, blockHeader.ExcessBlobGas) = RlpHelpers.DecodeULong(rlp, position);
-            if (position != headerCheck) (position, blockHeader.ParentBeaconBlockRoot) = RlpHelpers.DecodeKeccakOrNull(rlp, position);
-            if (position != headerCheck) (position, blockHeader.RequestsHash) = RlpHelpers.DecodeKeccakOrNull(rlp, position);
-            if (position != headerCheck) (position, blockHeader.BlockAccessListHash) = RlpHelpers.DecodeKeccakOrNull(rlp, position);
-            if (position != headerCheck) (position, blockHeader.SlotNumber) = RlpHelpers.DecodeULong(rlp, position);
+            // BaseFeePerGas is a field, so it takes the `out` form; the rest are properties and take the return value.
+            if (position != headerCheck) rlp.DecodeUInt256(ref position, out blockHeader.BaseFeePerGas);
+            if (position != headerCheck) blockHeader.WithdrawalsRoot = rlp.DecodeKeccak(ref position);
+            if (position != headerCheck) blockHeader.BlobGasUsed = rlp.DecodeULong(ref position);
+            if (position != headerCheck) blockHeader.ExcessBlobGas = rlp.DecodeULong(ref position);
+            if (position != headerCheck) blockHeader.ParentBeaconBlockRoot = rlp.DecodeKeccakOrNull(ref position);
+            if (position != headerCheck) blockHeader.RequestsHash = rlp.DecodeKeccakOrNull(ref position);
+            if (position != headerCheck) blockHeader.BlockAccessListHash = rlp.DecodeKeccakOrNull(ref position);
+            if (position != headerCheck) blockHeader.SlotNumber = rlp.DecodeULong(ref position);
 
             decoderContext.Position = position;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/LiteRlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/LiteRlpReader.cs
@@ -1,0 +1,285 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Runtime.CompilerServices;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Int256;
+
+namespace Nethermind.Serialization.Rlp;
+
+/// <summary>Decodes RLP from a borrowed span and advances an explicit cursor.</summary>
+/// <remarks>
+/// The small instance methods pass the span and cursor by value to static decoding helpers.
+/// Every forwarder is aggressively inlined so the caller's cursor can remain enregistered. This
+/// is a readability refactor intended to preserve the existing helper cost, not a measured
+/// performance claim. The cursor advances only after a helper returns successfully; no cursor or
+/// memory backing is retained.
+/// </remarks>
+internal readonly ref struct LiteRlpReader(ReadOnlySpan<byte> data)
+{
+    private readonly ReadOnlySpan<byte> _data = data;
+
+    public ReadOnlySpan<byte> Data => _data;
+
+    /// <inheritdoc cref="RlpHelpers.PeekPrefixAndContentLength(ReadOnlySpan{byte}, int)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public (int PrefixLength, int ContentLength) PeekPrefixAndContentLength(int position)
+        => RlpHelpers.PeekPrefixAndContentLength(_data, position);
+
+    /// <inheritdoc cref="RlpHelpers.PeekNextRlpLength(ReadOnlySpan{byte}, int)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int PeekNextRlpLength(int position)
+        => RlpHelpers.PeekNextRlpLength(_data, position);
+
+    /// <inheritdoc cref="RlpHelpers.CountItems(ReadOnlySpan{byte}, int, int, int)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int CountItems(int position, int end, int maxSearch)
+        => RlpHelpers.CountItems(_data, position, end, maxSearch);
+
+    /// <inheritdoc cref="RlpHelpers.SkipLength(ReadOnlySpan{byte}, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SkipLength(scoped ref int position)
+        => position = RlpHelpers.SkipLength(_data, position);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeULong(ReadOnlySpan{byte}, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ulong DecodeULong(scoped ref int position)
+    {
+        (position, ulong value) = RlpHelpers.DecodeULong(_data, position);
+        return value;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.DecodePositiveInt(ReadOnlySpan{byte}, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int DecodePositiveInt(scoped ref int position)
+    {
+        (position, int value) = RlpHelpers.DecodePositiveInt(_data, position);
+        return value;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.DecodeKeccak(ReadOnlySpan{byte}, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Hash256 DecodeKeccak(scoped ref int position)
+    {
+        (position, Hash256 value) = RlpHelpers.DecodeKeccak(_data, position);
+        return value;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.DecodeKeccakOrNull(ReadOnlySpan{byte}, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Hash256? DecodeKeccakOrNull(scoped ref int position)
+    {
+        (position, Hash256? value) = RlpHelpers.DecodeKeccakOrNull(_data, position);
+        return value;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.DecodeAddressOrNull(ReadOnlySpan{byte}, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Address? DecodeAddressOrNull(scoped ref int position)
+    {
+        (position, Address? value) = RlpHelpers.DecodeAddressOrNull(_data, position);
+        return value;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.DecodeBloomOrNull(ReadOnlySpan{byte}, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Bloom? DecodeBloomOrNull(scoped ref int position)
+    {
+        (position, Bloom? value) = RlpHelpers.DecodeBloomOrNull(_data, position);
+        return value;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.DecodeBloomNonNull(ReadOnlySpan{byte}, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Bloom DecodeBloomNonNull(scoped ref int position)
+    {
+        (position, Bloom value) = RlpHelpers.DecodeBloomNonNull(_data, position);
+        return value;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.DecodeString(ReadOnlySpan{byte}, int, RlpLimit?)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public string DecodeString(scoped ref int position)
+    {
+        (position, string value) = RlpHelpers.DecodeString(_data, position);
+        return value;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.DecodeString(ReadOnlySpan{byte}, int, RlpLimit?)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public string DecodeString(scoped ref int position, RlpLimit limit)
+    {
+        (position, string value) = RlpHelpers.DecodeString(_data, position, limit);
+        return value;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.IsSequenceNext(ReadOnlySpan{byte}, int)"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsSequenceNext(int position)
+        => RlpHelpers.IsSequenceNext(_data, position);
+
+    /// <inheritdoc cref="RlpHelpers.SkipItem(ReadOnlySpan{byte}, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SkipItem(scoped ref int position)
+        => position = RlpHelpers.SkipItem(_data, position);
+
+    /// <inheritdoc cref="RlpHelpers.SkipItems(ReadOnlySpan{byte}, int, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SkipItems(scoped ref int position, int count)
+        => position = RlpHelpers.SkipItems(_data, position, count);
+
+    /// <inheritdoc cref="RlpHelpers.ReadSequenceLength(ReadOnlySpan{byte}, int, out int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void ReadSequenceLength(scoped ref int position, out int contentLength)
+        => position = RlpHelpers.ReadSequenceLength(_data, position, out contentLength);
+
+    /// <inheritdoc cref="RlpHelpers.ReadPrefixAndContentLength(ReadOnlySpan{byte}, int, out int, out int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void ReadPrefixAndContentLength(scoped ref int position, out int prefixLength, out int contentLength)
+        => position = RlpHelpers.ReadPrefixAndContentLength(_data, position, out prefixLength, out contentLength);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeByteArraySpan(ReadOnlySpan{byte}, int, out ReadOnlySpan{byte}, RlpLimit?, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeByteArraySpan(scoped ref int position, out ReadOnlySpan<byte> value)
+        => position = RlpHelpers.DecodeByteArraySpan(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeByteArraySpan(ReadOnlySpan{byte}, int, out ReadOnlySpan{byte}, RlpLimit?, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeByteArraySpan(scoped ref int position, out ReadOnlySpan<byte> value, RlpLimit? limit)
+        => position = RlpHelpers.DecodeByteArraySpan(_data, position, out value, limit);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeByteArraySpan(ReadOnlySpan{byte}, int, out ReadOnlySpan{byte}, RlpLimit?, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeByteArraySpan(scoped ref int position, out ReadOnlySpan<byte> value, RlpLimit? limit, int size)
+        => position = RlpHelpers.DecodeByteArraySpan(_data, position, out value, limit, size);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeULong(ReadOnlySpan{byte}, int, out ulong)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeULong(scoped ref int position, out ulong value)
+        => position = RlpHelpers.DecodeULong(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeUInt(ReadOnlySpan{byte}, int, out uint)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeUInt(scoped ref int position, out uint value)
+        => position = RlpHelpers.DecodeUInt(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodePositiveInt(ReadOnlySpan{byte}, int, out int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodePositiveInt(scoped ref int position, out int value)
+        => position = RlpHelpers.DecodePositiveInt(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodePositiveLong(ReadOnlySpan{byte}, int, out long)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodePositiveLong(scoped ref int position, out long value)
+        => position = RlpHelpers.DecodePositiveLong(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeUShort(ReadOnlySpan{byte}, int, out ushort)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeUShort(scoped ref int position, out ushort value)
+        => position = RlpHelpers.DecodeUShort(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeByte(ReadOnlySpan{byte}, int, out byte)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeByte(scoped ref int position, out byte value)
+        => position = RlpHelpers.DecodeByte(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeUInt256(ReadOnlySpan{byte}, int, out UInt256, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeUInt256(scoped ref int position, out UInt256 value)
+        => position = RlpHelpers.DecodeUInt256(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeUInt256(ReadOnlySpan{byte}, int, out UInt256, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeUInt256(scoped ref int position, out UInt256 value, int length)
+        => position = RlpHelpers.DecodeUInt256(_data, position, out value, length);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeEvmWord(ReadOnlySpan{byte}, int, out EvmWord)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeEvmWord(scoped ref int position, out EvmWord value)
+        => position = RlpHelpers.DecodeEvmWord(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeKeccakOrNull(ReadOnlySpan{byte}, int, out Hash256?)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeKeccakOrNull(scoped ref int position, out Hash256? keccak)
+        => position = RlpHelpers.DecodeKeccakOrNull(_data, position, out keccak);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeValueKeccakOrNull(ReadOnlySpan{byte}, int, out ValueHash256?)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeValueKeccakOrNull(scoped ref int position, out ValueHash256? keccak)
+        => position = RlpHelpers.DecodeValueKeccakOrNull(_data, position, out keccak);
+
+    /// <inheritdoc cref="RlpHelpers.TryDecodeValueKeccak(ReadOnlySpan{byte}, int, out ValueHash256, out bool)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryDecodeValueKeccak(scoped ref int position, out ValueHash256 keccak)
+    {
+        position = RlpHelpers.TryDecodeValueKeccak(_data, position, out keccak, out bool hasValue);
+        return hasValue;
+    }
+
+    /// <inheritdoc cref="RlpHelpers.DecodeAddress(ReadOnlySpan{byte}, int, out Address)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeAddress(scoped ref int position, out Address address)
+        => position = RlpHelpers.DecodeAddress(_data, position, out address);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeBloom(ReadOnlySpan{byte}, int, out Bloom)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeBloom(scoped ref int position, out Bloom bloom)
+        => position = RlpHelpers.DecodeBloom(_data, position, out bloom);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeBloomSpan(ReadOnlySpan{byte}, int, out ReadOnlySpan{byte})" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeBloomSpan(scoped ref int position, out ReadOnlySpan<byte> bloomBytes)
+        => position = RlpHelpers.DecodeBloomSpan(_data, position, out bloomBytes);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeByteArray(ReadOnlySpan{byte}, int, out byte[], RlpLimit?, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeByteArray(scoped ref int position, out byte[] value)
+        => position = RlpHelpers.DecodeByteArray(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeByteArray(ReadOnlySpan{byte}, int, out byte[], RlpLimit?, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeByteArray(scoped ref int position, out byte[] value, RlpLimit? limit)
+        => position = RlpHelpers.DecodeByteArray(_data, position, out value, limit);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeByteArray(ReadOnlySpan{byte}, int, out byte[], RlpLimit?, int)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeByteArray(scoped ref int position, out byte[] value, RlpLimit? limit, int size)
+        => position = RlpHelpers.DecodeByteArray(_data, position, out value, limit, size);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeBool(ReadOnlySpan{byte}, int, out bool)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeBool(scoped ref int position, out bool value)
+        => position = RlpHelpers.DecodeBool(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeZeroPrefixKeccakNonNull(ReadOnlySpan{byte}, int, out Hash256)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeZeroPrefixKeccakNonNull(scoped ref int position, out Hash256 keccak)
+        => position = RlpHelpers.DecodeZeroPrefixKeccakNonNull(_data, position, out keccak);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeZeroPrefixKeccak(ReadOnlySpan{byte}, int, out Hash256?)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeZeroPrefixKeccak(scoped ref int position, out Hash256? keccak)
+        => position = RlpHelpers.DecodeZeroPrefixKeccak(_data, position, out keccak);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeKeccak(ReadOnlySpan{byte}, int, out Hash256)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeKeccak(scoped ref int position, out Hash256 keccak)
+        => position = RlpHelpers.DecodeKeccak(_data, position, out keccak);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeValueKeccakNonNull(ReadOnlySpan{byte}, int, out ValueHash256)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeValueKeccakNonNull(scoped ref int position, out ValueHash256 keccak)
+        => position = RlpHelpers.DecodeValueKeccakNonNull(_data, position, out keccak);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeString(ReadOnlySpan{byte}, int, out string, RlpLimit?)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeString(scoped ref int position, out string value)
+        => position = RlpHelpers.DecodeString(_data, position, out value);
+
+    /// <inheritdoc cref="RlpHelpers.DecodeString(ReadOnlySpan{byte}, int, out string, RlpLimit?)" path="/summary"/>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void DecodeString(scoped ref int position, out string value, RlpLimit? limit)
+        => position = RlpHelpers.DecodeString(_data, position, out value, limit);
+}

--- a/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/LogEntryDecoder.cs
@@ -52,26 +52,26 @@ namespace Nethermind.Serialization.Rlp
 
         protected override LogEntry? DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position)) return null;
+            if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int logEntryLength);
-            Rlp.GuardLimit(logEntryLength, rlp.Length - position, RlpLimit);
+            rlp.ReadSequenceLength(ref position, out int logEntryLength);
+            Rlp.GuardLimit(logEntryLength, rlp.Data.Length - position, RlpLimit);
             int logEntryCheck = position + logEntryLength;
 
-            position = RlpHelpers.DecodeAddress(rlp, position, out Address address);
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int topicsLength);
+            rlp.DecodeAddress(ref position, out Address address);
+            rlp.ReadSequenceLength(ref position, out int topicsLength);
             int topicsCheck = position + topicsLength;
             int topicCount = topicsLength / Rlp.LengthOfKeccakRlp;
-            Rlp.GuardLimit(topicCount, rlp.Length - position, RlpLimit.L4);
+            Rlp.GuardLimit(topicCount, rlp.Data.Length - position, RlpLimit.L4);
 
             Hash256[] topics = new Hash256[topicCount];
             for (int i = 0; i < topics.Length; i++)
             {
-                position = RlpHelpers.DecodeKeccak(rlp, position, out topics[i]);
+                rlp.DecodeKeccak(ref position, out topics[i]);
             }
 
             RlpHelpers.Check(position, topicsCheck);
-            position = RlpHelpers.DecodeByteArray(rlp, position, out byte[] data);
+            rlp.DecodeByteArray(ref position, out byte[] data);
             RlpHelpers.Check(position, logEntryCheck);
             decoderContext.Position = position;
 

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Nethermind.Core;
@@ -18,22 +17,22 @@ namespace Nethermind.Serialization.Rlp
         [return: MaybeNull]
         protected override TxReceipt DecodeInternal(ref RlpReader ctx, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (RlpHelpers.TryConsumeNull(ref ctx, out ReadOnlySpan<byte> rlp, out int position)) return null;
+            if (ctx.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
             TxReceipt txReceipt = new();
-            if (!RlpHelpers.IsSequenceNext(rlp, position))
+            if (!rlp.IsSequenceNext(position))
             {
-                position = RlpHelpers.SkipLength(rlp, position);
-                txReceipt.TxType = (TxType)rlp[position++];
+                rlp.SkipLength(ref position);
+                txReceipt.TxType = (TxType)rlp.Data[position++];
             }
 
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int sequenceLength);
+            rlp.ReadSequenceLength(ref position, out int sequenceLength);
             int receiptEnd = position + sequenceLength;
-            position = RlpHelpers.DecodeByteArray(rlp, position, out byte[] firstItem);
+            rlp.DecodeByteArray(ref position, out byte[] firstItem);
             if (firstItem.Length == 1 && (firstItem[0] == 0 || firstItem[0] == 1))
             {
                 txReceipt.StatusCode = firstItem[0];
-                (position, txReceipt.GasUsedTotal) = RlpHelpers.DecodeULong(rlp, position);
+                txReceipt.GasUsedTotal = rlp.DecodeULong(ref position);
             }
             else if (firstItem.Length is >= 1 and <= 4)
             {
@@ -42,16 +41,16 @@ namespace Nethermind.Serialization.Rlp
             else
             {
                 txReceipt.PostTransactionState = firstItem.Length == 0 ? null : new Hash256(firstItem);
-                (position, txReceipt.GasUsedTotal) = RlpHelpers.DecodeULong(rlp, position);
+                txReceipt.GasUsedTotal = rlp.DecodeULong(ref position);
             }
 
             // When skipBloom is true (slim receipt), bloom is absent from the stream — nothing to skip.
             if (!skipBloom)
             {
-                (position, txReceipt.Bloom) = RlpHelpers.DecodeBloomNonNull(rlp, position);
+                txReceipt.Bloom = rlp.DecodeBloomNonNull(ref position);
             }
 
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int logsLength);
+            rlp.ReadSequenceLength(ref position, out int logsLength);
             int lastCheck = position + logsLength;
 
             ctx.Position = position;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs
@@ -26,19 +26,19 @@ namespace Nethermind.Serialization.Rlp
         protected override TxReceipt? DecodeInternal(ref RlpReader decoderContext,
             RlpBehaviors rlpBehaviors = RlpBehaviors.None)
         {
-            if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position)) return null;
+            if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
             bool isStorage = (rlpBehaviors & RlpBehaviors.Storage) != 0;
             TxReceipt txReceipt = new();
-            if (!RlpHelpers.IsSequenceNext(rlp, position))
+            if (!rlp.IsSequenceNext(position))
             {
-                position = RlpHelpers.SkipLength(rlp, position);
-                txReceipt.TxType = (TxType)rlp[position++];
+                rlp.SkipLength(ref position);
+                txReceipt.TxType = (TxType)rlp.Data[position++];
             }
 
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int receiptLength);
+            rlp.ReadSequenceLength(ref position, out int receiptLength);
             int receiptEnd = position + receiptLength;
-            position = RlpHelpers.DecodeByteArray(rlp, position, out byte[] firstItem);
+            rlp.DecodeByteArray(ref position, out byte[] firstItem);
             if (firstItem.Length == 1)
             {
                 txReceipt.StatusCode = firstItem[0];
@@ -50,19 +50,19 @@ namespace Nethermind.Serialization.Rlp
 
             if (isStorage)
             {
-                (position, txReceipt.BlockHash) = RlpHelpers.DecodeKeccakOrNull(rlp, position);
-                (position, txReceipt.BlockNumber) = RlpHelpers.DecodeULong(rlp, position);
-                (position, txReceipt.Index) = RlpHelpers.DecodePositiveInt(rlp, position);
-                (position, txReceipt.Sender) = RlpHelpers.DecodeAddressOrNull(rlp, position);
-                (position, txReceipt.Recipient) = RlpHelpers.DecodeAddressOrNull(rlp, position);
-                (position, txReceipt.ContractAddress) = RlpHelpers.DecodeAddressOrNull(rlp, position);
-                (position, txReceipt.GasUsed) = RlpHelpers.DecodeULong(rlp, position);
+                txReceipt.BlockHash = rlp.DecodeKeccakOrNull(ref position);
+                txReceipt.BlockNumber = rlp.DecodeULong(ref position);
+                txReceipt.Index = rlp.DecodePositiveInt(ref position);
+                txReceipt.Sender = rlp.DecodeAddressOrNull(ref position);
+                txReceipt.Recipient = rlp.DecodeAddressOrNull(ref position);
+                txReceipt.ContractAddress = rlp.DecodeAddressOrNull(ref position);
+                txReceipt.GasUsed = rlp.DecodeULong(ref position);
             }
 
-            (position, txReceipt.GasUsedTotal) = RlpHelpers.DecodeULong(rlp, position);
-            (position, txReceipt.Bloom) = RlpHelpers.DecodeBloomOrNull(rlp, position);
+            txReceipt.GasUsedTotal = rlp.DecodeULong(ref position);
+            txReceipt.Bloom = rlp.DecodeBloomOrNull(ref position);
 
-            position = RlpHelpers.ReadSequenceLength(rlp, position, out int logsLength);
+            rlp.ReadSequenceLength(ref position, out int logsLength);
             int lastCheck = position + logsLength;
             decoderContext.Position = position;
             List<LogEntry> logEntries = [];
@@ -84,15 +84,16 @@ namespace Nethermind.Serialization.Rlp
                 RlpHelpers.Check(position, lastCheck);
 
                 // since txHash was added later and may not be in rlp, we provide special mark byte that it will be next
-                if (isStorage && supportTxHash && position < receiptEnd && rlp[position] == MarkTxHashByte)
+                if (isStorage && supportTxHash && position < receiptEnd && rlp.Data[position] == MarkTxHashByte)
                 {
-                    (position, txReceipt.TxHash) = RlpHelpers.DecodeKeccakOrNull(rlp, position + 1);
+                    position++;
+                    txReceipt.TxHash = rlp.DecodeKeccakOrNull(ref position);
                 }
 
                 // since error was added later we can only rely on it in cases where we read receipt only and no data follows, empty errors might not be serialized
                 if (position < receiptEnd)
                 {
-                    (position, txReceipt.Error) = RlpHelpers.DecodeString(rlp, position);
+                    txReceipt.Error = rlp.DecodeString(ref position);
                 }
 
                 decoderContext.Position = position;

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.Cursor.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.Cursor.cs
@@ -27,7 +27,7 @@ namespace Nethermind.Serialization.Rlp;
 /// The buffer and the cursor stay two separate values rather than one cursor type because a struct
 /// pairing a <see cref="ReadOnlySpan{T}"/> with an <see cref="int"/> is past the size the ABI returns
 /// in registers, so handing one back would put the cursor into memory again — the cost this file
-/// exists to remove. A decoder therefore picks the pair up once through <see cref="TryConsumeNull"/>
+/// exists to remove. A decoder therefore picks the pair up once through <see cref="RlpReader.TryConsumeNull"/>
 /// and stores the cursor back once on the way out. The reader's cursor is only meaningful on that
 /// success path: a decode that throws mid-record leaves it wherever the last store put it, so callers
 /// that retry (see <c>ReceiptArrayStorageDecoder</c>) must reset it themselves.
@@ -44,9 +44,8 @@ internal static partial class RlpHelpers
     public static int SkipLength(ReadOnlySpan<byte> data, int position)
         => position + GetPrefixLength(data[position]);
 
-    // Pair forms of the primitives below, for call sites whose decode target is a property and so
-    // cannot be an `out` argument. `(position, item.Field) = Decode…(data, position);` keeps the
-    // cursor threading on one line there instead of an `out` local plus an assignment.
+    // Pair forms back LiteRlpReader's return-value methods, which need the decoded value and the
+    // advanced cursor together when the destination cannot be an `out` argument.
 
     /// <inheritdoc cref="DecodeULong(ReadOnlySpan{byte}, int, out ulong)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -91,33 +90,6 @@ internal static partial class RlpHelpers
     /// <summary>Tells whether the item at <paramref name="position"/> is a sequence rather than a byte string.</summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsSequenceNext(ReadOnlySpan<byte> data, int position) => data[position] >= ListOffset;
-
-    /// <summary>Tells whether the item at <paramref name="position"/> is the empty sequence.</summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsEmptySequenceNext(ReadOnlySpan<byte> data, int position) => data[position] == Rlp.EmptyListByte;
-
-    /// <summary>Picks up a reader's buffer and cursor, consuming the empty sequence that encodes a null item.</summary>
-    /// <remarks>
-    /// The opening step of every cursor-threaded decoder: the reader is picked up here once, and a decoder
-    /// that does not re-enter a <c>ref RlpReader</c> API mid-run touches <see cref="RlpReader.Position"/>
-    /// only again on the way out. The reader is <see langword="scoped"/> <see langword="ref"/> so that
-    /// <paramref name="data"/> may escape to the caller: a plain <see langword="ref"/> parameter is
-    /// return-only, which would stop callers passing slices of the buffer onward.
-    /// </remarks>
-    /// <returns>
-    /// <see langword="true"/> when an encoded null was consumed and the reader advanced past it; otherwise
-    /// <see langword="false"/>, with the cursor to thread in <paramref name="data"/> and <paramref name="position"/>.
-    /// </returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool TryConsumeNull(scoped ref RlpReader reader, out ReadOnlySpan<byte> data, out int position)
-    {
-        data = reader.Data;
-        position = reader.Position;
-        if (!IsEmptySequenceNext(data, position)) return false;
-
-        reader.Position = position + 1;
-        return true;
-    }
 
     /// <summary>Asserts that a decode finished exactly at <paramref name="expected"/>.</summary>
     /// <remarks>

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpHelpers.cs
@@ -308,7 +308,7 @@ internal static partial class RlpHelpers
         => throw new RlpException($"Non-canonical integer at position {position}");
 
     [DoesNotReturn, StackTraceHidden]
-    public static ulong ThrowNonceTooWide(int position)
+    public static int ThrowNonceTooWide(int position)
         => throw new RlpException($"NonceTooWide: Transaction nonce exceeds uint64 at position {position}");
 
     [DoesNotReturn, StackTraceHidden]

--- a/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/RlpReader.cs
@@ -49,6 +49,30 @@ public ref struct RlpReader
 
     public int Position { get; set; }
 
+    /// <summary>Captures the decoder and cursor, consuming an empty sequence if it encodes a null item.</summary>
+    /// <remarks>
+    /// The ref-struct receiver is implicitly scoped ref, which lets the returned decoder borrow <see cref="Data"/>
+    /// in the caller without copying while keeping the borrow within the source lifetime. The cursor is meaningful
+    /// only when the decode completes successfully; a failure can leave it after the last field that was decoded,
+    /// so a retrying caller must reset it itself.
+    /// </remarks>
+    /// <returns>
+    /// <see langword="true"/> when the item at the original <see cref="Position"/> is an empty sequence;
+    /// <paramref name="position"/> is that original offset and <see cref="Position"/> has advanced by one.
+    /// Otherwise, returns <see langword="false"/> with both cursors unchanged.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal bool TryConsumeNull(out LiteRlpReader reader, out int position)
+    {
+        ReadOnlySpan<byte> data = Data;
+        reader = new(data);
+        position = Position;
+        if (data[position] != Rlp.EmptyListByte) return false;
+
+        Position = position + 1;
+        return true;
+    }
+
     public readonly int Length => Data.Length;
 
     public readonly bool IsSequenceNext() => RlpHelpers.IsSequenceNext(Data, Position);

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoder.cs
@@ -88,33 +88,33 @@ public class TxDecoder<T> : RlpDecoder<T> where T : Transaction, new()
 
     public void Decode(ref RlpReader decoderContext, ref T? transaction, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
-        if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position))
+        if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position))
         {
             transaction = null;
             return;
         }
 
         int txSequenceStart = position;
-        ReadOnlySpan<byte> transactionSequence = rlp.Slice(position, RlpHelpers.PeekNextRlpLength(rlp, position));
+        ReadOnlySpan<byte> transactionSequence = rlp.Data.Slice(position, rlp.PeekNextRlpLength(position));
 
         TxType txType = TxType.Legacy;
         if (rlpBehaviors.HasFlag(RlpBehaviors.SkipTypedWrapping))
         {
-            if (rlp[position] <= Transaction.MaxTxType) // it is typed transactions
+            if (rlp.Data[position] <= Transaction.MaxTxType) // it is typed transactions
             {
-                transactionSequence = rlp.Slice(position);
-                txType = (TxType)rlp[position++];
+                transactionSequence = rlp.Data.Slice(position);
+                txType = (TxType)rlp.Data[position++];
                 ThrowIfLegacy(txType);
             }
         }
         else
         {
-            if (!RlpHelpers.IsSequenceNext(rlp, position))
+            if (!rlp.IsSequenceNext(position))
             {
-                position = RlpHelpers.ReadPrefixAndContentLength(rlp, position, out _, out int contentLength);
+                rlp.ReadPrefixAndContentLength(ref position, out _, out int contentLength);
                 txSequenceStart = position;
-                transactionSequence = rlp.Slice(position, contentLength);
-                txType = (TxType)rlp[position++];
+                transactionSequence = rlp.Data.Slice(position, contentLength);
+                txType = (TxType)rlp.Data[position++];
                 ThrowIfLegacy(txType);
             }
         }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs
@@ -96,17 +96,18 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
 
     protected virtual void DecodePayload(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
-        ReadOnlySpan<byte> rlp = decoderContext.Data;
+        LiteRlpReader rlp = new(decoderContext.Data);
         decoderContext.Position = DecodeNonce(rlp, decoderContext.Position, out ulong nonce);
         transaction.Nonce = nonce;
 
         // The gas price is a virtual extension point, so the cursor goes back to the reader here.
         DecodeGasPrice(transaction, ref decoderContext);
 
-        int position = RlpHelpers.DecodeULong(rlp, decoderContext.Position, out ulong gasLimit);
+        int position = decoderContext.Position;
+        rlp.DecodeULong(ref position, out ulong gasLimit);
         transaction.GasLimit = gasLimit;
-        (position, transaction.To) = RlpHelpers.DecodeAddressOrNull(rlp, position);
-        position = RlpHelpers.DecodeUInt256(rlp, position, out UInt256 value);
+        transaction.To = rlp.DecodeAddressOrNull(ref position);
+        rlp.DecodeUInt256(ref position, out UInt256 value);
         transaction.Value = value;
         decoderContext.Position = position;
 
@@ -114,32 +115,35 @@ public abstract class BaseTxDecoder<T>(TxType txType, Func<T>? transactionFactor
         transaction.Data = decoderContext.DecodeByteArrayMemory(_dataRlpLimit);
     }
 
-    private static int DecodeNonce(ReadOnlySpan<byte> rlp, int position, out ulong nonce)
+    private static int DecodeNonce(LiteRlpReader rlp, int position, out ulong nonce)
     {
-        (_, int contentLength) = RlpHelpers.PeekPrefixAndContentLength(rlp, position);
+        (_, int contentLength) = rlp.PeekPrefixAndContentLength(position);
         if (contentLength <= sizeof(ulong))
         {
-            return RlpHelpers.DecodeULong(rlp, position, out nonce);
+            rlp.DecodeULong(ref position, out nonce);
+            return position;
         }
 
-        RlpHelpers.DecodeByteArraySpan(rlp, position, out ReadOnlySpan<byte> nonceBytes, RlpLimit.DefaultLimit);
+        int noncePosition = position;
+        _ = RlpHelpers.DecodeByteArraySpan(rlp.Data, position, out ReadOnlySpan<byte> nonceBytes, RlpLimit.DefaultLimit);
         if (nonceBytes[0] == 0)
         {
-            RlpHelpers.ThrowNonCanonicalInteger(position);
+            RlpHelpers.ThrowNonCanonicalInteger(noncePosition);
         }
 
-        nonce = RlpHelpers.ThrowNonceTooWide(position);
-        return position;
+        nonce = default;
+        return RlpHelpers.ThrowNonceTooWide(noncePosition);
     }
 
     protected virtual void DecodeGasPrice(Transaction transaction, ref RlpReader decoderContext) => transaction.GasPrice = decoderContext.DecodeUInt256();
 
     protected Signature? DecodeSignature(Transaction transaction, ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
-        ReadOnlySpan<byte> rlp = decoderContext.Data;
-        int position = RlpHelpers.DecodeULong(rlp, decoderContext.Position, out ulong v);
-        position = RlpHelpers.DecodeByteArraySpan(rlp, position, out ReadOnlySpan<byte> rBytes, RlpLimit.L32);
-        position = RlpHelpers.DecodeByteArraySpan(rlp, position, out ReadOnlySpan<byte> sBytes, RlpLimit.L32);
+        LiteRlpReader rlp = new(decoderContext.Data);
+        int position = decoderContext.Position;
+        rlp.DecodeULong(ref position, out ulong v);
+        rlp.DecodeByteArraySpan(ref position, out ReadOnlySpan<byte> rBytes, RlpLimit.L32);
+        rlp.DecodeByteArraySpan(ref position, out ReadOnlySpan<byte> sBytes, RlpLimit.L32);
         decoderContext.Position = position;
         return DecodeSignature(v, rBytes, sBytes, transaction.Signature, rlpBehaviors);
     }

--- a/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
+++ b/src/Nethermind/Nethermind.Serialization.Rlp/WithdrawalDecoder.cs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
-using System;
 using Nethermind.Core;
 using System.Diagnostics.CodeAnalysis;
 
@@ -12,15 +11,15 @@ public sealed class WithdrawalDecoder() : RlpDecoder<Withdrawal>
 {
     protected override Withdrawal? DecodeInternal(ref RlpReader decoderContext, RlpBehaviors rlpBehaviors = RlpBehaviors.None)
     {
-        if (RlpHelpers.TryConsumeNull(ref decoderContext, out ReadOnlySpan<byte> rlp, out int position)) return null;
+        if (decoderContext.TryConsumeNull(out LiteRlpReader rlp, out int position)) return null;
 
-        position = RlpHelpers.ReadSequenceLength(rlp, position, out int sequenceLength);
+        rlp.ReadSequenceLength(ref position, out int sequenceLength);
         int checkPosition = position + sequenceLength;
 
-        position = RlpHelpers.DecodeULong(rlp, position, out ulong index);
-        position = RlpHelpers.DecodeULong(rlp, position, out ulong validatorIndex);
-        position = RlpHelpers.DecodeAddress(rlp, position, out Address address);
-        position = RlpHelpers.DecodeULong(rlp, position, out ulong amountInGwei);
+        rlp.DecodeULong(ref position, out ulong index);
+        rlp.DecodeULong(ref position, out ulong validatorIndex);
+        rlp.DecodeAddress(ref position, out Address address);
+        rlp.DecodeULong(ref position, out ulong amountInGwei);
         decoderContext.Position = position;
 
         Withdrawal withdrawal = new()

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.std.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.std.cs
@@ -52,7 +52,7 @@ internal sealed partial class PersistentStorageProvider
         ParallelUnbalancedWork.For(
             0,
             storages.Count,
-            RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+            RuntimeInformation.ParallelOptionsLogicalCores,
             (storages, toUpdateRoots: _toUpdateRoots, writes: 0, skips: 0),
             static (i, state) =>
             {

--- a/src/Nethermind/Nethermind.State/Proofs/IndexedTrieRoot.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/IndexedTrieRoot.cs
@@ -51,7 +51,7 @@ internal static class IndexedTrieRoot
             TEncoder leafEncoder = encoder;
             try
             {
-                Parallel.For(0, (_items.Length - 1) / LeafBatchSize + 1, RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16, batch =>
+                Parallel.For(0, (_items.Length - 1) / LeafBatchSize + 1, RuntimeInformation.ParallelOptionsLogicalCores, batch =>
                 {
                     Calculator<T, TEncoder> calculator = new(inputs.AsSpan(), leafEncoder);
                     int start = batch * LeafBatchSize;

--- a/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
+++ b/src/Nethermind/Nethermind.Trie/Pruning/TrieStore.cs
@@ -933,7 +933,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
         ParallelUnbalancedWork.For(
             0,
             _dirtyNodes.Length,
-            RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+            RuntimeInformation.ParallelOptionsLogicalCores,
             (prunePersisted, forceRemovePersistedNodes, dirtyNodes: _dirtyNodes, persistedHashes: _persistedHashes, nodeStorage),
             static (index, state) =>
             {
@@ -977,7 +977,7 @@ public sealed class TrieStore : ITrieStore, IPruningTrieStore
             ParallelUnbalancedWork.For(
                 0,
                 shardCountToPrune,
-                RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+                RuntimeInformation.ParallelOptionsLogicalCores,
                 (dirtyNodes: _dirtyNodes, shardedCount: _shardedDirtyNodeCount, startShardIdx),
                 static (i, state) =>
                 {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -346,7 +346,7 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchNonRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
-                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
                     (local: 0, item, tree, bufferPool, rootPath, canBeParallel),
                     static (i, state) =>
                     {
@@ -432,7 +432,7 @@ namespace Nethermind.Trie
             private static int GetChildrenRlpLengthForBranchRlpParallel(ITrieNodeResolver tree, TreePath rootPath, TrieNode item, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
                 int totalLength = 0;
-                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsPhysicalCoresUpTo16,
+                ParallelUnbalancedWork.For(0, BranchesCount, RuntimeInformation.ParallelOptionsLogicalCores,
                     (local: 0, item, tree, bufferPool, rootPath, canBeParallel),
                     static (i, state) =>
                     {

--- a/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.Decoder.cs
@@ -439,9 +439,9 @@ namespace Nethermind.Trie
                         object? data = BranchChildren(state.item)[i];
                         if (data is null)
                         {
-                            ReadOnlySpan<byte> nodeRlp = state.item.FullRlp.AsSpan();
+                            LiteRlpReader nodeRlp = new(state.item.FullRlp);
                             int cursor = state.item.SeekChildPosition(nodeRlp, i);
-                            state.local += RlpHelpers.PeekNextRlpLength(nodeRlp, cursor);
+                            state.local += nodeRlp.PeekNextRlpLength(cursor);
                         }
                         else if (ReferenceEquals(data, _nullNode))
                         {
@@ -475,7 +475,7 @@ namespace Nethermind.Trie
             {
                 int totalLength = 0;
                 ushort candidateMask = 0;
-                ReadOnlySpan<byte> nodeRlp = item.FullRlp.AsSpan();
+                LiteRlpReader nodeRlp = new(item.FullRlp);
                 int cursor = item.SeekChildPosition(nodeRlp, 0);
                 ref object? child = ref FirstBranchChild(item);
                 for (int i = 0; i < BranchesCount; i++, child = ref Unsafe.Add(ref child, 1))
@@ -483,7 +483,7 @@ namespace Nethermind.Trie
                     object? data = child;
                     if (data is null)
                     {
-                        int length = RlpHelpers.PeekNextRlpLength(nodeRlp, cursor);
+                        int length = nodeRlp.PeekNextRlpLength(cursor);
                         totalLength += length;
                         cursor += length;
                     }
@@ -524,7 +524,7 @@ namespace Nethermind.Trie
                             path.TruncateOne();
                         }
 
-                        cursor = RlpHelpers.SkipItem(nodeRlp, cursor);
+                        nodeRlp.SkipItem(ref cursor);
                     }
                 }
 
@@ -589,9 +589,10 @@ namespace Nethermind.Trie
             /// <inheritdoc cref="WriteChildrenRlpBranch" />
             private static int WriteChildrenRlpBranchRlp(ITrieNodeResolver tree, ref TreePath path, TrieNode item, Span<byte> destination, ICappedArrayPool? bufferPool, bool canBeParallel)
             {
-                ReadOnlySpan<byte> nodeRlp = item.FullRlp.AsSpan();
-                if (nodeRlp.Length == FullBranchRlpLength && destination.Length >= BranchesCount * Rlp.LengthOfKeccakRlp
-                    && TryPatchFullBranch(tree, ref path, item, nodeRlp, destination, bufferPool, canBeParallel))
+                LiteRlpReader nodeRlp = new(item.FullRlp);
+                ReadOnlySpan<byte> nodeRlpData = nodeRlp.Data;
+                if (nodeRlpData.Length == FullBranchRlpLength && destination.Length >= BranchesCount * Rlp.LengthOfKeccakRlp
+                    && TryPatchFullBranch(tree, ref path, item, nodeRlpData, destination, bufferPool, canBeParallel))
                 {
                     return BranchesCount * Rlp.LengthOfKeccakRlp;
                 }
@@ -608,7 +609,7 @@ namespace Nethermind.Trie
                     object? data = child;
                     if (data is null)
                     {
-                        int length = RlpHelpers.PeekNextRlpLength(nodeRlp, cursor);
+                        int length = nodeRlp.PeekNextRlpLength(cursor);
                         if (runStart < 0) runStart = cursor;
                         runLength += length;
                         cursor += length;
@@ -617,7 +618,7 @@ namespace Nethermind.Trie
                     {
                         if (runStart >= 0)
                         {
-                            nodeRlp.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
+                            nodeRlp.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
                             position += runLength;
                             runStart = -1;
                             runLength = 0;
@@ -652,13 +653,13 @@ namespace Nethermind.Trie
                             }
                         }
 
-                        cursor = RlpHelpers.SkipItem(nodeRlp, cursor);
+                        nodeRlp.SkipItem(ref cursor);
                     }
                 }
 
                 if (runStart >= 0)
                 {
-                    nodeRlp.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
+                    nodeRlp.Data.Slice(runStart, runLength).CopyTo(destination.Slice(position, runLength));
                     position += runLength;
                 }
 

--- a/src/Nethermind/Nethermind.Trie/TrieNode.cs
+++ b/src/Nethermind/Nethermind.Trie/TrieNode.cs
@@ -630,10 +630,13 @@ namespace Nethermind.Trie
         {
             Metrics.IncrementTreeNodeRlpDecodings();
 
-            int position = RlpHelpers.ReadSequenceLength(data, 0, out _);
+            LiteRlpReader reader = new(data);
+
+            int position = 0;
+            reader.ReadSequenceLength(ref position, out _);
 
             // micro optimization to prevent searches beyond 3 items for branches (search up to three)
-            int numberOfItems = itemsCount = RlpHelpers.CountItems(data, position, data.Length, 3);
+            int numberOfItems = itemsCount = reader.CountItems(position, data.Length, 3);
 
             if (numberOfItems < 2)
             {
@@ -645,11 +648,11 @@ namespace Nethermind.Trie
             }
             else
             {
-                position = RlpHelpers.DecodeByteArraySpan(data, position, out ReadOnlySpan<byte> valueSpan);
+                reader.DecodeByteArraySpan(ref position, out ReadOnlySpan<byte> valueSpan);
                 (byte[] key, bool isLeaf) = HexPrefix.FromBytes(valueSpan);
                 if (isLeaf)
                 {
-                    RlpHelpers.DecodeByteArraySpan(data, position, out valueSpan);
+                    reader.DecodeByteArraySpan(ref position, out valueSpan);
                     CappedArray<byte> buffer = bufferPool.SafeRent(valueSpan.Length);
                     valueSpan.CopyTo(buffer.AsSpan());
                     _nodeData = new LeafData(key, buffer);
@@ -760,14 +763,14 @@ namespace Nethermind.Trie
                 return null;
             }
 
-            ReadOnlySpan<byte> nodeRlp = rlp.AsSpan();
+            LiteRlpReader nodeRlp = new(rlp);
             int position = SeekChildPosition(nodeRlp, i);
             if (!IsChildHashNext(nodeRlp, position))
             {
                 return null;
             }
 
-            RlpHelpers.DecodeKeccak(nodeRlp, position, out Hash256 keccak);
+            nodeRlp.DecodeKeccak(ref position, out Hash256 keccak);
             return keccak;
         }
 
@@ -779,9 +782,9 @@ namespace Nethermind.Trie
         /// an embedded child.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool IsChildHashNext(ReadOnlySpan<byte> nodeRlp, int position)
-            => nodeRlp[position] == RlpHelpers.KeccakRlpPrefix
-                || RlpHelpers.PeekPrefixAndContentLength(nodeRlp, position).ContentLength == Hash256.Size;
+        private static bool IsChildHashNext(LiteRlpReader nodeRlp, int position)
+            => nodeRlp.Data[position] == RlpHelpers.KeccakRlpPrefix
+                || nodeRlp.PeekPrefixAndContentLength(position).ContentLength == Hash256.Size;
 
         public byte[]? GetInlineNodeRlp(int i)
         {
@@ -791,15 +794,15 @@ namespace Nethermind.Trie
                 return null;
             }
 
-            ReadOnlySpan<byte> nodeRlp = rlp.AsSpan();
+            LiteRlpReader nodeRlp = new(rlp);
             int position = SeekChildPosition(nodeRlp, i);
 
-            if (!RlpHelpers.IsSequenceNext(nodeRlp, position))
+            if (!nodeRlp.IsSequenceNext(position))
             {
                 return null;
             }
 
-            return nodeRlp.Slice(position, RlpHelpers.PeekNextRlpLength(nodeRlp, position)).ToArray();
+            return nodeRlp.Data.Slice(position, nodeRlp.PeekNextRlpLength(position)).ToArray();
         }
 
         public bool GetChildHashAsValueKeccak(int i, out ValueHash256 keccak)
@@ -811,14 +814,14 @@ namespace Nethermind.Trie
                 return false;
             }
 
-            ReadOnlySpan<byte> nodeRlp = rlp.AsSpan();
+            LiteRlpReader nodeRlp = new(rlp);
             int position = SeekChildPosition(nodeRlp, i);
             if (!IsChildHashNext(nodeRlp, position))
             {
                 return false;
             }
 
-            RlpHelpers.DecodeValueKeccakNonNull(nodeRlp, position, out keccak);
+            nodeRlp.DecodeValueKeccakNonNull(ref position, out keccak);
             return true;
         }
 
@@ -835,8 +838,8 @@ namespace Nethermind.Trie
                 CappedArray<byte> rlp = ReadRlp();
                 if (rlp.IsNotNull)
                 {
-                    ReadOnlySpan<byte> nodeRlp = rlp.AsSpan();
-                    return RlpHelpers.PeekNextRlpLength(nodeRlp, SeekChildPosition(nodeRlp, i)) == 1;
+                    LiteRlpReader nodeRlp = new(rlp);
+                    return nodeRlp.PeekNextRlpLength(SeekChildPosition(nodeRlp, i)) == 1;
                 }
             }
 
@@ -1399,10 +1402,10 @@ namespace Nethermind.Trie
 
         /// <summary>Returns the offset of child <paramref name="index"/> within this node's RLP.</summary>
         /// <param name="nodeRlp">This node's RLP; every caller has already established that it is present.</param>
-        private int SeekChildPosition(ReadOnlySpan<byte> nodeRlp, int index)
+        private int SeekChildPosition(LiteRlpReader nodeRlp, int index)
         {
-            Debug.Assert(!nodeRlp.IsEmpty, "Seeking a child of a node with no RLP");
-            if (nodeRlp.Length == FullBranchRlpLength && IsBranch)
+            Debug.Assert(!nodeRlp.Data.IsEmpty, "Seeking a child of a node with no RLP");
+            if (nodeRlp.Data.Length == FullBranchRlpLength && IsBranch)
             {
                 return 3 + index * Rlp.LengthOfKeccakRlp;
             }
@@ -1413,7 +1416,10 @@ namespace Nethermind.Trie
                 index = 1;
             }
 
-            return RlpHelpers.SkipItems(nodeRlp, RlpHelpers.SkipLength(nodeRlp, 0), index);
+            int position = 0;
+            nodeRlp.SkipLength(ref position);
+            nodeRlp.SkipItems(ref position, index);
+            return position;
         }
 
         private TrieNode CreateInlineChild(ReadOnlySpan<byte> fullRlp)
@@ -1438,10 +1444,10 @@ namespace Nethermind.Trie
                 if (rlp.IsNotNull)
                 {
                     // Allows to load children in parallel
-                    ReadOnlySpan<byte> nodeRlp = rlp.AsSpan();
+                    LiteRlpReader nodeRlp = new(rlp);
                     int position = SeekChildPosition(nodeRlp, i);
 
-                    switch (nodeRlp[position])
+                    switch (nodeRlp.Data[position])
                     {
                         case 0:
                         case 128:
@@ -1451,7 +1457,7 @@ namespace Nethermind.Trie
                             }
                         case 160:
                             {
-                                RlpHelpers.DecodeKeccak(nodeRlp, position, out Hash256 keccak);
+                                nodeRlp.DecodeKeccak(ref position, out Hash256 keccak);
 
                                 TrieNode child = tree.FindCachedOrUnknown(childPath, keccak);
                                 data = child.IsUnresolvedWarmerOwned ? keccak : child;
@@ -1461,8 +1467,8 @@ namespace Nethermind.Trie
                             }
                         default:
                             {
-                                int length = RlpHelpers.PeekNextRlpLength(nodeRlp, position);
-                                TrieNode child = CreateInlineChild(nodeRlp.Slice(position, length));
+                                int length = nodeRlp.PeekNextRlpLength(position);
+                                TrieNode child = CreateInlineChild(nodeRlp.Data.Slice(position, length));
                                 data = childOrRef = child;
                                 break;
                             }
@@ -1499,13 +1505,14 @@ namespace Nethermind.Trie
                 return chCount;
             }
 
-            ReadOnlySpan<byte> nodeRlp = rlp.AsSpan();
-            int position = RlpHelpers.SkipLength(nodeRlp, 0);
+            LiteRlpReader nodeRlp = new(rlp);
+            int position = 0;
+            nodeRlp.SkipLength(ref position);
 
             path.AppendMut(0);
             for (int i = 0; i < 16; i++)
             {
-                switch (nodeRlp[position])
+                switch (nodeRlp.Data[position])
                 {
                     case 0:
                     case 128:
@@ -1517,7 +1524,7 @@ namespace Nethermind.Trie
                     case 160:
                         {
                             path.SetLast(i);
-                            position = RlpHelpers.DecodeKeccak(nodeRlp, position, out Hash256 keccak);
+                            nodeRlp.DecodeKeccak(ref position, out Hash256 keccak);
                             TrieNode child = tree.FindCachedOrUnknown(path, keccak);
                             chCount++;
                             output[i] = child;
@@ -1526,8 +1533,8 @@ namespace Nethermind.Trie
                         }
                     default:
                         {
-                            int length = RlpHelpers.PeekNextRlpLength(nodeRlp, position);
-                            TrieNode child = CreateInlineChild(nodeRlp.Slice(position, length));
+                            int length = nodeRlp.PeekNextRlpLength(position);
+                            TrieNode child = CreateInlineChild(nodeRlp.Data.Slice(position, length));
                             position += length;
                             chCount++;
                             output[i] = child;
@@ -1575,7 +1582,7 @@ namespace Nethermind.Trie
             /// <summary>Sentinel for <see cref="_currentStreamIndex"/> before the first seek.</summary>
             private const int NoCursor = -1;
 
-            private ReadOnlySpan<byte> _nodeRlp;
+            private LiteRlpReader _nodeRlp;
             private int _position;
 
             /// <summary>Index of the child <see cref="_position"/> sits at, or <see cref="NoCursor"/>.</summary>
@@ -1593,33 +1600,35 @@ namespace Nethermind.Trie
                     {
                         // The cursor is only meaningful against the buffer it was measured on, and
                         // ReadRlp() can hand back a different one once WriteRlp swaps the node's array.
-                        ReadOnlySpan<byte> nodeRlp;
+                        LiteRlpReader nodeRlp;
                         int position;
                         if ((uint)_currentStreamIndex <= (uint)i)
                         {
                             nodeRlp = _nodeRlp;
                             int toSkip = i - _currentStreamIndex;
-                            position = RlpHelpers.SkipItems(nodeRlp, _position, toSkip);
+                            position = _position;
+                            nodeRlp.SkipItems(ref position, toSkip);
                             _currentStreamIndex += toSkip;
                         }
                         else
                         {
-                            nodeRlp = _nodeRlp = rlp.AsSpan();
-                            position = RlpHelpers.SkipLength(nodeRlp, 0);
+                            nodeRlp = _nodeRlp = new(rlp.AsSpan());
+                            position = 0;
+                            nodeRlp.SkipLength(ref position);
                             if (node.IsExtension)
                             {
-                                position = RlpHelpers.SkipItem(nodeRlp, position);
+                                nodeRlp.SkipItem(ref position);
                                 i--;
                             }
                             else
                             {
-                                position = RlpHelpers.SkipItems(nodeRlp, position, i);
+                                nodeRlp.SkipItems(ref position, i);
                             }
 
                             _currentStreamIndex = i;
                         }
 
-                        switch (nodeRlp[position])
+                        switch (nodeRlp.Data[position])
                         {
                             case 0:
                             case 128:
@@ -1631,7 +1640,7 @@ namespace Nethermind.Trie
                                 }
                             case 160:
                                 {
-                                    position = RlpHelpers.DecodeKeccak(nodeRlp, position, out Hash256 keccak);
+                                    nodeRlp.DecodeKeccak(ref position, out Hash256 keccak);
                                     _currentStreamIndex++;
 
                                     TrieNode child = tree.FindCachedOrUnknown(childPath, keccak);
@@ -1642,8 +1651,8 @@ namespace Nethermind.Trie
                                 }
                             default:
                                 {
-                                    int length = RlpHelpers.PeekNextRlpLength(nodeRlp, position);
-                                    TrieNode child = node.CreateInlineChild(nodeRlp.Slice(position, length));
+                                    int length = nodeRlp.PeekNextRlpLength(position);
+                                    TrieNode child = node.CreateInlineChild(nodeRlp.Data.Slice(position, length));
                                     data = childOrRef = child;
                                     break;
                                 }


### PR DESCRIPTION
Merges `master` (`a66d9cae24`) into `eip8141-frame-txs-devnet7` (`9ecfd3085c`), bringing across 3 commits.

## :warning: Merge with a merge commit — do not squash

This PR **must** be merged with a real merge commit. Squashing discards the recorded merge base, so the *next* master merge into this branch replays every conflict resolved here. That has already cost this series once.

## What master brings

| Commit | Effect on this branch |
|---|---|
| `238ab20bb6` perf: skip unobserved EVM logs based on tracer requirements (#13372) | Redefines `SuppressLogs` and adds `MaterializeLogMemory`. **Collides semantically with EIP-7906** — see resolution 1. |
| `aa5b2aab23` Add a `LiteRlpReader` for explicit cursor decoding (#13303) | Rewrites the cursor-threaded RLP decoders, including both receipt decoders. Removes `RlpHelpers.TryConsumeNull`. |
| `a66d9cae24` perf: remove fixed block prewarming and trie concurrency caps (#13388) | No overlap with this branch. |

## Resolution surface

Git reported **three** textual conflicts. `git show --cc` reports **six** files with combined hunks, and across the whole merge only **six lines** differ from *both* parents, in **two** files. Every site is enumerated below.

### 1. `Nethermind.Evm/TransactionProcessing/TransactionProcessor.cs` — textual conflict, outcome differs

One hunk, and the two sides differ in *outcome*, not plumbing:

- **Master** redefines suppression as "no tracer wants the logs": `SuppressLogs = !tracer.IsCollectingLogs && !tracer.IsTracingLogs`, and adds `MaterializeLogMemory` so an instruction tracer still sees the expanded memory. `ITxTracer.IsCollectingLogs` defaults to `IsTracingReceipt`, and master sets it to `false` on `CallOutputTracer`, `EstimateGasTracer` and friends.
- **Frames** had only extracted the *pre-existing* condition (warm-up run under `NullTxTracer`) into a `ShouldSuppressLogs` helper so the three frame-tx context sites could share it. Same outcome as the merge base.

**Resolution: master's outcome on the non-frame path; the frames helper keeps its narrower rule for the frame path.**

Master's premise — that only a tracer consumes a transaction's logs — does not hold on this branch. EIP-7906's `TXTRACE` (`0x0C`, `0x0D`–`0x13`) and `EVENTDATACOPY` read the transaction's own logs back **from inside the EVM**, via `TransactionDiffView.Logs`, and no tracer flag describes that consumer. Adopting master's rule at the frame sites made four `FrameTxProcessorTests` cases fail under `CallOutputTracer` — the tracer says it does not collect logs, so the log journal is empty and the assertion opcodes read nothing:

```
failed Execute_EventDataCopy_WholeRange_Copies
failed Execute_EventDataCopy_ZeroLengthAtTheEnd_Copies
failed Execute_TxTraceAndEventDataCopy_ReadTransactionLogs
failed Execute_TxTraceTopic_PresentTopic_Reads
```

So:

- `ExecuteEvmTransaction` (the only caller is guarded by the `tx.Type == TxType.FrameTx` diversion added earlier in `Execute`, so it never sees a frame transaction) takes **master verbatim**, including `MaterializeLogMemory`.
- The two `SetTxExecutionContext` sites in `TransactionProcessorBase.FrameTx.cs` keep the frames-branch `ShouldSuppressLogs(opts, tracer)` **unchanged** — the file is byte-identical to the branch tip.
- The helper gains a two-line `<remarks>` recording *why* it stays narrower, so the next merge does not "fix" it back.

The only lines differing from both parents here are those two comment lines. Extending master's optimisation to frame transactions is possible — the gate would be "no frame runs in `POST_TX` mode" — but that is a design decision for the branch, not for a merge, so it is left out.

### 2. `Nethermind.Serialization.Rlp/ReceiptMessageDecoder.cs` — textual conflict, pure union

One hunk, where the branch's `TxType.FrameTx` early dispatch sits immediately above the line master rewrote from `RlpHelpers.DecodeByteArray(rlp, position, out …)` to `rlp.DecodeByteArray(ref position, out …)`.

**Resolution: both sides, in full.** The FrameTx dispatch block is kept verbatim; the `DecodeByteArray` call takes master's `LiteRlpReader` form. No line in the result differs from both parents.

Critically, the branch's `ctx.Check(lastCheck)` after `LogEntryDecoder.DecodeLogs(...)` **survives**. This is the exact line a previous merge in this series silently dropped by taking master's `DecodeLogs` block in full; `DecodeLogs` performs no end-of-list check of its own. It is verified explicitly below, by mutation.

### 3. `Nethermind.Serialization.Rlp/ReceiptStorageDecoder.cs` — textual conflict, structure vs plumbing

The two sides disagree about *both* structure and call form in the same hunk:

- **Frames** lifted the `txHash` and `error` reads **out of** the `if (!allowExtraBytes)` block, so they run regardless of `AllowExtraBytes`, and appended the `[payer, [frame_receipt, …]]` read plus the realign-to-`receiptEnd` step.
- **Master** left them inside that block and converted the call form to `rlp.Data[position]` / `rlp.DecodeKeccakOrNull(ref position)` / `rlp.DecodeString(ref position)`.

**Resolution: the branch's structure, master's call forms.** The structure is load-bearing for the frames extension (the frame read must happen on the `AllowExtraBytes` path too), and the call form is pure plumbing. The four lines that differ from both parents are exactly the re-indented `LiteRlpReader` calls.

### 4–6. Combined hunks with no manual resolution

`git show --cc --name-only` over-reports (9 paths; `BlockProcessorTests.cs`, `CompactReceiptStorageDecoder.cs` and `TxDecoder.cs` yield zero combined hunks). Three further files do produce a combined hunk, but every line in each came from one parent or the other:

- **`Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs`** — master's `public bool IsCollectingLogs => true;` lands adjacent to the branch's `IFrameTxReceiptTracer` implementation. The block tracer keeps collecting logs, which is what makes master's optimisation safe for ordinary block processing.
- **`Nethermind.Evm/TxExecutionContext.cs`** — master's `MaterializeLogMemory` property next to the branch's `FrameTxContext` field.
- **`Nethermind.Serialization.Rlp/TxDecoders/BaseTxDecoder.cs`** — the branch's `DecodePayload(…, int payloadEnd, …)` signature with master's `LiteRlpReader rlp = new(decoderContext.Data);` local.

### Silent conflicts

Checked for, none found. `RlpHelpers.TryConsumeNull` and `IsEmptySequenceNext` were deleted by master; no frames-only file referenced either, and the release build is clean at 0 warnings. The three over-reported paths above were each diffed against both branch tips to confirm both sides' changes are present.

Worth recording for the next merge in this series: the defect that nearly shipped here compiled cleanly and produced 0 warnings. It was caught only because `Nethermind.Evm.Test` was run, and it lived in a hunk that *did* conflict textually — a clean build is not evidence that an outcome-differing hunk was resolved the right way round.

## Receipt-decoder verification

The receipt pair is where a previous merge in this series lost branch work, so each guarantee was checked explicitly rather than inferred from a green aggregate.

1. **`Check(` survives on both message decoders.** `ReceiptMessageDecoder.DecodeInternal` line 69 (`ctx.Check(lastCheck)`) and `ReceiptMessageDecoder69` line 59 (`ctx.Check(lastCheck)`). `ReceiptStorageDecoder` retains its `RlpHelpers.Check(position, lastCheck)`.
2. **Write-side `GuardEncodable` still called from all four entry points** in `FrameReceiptRlp.cs`: `GetStoredExtensionLength` (L77), `EncodeStoredExtension` (L86), `GetPayloadLength` (L146), `EncodePayload` (L157).
3. **`DecodeStoredFrames`' read path is still unguarded**, and the payer still heals via `decoderContext.DecodeAddressOrNull()` in `ReceiptStorageDecoder`. No `MaxFrames` bound, no status-range check, no frame-log-list bound on the read path — only the per-frame `reader.Check(frameEnd)` alignment. Deliberate: earlier builds of this branch wrote payer-`0x80`, out-of-range statuses and oversized frame log lists, and a read-side bound would orphan those rows and take their whole block's receipt array with them.
4. **`Decode_UnderDeclaredLogsHeader_Throws` passes and discriminates.** Both copies pass. Mutating each decoder by removing its `ctx.Check(lastCheck)` and rebuilding turns **both** red:

| Test | With `Check` | `Check` removed |
|---|---|---|
| `Nethermind.Core.Test` · `ReceiptMessageDecoderTests` | 1 passed | **1 failed** |
| `Nethermind.Network.Test` · `ReceiptMessageDecoder69Tests` | 1 passed | **1 failed** |

The padded 47-byte log from `ReceiptRlpBuilder.PaddedLog()` is what keeps this honest — without it the byte arm would reject the under-declaration by coincidence and the test would pass with the check gone. The mutation was reverted and the tree confirmed clean before the merge commit was finalised.

## Verification

**Release build** (`-nodeReuse:false`): **0 warnings, 0 errors**.

**Checked build** (`-p:DefineConstants=TRACE;DEBUG`, from a cleaned `artifacts/`): **0 warnings, 0 errors**.

| Suite | Release | Checked |
|---|---|---|
| `Nethermind.Core.Test` | 6578 · 0 failed (136 skipped) | 6579 · 0 failed (137 skipped) |
| `Nethermind.Network.Test` | 1778 · 0 failed (8 skipped) | 1778 · 1 failed (known flake, see below) |
| `Nethermind.Blockchain.Test` | 2303 · 0 failed (151 skipped) | 2303 · 0 failed (151 skipped) |
| `Nethermind.Evm.Test` | 12819 · 0 failed (19 skipped) | 12817 · 0 failed (19 skipped) |
| `Nethermind.TxPool.Test` | 1233 · 0 failed (24 skipped) | 1233 · 0 failed (24 skipped) |
| `Nethermind.JsonRpc.Test` | 2219 · 0 failed (22 skipped) | 2219 · 0 failed (22 skipped) |
| `Nethermind.EraE.Test` | 166 · 0 failed (3 skipped) | 166 · 0 failed (3 skipped) |
| `Nethermind.Optimism.Test` | 746 · 0 failed | 746 · 0 failed |

Note there is no `Nethermind.Serialization.Rlp.Test` project; naming one would print nothing and exit 0, which reads as a pass. The receipt-decoder coverage lives in `Nethermind.Core.Test` and `Nethermind.Network.Test`, both in the table.

The one checked-configuration failure is `PeerManagerTests.Will_disconnect_on_remove_static_node` — a timing flake in the same fixture as the documented `Will_only_connect_up_to_max_peers` one, asserting a disconnect count that had not yet settled (`Expected: 1, But was: 0`). It passed in release, passed 3/3 when re-run in isolation against the same checked binaries, and this merge changes no file under the peer-management path — `git show --cc --name-only` lists nothing network-related, and the merge's full diff against the branch tip touches no peer file.

The `Nethermind.Evm.Test` and `Nethermind.Core.Test` counts differ by two and one between configurations; those are the `DEBUG`-conditional cases, not failures.

**Pinned on-disk receipt sizes** — `FrameTxReceiptDecoderTests.StorageEncoding_MultiFrameReceiptWithLogs_StoresLogsTwiceAtPinnedSizeAndRoundtrips` run on its own rather than inside an aggregate: both parameterisations pass, so the compact encoding is still **435** bytes and the non-compact **701**. The stored size counts every log twice by design, so an unchanged number is the evidence that neither the union-log copy nor the per-frame copy moved.

**Frame fixture lanes** (`tests-frames-devnet@v0.3.0`, `--forkAlias=Bogota=Eip8141Prototype`, chunk `1of1`), counts read from the runner JSON, on a release build rebuilt from scratch after the checked configuration:

| Lane | Result |
|---|---|
| `blockTest` | **218 / 218** |
| `engineTest` | **218 / 218** |


## Review follow-up (`d7a8a88`)

One commit on top of the merge, from the `claude[bot]` review. It does not touch the merge commit — both parents are intact.

The two frame-path `SetTxExecutionContext` sites set only `SuppressLogs`, leaving master's new `MaterializeLogMemory` at `false`. That was a no-op, and the reachability argument was checked rather than assumed: `ShouldSuppressLogs` is true only for `NullTxTracer.Instance` (reference equality against a private-constructor singleton), which overrides none of the `IsTracing*` flags, so master's `IsTracingInstructions || IsTracingMemory` is `false` for the only tracer that can reach it — and the read site is behind `DispatchFlags.ConstTracing` as well.

Both sites now set the flag with master's exact expression, so they stay correct under **any** future `ShouldSuppressLogs`, not only a narrow one. No helper was extracted and no master-authored line was edited, to keep the next merge's conflict surface unchanged.

The `<remarks>` on `ShouldSuppressLogs` is unchanged. What was added instead is evidence that the rule has an executable guard: mutating the helper back to master's `!tracer.IsCollectingLogs && !tracer.IsTracingLogs` turns all four EIP-7906 `FrameTxProcessorTests` cases red (4 passed → 4 failed), and reverting restores them.

Re-verified with the follow-up on top: 0 warnings in both configurations; `Nethermind.Evm.Test` 12819 / 12817, `Nethermind.Core.Test` 6578 / 6579, `Nethermind.Blockchain.Test` 2303 / 2303, `Nethermind.JsonRpc.Test` 2219 / 2219, `Nethermind.TxPool.Test` 1233 / 1233, all 0 failed. Pinned receipt sizes still **435** / **701** from the fixture run on its own. Both frame lanes **218 / 218**. Lint clean under CI's invocation, positive-controlled with an injected unused `using` that produced `IDE0005`.

`master` has since advanced 18 commits past `a66d9cae24` (now `c790bdf5e1`). That is for the next merge PR in this series, not this one.
