### PR TITLE
test: keep the filter-expiry fixture from dropping other tests' filters

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Filters/FilterManagerTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Nethermind.Facade.Filters;
 using Nethermind.Blockchain.Receipts;
@@ -36,7 +37,7 @@ public class FilterManagerTests
     public void Setup()
     {
         _currentFilterId = 0;
-        _filterStore = new FilterStore(new TimerFactory(), 400, 100);
+        _filterStore = new FilterStore(new TimerFactory());
         _mainProcessingContext = new TestMainProcessingContext();
         _txPool = Substitute.For<ITxPool>();
         _receiptMonitor = Substitute.For<IReceiptMonitor>();
@@ -53,6 +54,11 @@ public class FilterManagerTests
     [Test, MaxTime(Timeout.MaxTestTime)]
     public async Task removing_filter_removes_data()
     {
+        // Only this test expects filters to expire. A fixture-wide short lifetime also drops the data of any
+        // other test whose filter goes unused for that long, which on a loaded runner is a matter of scheduling.
+        _filterStore.Dispose();
+        _filterStore = new FilterStore(new TimerFactory(), timeout: 400, cleanupInterval: 100);
+
         LogsShouldNotBeEmpty(static _ => { }, static _ => { });
         Assert.That(_filterManager.GetLogs(0), Is.Not.Empty);
         await Task.Delay(600);
@@ -285,8 +291,8 @@ public class FilterManagerTests
     }
 
 
-    [Test, MaxTime(Timeout.MaxTestTime)]
-    public async Task concurrent_block_processing_and_poll_does_not_lose_data()
+    [Test, CancelAfter(Timeout.MaxTestTime)]
+    public async Task concurrent_block_processing_and_poll_does_not_lose_data(CancellationToken cancellationToken)
     {
         BlockFilter blockFilter = new(_currentFilterId++);
         _filterStore.SaveFilter(blockFilter);
@@ -316,11 +322,12 @@ public class FilterManagerTests
         {
             while (totalPolled < blockCount)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 Hash256[] polled = _filterManager.PollBlockHashes(blockFilter.Id);
                 totalPolled += polled.Length;
                 if (polled.Length == 0) await Task.Yield();
             }
-        });
+        }, cancellationToken);
 
         List<Task> allTasks = new(producerCount + 1);
         for (int p = 0; p < producerCount; p++)


### PR DESCRIPTION
## Changes

`Nethermind.Blockchain.Test` has been hanging for the full 8-minute hang-dump budget with
`concurrent_block_processing_and_poll_does_not_lose_data` named in the dump log, on PRs whose diffs cannot
reach it (#13404, #13366). The job then reports `Zero tests ran`, so the whole assembly is lost.

The fixture builds every test's store with a 400 ms filter lifetime and a 100 ms cleanup interval:

```csharp
_filterStore = new FilterStore(new TimerFactory(), 400, 100);
```

Only `removing_filter_removes_data` wants that. For the concurrency test it is a trap: its consumer polls one
block filter in a loop, and if the runner does not schedule that loop for 400 ms — ordinary thread-pool
contention on a busy 2-core runner — `CleanupStaleFilters` removes the filter, `FilterManager.OnFilterRemoved`
drops the queued hashes with it, and `GetFilters<BlockFilter>()` stops yielding it, so the producers' remaining
blocks are never stored. `while (totalPolled < blockCount)` then spins forever on a filter that can never
deliver another hash.

Confirmed locally by inserting a 600 ms delay before the consumer starts, reproducing the CI failure exactly:

```
INSTR total=20000ms producersDone=623ms iterations=70404987 filterExists=False
Expected: 500  But was: 1
```

(The surviving 1 is the `_lastBlockHash` "truffle hack" path that `PollBlockHashes` falls back to once the
filter's queue is gone.) With the same delay on this branch the test passes.

- Give the fixture a store with the default filter lifetime, and let `removing_filter_removes_data` build the
  short-lived store it actually needs.
- Bound the consumer loop: `CancelAfter` in place of `MaxTime`, which only reports an overrun after the test
  returns and so cannot end a spin. Lost data now fails the test instead of hanging the host.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: _Flaky test fix_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [ ] Yes
- [x] No

#### Notes on testing

`FilterManagerTests` 36/36, including `removing_filter_removes_data` against its own short-lived store. The
starvation scenario above fails on master (`Expected: 500 / But was: 1`, after spinning) and passes here.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

The 400 ms lifetime was a hazard for every test in the fixture, not just this one — any test that leaves a
filter unused for longer than that loses its data to the cleanup timer. This is unrelated to the DotNetty
graceful-shutdown livelock behind the `Nethermind.Network.Discovery.Test` hangs (#13404,
NethermindEth/DotNetty#8), which produces the same job-level symptom from a different cause.
