### PR TITLE
test(eip8141): make three frame-tx regressions hold what they name

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -1260,6 +1260,7 @@ public class FrameTxProcessorTests
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(result.TransactionExecuted, Is.False, "a frame count outside the admitted range executed");
             Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
             Assert.That(result.ErrorDescription, Is.EqualTo(FrameTxValidation.MissingFrames));
         }
@@ -1734,28 +1735,6 @@ public class FrameTxProcessorTests
             new TestCaseData(frames, expectedError).SetName($"CallAndRestore_{name}_IsRejected");
     }
 
-    /// <remarks>
-    /// A frame transaction carrying no frame list at all: reachable from <c>eth_call</c>, where the JSON view
-    /// leaves <see cref="Transaction.Frames"/> null when the request omits the field. Before the check was
-    /// hoisted this left the processor as an <see cref="NullReferenceException"/> rather than a refusal.
-    /// </remarks>
-    [Test]
-    public void CallAndRestore_FrameTransactionWithoutAFrameList_IsRejected()
-    {
-        DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
-        Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame());
-        tx.Frames = null;
-
-        TransactionResult result = CallAndRestore(tx);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(result.TransactionExecuted, Is.False);
-            Assert.That(result.Error, Is.EqualTo(TransactionResult.ErrorType.MalformedTransaction));
-            Assert.That(result.ErrorDescription, Is.EqualTo(FrameTxValidation.MissingFrames));
-        }
-    }
-
     /// <summary>
     /// A <c>VERIFY</c> frame may only approve execution for the sender, and the codeless-target default code
     /// is held to that too.
@@ -2042,11 +2021,12 @@ public class FrameTxProcessorTests
         }
     }
 
-    /// <summary>A frame transaction's <c>CallAndRestore</c> must leave nothing behind.</summary>
-    /// <remarks><c>eth_estimateGas</c> binary-searches <c>CallAndRestore</c> against one world state, so a
-    /// surviving nonce bump makes the next iteration fail its nonce pre-check.</remarks>
+    /// <summary>A frame transaction's <c>CallAndRestore</c> must leave nothing behind, so the same world state
+    /// takes the same call again with the same outcome.</summary>
+    /// <remarks><c>EstimateFrameTx</c> prices the signed reservation without re-executing, so the repeat here
+    /// stands in for the <c>eth_call</c> traffic that shares one world state with the estimator's probe.</remarks>
     [Test]
-    public void CallAndRestore_RepeatedForGasEstimation_LeavesNoStateAndEstimates()
+    public void CallAndRestore_RepeatedAgainstOneWorldState_LeavesNoStateAndEstimates()
     {
         DeploySmartSender(ApproveCode(TxFrame.ApproveExecutionAndPayment));
         Transaction tx = FrameTx(nonce: 0, SelfVerifyFrame(), Frame(TxFrame.ModeDefault, target: Recipient));
@@ -2054,16 +2034,26 @@ public class FrameTxProcessorTests
             .WithBeneficiary(Beneficiary)
             .WithGasLimit(30_000_000).TestObject;
 
-        EstimateGasTracer gasTracer = new();
+        CallOutputTracer firstTracer = new();
         _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, Spec));
-        TransactionResult probe = _transactionProcessor.CallAndRestore(tx, gasTracer);
-        Assert.That(probe.TransactionExecuted, Is.True, probe.ErrorDescription ?? probe.Error.ToString());
+        TransactionResult first = _transactionProcessor.CallAndRestore(tx, firstTracer);
+        UInt256 nonceBetween = _stateProvider.GetNonce(Sender);
+        UInt256 balanceBetween = _stateProvider.GetBalance(Sender);
+
+        CallOutputTracer secondTracer = new();
+        TransactionResult second = _transactionProcessor.CallAndRestore(tx, secondTracer);
 
         GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
-        ulong estimate = estimator.Estimate(tx, header, gasTracer, out string? error);
+        ulong estimate = estimator.Estimate(tx, header, new EstimateGasTracer(), out string? error);
 
         using (Assert.EnterMultipleScope())
         {
+            Assert.That(first.TransactionExecuted, Is.True, first.ErrorDescription ?? first.Error.ToString());
+            Assert.That(nonceBetween, Is.EqualTo(UInt256.Zero), "the first call left a nonce bump behind");
+            Assert.That(balanceBetween, Is.EqualTo(1.Ether), "the first call left a payer charge behind");
+            Assert.That(second.TransactionExecuted, Is.True, second.ErrorDescription ?? second.Error.ToString());
+            Assert.That(secondTracer.StatusCode, Is.EqualTo(firstTracer.StatusCode), "the repeat ended differently from the first call");
+            Assert.That(secondTracer.GasSpent, Is.EqualTo(firstTracer.GasSpent), "the repeat ran against a state the first call had moved");
             Assert.That(error, Is.Null);
             Assert.That(estimate, Is.GreaterThan((ulong)GasCostOf.Transaction), "the estimate collapsed to the regular-path lower bound");
             Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0ul), "the estimation loop committed a nonce bump");

--- a/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/FrameTxProcessorTests.cs
@@ -2034,13 +2034,13 @@ public class FrameTxProcessorTests
             .WithBeneficiary(Beneficiary)
             .WithGasLimit(30_000_000).TestObject;
 
-        CallOutputTracer firstTracer = new();
+        FrameReceiptTracer firstTracer = new();
         _transactionProcessor.SetBlockExecutionContext(new BlockExecutionContext(header, Spec));
         TransactionResult first = _transactionProcessor.CallAndRestore(tx, firstTracer);
         UInt256 nonceBetween = _stateProvider.GetNonce(Sender);
         UInt256 balanceBetween = _stateProvider.GetBalance(Sender);
 
-        CallOutputTracer secondTracer = new();
+        FrameReceiptTracer secondTracer = new();
         TransactionResult second = _transactionProcessor.CallAndRestore(tx, secondTracer);
 
         GasEstimator estimator = new(_transactionProcessor, _stateProvider, _specProvider, new BlocksConfig());
@@ -2052,12 +2052,13 @@ public class FrameTxProcessorTests
             Assert.That(nonceBetween, Is.EqualTo(UInt256.Zero), "the first call left a nonce bump behind");
             Assert.That(balanceBetween, Is.EqualTo(1.Ether), "the first call left a payer charge behind");
             Assert.That(second.TransactionExecuted, Is.True, second.ErrorDescription ?? second.Error.ToString());
-            Assert.That(secondTracer.StatusCode, Is.EqualTo(firstTracer.StatusCode), "the repeat ended differently from the first call");
-            Assert.That(secondTracer.GasSpent, Is.EqualTo(firstTracer.GasSpent), "the repeat ran against a state the first call had moved");
+            Assert.That(firstTracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess), "the first call did not run the body to completion");
+            Assert.That(secondTracer.FrameReceipts![1].Status, Is.EqualTo(TxFrameReceipt.StatusSuccess), "the repeat did not run the body to completion");
+            Assert.That(secondTracer.GasSpent, Is.EqualTo(firstTracer.GasSpent), "the repeat ended differently from the first call");
             Assert.That(error, Is.Null);
             Assert.That(estimate, Is.GreaterThan((ulong)GasCostOf.Transaction), "the estimate collapsed to the regular-path lower bound");
-            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0ul), "the estimation loop committed a nonce bump");
-            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether), "the estimation loop committed a payer charge");
+            Assert.That(_stateProvider.GetNonce(Sender), Is.EqualTo(0ul), "the repeat or the estimate left a nonce bump behind");
+            Assert.That(_stateProvider.GetBalance(Sender), Is.EqualTo(1.Ether), "the repeat or the estimate left a payer charge behind");
         }
     }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -4726,17 +4726,29 @@ namespace Nethermind.TxPool.Test
             _stateProvider.InsertCode([0x60, 0x00], sponsor);
 
             Task<AcceptTxResult> doomedResult = Task.Run(() => _txPool.SubmitTx(doomed, TxHandlingOptions.None));
-            Assert.That(reachedFilter.Wait(TimeSpan.FromSeconds(10)), Is.True, "the doomed submission never reached the injected filter");
+            bool reached;
+            AcceptTxResult sponsored;
+            AcceptTxResult doomedOutcome;
+            try
+            {
+                reached = reachedFilter.Wait(TimeSpan.FromSeconds(10));
 
-            // Submitted while the doomed one is parked past the cap gate and has not been rejected yet.
-            AcceptTxResult sponsored = _txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyB, TestItem.PrivateKeyD), TxHandlingOptions.None);
-
-            releaseFilter.Set();
+                // Submitted while the doomed one is parked past the cap gate and has not been rejected yet.
+                sponsored = _txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyB, TestItem.PrivateKeyD), TxHandlingOptions.None);
+            }
+            finally
+            {
+                // On every path, including a failure above: the events and the pool are disposed when this
+                // method returns, so the parked submission has to be let go and drained before that.
+                releaseFilter.Set();
+                doomedOutcome = await doomedResult;
+            }
 
             using (Assert.EnterMultipleScope())
             {
+                Assert.That(reached, Is.True, "the doomed submission never reached the injected filter");
                 Assert.That(sponsored, Is.EqualTo(AcceptTxResult.Accepted), "a submission that never pools must not occupy the sponsor's slot");
-                Assert.That(await doomedResult, Is.EqualTo(AcceptTxResult.Invalid));
+                Assert.That(doomedOutcome, Is.EqualTo(AcceptTxResult.Invalid));
             }
         }
 

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.cs
@@ -4707,64 +4707,72 @@ namespace Nethermind.TxPool.Test
         }
 
         [Test]
-        public async Task Frame_transaction_rejected_after_the_cap_gate_does_not_hold_the_sponsor_slot()
+        public async Task Frame_transaction_parked_past_the_cap_gate_holds_the_sponsor_slot_until_it_is_refused()
         {
-            // The slot is a reservation over pending transactions, so it must not be taken by a submission
-            // that is still going to be rejected: at a cap of one, that would let unpooled traffic naming a
-            // sponsor deny the sponsor's real transaction for as long as the remaining filters run.
+            // Counting is the reservation, so the slot stays taken for the rest of the filter chain — that
+            // hold is what bounds the per-sponsor simulation work — and is handed back once the refusal lands.
             Address sponsor = TestItem.PrivateKeyD.Address;
-            using ManualResetEventSlim reachedFilter = new(false);
-            using ManualResetEventSlim releaseFilter = new(false);
+            using ManualResetEventSlim reachedSimulator = new(false);
+            using ManualResetEventSlim releaseSimulator = new(false);
 
             Transaction doomed = SponsoredFrameTx(TestItem.PrivateKeyA, TestItem.PrivateKeyD);
-            BlockingRejectFilter blocker = new(() => doomed.Hash, reachedFilter, releaseFilter);
+            IFrameTxPrefixSimulator simulator = Substitute.For<IFrameTxPrefixSimulator>();
+            simulator.Simulate(Arg.Any<Transaction>(), Arg.Any<bool>(), Arg.Any<CancellationToken>(), Arg.Any<bool>())
+                .Returns(call =>
+                {
+                    if (((Transaction)call[0]).Hash != doomed.Hash) return FrameTxSimulationResult.Accept(sponsor);
 
-            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance), incomingTxFilter: blocker);
+                    reachedSimulator.Set();
+                    releaseSimulator.Wait(TimeSpan.FromSeconds(10));
+                    return FrameTxSimulationResult.Reject("declined");
+                });
+
+            _txPool = CreatePool(new TxPoolConfig { FrameTxMaxVerifyGas = 0 }, new TestSpecProvider(Eip8141Prototype.Instance), frameTxPrefixSimulator: simulator);
             EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
             EnsureSenderBalance(TestItem.PrivateKeyB.Address, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.PrivateKeyC.Address, UInt256.MaxValue);
             EnsureSenderBalance(sponsor, UInt256.MaxValue);
             _stateProvider.InsertCode([0x60, 0x00], sponsor);
 
             Task<AcceptTxResult> doomedResult = Task.Run(() => _txPool.SubmitTx(doomed, TxHandlingOptions.None));
             bool reached;
-            AcceptTxResult sponsored;
-            AcceptTxResult doomedOutcome;
+            AcceptTxResult whileHeld;
+            AcceptTxResult doomedOutcome = default;
+            Exception drainFailure = null;
             try
             {
-                reached = reachedFilter.Wait(TimeSpan.FromSeconds(10));
+                reached = reachedSimulator.Wait(TimeSpan.FromSeconds(10));
 
-                // Submitted while the doomed one is parked past the cap gate and has not been rejected yet.
-                sponsored = _txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyB, TestItem.PrivateKeyD), TxHandlingOptions.None);
+                // Submitted while the doomed one is parked past the cap gate and has not been refused yet.
+                whileHeld = _txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyB, TestItem.PrivateKeyD), TxHandlingOptions.None);
             }
             finally
             {
                 // On every path, including a failure above: the events and the pool are disposed when this
                 // method returns, so the parked submission has to be let go and drained before that.
-                releaseFilter.Set();
-                doomedOutcome = await doomedResult;
+                releaseSimulator.Set();
+                try
+                {
+                    doomedOutcome = await doomedResult;
+                }
+                catch (Exception e)
+                {
+                    // Stashed rather than thrown: out of a finally it would replace the failure being unwound.
+                    drainFailure = e;
+                }
             }
+
+            AcceptTxResult afterRelease = _txPool.SubmitTx(SponsoredFrameTx(TestItem.PrivateKeyC, TestItem.PrivateKeyD), TxHandlingOptions.None);
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(reached, Is.True, "the doomed submission never reached the injected filter");
-                Assert.That(sponsored, Is.EqualTo(AcceptTxResult.Accepted), "a submission that never pools must not occupy the sponsor's slot");
-                Assert.That(doomedOutcome, Is.EqualTo(AcceptTxResult.Invalid));
-            }
-        }
-
-        /// <summary>Parks one transaction inside the filter chain, then rejects it.</summary>
-        private sealed class BlockingRejectFilter(
-            Func<Hash256> target,
-            ManualResetEventSlim reached,
-            ManualResetEventSlim release) : IIncomingTxFilter
-        {
-            public AcceptTxResult Accept(Transaction tx, ref TxFilteringState state, TxHandlingOptions txHandlingOptions)
-            {
-                if (tx.Hash != target()) return AcceptTxResult.Accepted;
-
-                reached.Set();
-                release.Wait(TimeSpan.FromSeconds(10));
-                return AcceptTxResult.Invalid;
+                Assert.That(reached, Is.True, "the doomed submission never reached the simulator");
+                Assert.That(drainFailure, Is.Null, "the parked submission faulted");
+                Assert.That(whileHeld, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached),
+                    "the slot must stay reserved while the filters that follow the cap gate run");
+                Assert.That(doomedOutcome, Is.EqualTo(AcceptTxResult.FrameSimulationFailed));
+                Assert.That(afterRelease, Is.EqualTo(AcceptTxResult.Accepted),
+                    "the refused submission must have handed the slot back");
             }
         }
 


### PR DESCRIPTION
## Changes

Addresses the three P3 review threads on #12526 about frame-transaction tests that claim more than they pin. Tests only; no production code is touched.

**`TxPoolTests.Frame_transaction_parked_past_the_cap_gate_holds_the_sponsor_slot_until_it_is_refused`** — was `Frame_transaction_rejected_after_the_cap_gate_does_not_hold_the_sponsor_slot`, and it named an invariant the pool does not have. Its blocker was an injected `IIncomingTxFilter`, which the pool appends to `_postHashFilters` *ahead* of `FrameTxPaymasterFilter`, so the doomed submission parked before the reservation was ever taken and the test held with or without the release.

Holding the slot across the remaining filters is the design, not a window to close: counting *is* the reservation, so that two concurrent submissions cannot both read the slot free, and the gate sits ahead of the prefix simulation precisely because that per-sponsor work is what the cap exists to bound. Releasing at the gate would leave both properties unenforced. The test now parks in the simulator — after the gate — and asserts what does hold: a second submission naming the same sponsor is refused with `NonCanonicalPaymasterLimitReached` while the first is still in the filters, and a submission after the refusal lands is `Accepted` because the slot was handed back.

`releaseFilter.Set()` and the await of the background submission also ran only on the happy path, so a failed assertion or a throwing `SubmitTx` disposed the events under a still-parked worker. Both moved into a `finally`; the await is wrapped so a fault in the drain is stashed and asserted rather than thrown out of the `finally` over the exception being unwound.

**`FrameTxProcessorTests.CallAndRestore_RepeatedAgainstOneWorldState_LeavesNoStateAndEstimates`** — executed `CallAndRestore` exactly once. `GasEstimator` routes a frame transaction to `EstimateFrameTx`, which prices the signed reservation without re-executing or binary-searching, so the repeat the test was named for never happened. It now calls `CallAndRestore` twice against one world state and pins the entry nonce and payer balance between the two calls.

The two calls' outcomes are compared through `FrameReceiptTracer` rather than `CallOutputTracer`: a frame transaction's tracer `StatusCode` turns on a `POST_TX` revert, not on the body, and this transaction carries no `POST_TX` frame, so `StatusCode` was structurally constant and could not fail. Both calls now assert the `DEFAULT` frame's own receipt status. Renamed from `CallAndRestore_RepeatedForGasEstimation_LeavesNoStateAndEstimates`, and the remarks no longer describe a binary search.

**`FrameTxProcessorTests.CallAndRestore_FrameTransactionWithoutAFrameList_IsRejected`** — duplicated the `Frames = null` case of `Execute_FrameTxWithAFrameCountOutsideTheAdmittedRange_IsRejectedAsMalformed`, which reaches the same check on the same path and asserts the same error. Its one extra assertion (`TransactionExecuted` is false) moved into the parameterized case; the duplicate is deleted. Its rationale — `eth_call` arrives without a validator and the processor dereferences the list — is already in the surviving test's remarks.

## Discrimination checks

Each repaired form was mutation-tested rather than read.

| injection | site | pre-repair form | repaired form |
|---|---|---|---|
| drop the paymaster-slot release | `TxPool.cs:1408` | **green** | **red** — "the refused submission must have handed the slot back" |
| release the reservation at the gate instead of holding it across the later filters | `FrameTxPaymasterFilter.Accept` | **green** | **red** — "the slot must stay reserved while the filters that follow the cap gate run" |
| make every `DEFAULT` frame report failure | `frameSucceeded` | green | **red** — both calls' `DEFAULT` receipts, `Expected: 1 / But was: 0` |
| apply the `CallAndRestore` restore to the first execution only | | **green** | **red** — `GetNonce(Sender)` was 1, `GetBalance(Sender)` short by 16 059 wei |
| restore the frame-tx settlement to commit-before-restore (reverting #12702) | | red | red |
| drop the null guard from `FrameTxValidation.IsWellFormed`'s frame-count check | | n/a | **red** — `NullReferenceException` on the `null` case only; the `0` and `MaxFrames + 1` cases stayed green |

The first two rows are the ones that matter for the paymaster test: its two headline assertions now fail in opposite directions, so neither the reservation nor its release can regress unobserved. The `DEFAULT`-frame row is a real regression — 7 other `FrameTxProcessorTests` cases go red under it — and the pre-repair status comparison did not see it. The fourth row is what carries the repeat: a defect that only affects a *second* execution against the same world state is structurally invisible to the single-call form.

For the background-submission leak, an injected throw immediately after the parked wait fails the test in ~2.5 s with the worker released and drained inside the method; without the `finally` the same injection leaves the submission parked on events the method then disposes, with its result never observed.

## Types of changes

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [x] Other: test-only change

## Testing

Both configurations built with 0 warnings, `artifacts/{bin,obj}` removed between them.

| suite | release | checked (`DefineConstants=TRACE;DEBUG`) |
|---|---|---|
| `Nethermind.Evm.Test` | 12 787 total, 0 failed, 19 skipped | 12 785 total, 0 failed, 19 skipped |
| `Nethermind.TxPool.Test` | 1 233 total, 0 failed, 24 skipped — 3 consecutive runs | 1 233 total, 0 failed, 24 skipped — 3 consecutive runs |

The checked build was confirmed to have taken the define (the `DEBUG`-only `_poolMutations` field is present in the built `Nethermind.TxPool.dll`), which is what arms the pool's bookkeeping assertions. The `Nethermind.TxPool.Test` fixture was run three times in each configuration to show the removed background-task leak has not been replaced by a new source of cross-test flakiness.

CI's lint invocation passes, positive-controlled: with an unused `using` injected into `TxPoolTests.cs` the gate reports `IDE0005` and fails; with it removed the solution builds with 0 warnings and the gate passes. `dotnet format whitespace --verify-no-changes` is clean on both files.

### Requires testing

- [ ] Yes
- [x] No
