### PR TITLE
perf(tracer): Reduce native callTracer execution overhead

### DIFF
--- a/scripts/rpc-bench/configs/native-calltracer-block-control.json
+++ b/scripts/rpc-bench/configs/native-calltracer-block-control.json
@@ -1,0 +1,31 @@
+{
+  "test_name": "Native block tracing and action-tracer controls",
+  "description": "Whole-block native call tracing with unchanged trace namespace controls at the same snapshot head.",
+  "clients": ["nethermind"],
+  "duration": "120s",
+  "rps": 2,
+  "vus": 16,
+  "calls": [
+    {
+      "name": "debug_traceBlockByNumber_callTracer",
+      "method": "debug_traceBlockByNumber",
+      "params": ["latest", {"tracer": "callTracer"}],
+      "weight": 1,
+      "thresholds": ["p(99)<600000"]
+    },
+    {
+      "name": "trace_block_control",
+      "method": "trace_block",
+      "params": ["latest"],
+      "weight": 1,
+      "thresholds": ["p(99)<600000"]
+    },
+    {
+      "name": "trace_replayBlockTransactions_control",
+      "method": "trace_replayBlockTransactions",
+      "params": ["latest", ["trace"]],
+      "weight": 1,
+      "thresholds": ["p(99)<600000"]
+    }
+  ]
+}

--- a/scripts/rpc-bench/configs/native-calltracer-head.json
+++ b/scripts/rpc-bench/configs/native-calltracer-head.json
@@ -1,0 +1,188 @@
+{
+  "test_name": "Native callTracer at head",
+  "description": "Native callTracer subset of json-bench bee3dd3e28b91ebbab217e3f9a5e2a70d32b21e6 debug trace head workload.",
+  "clients": [
+    "nethermind"
+  ],
+  "duration": "120s",
+  "rps": 100,
+  "vus": 64,
+  "calls": [
+    {
+      "name": "native_call_1",
+      "method": "debug_traceCall",
+      "params": [
+        {
+          "from": "0xa9Ac1233699BDae25abeBae4f9Fb54DbB1b44700",
+          "to": "0x252568abdeb9de59fd8963dfcd87be2db65f1ce1",
+          "gas": "0x493E0",
+          "data": "0x60606040526040516102b43803806102b48339016040526060805160600190602001505b5b33600060006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908302179055505b806001600050908051906020019082805482825590600052602060002090601f01602090048101928215609e579182015b82811115609d5782518260005055916020019190600101906081565b5b50905060c5919060a9565b8082111560c1576000818150600090555060010160a9565b5090565b50505b506101dc806100d86000396000f30060606040526000357c01000000000000000000000000000000000000000000000000000000009004806341c0e1b514610044578063cfae32171461005157610042565b005b61004f6004506100ca565b005b61005c60045061015e565b60405180806020018281038252838181518152602001915080519060200190808383829060006004602084601f0104600302600f01f150905090810190601f1680156100bc5780820380516001836020036101000a031916815260200191505b509250505060405180910390f35b600060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff16141561015b57600060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16ff5b5b565b60206040519081016040528060008152602001506001600050805480601f016020809104026020016040519081016040528092919081815260200182805480156101cd57820191906000526020600020905b8154815290600101906020018083116101b057829003601f168201915b505050505090506101d9565b90560000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000c48656c6c6f20576f726c64210000000000000000000000000000000000000000"
+        },
+        "latest",
+        {
+          "tracer": "callTracer"
+        }
+      ],
+      "weight": 1,
+      "thresholds": [
+        "p(99)<600000"
+      ]
+    },
+    {
+      "name": "native_call_2",
+      "method": "debug_traceCall",
+      "params": [
+        {
+          "from": "0xa9Ac1233699BDae25abeBae4f9Fb54DbB1b44700",
+          "to": "0x4debB0dF4da8D1f51EF67B727c3F1c0eCC7ed009",
+          "gas": "0x5208",
+          "gasPrice": "0x2CB417800",
+          "value": "0x229322"
+        },
+        "latest",
+        {
+          "tracer": "callTracer",
+          "tracerConfig": {
+            "onlyTopCall": false
+          }
+        }
+      ],
+      "weight": 1,
+      "thresholds": [
+        "p(99)<600000"
+      ]
+    },
+    {
+      "name": "native_call_3",
+      "method": "debug_traceCall",
+      "params": [
+        {
+          "from": "0xF21079d225F4f3e7FDd3E258042a55cED651b2a1",
+          "to": "0xa9D53f7B4836a595db7E11A7f92F9EF3810E04B6",
+          "data": "0x46c474a60000000000000000000000000000000000000000000000000000000000bc614e00000000000000000000000000000000000000000000000000000000000f455a000000000000000000000000125f4b6650e205a987ba92972a87c833dcf5a84700000000000000000000000000000000000000000000000000000000000f455a"
+        },
+        "latest",
+        {
+          "tracer": "callTracer",
+          "tracerConfig": {
+            "onlyTopCall": true
+          }
+        }
+      ],
+      "weight": 1,
+      "thresholds": [
+        "p(99)<600000"
+      ]
+    },
+    {
+      "name": "native_call_4",
+      "method": "debug_traceCall",
+      "params": [
+        {
+          "from": "0xF21079d225F4f3e7FDd3E258042a55cED651b2a1",
+          "to": "0xa9D53f7B4836a595db7E11A7f92F9EF3810E04B6",
+          "data": "0x46c474a60000000000000000000000000000000000000000000000000000000000bc614e00000000000000000000000000000000000000000000000000000000000f455a000000000000000000000000125f4b6650e205a987ba92972a87c833dcf5a84700000000000000000000000000000000000000000000000000000000000f455a"
+        },
+        "latest",
+        {
+          "enableMemory": false,
+          "tracer": "callTracer",
+          "stateOverrides": {
+            "0xdAC17F958D2ee523a2206206994597C13D831ec7": {
+              "stateDiff": {
+                "0xe8668fbdcb49eea01f71c55f2c539b0953b137a92283519b2e33d48a03e1e3e7": "0x000000000000000000000000000000000000000000000000000000000098a0a8",
+                "0xa2d1bb9934928c34b005700965f54467eef400cea7fd9fbfc0d1d1eb2184eee8": "0x000000000000000000000000000000000000000000000000000000000098a0a8"
+              }
+            },
+            "0xa9D53f7B4836a595db7E11A7f92F9EF3810E04B6": {
+              "stateDiff": {
+                "0xe8668fbdcb49eea01f71c55f2c539b0953b137a92283519b2e33d48a03e1e3e7": "0x000000000000000000000000000000000000000000000000000000000098a0a8",
+                "0xa2d1bb9934928c34b005700965f54467eef400cea7fd9fbfc0d1d1eb2184eee8": "0x000000000000000000000000000000000000000000000000000000000098a0a8"
+              }
+            },
+            "0xF21079d225F4f3e7FDd3E258042a55cED651b2a1": {
+              "nonce": "0x1",
+              "balance": "0x2386f26fc10000"
+            }
+          }
+        }
+      ],
+      "weight": 1,
+      "thresholds": [
+        "p(99)<600000"
+      ]
+    },
+    {
+      "name": "native_call_5",
+      "method": "debug_traceCall",
+      "params": [
+        {
+          "data": "0xf242432a000000000000000000000000d3181ddbb2cea7b4954b8d4a05dbf85d8fc36aef000000000000000000000000e44249550d8a03737f185e054a686e55577f38400000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000",
+          "from": "0x7b98421B9314E3Ffc0B7a593DBa2FBBd3b789c7D",
+          "to": "0xe3782B8688ad2b0D5ba42842d400F7AdF310F88d",
+          "gas": "0xDDD002",
+          "gasPrice": "0x2098A67800",
+          "value": "0x0"
+        },
+        "latest",
+        {
+          "tracer": "callTracer"
+        }
+      ],
+      "weight": 1,
+      "thresholds": [
+        "p(99)<600000"
+      ]
+    },
+    {
+      "name": "native_call_6",
+      "method": "debug_traceCall",
+      "params": [
+        {
+          "data": "0xf242432a000000000000000000000000d3181ddbb2cea7b4954b8d4a05dbf85d8fc36aef000000000000000000000000e44249550d8a03737f185e054a686e55577f38400000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000000",
+          "from": "0x7b98421B9314E3Ffc0B7a593DBa2FBBd3b789c7D",
+          "to": "0xe3782B8688ad2b0D5ba42842d400F7AdF310F88d",
+          "gas": "0xDDD002",
+          "gasPrice": "0x2098A67800",
+          "value": "0x0"
+        },
+        "latest",
+        {
+          "tracer": "callTracer",
+          "tracerConfig": {
+            "onlyTopCall": true
+          }
+        }
+      ],
+      "weight": 1,
+      "thresholds": [
+        "p(99)<600000"
+      ]
+    },
+    {
+      "name": "native_call_7",
+      "method": "debug_traceCall",
+      "params": [
+        {
+          "data": "0xa1ba444dffffffffffffffffffffffffffffffd5ffffffffffffffffffffffffffffffb80000000000000000000000000000000000000000000003ca5c66d9bc443000000000000000000000000000000000000000000000000000000000016342329000",
+          "from": "0x2D9eEfF21Cf846b4471CA7DE7A0f082B24773579",
+          "gas": "0x2BF20",
+          "gasPrice": "0xF4240",
+          "to": "0xB3BCa6F5052c7e24726b44da7403b56A8A1b98f8",
+          "value": "0x0"
+        },
+        "latest",
+        {
+          "tracer": "callTracer",
+          "enableMemory": false,
+          "disableStack": false,
+          "disableStorage": false
+        }
+      ],
+      "weight": 1,
+      "thresholds": [
+        "p(99)<600000"
+      ]
+    }
+  ]
+}

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/AlwaysCancelTxTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/AlwaysCancelTxTracer.cs
@@ -97,6 +97,7 @@ public class AlwaysCancelTxTracer : ITxTracer
 
     public void ReportActionEnd(ulong gas, ReadOnlyMemory<byte> output) => throw new OperationCanceledException(ErrorMessage);
     public void ReportActionError(EvmExceptionType exceptionType) => throw new OperationCanceledException(ErrorMessage);
+    public void ReportActionRemainingGas(ulong gas) => throw new OperationCanceledException(ErrorMessage);
     public void ReportActionRevert(ulong gas, ReadOnlyMemory<byte> output) => throw new OperationCanceledException(ErrorMessage);
 
     public void ReportActionEnd(ulong gas, Address deploymentAddress, ReadOnlyMemory<byte> deployedCode) => throw new OperationCanceledException(ErrorMessage);

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -15,7 +15,7 @@ using Nethermind.Int256;
 
 namespace Nethermind.Blockchain.Tracing;
 
-public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTracer, IJournal<int>, ITxTracerWrapper
+public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTracer, IJournal<int>, ITxTracerWrapper, IInstructionTracingFilter
 {
     private IBlockTracer _otherTracer = NullBlockTracer.Instance;
     protected Block Block = null!;
@@ -25,6 +25,9 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     public bool IsTracingOpLevelStorage => _currentTxTracer.IsTracingOpLevelStorage;
     public bool IsTracingMemory => _currentTxTracer.IsTracingMemory;
     public bool IsTracingInstructions => _currentTxTracer.IsTracingInstructions;
+    public UInt256 InstructionMask => _currentTxTracer is IInstructionTracingFilter filter
+        ? filter.InstructionMask
+        : UInt256.MaxValue;
     public bool IsTracingRefunds => _currentTxTracer.IsTracingRefunds;
     public bool IsTracingReturnData => _currentTxTracer.IsTracingReturnData;
     public bool IsTracingCode => _currentTxTracer.IsTracingCode;

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/BlockReceiptsTracer.cs
@@ -214,6 +214,9 @@ public class BlockReceiptsTracer(bool parallel = false) : IBlockTracer, ITxTrace
     public void ReportActionError(EvmExceptionType exceptionType) =>
         _currentTxTracer.ReportActionError(exceptionType);
 
+    public void ReportActionRemainingGas(ulong gas) =>
+        _currentTxTracer.ReportActionRemainingGas(gas);
+
     public void ReportActionRevert(ulong gasLeft, ReadOnlyMemory<byte> output) =>
         _currentTxTracer.ReportActionRevert(gasLeft, output);
 

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -44,6 +44,9 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         GethTraceOptions options) : base(options)
     {
         IsTracingActions = true;
+        IsTracingStack = false;
+        IsTracingOpLevelStorage = false;
+        IsTracingReturnData = false;
         _gasLimit = tx!.GasLimit;
         _txHash = tx.Hash;
         _isEip8037Enabled = spec.IsEip8037Enabled;
@@ -57,6 +60,8 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
     }
 
     protected override GethLikeTxTrace CreateTrace() => new(_disposables);
+
+    public override bool IsTracingInstructions => false;
 
     public override GethLikeTxTrace BuildResult()
     {
@@ -130,11 +135,7 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         callFrame.Logs.Add(callLog);
     }
 
-    public override void ReportOperationRemainingGas(ulong gas)
-    {
-        base.ReportOperationRemainingGas(gas);
-        _remainingGas = gas > 0 ? gas : 0;
-    }
+    public override void ReportActionRemainingGas(ulong gas) => _remainingGas = gas;
 
     public override void ReportActionEnd(ulong gas, Address deploymentAddress, ReadOnlyMemory<byte> deployedCode)
     {

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/FourByte/Native4ByteTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/FourByte/Native4ByteTracer.cs
@@ -30,13 +30,17 @@ public sealed class Native4ByteTracer : GethLikeNativeTxTracer
 
     private readonly Transaction _transaction;
     private readonly Dictionary<string, int> _4ByteIds = [];
-    private Instruction _op;
 
     public Native4ByteTracer(Transaction transaction, GethTraceOptions options) : base(options)
     {
         _transaction = transaction;
         IsTracingActions = true;
+        IsTracingStack = false;
+        IsTracingOpLevelStorage = false;
+        IsTracingReturnData = false;
     }
+
+    public override bool IsTracingInstructions => false;
 
     protected override GethLikeTxTrace CreateTrace() => new();
 
@@ -60,12 +64,9 @@ public sealed class Native4ByteTracer : GethLikeNativeTxTracer
         }
         else
         {
-            CaptureEnter(_op, input, to, isPrecompileCall);
+            CaptureEnter(callType, input, to, isPrecompileCall);
         }
     }
-
-    public override void StartOperation(int pc, Instruction opcode, ulong gas, in ExecutionEnvironment env) =>
-        _op = opcode;
 
     private void CaptureStart(ReadOnlyMemory<byte> input)
     {
@@ -75,10 +76,10 @@ public sealed class Native4ByteTracer : GethLikeNativeTxTracer
         }
     }
 
-    private void CaptureEnter(Instruction op, ReadOnlyMemory<byte> input, Address? to, bool isPrecompileCall)
+    private void CaptureEnter(ExecutionType callType, ReadOnlyMemory<byte> input, Address? to, bool isPrecompileCall)
     {
         if (input.Length >= 4
-            && op is Instruction.DELEGATECALL or Instruction.STATICCALL or Instruction.CALL or Instruction.CALLCODE
+            && callType.IsAnyCall()
             && to is not null
             && !isPrecompileCall)
         {

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
@@ -41,10 +41,11 @@ public class NativePrestateTracer : GethLikeNativeTxTracer
         Address? beneficiary = null)
         : base(options)
     {
-        IsTracingRefunds = true;
         IsTracingActions = true;
         IsTracingMemory = true;
         IsTracingStack = true;
+        IsTracingOpLevelStorage = false;
+        IsTracingReturnData = false;
 
         _worldState = worldState;
         _txHash = txHash;
@@ -102,6 +103,13 @@ public class NativePrestateTracer : GethLikeNativeTxTracer
 
         _op = opcode;
         _executingAccount = env.ExecutingAccount;
+
+        IsTracingMemory = _op == Instruction.CREATE2;
+        IsTracingStack = _op is Instruction.SLOAD or Instruction.SSTORE
+            or Instruction.EXTCODECOPY or Instruction.EXTCODEHASH or Instruction.EXTCODESIZE
+            or Instruction.BALANCE or Instruction.SELFDESTRUCT
+            or Instruction.DELEGATECALL or Instruction.CALL or Instruction.STATICCALL or Instruction.CALLCODE
+            or Instruction.CREATE or Instruction.CREATE2;
     }
 
     public override void SetOperationMemory(TraceMemory memoryTrace)

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
@@ -16,9 +16,13 @@ using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Prestate;
 
-public class NativePrestateTracer : GethLikeNativeTxTracer
+public class NativePrestateTracer : GethLikeNativeTxTracer, IInstructionTracingFilter
 {
     public const string PrestateTracer = "prestateTracer";
+
+    public UInt256 InstructionMask => CaptureMask;
+
+    private static readonly UInt256 CaptureMask = CreateCaptureMask();
 
     private readonly IWorldState? _worldState;
     private readonly Hash256? _txHash;
@@ -68,6 +72,23 @@ public class NativePrestateTracer : GethLikeNativeTxTracer
 
     protected override GethLikeTxTrace CreateTrace() => new();
 
+    private static UInt256 CreateCaptureMask()
+    {
+        UInt256 mask = UInt256.Zero;
+        for (int opcode = 0; opcode <= byte.MaxValue; opcode++)
+        {
+            if (RequiresStack((Instruction)opcode))
+                mask |= UInt256.One << opcode;
+        }
+        return mask;
+    }
+
+    private static bool RequiresStack(Instruction opcode) => opcode is Instruction.SLOAD or Instruction.SSTORE
+        or Instruction.EXTCODECOPY or Instruction.EXTCODEHASH or Instruction.EXTCODESIZE
+        or Instruction.BALANCE or Instruction.SELFDESTRUCT
+        or Instruction.DELEGATECALL or Instruction.CALL or Instruction.STATICCALL or Instruction.CALLCODE
+        or Instruction.CREATE or Instruction.CREATE2;
+
     public override GethLikeTxTrace BuildResult()
     {
         GethLikeTxTrace result = base.BuildResult();
@@ -115,11 +136,7 @@ public class NativePrestateTracer : GethLikeNativeTxTracer
         _executingAccount = env.ExecutingAccount;
 
         IsTracingMemory = _op == Instruction.CREATE2;
-        IsTracingStack = _op is Instruction.SLOAD or Instruction.SSTORE
-            or Instruction.EXTCODECOPY or Instruction.EXTCODEHASH or Instruction.EXTCODESIZE
-            or Instruction.BALANCE or Instruction.SELFDESTRUCT
-            or Instruction.DELEGATECALL or Instruction.CALL or Instruction.STATICCALL or Instruction.CALLCODE
-            or Instruction.CREATE or Instruction.CREATE2;
+        IsTracingStack = RequiresStack(_op);
     }
 
     public override void SetOperationMemory(TraceMemory memoryTrace)

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
@@ -46,8 +46,6 @@ public class NativePrestateTracer : GethLikeNativeTxTracer, IInstructionTracingF
         : base(options)
     {
         IsTracingActions = true;
-        // Seeded on, not left to the first StartOperation, because a wrapping CompositeTxTracer
-        // latches these flags in its own constructor and would otherwise never ask for stack or memory.
         IsTracingMemory = true;
         IsTracingStack = true;
         IsTracingOpLevelStorage = false;

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Prestate/NativePrestateTracer.cs
@@ -42,6 +42,8 @@ public class NativePrestateTracer : GethLikeNativeTxTracer
         : base(options)
     {
         IsTracingActions = true;
+        // Seeded on, not left to the first StartOperation, because a wrapping CompositeTxTracer
+        // latches these flags in its own constructor and would otherwise never ask for stack or memory.
         IsTracingMemory = true;
         IsTracingStack = true;
         IsTracingOpLevelStorage = false;
@@ -99,7 +101,15 @@ public class NativePrestateTracer : GethLikeNativeTxTracer
     {
         base.StartOperation(pc, opcode, gas, env);
 
-        if (_error is not null) return;
+        // Everything after an operation error is ignored, so stop pulling stack and memory for the
+        // frames that keep running; leaving the flags set would also freeze _op and _executingAccount
+        // at the failing operation.
+        if (_error is not null)
+        {
+            IsTracingMemory = false;
+            IsTracingStack = false;
+            return;
+        }
 
         _op = opcode;
         _executingAccount = env.ExecutingAccount;
@@ -121,6 +131,9 @@ public class NativePrestateTracer : GethLikeNativeTxTracer
     public override void SetOperationStack(TraceStack stack)
     {
         base.SetOperationStack(stack);
+
+        // A wrapping tracer may keep asking for the stack after the flags were cleared above.
+        if (_error is not null) return;
 
         int stackLen = stack.Count;
         Address address;

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/StateGas/NativeStateGasTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/StateGas/NativeStateGasTracer.cs
@@ -23,6 +23,7 @@ public sealed class NativeStateGasTracer : GethLikeNativeTxTracer
         // Terminal-only: reads only the final GasConsumed, so skip the per-opcode storage/stack callbacks.
         IsTracingOpLevelStorage = false;
         IsTracingStack = false;
+        IsTracingReturnData = false;
     }
 
     public override bool IsTracingInstructions => false;

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/CancellationTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/CancellationTracerTests.cs
@@ -23,6 +23,7 @@ namespace Nethermind.Evm.Test.Tracing
             CancellationTxTracer tracer = new(Substitute.For<ITxTracer>(), cancellationTokenSource.Token) { IsTracingActions = true };
 
             Assert.Throws<OperationCanceledException>(() => tracer.ReportActionError(EvmExceptionType.None));
+            Assert.Throws<OperationCanceledException>(() => tracer.ReportActionRemainingGas(1));
         }
 
         [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
@@ -15,23 +15,38 @@ namespace Nethermind.Evm.Test.Tracing;
 public class CompositeTxTracerTests
 {
     [Test]
-    public void Forwards_action_gas_only_to_action_tracers([Values] bool tracingActions)
+    public void StartOperation_WhenRequirementsChange_PreservesOtherTracers(
+        [Values] bool otherStack, [Values] bool otherMemory)
     {
-        ITxTracer inner = Substitute.For<ITxTracer>();
-        inner.IsTracingActions.Returns(tracingActions);
-        using CompositeTxTracer tracer = new(inner);
+        ITxTracer changing = Substitute.For<ITxTracer>();
+        changing.IsTracingInstructions.Returns(true);
+        changing.IsTracingStack.Returns(true);
+        changing.IsTracingMemory.Returns(true);
+        changing.When(tracer => tracer.StartOperation(0, Instruction.ADD, 100, null!)).Do(_ =>
+        {
+            changing.IsTracingStack.Returns(false);
+            changing.IsTracingMemory.Returns(false);
+        });
+        ITxTracer other = Substitute.For<ITxTracer>();
+        other.IsTracingStack.Returns(otherStack);
+        other.IsTracingMemory.Returns(otherMemory);
+        using CompositeTxTracer tracer = new(new CompositeTxTracer(changing), other);
 
-        tracer.ReportActionRemainingGas(1234);
+        tracer.StartOperation(0, Instruction.ADD, 100, null!);
 
-        inner.Received(tracingActions ? 1 : 0).ReportActionRemainingGas(1234);
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.IsTracingStack, Is.EqualTo(otherStack));
+            Assert.That(tracer.IsTracingMemory, Is.EqualTo(otherMemory));
+        }
     }
 
     [Test]
-    public void Cancellation_forwards_action_gas_only_to_action_tracers([Values] bool tracingActions)
+    public void Forwards_action_gas_only_to_action_tracers([Values] bool tracingActions, [Values] bool cancellation)
     {
         ITxTracer inner = Substitute.For<ITxTracer>();
         inner.IsTracingActions.Returns(tracingActions);
-        using CancellationTxTracer tracer = new(inner);
+        using ITxTracer tracer = cancellation ? new CancellationTxTracer(inner) : new CompositeTxTracer(inner);
 
         tracer.ReportActionRemainingGas(1234);
 

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
@@ -15,6 +15,30 @@ namespace Nethermind.Evm.Test.Tracing;
 public class CompositeTxTracerTests
 {
     [Test]
+    public void Forwards_action_gas_only_to_action_tracers([Values] bool tracingActions)
+    {
+        ITxTracer inner = Substitute.For<ITxTracer>();
+        inner.IsTracingActions.Returns(tracingActions);
+        using CompositeTxTracer tracer = new(inner);
+
+        tracer.ReportActionRemainingGas(1234);
+
+        inner.Received(tracingActions ? 1 : 0).ReportActionRemainingGas(1234);
+    }
+
+    [Test]
+    public void Cancellation_forwards_action_gas_only_to_action_tracers([Values] bool tracingActions)
+    {
+        ITxTracer inner = Substitute.For<ITxTracer>();
+        inner.IsTracingActions.Returns(tracingActions);
+        using CancellationTxTracer tracer = new(inner);
+
+        tracer.ReportActionRemainingGas(1234);
+
+        inner.Received(tracingActions ? 1 : 0).ReportActionRemainingGas(1234);
+    }
+
+    [Test]
     public void Aggregates_receipt_log_requirements([Values] bool firstRequiresLogs, [Values] bool secondRequiresLogs)
     {
         ITxTracer first = Substitute.For<ITxTracer>();

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/CompositeTxTracerTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using Nethermind.Evm.Tracing;
+using Nethermind.Int256;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -14,6 +15,40 @@ namespace Nethermind.Evm.Test.Tracing;
 [Parallelizable(ParallelScope.All)]
 public class CompositeTxTracerTests
 {
+    [Test]
+    public void InstructionMask_WhenSiblingNeedsSnapshots_RequiresFullTracing(
+        [Values] bool stack, [Values] bool memory, [Values] bool returnData)
+    {
+        ITxTracer filtered = Substitute.For<ITxTracer, IInstructionTracingFilter>();
+        filtered.IsTracingInstructions.Returns(true);
+        ((IInstructionTracingFilter)filtered).InstructionMask.Returns(UInt256.One);
+        ITxTracer observer = Substitute.For<ITxTracer>();
+        observer.IsTracingStack.Returns(stack);
+        observer.IsTracingMemory.Returns(memory);
+        observer.IsTracingReturnData.Returns(returnData);
+        using CompositeTxTracer tracer = new(filtered, observer);
+
+        Assert.That(tracer.InstructionMask, Is.EqualTo(stack || memory || returnData ? UInt256.MaxValue : UInt256.One));
+    }
+
+    [Test]
+    public void InstructionMask_WhenCancellationForcesSnapshots_RequiresFullTracing(
+        [Values] bool stack, [Values] bool memory, [Values] bool returnData, [Values] bool instructions)
+    {
+        ITxTracer filtered = Substitute.For<ITxTracer, IInstructionTracingFilter>();
+        filtered.IsTracingInstructions.Returns(true);
+        ((IInstructionTracingFilter)filtered).InstructionMask.Returns(UInt256.One);
+        using CancellationTxTracer tracer = new(filtered)
+        {
+            IsTracingStack = stack,
+            IsTracingMemory = memory,
+            IsTracingReturnData = returnData,
+            IsTracingInstructions = instructions,
+        };
+
+        Assert.That(tracer.InstructionMask, Is.EqualTo(stack || memory || returnData || instructions ? UInt256.MaxValue : UInt256.One));
+    }
+
     [Test]
     public void StartOperation_WhenRequirementsChange_PreservesOtherTracers(
         [Values] bool otherStack, [Values] bool otherMemory)

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLike4byteTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLike4byteTracerTests.cs
@@ -17,6 +17,29 @@ namespace Nethermind.Evm.Test.Tracing;
 [TestFixture]
 public class GethLike4byteTracerTests : VirtualMachineTestsBase
 {
+    [Test]
+    public void ReportAction_WithoutOpcodeCallbacks_CountsOnlyNestedCalls(
+        [Values(ExecutionType.CALL, ExecutionType.CALLCODE, ExecutionType.DELEGATECALL, ExecutionType.STATICCALL,
+            ExecutionType.CREATE, ExecutionType.CREATE2)] ExecutionType callType,
+        [Values] bool precompile)
+    {
+        Native4ByteTracer tracer = new(Build.A.Transaction.TestObject,
+            GethTraceOptions.Default with { EnableMemory = true, EnableReturnData = true });
+        tracer.ReportAction(100, UInt256.Zero, TestItem.AddressA, TestItem.AddressB, default, ExecutionType.TRANSACTION);
+        tracer.ReportAction(50, UInt256.Zero, TestItem.AddressB, TestItem.AddressC,
+            new byte[] { 1, 2, 3, 4 }, callType, precompile);
+        Dictionary<string, int> result = (Dictionary<string, int>)tracer.BuildResult().CustomTracerResult!.Value!;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.Count, Is.EqualTo(callType.IsAnyCall() && !precompile ? 1 : 0));
+            Assert.That(tracer.IsTracingInstructions, Is.False);
+            Assert.That(tracer.IsTracingStack, Is.False);
+            Assert.That(tracer.IsTracingOpLevelStorage, Is.False);
+            Assert.That(tracer.IsTracingReturnData, Is.False);
+        }
+    }
+
     [TestCaseSource(nameof(FourByteTracerTests))]
     public Dictionary<string, int>? four_byte_tracer_executes_correctly(byte[] code, byte[]? input) =>
         (Dictionary<string, int>)ExecuteAndTrace(code, input).CustomTracerResult?.Value;

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLike4byteTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLike4byteTracerTests.cs
@@ -23,7 +23,7 @@ public class GethLike4byteTracerTests : VirtualMachineTestsBase
             ExecutionType.CREATE, ExecutionType.CREATE2)] ExecutionType callType,
         [Values] bool precompile)
     {
-        Native4ByteTracer tracer = new(Build.A.Transaction.TestObject,
+        using Native4ByteTracer tracer = new(Build.A.Transaction.TestObject,
             GethTraceOptions.Default with { EnableMemory = true, EnableReturnData = true });
         tracer.ReportAction(100, UInt256.Zero, TestItem.AddressA, TestItem.AddressB, default, ExecutionType.TRANSACTION);
         tracer.ReportAction(50, UInt256.Zero, TestItem.AddressB, TestItem.AddressC,

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
@@ -17,6 +17,7 @@ using Nethermind.Evm.TransactionProcessing;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs;
 using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
 using NSubstitute;
 using NUnit.Framework;
 
@@ -44,6 +45,93 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
         Tracer = NativeCallTracer.CallTracer,
         TracerConfig = config is not null ? JsonSerializer.Deserialize<JsonElement>(config) : null
     };
+
+    [Test]
+    public void Call_tracer_does_not_request_opcode_capture([Values] bool enableCapture)
+    {
+        Transaction tx = Build.A.Transaction.TestObject;
+        GethTraceOptions options = GetGethTraceOptions(WithLog) with
+        {
+            DisableStack = !enableCapture,
+            DisableStorage = !enableCapture,
+            EnableMemory = enableCapture,
+            EnableReturnData = enableCapture
+        };
+        using NativeCallTracer tracer = new(tx, CancunSpec, options);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.IsTracingInstructions, Is.False);
+            Assert.That(tracer.IsTracingStack, Is.False);
+            Assert.That(tracer.IsTracingOpLevelStorage, Is.False);
+            Assert.That(tracer.IsTracingMemory, Is.False);
+            Assert.That(tracer.IsTracingReturnData, Is.False);
+            Assert.That(tracer.IsTracingActions, Is.True);
+            Assert.That(tracer.IsTracingLogs, Is.True);
+        }
+    }
+
+    public enum GasCheckpointCase { InvalidOpcode, StackUnderflow, OutOfGas, Revert, InvalidDeposit, DepositOutOfGas, PrecompileFailure }
+
+    [Test]
+    public void Action_gas_matches_instruction_gas([Values] GasCheckpointCase scenario)
+    {
+        byte[] childCode = scenario switch
+        {
+            GasCheckpointCase.InvalidOpcode => Prepare.EvmCode.Op(Instruction.INVALID).Done,
+            GasCheckpointCase.StackUnderflow => Prepare.EvmCode.Op(Instruction.POP).Done,
+            GasCheckpointCase.OutOfGas => Prepare.EvmCode.PushData(1).PushData(0).Op(Instruction.SSTORE).Done,
+            GasCheckpointCase.Revert => Prepare.EvmCode.Revert(0, 0).Done,
+            GasCheckpointCase.InvalidDeposit => Prepare.EvmCode.ForInitOf([0xEF]).Done,
+            GasCheckpointCase.DepositOutOfGas => Prepare.EvmCode.ForInitOf(new byte[1024]).Done,
+            _ => []
+        };
+        TestState.CreateAccount(TestItem.AddressC, 0);
+        TestState.InsertCode(TestItem.AddressC, childCode, Spec);
+        byte[] code = scenario switch
+        {
+            GasCheckpointCase.InvalidDeposit or GasCheckpointCase.DepositOutOfGas => Prepare.EvmCode.Create(childCode, 0).STOP().Done,
+            GasCheckpointCase.PrecompileFailure => Prepare.EvmCode.Call(new Address("0x0000000000000000000000000000000000000009"), 50000).STOP().Done,
+            _ => Prepare.EvmCode.Call(TestItem.AddressC, 10000).STOP().Done
+        };
+        (Block block, Transaction tx) = PrepareTx(MainnetSpecProvider.CancunActivation, 100000, code);
+        using NativeCallTracer native = new(tx, CancunSpec, GetGethTraceOptions(WithLog));
+        using CancellationTxTracer optimized = new(native);
+        _processor.CallAndRestore(tx, block.Header, optimized);
+        using GethLikeTxTrace actual = native.BuildResult();
+
+        using NativeCallTracer tracedNative = new(tx, CancunSpec, GetGethTraceOptions(WithLog));
+        GasCheckpointTracer checkpoints = new();
+        using CompositeTxTracer traced = new(tracedNative, checkpoints);
+        _processor.CallAndRestore(tx, block.Header, traced);
+        using GethLikeTxTrace expected = tracedNative.BuildResult();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(JsonSerializer.Serialize(actual.CustomTracerResult?.Value, SerializerOptions),
+                Is.EqualTo(JsonSerializer.Serialize(expected.CustomTracerResult?.Value, SerializerOptions)));
+            Assert.That(checkpoints.GasMatches, Is.True);
+            Assert.That(checkpoints.Errors, Is.EqualTo(scenario == GasCheckpointCase.Revert ? 0 : 1));
+        }
+    }
+
+    private sealed class GasCheckpointTracer : TxTracer
+    {
+        private ulong _instructionGas;
+        private ulong _actionGas;
+        public override bool IsTracingInstructions => true;
+        public override bool IsTracingActions => true;
+        public bool GasMatches { get; private set; } = true;
+        public int Errors { get; private set; }
+        public override void ReportOperationRemainingGas(ulong gas) => _instructionGas = gas;
+        public override void ReportActionRemainingGas(ulong gas) => _actionGas = gas;
+
+        public override void ReportActionError(EvmExceptionType evmExceptionType)
+        {
+            GasMatches &= _instructionGas == _actionGas;
+            Errors++;
+        }
+    }
 
     [Test]
     public void Test_CallTrace_SingleCall()

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
@@ -21,6 +21,45 @@ namespace Nethermind.Evm.Test.Tracing;
 [TestFixture]
 public class GethLikePrestateTracerTests : VirtualMachineTestsBase
 {
+    [Test]
+    public void Execute_WhenPrestateIsFiltered_ObservesOnlyRequiredOpcodes([Values] bool fullTrace)
+    {
+        RecordingPrestateTracer tracer = new(TestState);
+        using ITxTracer executionTracer = new CancellationTxTracer(new CompositeTxTracer(
+            tracer, fullTrace ? new FullInstructionTracer() : NullTxTracer.Instance));
+        byte[] code = Prepare.EvmCode
+            .PushData(1)
+            .PushData(2)
+            .Op(Instruction.ADD)
+            .PushData(0)
+            .Op(Instruction.SLOAD)
+            .Op(Instruction.STOP)
+            .Done;
+
+        Execute(executionTracer, code, MainnetSpecProvider.CancunActivation);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Operations, Does.Contain(Instruction.SLOAD));
+            Assert.That(tracer.Operations.Contains(Instruction.ADD), Is.EqualTo(fullTrace));
+            Assert.That(tracer.Error, Is.Null);
+        }
+    }
+
+    [Test]
+    public void Execute_WhenExcludedOpcodeFails_ReportsTheError()
+    {
+        using RecordingPrestateTracer tracer = new(TestState);
+
+        Execute(tracer, Prepare.EvmCode.Op(Instruction.ADD).Done, MainnetSpecProvider.CancunActivation);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.Operations, Does.Not.Contain(Instruction.ADD));
+            Assert.That(tracer.Error, Is.EqualTo(EvmExceptionType.StackUnderflow));
+        }
+    }
+
     private static readonly JsonSerializerOptions SerializerOptions = EthereumJsonSerializer.JsonOptionsIndented;
     private const string DiffMode = """{"diffMode":true}""";
     private const string PrestateMode = """{"diffMode":false}""";
@@ -496,9 +535,35 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
 
     private GethLikeTxTrace ExecutePrestate(NativePrestateTracer tracer, byte[] code, bool wrapped)
     {
-        using ITxTracer executionTracer = wrapped ? new CancellationTxTracer(new CompositeTxTracer(tracer), default) : tracer;
+        using ITxTracer executionTracer = wrapped
+            ? new CancellationTxTracer(new CompositeTxTracer(tracer, new FullInstructionTracer()), default)
+            : tracer;
         Execute(executionTracer, code, MainnetSpecProvider.CancunActivation);
         return tracer.BuildResult();
+    }
+
+    private sealed class FullInstructionTracer : TxTracer
+    {
+        public override bool IsTracingInstructions => true;
+    }
+
+    private sealed class RecordingPrestateTracer(IWorldState worldState)
+        : NativePrestateTracer(worldState, GetGethTraceOptions(), Hash256.Zero, TestItem.AddressA, TestItem.AddressB)
+    {
+        public List<Instruction> Operations { get; } = [];
+        public EvmExceptionType? Error { get; private set; }
+
+        public override void StartOperation(int pc, Instruction opcode, ulong gas, in ExecutionEnvironment env)
+        {
+            Operations.Add(opcode);
+            base.StartOperation(pc, opcode, gas, env);
+        }
+
+        public override void ReportOperationError(EvmExceptionType error)
+        {
+            Error = error;
+            base.ReportOperationError(error);
+        }
     }
 
     private static byte[] SStore => Prepare.EvmCode

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
@@ -108,7 +108,7 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
     [Test]
     public void SetOperationStack_WhenAnOperationHasErrored_CapturesNothingMore([Values] bool errored)
     {
-        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(),
+        using NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(),
             Hash256.Zero, TestItem.AddressA, TestItem.AddressB);
         using ExecutionEnvironment environment = ExecutionEnvironment.Rent(
             null!, TestItem.AddressB, TestItem.AddressA, null, 0, UInt256.Zero, default);
@@ -121,7 +121,6 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
             tracer.StartOperation(1, Instruction.ADD, 100, environment);
         }
 
-        // A wrapping tracer latches the capture flags, so the stack keeps arriving either way
         tracer.SetOperationStack(new TraceStack(new byte[EvmStack.WordSize]));
 
         NativePrestateTracerAccount account =

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
@@ -26,29 +26,17 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
     private const string PrestateMode = """{"diffMode":false}""";
     private const string? NoConfig = null;
 
-    [TestCase(Instruction.ADD, false, false)]
-    [TestCase(Instruction.SLOAD, true, false)]
-    [TestCase(Instruction.SSTORE, true, false)]
-    [TestCase(Instruction.BALANCE, true, false)]
-    [TestCase(Instruction.EXTCODECOPY, true, false)]
-    [TestCase(Instruction.EXTCODEHASH, true, false)]
-    [TestCase(Instruction.EXTCODESIZE, true, false)]
-    [TestCase(Instruction.SELFDESTRUCT, true, false)]
-    [TestCase(Instruction.CALL, true, false)]
-    [TestCase(Instruction.CALLCODE, true, false)]
-    [TestCase(Instruction.STATICCALL, true, false)]
-    [TestCase(Instruction.DELEGATECALL, true, false)]
-    [TestCase(Instruction.CREATE, true, false)]
-    [TestCase(Instruction.CREATE2, true, true)]
+    [TestCaseSource(nameof(CaptureCases))]
     public void StartOperation_WhenOpcodeChanges_CapturesOnlyRequiredInputs(Instruction opcode, bool stack, bool memory)
     {
         NativePrestateTracer tracer = new(TestState, GetGethTraceOptions() with { EnableReturnData = true },
             Hash256.Zero, TestItem.AddressA, TestItem.AddressB);
+        using ITxTracer outer = new CancellationTxTracer(new CompositeTxTracer(tracer));
         using ExecutionEnvironment environment = ExecutionEnvironment.Rent(
             null!, TestItem.AddressB, TestItem.AddressA, null, 0, UInt256.Zero, default);
 
-        tracer.StartOperation(0, Instruction.CREATE2, 100, environment);
-        tracer.StartOperation(1, opcode, 100, environment);
+        outer.StartOperation(0, Instruction.CREATE2, 100, environment);
+        outer.StartOperation(1, opcode, 100, environment);
 
         using (Assert.EnterMultipleScope())
         {
@@ -57,6 +45,24 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
             Assert.That(tracer.IsTracingOpLevelStorage, Is.False);
             Assert.That(tracer.IsTracingReturnData, Is.False);
             Assert.That(tracer.IsTracingRefunds, Is.False);
+            Assert.That(outer.IsTracingStack, Is.EqualTo(stack));
+            Assert.That(outer.IsTracingMemory, Is.EqualTo(memory));
+        }
+    }
+
+    private static IEnumerable<TestCaseData> CaptureCases()
+    {
+        yield return new TestCaseData(Instruction.ADD, false, false);
+        yield return new TestCaseData(Instruction.CREATE2, true, true);
+        Instruction[] stackInstructions =
+        [
+            Instruction.SLOAD, Instruction.SSTORE, Instruction.BALANCE,
+            Instruction.EXTCODECOPY, Instruction.EXTCODEHASH, Instruction.EXTCODESIZE, Instruction.SELFDESTRUCT,
+            Instruction.CALL, Instruction.CALLCODE, Instruction.STATICCALL, Instruction.DELEGATECALL, Instruction.CREATE,
+        ];
+        foreach (Instruction instruction in stackInstructions)
+        {
+            yield return new TestCaseData(instruction, true, false);
         }
     }
 
@@ -490,7 +496,7 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
 
     private GethLikeTxTrace ExecutePrestate(NativePrestateTracer tracer, byte[] code, bool wrapped)
     {
-        ITxTracer executionTracer = wrapped ? new CancellationTxTracer(new CompositeTxTracer(tracer), default) : tracer;
+        using ITxTracer executionTracer = wrapped ? new CancellationTxTracer(new CompositeTxTracer(tracer), default) : tracer;
         Execute(executionTracer, code, MainnetSpecProvider.CancunActivation);
         return tracer.BuildResult();
     }

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
@@ -11,6 +11,8 @@ using Nethermind.Blockchain.Tracing.GethStyle.Custom.Native.Prestate;
 using Nethermind.Serialization.Json;
 using Nethermind.Specs;
 using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Int256;
 using NUnit.Framework;
 
 namespace Nethermind.Evm.Test.Tracing;
@@ -22,6 +24,40 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
     private const string DiffMode = """{"diffMode":true}""";
     private const string PrestateMode = """{"diffMode":false}""";
     private const string? NoConfig = null;
+
+    [TestCase(Instruction.ADD, false, false)]
+    [TestCase(Instruction.SLOAD, true, false)]
+    [TestCase(Instruction.SSTORE, true, false)]
+    [TestCase(Instruction.BALANCE, true, false)]
+    [TestCase(Instruction.EXTCODECOPY, true, false)]
+    [TestCase(Instruction.EXTCODEHASH, true, false)]
+    [TestCase(Instruction.EXTCODESIZE, true, false)]
+    [TestCase(Instruction.SELFDESTRUCT, true, false)]
+    [TestCase(Instruction.CALL, true, false)]
+    [TestCase(Instruction.CALLCODE, true, false)]
+    [TestCase(Instruction.STATICCALL, true, false)]
+    [TestCase(Instruction.DELEGATECALL, true, false)]
+    [TestCase(Instruction.CREATE, true, false)]
+    [TestCase(Instruction.CREATE2, true, true)]
+    public void StartOperation_WhenOpcodeChanges_CapturesOnlyRequiredInputs(Instruction opcode, bool stack, bool memory)
+    {
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions() with { EnableReturnData = true },
+            Hash256.Zero, TestItem.AddressA, TestItem.AddressB);
+        using ExecutionEnvironment environment = ExecutionEnvironment.Rent(
+            null!, TestItem.AddressB, TestItem.AddressA, null, 0, UInt256.Zero, default);
+
+        tracer.StartOperation(0, Instruction.CREATE2, 100, environment);
+        tracer.StartOperation(1, opcode, 100, environment);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.IsTracingStack, Is.EqualTo(stack));
+            Assert.That(tracer.IsTracingMemory, Is.EqualTo(memory));
+            Assert.That(tracer.IsTracingOpLevelStorage, Is.False);
+            Assert.That(tracer.IsTracingReturnData, Is.False);
+            Assert.That(tracer.IsTracingRefunds, Is.False);
+        }
+    }
 
     private static GethTraceOptions GetGethTraceOptions(string? config = null) => GethTraceOptions.Default with
     {
@@ -77,10 +113,13 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
         }
         """;
 
-    [TestCase(NoConfig, ExpectedSStorePrestateTrace)]
-    [TestCase(PrestateMode, ExpectedSStorePrestateTrace)]
-    [TestCase(DiffMode, ExpectedSStoreDiffModeTrace)]
-    public void Test_PrestateTrace_SStore(string? config, string expectedTrace)
+    [TestCase(NoConfig, ExpectedSStorePrestateTrace, false)]
+    [TestCase(PrestateMode, ExpectedSStorePrestateTrace, false)]
+    [TestCase(DiffMode, ExpectedSStoreDiffModeTrace, false)]
+    [TestCase(NoConfig, ExpectedSStorePrestateTrace, true)]
+    [TestCase(PrestateMode, ExpectedSStorePrestateTrace, true)]
+    [TestCase(DiffMode, ExpectedSStoreDiffModeTrace, true)]
+    public void Test_PrestateTrace_SStore(string? config, string expectedTrace, bool wrapped)
     {
         TestState.CreateAccount(Address.Zero, 100.Ether);
         StorageCell storageCell = new(TestItem.AddressB, 32);
@@ -88,11 +127,7 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
         TestState.Set(storageCell, storageData);
 
         NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(config), Hash256.Zero, TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace trace = Execute(
-                tracer,
-                SStore,
-                MainnetSpecProvider.CancunActivation)
-            .BuildResult();
+        GethLikeTxTrace trace = ExecutePrestate(tracer, SStore, wrapped);
         Assert.That(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedTrace));
     }
 
@@ -232,10 +267,13 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
         }
         """;
 
-    [TestCase(NoConfig, ExpectedCreate2PrestateTrace)]
-    [TestCase(PrestateMode, ExpectedCreate2PrestateTrace)]
-    [TestCase(DiffMode, ExpectedCreate2DiffModeTrace)]
-    public void Test_PrestateTrace_Create2(string? config, string expectedTrace)
+    [TestCase(NoConfig, ExpectedCreate2PrestateTrace, false)]
+    [TestCase(PrestateMode, ExpectedCreate2PrestateTrace, false)]
+    [TestCase(DiffMode, ExpectedCreate2DiffModeTrace, false)]
+    [TestCase(NoConfig, ExpectedCreate2PrestateTrace, true)]
+    [TestCase(PrestateMode, ExpectedCreate2PrestateTrace, true)]
+    [TestCase(DiffMode, ExpectedCreate2DiffModeTrace, true)]
+    public void Test_PrestateTrace_Create2(string? config, string expectedTrace, bool wrapped)
     {
         byte[] salt = { 4, 5, 6 };
         byte[] deployedCode = { 1, 2, 3 };
@@ -252,11 +290,7 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
         TestState.InsertCode(TestItem.AddressC, createCode, Spec);
 
         NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(config), Hash256.Zero, TestItem.AddressA, TestItem.AddressB, Address.Zero);
-        GethLikeTxTrace trace = Execute(
-                tracer,
-                code,
-                MainnetSpecProvider.CancunActivation)
-            .BuildResult();
+        GethLikeTxTrace trace = ExecutePrestate(tracer, code, wrapped);
 
         Assert.That(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedTrace));
     }
@@ -422,6 +456,13 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
             .BuildResult();
 
         Assert.That(JsonSerializer.Serialize(trace.CustomTracerResult?.Value, SerializerOptions), Is.EqualTo(expectedTrace));
+    }
+
+    private GethLikeTxTrace ExecutePrestate(NativePrestateTracer tracer, byte[] code, bool wrapped)
+    {
+        ITxTracer executionTracer = wrapped ? new CancellationTxTracer(new CompositeTxTracer(tracer), default) : tracer;
+        Execute(executionTracer, code, MainnetSpecProvider.CancunActivation);
+        return tracer.BuildResult();
     }
 
     private static byte[] SStore => Prepare.EvmCode

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikePrestateTracerTests.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Collections.Generic;
 using System.Text.Json;
 using Nethermind.Core;
 using Nethermind.Core.Crypto;
@@ -56,6 +57,35 @@ public class GethLikePrestateTracerTests : VirtualMachineTestsBase
             Assert.That(tracer.IsTracingOpLevelStorage, Is.False);
             Assert.That(tracer.IsTracingReturnData, Is.False);
             Assert.That(tracer.IsTracingRefunds, Is.False);
+        }
+    }
+
+    [Test]
+    public void SetOperationStack_WhenAnOperationHasErrored_CapturesNothingMore([Values] bool errored)
+    {
+        NativePrestateTracer tracer = new(TestState, GetGethTraceOptions(),
+            Hash256.Zero, TestItem.AddressA, TestItem.AddressB);
+        using ExecutionEnvironment environment = ExecutionEnvironment.Rent(
+            null!, TestItem.AddressB, TestItem.AddressA, null, 0, UInt256.Zero, default);
+
+        tracer.StartOperation(0, Instruction.SLOAD, 100, environment);
+        if (errored)
+        {
+            tracer.ReportOperationError(EvmExceptionType.OutOfGas);
+            // The frame that halted unwinds, but its caller keeps executing unrelated opcodes
+            tracer.StartOperation(1, Instruction.ADD, 100, environment);
+        }
+
+        // A wrapping tracer latches the capture flags, so the stack keeps arriving either way
+        tracer.SetOperationStack(new TraceStack(new byte[EvmStack.WordSize]));
+
+        NativePrestateTracerAccount account =
+            ((Dictionary<AddressAsKey, NativePrestateTracerAccount>)tracer.BuildResult().CustomTracerResult!.Value)[TestItem.AddressB];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracer.IsTracingStack, Is.EqualTo(!errored));
+            Assert.That(account.Storage?.Count ?? 0, Is.EqualTo(errored ? 0 : 1));
         }
     }
 

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/InstructionTracingFilterTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/InstructionTracingFilterTests.cs
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Collections.Generic;
+using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
+using Nethermind.Int256;
+using Nethermind.Specs;
+using NUnit.Framework;
+
+namespace Nethermind.Evm.Test.Tracing;
+
+[TestFixture]
+public class InstructionTracingFilterTests : VirtualMachineTestsBase
+{
+    [Test]
+    public void Execute_WhenMaskChanges_ObservesTheCurrentMask([Values] bool reverse)
+    {
+        byte[] code = Prepare.EvmCode
+            .PushData(2)
+            .PushData(3)
+            .Op(Instruction.ADD)
+            .PushData(4)
+            .Op(Instruction.MUL)
+            .Op(Instruction.STOP)
+            .Done;
+        Instruction first = reverse ? Instruction.MUL : Instruction.ADD;
+        Instruction second = reverse ? Instruction.ADD : Instruction.MUL;
+        foreach (Instruction selected in new[] { first, second, first })
+        {
+            using FilteredTracer tracer = new(selected);
+            Execute(tracer, code, MainnetSpecProvider.CancunActivation);
+
+            Assert.That(tracer.StatusCode, Is.EqualTo(StatusCode.Success), "each transaction must execute successfully");
+            Assert.That(tracer.Operations, Does.Contain(selected), "the current mask must select its opcode");
+            Assert.That(tracer.Operations, Does.Not.Contain(selected == first ? second : first), "the cached previous mask must not leak observations");
+        }
+    }
+
+    [Test]
+    public void Execute_WhenOpcodeActivationChanges_UsesCurrentFork([Values] bool activatedFirst)
+    {
+        byte[] code = Prepare.EvmCode
+            .Op(Instruction.PUSH0)
+            .Op(Instruction.STOP)
+            .Done;
+        foreach (bool activated in new[] { activatedFirst, !activatedFirst, activatedFirst })
+        {
+            using FilteredTracer tracer = new(Instruction.PUSH0);
+            Execute(tracer, code, (MainnetSpecProvider.ParisBlockNumber + 1,
+                MainnetSpecProvider.ShanghaiBlockTimestamp - (activated ? 0UL : 1UL)));
+
+            Assert.That(tracer.StatusCode, Is.EqualTo(activated ? StatusCode.Success : StatusCode.Failure), "PUSH0 must follow the current fork");
+            Assert.That(tracer.OperationError, Is.EqualTo(activated ? null : (EvmExceptionType?)EvmExceptionType.BadInstruction), "the pre-activation transaction must reject PUSH0");
+            Assert.That(tracer.Operations, Does.Contain(Instruction.PUSH0), "selected opcodes must remain observable across fork changes");
+        }
+    }
+
+    [Test]
+    public void Execute_WhenCancellationModeChanges_UsesCurrentDispatch([Values] bool cancelableFirst)
+    {
+        byte[] code = new byte[2049];
+        Array.Fill(code, (byte)Instruction.JUMPDEST);
+        code[^1] = (byte)Instruction.STOP;
+        using FilteredTracer warmup = new(Instruction.JUMPDEST, cancelableFirst);
+        Execute(warmup, code, MainnetSpecProvider.CancunActivation);
+        Assert.That(warmup.StatusCode, Is.EqualTo(StatusCode.Success), "populate the cache with the first cancellation mode");
+
+        using FilteredTracer next = new(Instruction.JUMPDEST, !cancelableFirst, cancelOnOperation: true);
+        Assert.That(next.CancellationRequested, Is.False, "cancellation must happen after dispatch begins");
+        if (cancelableFirst)
+        {
+            Execute(next, code, MainnetSpecProvider.CancunActivation);
+            Assert.That(next.StatusCode, Is.EqualTo(StatusCode.Success), "noncancelable dispatch must not retain cancellation handlers");
+            Assert.That(next.Operations.Count, Is.EqualTo(2048), "a stale cancelable handler must not truncate execution at its batch boundary");
+        }
+        else
+        {
+            Assert.Throws<OperationCanceledException>(() => Execute(next, code, MainnetSpecProvider.CancunActivation),
+                "cancelable dispatch must observe cancellation requested during execution");
+        }
+        Assert.That(next.Operations, Does.Contain(Instruction.JUMPDEST), "the filtered callback must execute before cancellation");
+        Assert.That(next.CancellationRequested, Is.True, "the callback must request cancellation deterministically");
+        Assert.That(next.CancellationPolls > 0, Is.EqualTo(!cancelableFirst), "only cancelable execution may poll cancellation");
+    }
+
+    private sealed class FilteredTracer(Instruction selected, bool cancelable = false, bool cancelOnOperation = false)
+        : TestAllTracerWithOutput, IInstructionTracingFilter, ITxTracer
+    {
+        public UInt256 InstructionMask => UInt256.One << (int)selected;
+        public List<Instruction> Operations { get; } = [];
+        public EvmExceptionType? OperationError { get; private set; }
+        public bool CancellationRequested { get; private set; }
+        public int CancellationPolls { get; private set; }
+        bool ITxTracer.IsCancelable => cancelable;
+        bool ITxTracer.IsCancelled
+        {
+            get
+            {
+                CancellationPolls++;
+                return CancellationRequested;
+            }
+        }
+
+        public override void ReportOperationError(EvmExceptionType error) => OperationError = error;
+
+        public override void StartOperation(int pc, Instruction opcode, ulong gas, in ExecutionEnvironment env)
+        {
+            Operations.Add(opcode);
+            CancellationRequested |= cancelOnOperation;
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/InstructionTracingFilterTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/InstructionTracingFilterTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Nethermind.Evm.State;
 using Nethermind.Evm.Tracing;
 using Nethermind.Int256;
 using Nethermind.Specs;

--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -388,6 +388,15 @@ public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token
         }
     }
 
+    public void ReportActionRemainingGas(ulong gas)
+    {
+        token.ThrowIfCancellationRequested();
+        if (innerTracer.IsTracingActions)
+        {
+            innerTracer.ReportActionRemainingGas(gas);
+        }
+    }
+
     public void ReportActionRevert(ulong gasLeft, ReadOnlyMemory<byte> output)
     {
         token.ThrowIfCancellationRequested();

--- a/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CancellationTxTracer.cs
@@ -11,13 +11,14 @@ using Nethermind.Int256;
 
 namespace Nethermind.Evm.Tracing;
 
-public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token = default) : ITxTracer, ITxTracerWrapper
+public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token = default) : ITxTracer, ITxTracerWrapper, IInstructionTracingFilter
 {
     private readonly bool _isTracingReceipt;
     private readonly bool _isTracingActions;
     private readonly bool _isTracingOpLevelStorage;
     private readonly bool _isTracingMemory;
     private readonly bool _isTracingInstructions;
+
     private readonly bool _isTracingRefunds;
     private readonly bool _isTracingReturnData;
     private readonly bool _isTracingCode;
@@ -30,6 +31,11 @@ public class CancellationTxTracer(ITxTracer innerTracer, CancellationToken token
     private readonly bool _isTracingOpLevelLogs;
 
     public ITxTracer InnerTracer => innerTracer;
+
+    public UInt256 InstructionMask => !_isTracingInstructions && !_isTracingStack && !_isTracingMemory && !_isTracingReturnData
+        && innerTracer is IInstructionTracingFilter filter
+        ? filter.InstructionMask
+        : UInt256.MaxValue;
 
     public bool IsCancelable => true;
     public bool IsCancelled => token.IsCancellationRequested;

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -424,6 +424,18 @@ public class CompositeTxTracer : ITxTracer
         }
     }
 
+    public void ReportActionRemainingGas(ulong gas)
+    {
+        for (int index = 0; index < _txTracers.Count; index++)
+        {
+            ITxTracer innerTracer = _txTracers[index];
+            if (innerTracer.IsTracingActions)
+            {
+                innerTracer.ReportActionRemainingGas(gas);
+            }
+        }
+    }
+
     public void ReportActionRevert(ulong gasLeft, ReadOnlyMemory<byte> output)
     {
         for (int index = 0; index < _txTracers.Count; index++)

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -10,7 +10,7 @@ using Nethermind.Int256;
 
 namespace Nethermind.Evm.Tracing;
 
-public class CompositeTxTracer : ITxTracer
+public class CompositeTxTracer : ITxTracer, IInstructionTracingFilter
 {
     internal readonly IList<ITxTracer> _txTracers;
 
@@ -75,6 +75,22 @@ public class CompositeTxTracer : ITxTracer
     public bool IsTracingAccess { get; }
     public bool IsTracingFees { get; }
     public bool IsTracingLogs { get; }
+
+    public UInt256 InstructionMask
+    {
+        get
+        {
+            UInt256 mask = UInt256.Zero;
+            for (int index = 0; index < _txTracers.Count; index++)
+            {
+                ITxTracer tracer = _txTracers[index];
+                if (!tracer.IsTracingInstructions && !tracer.IsTracingStack && !tracer.IsTracingMemory && !tracer.IsTracingReturnData) continue;
+                if (tracer is not IInstructionTracingFilter filter) return UInt256.MaxValue;
+                mask |= filter.InstructionMask;
+            }
+            return mask;
+        }
+    }
 
     public void ReportBalanceChange(Address address, UInt256? before, UInt256? after)
     {

--- a/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/CompositeTxTracer.cs
@@ -65,12 +65,12 @@ public class CompositeTxTracer : ITxTracer
     public bool IsCollectingLogs { get; }
     public bool IsTracingActions { get; }
     public bool IsTracingOpLevelStorage { get; }
-    public bool IsTracingMemory { get; }
+    public bool IsTracingMemory { get; private set; }
     public bool IsTracingInstructions { get; }
     public bool IsTracingRefunds { get; }
     public bool IsTracingReturnData { get; }
     public bool IsTracingCode { get; }
-    public bool IsTracingStack { get; }
+    public bool IsTracingStack { get; private set; }
     public bool IsTracingBlockHash { get; }
     public bool IsTracingAccess { get; }
     public bool IsTracingFees { get; }
@@ -174,6 +174,8 @@ public class CompositeTxTracer : ITxTracer
 
     public void StartOperation(int pc, Instruction opcode, ulong gas, in ExecutionEnvironment env)
     {
+        bool tracingMemory = false;
+        bool tracingStack = false;
         for (int index = 0; index < _txTracers.Count; index++)
         {
             ITxTracer innerTracer = _txTracers[index];
@@ -181,7 +183,11 @@ public class CompositeTxTracer : ITxTracer
             {
                 innerTracer.StartOperation(pc, opcode, gas, env);
             }
+            tracingMemory |= innerTracer.IsTracingMemory;
+            tracingStack |= innerTracer.IsTracingStack;
         }
+        IsTracingMemory = tracingMemory;
+        IsTracingStack = tracingStack;
     }
 
     public void ReportOperationError(EvmExceptionType error)

--- a/src/Nethermind/Nethermind.Evm/Tracing/IInstructionTracingFilter.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/IInstructionTracingFilter.cs
@@ -5,7 +5,16 @@ using Nethermind.Int256;
 
 namespace Nethermind.Evm.Tracing;
 
+/// <summary>
+/// Optionally restricts instruction snapshots without changing EVM execution semantics.
+/// </summary>
 public interface IInstructionTracingFilter
 {
+    /// <summary>
+    /// Bit N requests snapshots for opcode N. <see cref="UInt256.MaxValue"/> requests full instruction capture.
+    /// Dispatch samples the mask once per transaction; implementations must keep it stable for that transaction.
+    /// This is not a filter for every callback: errors, execution-segment gas checkpoints and implicit STOP
+    /// can still be reported. Composite tracers can also deliver opcodes requested by sibling tracers.
+    /// </summary>
     UInt256 InstructionMask { get; }
 }

--- a/src/Nethermind/Nethermind.Evm/Tracing/IInstructionTracingFilter.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/IInstructionTracingFilter.cs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using Nethermind.Int256;
+
+namespace Nethermind.Evm.Tracing;
+
+public interface IInstructionTracingFilter
+{
+    UInt256 InstructionMask { get; }
+}

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -381,6 +381,8 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
     /// <remarks>Depends on <see cref="IsTracingActions"/></remarks>
     void ReportActionError(EvmExceptionType evmExceptionType);
 
+    void ReportActionRemainingGas(ulong gas) { }
+
     /// <summary>
     ///
     /// </summary>

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -381,6 +381,15 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
     /// <remarks>Depends on <see cref="IsTracingActions"/></remarks>
     void ReportActionError(EvmExceptionType evmExceptionType);
 
+    /// <summary>
+    /// Reports the gas left in the current call frame at the point it stops executing.
+    /// </summary>
+    /// <param name="gas">Gas remaining in the frame.</param>
+    /// <remarks>
+    /// Depends on <see cref="IsTracingActions"/>. Always raised before <see cref="ReportActionError"/>
+    /// for the same frame, which carries no gas of its own; tracers that need the gas of a failed frame
+    /// must implement this, as the default implementation drops it.
+    /// </remarks>
     void ReportActionRemainingGas(ulong gas) { }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/ITxTracer.cs
@@ -382,13 +382,14 @@ public interface ITxTracer : IWorldStateTracer, IDisposable
     void ReportActionError(EvmExceptionType evmExceptionType);
 
     /// <summary>
-    /// Reports the gas left in the current call frame at the point it stops executing.
+    /// Reports the remaining gas observed at an execution-segment boundary.
     /// </summary>
     /// <param name="gas">Gas remaining in the frame.</param>
     /// <remarks>
-    /// Depends on <see cref="IsTracingActions"/>. Always raised before <see cref="ReportActionError"/>
-    /// for the same frame, which carries no gas of its own; tracers that need the gas of a failed frame
-    /// must implement this, as the default implementation drops it.
+    /// Depends on <see cref="IsTracingActions"/>. Checkpoints are emitted when execution suspends,
+    /// resumes, completes or fails, before the corresponding action completion or error notification
+    /// where applicable. These are not per-opcode updates; early action failures can occur without
+    /// a new checkpoint, leaving the previous observation in effect. The default implementation drops it.
     /// </remarks>
     void ReportActionRemainingGas(ulong gas) { }
 

--- a/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
+++ b/src/Nethermind/Nethermind.Evm/Tracing/TxTracer.cs
@@ -75,6 +75,7 @@ public abstract class TxTracer : ITxTracer
     public virtual void ReportAction(ulong gas, UInt256 value, Address from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false) { }
     public virtual void ReportActionEnd(ulong gas, ReadOnlyMemory<byte> output) { }
     public virtual void ReportActionError(EvmExceptionType evmExceptionType) { }
+    public virtual void ReportActionRemainingGas(ulong gas) { }
     public virtual void ReportActionEnd(ulong gas, Address deploymentAddress, ReadOnlyMemory<byte> deployedCode) { }
     public virtual void ReportActionRevert(ulong gas, ReadOnlyMemory<byte> output) { }
     public virtual void ReportBlockHash(Hash256 blockHash) { }

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.Dispatch.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.Dispatch.cs
@@ -7,6 +7,8 @@ using System.Runtime.CompilerServices;
 using InlineIL;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
+using Nethermind.Evm.Tracing;
+using Nethermind.Int256;
 
 namespace Nethermind.Evm;
 
@@ -36,6 +38,16 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
     /// <summary>The dispatch table the running transaction uses, resolved once by <c>PrepareOpcodes</c>.</summary>
     private delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[] _opcodeHandlers = null!;
+
+    private delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]? _filteredOpcodeHandlers;
+    private delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]? _filteredTracedSource;
+    private delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]? _filteredSilentSource;
+    private UInt256 _filteredInstructionMask;
+
+    private struct SilentInstructionFlag : IFlag
+    {
+        public static bool IsActive => true;
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]
@@ -81,6 +93,31 @@ public unsafe partial class VirtualMachine<TGasPolicy>
 
         _executionHandlers = table.GetExecutionHandlers(spec);
         _opcodeHandlers = table.GetHandlers<TTracingInst, TCancelable>(spec);
+        if (TTracingInst.IsActive && _txTracer is IInstructionTracingFilter filter)
+        {
+            UInt256 mask = filter.InstructionMask;
+            if (mask != UInt256.MaxValue)
+                PrepareFilteredOpcodes(mask, table.GetHandlers<SilentInstructionFlag, TCancelable>(spec));
+        }
+    }
+
+    private void PrepareFilteredOpcodes(UInt256 mask,
+        delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[] silent)
+    {
+        if (_filteredTracedSource != _opcodeHandlers || _filteredSilentSource != silent || _filteredInstructionMask != mask)
+        {
+            _filteredOpcodeHandlers ??= new delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[256];
+            _filteredTracedSource = _opcodeHandlers;
+            _filteredSilentSource = silent;
+            _filteredInstructionMask = mask;
+            for (int opcode = 0; opcode < _filteredOpcodeHandlers.Length; opcode++)
+            {
+                _filteredOpcodeHandlers[opcode] = (mask & (UInt256.One << opcode)) != UInt256.Zero
+                    ? _opcodeHandlers[opcode]
+                    : silent[opcode];
+            }
+        }
+        _opcodeHandlers = _filteredOpcodeHandlers!;
     }
 
     private sealed unsafe class OpcodeTable
@@ -89,6 +126,8 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         public delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]? NoTraceCancelable;
         public delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]? Traced;
         public delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]? TracedCancelable;
+        public delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]? Silent;
+        public delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]? SilentCancelable;
 
         private ExecutionHandlers? _executionHandlers;
 
@@ -108,7 +147,9 @@ public unsafe partial class VirtualMachine<TGasPolicy>
             where TCancelable : struct, IFlag
         {
             ref delegate*<ref EvmStack, ref TGasPolicy, ref DispatchState, nint, int, EvmExceptionType>[]? table =
-                ref TTracingInst.IsActive
+                ref typeof(TTracingInst) == typeof(SilentInstructionFlag)
+                    ? ref (TCancelable.IsActive ? ref SilentCancelable : ref Silent)
+                    : ref TTracingInst.IsActive
                     ? ref (TCancelable.IsActive ? ref TracedCancelable : ref Traced)
                     : ref (TCancelable.IsActive ? ref NoTraceCancelable : ref NoTrace);
 
@@ -219,7 +260,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         where TContinuable : struct, IFlag
     {
         // Only a traced run reads the opcode out of the bytecode. The read costs two dependent loads.
-        if (TTracingInst.IsActive)
+        if (TTracingInst.IsActive && typeof(TTracingInst) != typeof(SilentInstructionFlag))
         {
             Instruction instruction = (Instruction)Unsafe.Add(ref stack.Code, pc);
             state.Vm.StartInstructionTrace(instruction, TGasPolicy.GetRemainingGas(in gas), (int)pc, in stack);
@@ -265,7 +306,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         Debug.Assert(state.Vm.ReturnData is null,
             "A handler that stages ReturnData must report a non-None status, or dispatch will continue past the halt");
 
-        if (TTracingInst.IsActive)
+        if (TTracingInst.IsActive && typeof(TTracingInst) != typeof(SilentInstructionFlag))
             state.Vm.EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));
 
         // Reaching here means the halt check passed, so the status is None and gas is valid: the exit
@@ -324,7 +365,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
     {
         VirtualMachine<TGasPolicy> vm = state.Vm;
 
-        if (TTracingInst.IsActive)
+        if (TTracingInst.IsActive && typeof(TTracingInst) != typeof(SilentInstructionFlag))
         {
             Instruction instruction = (Instruction)Unsafe.Add(ref stack.Code, pc);
             vm.StartInstructionTrace(instruction, TGasPolicy.GetRemainingGas(in gas), (int)pc, in stack);
@@ -344,7 +385,7 @@ public unsafe partial class VirtualMachine<TGasPolicy>
         Debug.Assert(vm.ReturnData is null,
             "A handler that stages ReturnData must report a non-None status, or dispatch will continue past the halt");
 
-        if (TTracingInst.IsActive)
+        if (TTracingInst.IsActive && typeof(TTracingInst) != typeof(SilentInstructionFlag))
             vm.EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));
 
         if (TCancelable.IsActive && (opCodeCount & CancellationCheckMask) == 0)

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -661,6 +661,7 @@ public partial class VirtualMachine<TGasPolicy>(
         // If action-level tracing is enabled, report the error associated with the action.
         if (IsTracingActions)
         {
+            txTracer.ReportActionRemainingGas(0);
             txTracer.ReportActionError(errorType);
         }
 
@@ -1304,6 +1305,10 @@ public partial class VirtualMachine<TGasPolicy>(
             {
                 _txTracer.ReportOperationRemainingGas(TGasPolicy.GetRemainingGas(vmState.Gas));
             }
+            if (IsTracingActions)
+            {
+                _txTracer.ReportActionRemainingGas(TGasPolicy.GetRemainingGas(vmState.Gas));
+            }
         }
 
         // CALL already expanded this range; returned output is clipped to the requested length.
@@ -1364,6 +1369,8 @@ public partial class VirtualMachine<TGasPolicy>(
         {
             if (TTracingInst.IsActive && !tracedImplicitStop)
                 EndInstructionTrace(TGasPolicy.GetRemainingGas(in gas));
+            if (IsTracingActions)
+                _txTracer.ReportActionRemainingGas(TGasPolicy.GetRemainingGas(in gas));
             int stackHead = (int)stack.Head;
             VmState<TGasPolicy> state = VmState;
             state.ProgramCounter = (int)programCounter;
@@ -1404,6 +1411,7 @@ public partial class VirtualMachine<TGasPolicy>(
     private CallResult GetFailureReturn(ulong gasAvailable, EvmExceptionType exceptionType)
     {
         if (DispatchFlags.ConstTracing && _txTracer.IsTracingInstructions) EndInstructionTraceError(gasAvailable, exceptionType);
+        if (IsTracingActions) _txTracer.ReportActionRemainingGas(gasAvailable);
 
         return exceptionType switch
         {

--- a/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
+++ b/src/Nethermind/Nethermind.Evm/VirtualMachine.cs
@@ -248,6 +248,10 @@ public partial class VirtualMachine<TGasPolicy>(
                     }
                     else
                     {
+                        // The frame halts without running, so its gas is untouched. Report it to keep
+                        // the contract that ReportActionError is preceded by this frame's gas — otherwise
+                        // a tracer would attribute the caller's gas to it.
+                        if (IsTracingActions) _txTracer.ReportActionRemainingGas(TGasPolicy.GetRemainingGas(in _currentState.Gas));
                         callResult = new(EvmExceptionType.InvalidCode);
                     }
 


### PR DESCRIPTION
## Changes

| Tracer / area | Optimization |
|---|---|
| callTracer | Action-level gas checkpoints replace opcode capture, including wrapper forwarding and no-code frames |
| prestateTracer | Cached selective opcode dispatch skips unneeded instruction snapshots; stack capture only for relevant opcodes and memory capture only for CREATE2 |
| Tracer wrappers | Preserve selective capture; full capture fallback for other observers and forced snapshot requirements |
| 4byteTracer | Action events replace opcode callbacks, preserving call-type and precompile filters |
| stateGasTracer | Disable unused return-data capture |
| Compatibility | Preserve response schemas and literal JSON fixtures; no database, prewarming, admission-limit or JavaScript changes |

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

### Requires testing

- [x] Yes
- [ ] No

### Tests added

- [x] Yes
- [ ] No

| Verification | Status |
|---|---|
| Release compile at b032b3a, Evm.Test | Passed, 0 warnings/errors; no local test-suite execution |
| Added coverage | Action gas, nested failures, capture flags, four-byte call types/precompiles, prestate storage/CREATE2, filtered/full dispatch, excluded-opcode errors and wrapper fallback |
| Reviewer validation at f9fbdebb | 541 tracing tests passed, one existing skip; 168 RPC debug tests passed; predates selective dispatch |
| Full output parity | Not established by benchmark HTTP/result checks |

## AMD64 benchmark

[Run 34657499774](https://github.com/NethermindEth/nethermind/actions/runs/34657499774)

| Setting | Value |
|---|---|
| Measured commits | Baseline f5f457c, candidate b032b3a |
| Images | native-tracers-base-f5f457c-v1 vs native-tracers-b032b3a-v1 |
| Workload | Block tracing, 1 rps, 60 seconds, one A/B round, flat snapshot 25490000 |
| Workflow | refactor/rpc-bench-reliability; jsonbench-sweep; debug-trace-block-head.yaml |
| HTTP / result checks | 100% passed on both images; 0% HTTP failures; 60 baseline / 61 candidate requests |
| Samples | callTracer 16/16; prestateTracer 19/19; trace_block 15/15; replay 10/11 |
| Scope | Cumulative PR changes through b032b3a, not an isolated measurement of its last commit |
| Limitations | One block, small sample, variable tails; latency test, not saturation throughput or broad no-regression proof |

| Endpoint / tracer | Baseline p50 | Candidate p50 | p50 change | Baseline p95 | Candidate p95 |
|---|---:|---:|---:|---:|---:|
| callTracer | 124.37 ms | 40.53 ms | -67.4% / 3.07x faster | 136.02 ms | 46.34 ms |
| prestateTracer | 158.97 ms | 84.80 ms | -46.7% / 1.87x faster | 301.98 ms | 199.82 ms |
| trace_block | 40.09 ms | 41.01 ms | +2.3% | 68.93 ms | 72.46 ms |
| trace_replayBlockTransactions | 40.14 ms | 38.91 ms | -3.1% | 57.69 ms | 54.36 ms |

| Additional load test | Status |
|---|---|
| [AMD64 100 rps, 60s](https://github.com/NethermindEth/nethermind/actions/runs/34658023226) | Dispatched with the same images and four block-tracing endpoints; results not yet analyzed |

## Documentation

### Requires documentation update

- [ ] Yes
- [x] No

### Requires explanation in Release Notes

- [ ] Yes
- [x] No
