### PR TITLE
test: bound the event-loop shutdown wait in the discovery tests

### DIFF
--- a/src/Nethermind/Nethermind.Network.Discovery.Test/CompositeDiscoveryAppTests.cs
+++ b/src/Nethermind/Nethermind.Network.Discovery.Test/CompositeDiscoveryAppTests.cs
@@ -226,7 +226,7 @@ public class CompositeDiscoveryAppTests
         finally
         {
             await pool.StopAsync();
-            await eventLoopGroup.ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            await ShutdownEventLoopAsync(eventLoopGroup);
         }
     }
 
@@ -270,7 +270,7 @@ public class CompositeDiscoveryAppTests
         finally
         {
             await pool.StopAsync();
-            await eventLoopGroup.ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            await ShutdownEventLoopAsync(eventLoopGroup);
         }
     }
 
@@ -311,7 +311,7 @@ public class CompositeDiscoveryAppTests
             finally
             {
                 await pool.StopAsync();
-                await eventLoopGroup.ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+                await ShutdownEventLoopAsync(eventLoopGroup);
             }
 
             underlyingLogger.Received(1).Error(
@@ -356,7 +356,7 @@ public class CompositeDiscoveryAppTests
             finally
             {
                 await pool.StopAsync();
-                await eventLoopGroup.ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+                await ShutdownEventLoopAsync(eventLoopGroup);
             }
         }
 
@@ -390,7 +390,7 @@ public class CompositeDiscoveryAppTests
             {
                 await pool.StopAsync();
             }
-            await eventLoopGroup.ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            await ShutdownEventLoopAsync(eventLoopGroup);
         }
     }
 
@@ -421,9 +421,19 @@ public class CompositeDiscoveryAppTests
         finally
         {
             await pool.StopAsync();
-            await eventLoopGroup.ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.FromSeconds(1));
+            await ShutdownEventLoopAsync(eventLoopGroup);
         }
     }
+
+    /// <summary>Shuts <paramref name="eventLoopGroup"/> down, failing rather than hanging when it does not terminate.</summary>
+    /// <remarks>
+    /// While confirming shutdown, DotNetty queues a wake-up task that its own next confirmation then reads as
+    /// pending work, so a task landing in the queue at that moment leaves the event loop spinning instead of
+    /// terminating. Bounding the wait turns that livelock into a failure of this test rather than a hang that
+    /// takes down the whole test host.
+    /// </remarks>
+    private static Task ShutdownEventLoopAsync(IEventLoopGroup eventLoopGroup)
+        => eventLoopGroup.ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.FromSeconds(1)).WaitAsync(TimeSpan.FromSeconds(5));
 
     private static NodeRecord CreateDualStackRecord()
     {


### PR DESCRIPTION
## Changes

`Nethermind.Network.Discovery.Test` has been dying as a *host hang* rather than a test failure — `failed: 0`,
`error: 1`, exit code 7, plus an 8-minute `*_hang.dmp`. The dump from #13396 names
`Listener_HonorsExplicitAddress("::",True,True)`, and its stacks show where the time goes: the NUnit thread is
blocked on the test's task while a DotNetty event-loop thread spins in

```
DotNetty.Common.Concurrency.SingleThreadEventExecutor.Execute()
DotNetty.Common.Concurrency.SingleThreadEventExecutor.ConfirmShutdown()
DotNetty.Common.Concurrency.SingleThreadEventExecutor.CleanupAndTerminate()
```

`ConfirmShutdown` queues a `WAKEUP_TASK` whenever it has just run tasks, and `PollTask` returns that wake-up
like any other task — so the next `RunAllTasks()` reports work again, and the shutdown timeout, which lives on
the "queue was idle" branch, is never reached. A task landing in the queue as shutdown starts therefore leaves
the event loop spinning and `TerminationCompletion` unset, forever.

- Route the six `ShutdownGracefullyAsync` call sites in `CompositeDiscoveryAppTests` through one helper that
  bounds the wait.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: _Flaky test fix_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

`CompositeDiscoveryAppTests` 22/22 locally.

## Remarks

**This is containment, not the fix.** It turns a hang that takes down the whole assembly — every other test in
it reported as an error, eight minutes of job time, a dump artifact — into a single failing test, and the
spinning thread survives until the underlying bug is fixed.

The real fix belongs in `NethermindEth/DotNetty`: `PollTask()` should skip `WAKEUP_TASK`, which is what
upstream Netty's `pollTask` does. Reproduced deterministically against the shipped
`Nethermind.DotNetty.Transport 1.0.2.76` — queue tasks from another thread while calling
`ShutdownGracefullyAsync(TimeSpan.Zero, TimeSpan.FromSeconds(1))` and the returned task never completes.

The same livelock is behind the recurring `E2EDiscoveryTests.TestDiscovery(False)` hang, which took out the
Discovery job on three of the last ten runs of this workflow (`perf/blockhash-alloc`, `chore/int256-1.9.0`,
both ubuntu and windows); its dump carries the identical `ConfirmShutdown → Execute` frame. That path runs
through container disposal, so it is not reachable from the test side and only the DotNetty fix will settle it.
Production shutdown (`CompositeDiscoveryApp.StopAsync`, `RlpxHost`) uses the same API and can livelock the
same way.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No
