### PR TITLE
test: wait for the tx-carrying improvement in the V6 BAL test

### DIFF
--- a/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
+++ b/src/Nethermind/Nethermind.Merge.Plugin.Test/EngineModuleTests.V6.cs
@@ -542,10 +542,12 @@ public partial class EngineModuleTests
 
         ForkchoiceStateV1 fcuState = new(genesis.Hash!, genesis.Hash!, genesis.Hash!);
 
+        Task improvedBlockWait = chain.WaitForImprovedBlock(genesis.Hash!, minTransactions: 1);
+
         ResultWrapper<ForkchoiceUpdatedV1Result> fcuResponse = await chain.EngineRpcModule.engine_forkchoiceUpdatedV4(fcuState, payloadAttributes);
         Assert.That(fcuResponse.Result.ResultType, Is.EqualTo(ResultType.Success));
 
-        await Task.Delay(1000);
+        await improvedBlockWait;
 
         ResultWrapper<GetPayloadV6Result?> getPayloadResult =
             await chain.EngineRpcModule.engine_getPayloadV6(Bytes.FromHexString(fcuResponse.Data.PayloadId!));


### PR DESCRIPTION
## Changes

`GetPayloadV6_builds_block_with_BAL` slept a fixed `Task.Delay(1000)` between `engine_forkchoiceUpdatedV4` and
`engine_getPayloadV6`. On a loaded runner the improvement that carries the submitted transaction has not landed
within that second, so the payload retrieved is still the empty first block and the assertion compares the
expected 9-account BAL against the empty block's 6 accounts:

```
Expected: <ReadOnlyBlockAccessList (Accounts=9) ...
But was:  <ReadOnlyBlockAccessList (Accounts=6) ...
```

- Replace the sleep with `chain.WaitForImprovedBlock(genesis.Hash!, minTransactions: 1)`, created *before* the
  forkchoice call so the improvement event cannot fire before the wait is subscribed.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: _Flaky test fix_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

The changed test is itself the coverage. `GetPayloadV6_builds_block_with_BAL` 2/2, the wider
`FullyQualifiedName~V6` subset 29/29, and the AuRa override
(`AuRaMergeEngineModuleTests.GetPayloadV6_builds_block_with_BAL`) 2/2.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Seen on #13396 (`Nethermind.Merge.Plugin.Test [no-intrinsics]`), whose diff is confined to the MODEXP
precompile. Same improvement-timing family as the other `PayloadPreparationService` flakes: the payload
service publishes the empty block for a parent before improving it, so anything that waits on wall-clock
time rather than on the improvement is a race.
