### PR TITLE
test(focil): assert inclusionListSatisfied on the forkchoice response

### DIFF
--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -649,6 +649,26 @@ jobs:
               echo "| Failed | **$FAILED** |"
             } >> "$GITHUB_STEP_SUMMARY"
 
+            # The inclusion-list tripwire reports on stderr and fails the run without failing a test, so
+            # without this a tripped lane is a red job above an all-green table.
+            IL_COVERAGE=$(sed 's/\x1b\[[0-9;]*m//g' "$STDERR_FILE" 2>/dev/null \
+              | grep -E "^(engine_forkchoiceUpdated inclusionListSatisfied asserted|COVERAGE GAP)" || true)
+            if [ -n "$IL_COVERAGE" ]; then
+              {
+                echo ""
+                echo "### EIP-7805 fork-choice assertion coverage"
+                echo ""
+                echo '```'
+                echo "$IL_COVERAGE"
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+
+              COVERAGE_GAP=$(echo "$IL_COVERAGE" | grep "^COVERAGE GAP" || true)
+              if [ -n "$COVERAGE_GAP" ]; then
+                echo "::error::$COVERAGE_GAP"
+              fi
+            fi
+
             if [ "$FAILED" -gt 0 ]; then
               MAX_SUMMARY_FAILURES=500
               echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/run-nethtest.yml
+++ b/.github/workflows/run-nethtest.yml
@@ -539,6 +539,13 @@ jobs:
             )
             EXCLUSIONS="$(IFS='|'; echo "${KNOWN_FAILURES[*]}")"
             echo "extra_filter=(?!(?:$EXCLUSIONS)).*" >> "$GITHUB_OUTPUT"
+
+            # Every for_bogota fixture states inclusionListSatisfied, so a release that stopped stating it
+            # would leave the EIP-7805 fork-choice rule uncovered with the lane still green. An explicit
+            # `filter` input may legitimately narrow the run to nothing, so it opts out.
+            if [ -z "$FILTER" ]; then
+              echo "min_il_assertions=1" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
           echo "fixture_dir=$FIXTURE_DIR" >> "$GITHUB_OUTPUT"
@@ -555,6 +562,7 @@ jobs:
           EEST_ARCHIVE: ${{ steps.eest_release.outputs.archive }}
           RUNNER_FLAG: ${{ steps.fixtures.outputs.runner_flag }}
           EXTRA_FILTER: ${{ steps.fixtures.outputs.extra_filter }}
+          MIN_IL_ASSERTIONS: ${{ steps.fixtures.outputs.min_il_assertions }}
         run: |
           # Empty for every test type that declares no known-failure exclusions.
           [ -z "$FILTER" ] && FILTER="$EXTRA_FILTER"
@@ -572,6 +580,10 @@ jobs:
           fi
           if [ -n "$BATCHREAD" ]; then
             SETUP_ARGS="$SETUP_ARGS --batchRead $BATCHREAD"
+          fi
+          # Tripwire against fixtures that stop stating inclusionListSatisfied; see the fixtures step.
+          if [ -n "$MIN_IL_ASSERTIONS" ]; then
+            SETUP_ARGS="$SETUP_ARGS --minFcuInclusionListAssertions $MIN_IL_ASSERTIONS"
           fi
 
           RUNNER_TMP="${RUNNER_TEMP:-/tmp}"

--- a/src/Nethermind/Ethereum.Basic.Test/EngineInclusionListExpectationTests.cs
+++ b/src/Nethermind/Ethereum.Basic.Test/EngineInclusionListExpectationTests.cs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#nullable enable annotations
+
+using System;
+using Ethereum.Test.Base;
+using Nethermind.Serialization.Json;
+using NUnit.Framework;
+
+namespace Ethereum.Basic.Test;
+
+// EIP-7805 compliance is reported twice: by engine_newPayloadV6 and again by the fork-choice update to
+// that head. The harness only ever asserted the first, so the fork-choice rule had no fixture coverage.
+[TestFixture]
+public class EngineInclusionListExpectationTests
+{
+    private const string Unasserted = "unasserted";
+
+    private static readonly IJsonSerializer _serializer = new EthereumJsonSerializer();
+
+    [TestCase("{}", ExpectedResult = Unasserted, TestName = "Silent fixture leaves the fork-choice response unasserted")]
+    [TestCase("""{"newPayloadVersion": "6"}""", ExpectedResult = Unasserted, TestName = "Pre-EIP-7805 fixture is unaffected")]
+    // execution-apis bogota.md: a head just deemed VALID by newPayload must repeat its compliance answer.
+    [TestCase("""{"inclusionListSatisfied": true}""", ExpectedResult = "True", TestName = "Satisfied payload is inherited")]
+    [TestCase("""{"inclusionListSatisfied": false}""", ExpectedResult = "False", TestName = "Unsatisfied payload is inherited")]
+    [TestCase("""{"inclusionListSatisfied": true, "forkchoiceUpdatedInclusionListSatisfied": false}""", ExpectedResult = "False", TestName = "Override wins over the inherited value")]
+    [TestCase("""{"inclusionListSatisfied": true, "forkchoiceUpdatedInclusionListSatisfied": null}""", ExpectedResult = "null", TestName = "Explicit null demands an absent field")]
+    [TestCase("""{"forkchoiceUpdatedInclusionListSatisfied": true}""", ExpectedResult = "True", TestName = "Override alone")]
+    public string Fixture_forkchoice_expectation_is_parsed(string json)
+    {
+        TestEngineNewPayloadsJson enginePayload = _serializer.Deserialize<TestEngineNewPayloadsJson>(json);
+        return JsonToEthereumTest.TryParseForkchoiceInclusionListSatisfied(enginePayload, out bool? expected)
+            ? expected?.ToString() ?? "null"
+            : Unasserted;
+    }
+
+    [Test]
+    public void Unparsable_forkchoice_expectation_is_not_silently_ignored() =>
+        Assert.That(() => JsonToEthereumTest.TryParseForkchoiceInclusionListSatisfied(
+                _serializer.Deserialize<TestEngineNewPayloadsJson>("""{"forkchoiceUpdatedInclusionListSatisfied": "yes"}"""), out _),
+            Throws.TypeOf<FormatException>());
+}

--- a/src/Nethermind/Ethereum.Basic.Test/EngineInclusionListExpectationTests.cs
+++ b/src/Nethermind/Ethereum.Basic.Test/EngineInclusionListExpectationTests.cs
@@ -47,11 +47,30 @@ public class EngineInclusionListExpectationTests
 
     [TestCase("{}", true, ExpectedResult = null, TestName = "Silent fixture accepts any answer")]
     [TestCase("""{"inclusionListSatisfied": true}""", true, ExpectedResult = null, TestName = "Reported value matches")]
-    [TestCase("""{"inclusionListSatisfied": true}""", false, ExpectedResult = "engine_forkchoiceUpdatedV5 reported inclusionListSatisfied=False, expected True", TestName = "Reported value contradicts")]
-    [TestCase("""{"inclusionListSatisfied": true}""", null, ExpectedResult = "engine_forkchoiceUpdatedV5 reported inclusionListSatisfied=null, expected True", TestName = "Field absent where one was expected")]
+    [TestCase("""{"inclusionListSatisfied": true}""", false, ExpectedResult = "engine_forkchoiceUpdatedV5 returned VALID and reported inclusionListSatisfied=False, expected True", TestName = "Reported value contradicts")]
+    [TestCase("""{"inclusionListSatisfied": true}""", null, ExpectedResult = "engine_forkchoiceUpdatedV5 returned VALID and reported inclusionListSatisfied=null, expected True", TestName = "Field absent where one was expected")]
     [TestCase("""{"inclusionListSatisfied": true, "forkchoiceUpdatedInclusionListSatisfied": null}""", null, ExpectedResult = null, TestName = "Field absent as demanded")]
     public string? Forkchoice_response_is_checked_against_the_fixture(string json, bool? reported) =>
         BlockchainTestBase.DescribeFcuInclusionListMismatch(ForkchoiceResponse(reported), _serializer.Deserialize<TestEngineNewPayloadsJson>(json), fcuVersion: 5);
+
+    // A head that never became VALID reports no compliance either, so the message must not read as an
+    // EIP-7805 contradiction.
+    [Test]
+    public void Non_valid_head_is_named_rather_than_blamed_on_the_inclusion_list() =>
+        Assert.That(BlockchainTestBase.DescribeFcuInclusionListMismatch(
+                ForkchoiceResponse(null, PayloadStatus.Syncing),
+                _serializer.Deserialize<TestEngineNewPayloadsJson>("""{"inclusionListSatisfied": true}"""), fcuVersion: 5),
+            Is.EqualTo("engine_forkchoiceUpdatedV5 returned SYNCING and reported inclusionListSatisfied=null, expected True"));
+
+    // A version that cannot carry the field must fail rather than read as an absent one, or a null
+    // expectation would pass vacuously while counting as a check that ran.
+    [TestCase("""{"inclusionListSatisfied": true}""", TestName = "Boolean expectation against an older version")]
+    [TestCase("""{"forkchoiceUpdatedInclusionListSatisfied": null}""", TestName = "Null expectation against an older version")]
+    public void Fork_choice_version_that_cannot_report_compliance_is_a_mismatch(string json) =>
+        Assert.That(BlockchainTestBase.DescribeFcuInclusionListMismatch(
+                ResultWrapper<ForkchoiceUpdatedV1Result>.Success(new ForkchoiceUpdatedV1Result()),
+                _serializer.Deserialize<TestEngineNewPayloadsJson>(json), fcuVersion: 4),
+            Does.StartWith("engine_forkchoiceUpdatedV4 answered with ForkchoiceUpdatedV1Result, which cannot report inclusionListSatisfied"));
 
     // A release that dropped the field would leave the rule uncovered with every test still green, so the
     // FOCIL lane gates on how many checks actually ran.
@@ -66,9 +85,9 @@ public class EngineInclusionListExpectationTests
         return BlockchainTestBase.FcuInclusionListAssertionCount - before;
     }
 
-    private static ResultWrapper<ForkchoiceUpdatedV2Result> ForkchoiceResponse(bool? inclusionListSatisfied) =>
+    private static ResultWrapper<ForkchoiceUpdatedV2Result> ForkchoiceResponse(bool? inclusionListSatisfied, string status = PayloadStatus.Valid) =>
         ResultWrapper<ForkchoiceUpdatedV2Result>.Success(new ForkchoiceUpdatedV2Result
         {
-            PayloadStatus = new PayloadStatusV2 { Status = PayloadStatus.Valid, InclusionListSatisfied = inclusionListSatisfied }
+            PayloadStatus = new PayloadStatusV2 { Status = status, InclusionListSatisfied = inclusionListSatisfied }
         });
 }

--- a/src/Nethermind/Ethereum.Basic.Test/EngineInclusionListExpectationTests.cs
+++ b/src/Nethermind/Ethereum.Basic.Test/EngineInclusionListExpectationTests.cs
@@ -5,6 +5,8 @@
 
 using System;
 using Ethereum.Test.Base;
+using Nethermind.JsonRpc;
+using Nethermind.Merge.Plugin.Data;
 using Nethermind.Serialization.Json;
 using NUnit.Framework;
 
@@ -12,7 +14,9 @@ namespace Ethereum.Basic.Test;
 
 // EIP-7805 compliance is reported twice: by engine_newPayloadV6 and again by the fork-choice update to
 // that head. The harness only ever asserted the first, so the fork-choice rule had no fixture coverage.
+// The assertion counter is process-wide, so these cases measure it one at a time.
 [TestFixture]
+[NonParallelizable]
 public class EngineInclusionListExpectationTests
 {
     private const string Unasserted = "unasserted";
@@ -40,4 +44,31 @@ public class EngineInclusionListExpectationTests
         Assert.That(() => JsonToEthereumTest.TryParseForkchoiceInclusionListSatisfied(
                 _serializer.Deserialize<TestEngineNewPayloadsJson>("""{"forkchoiceUpdatedInclusionListSatisfied": "yes"}"""), out _),
             Throws.TypeOf<FormatException>());
+
+    [TestCase("{}", true, ExpectedResult = null, TestName = "Silent fixture accepts any answer")]
+    [TestCase("""{"inclusionListSatisfied": true}""", true, ExpectedResult = null, TestName = "Reported value matches")]
+    [TestCase("""{"inclusionListSatisfied": true}""", false, ExpectedResult = "engine_forkchoiceUpdatedV5 reported inclusionListSatisfied=False, expected True", TestName = "Reported value contradicts")]
+    [TestCase("""{"inclusionListSatisfied": true}""", null, ExpectedResult = "engine_forkchoiceUpdatedV5 reported inclusionListSatisfied=null, expected True", TestName = "Field absent where one was expected")]
+    [TestCase("""{"inclusionListSatisfied": true, "forkchoiceUpdatedInclusionListSatisfied": null}""", null, ExpectedResult = null, TestName = "Field absent as demanded")]
+    public string? Forkchoice_response_is_checked_against_the_fixture(string json, bool? reported) =>
+        BlockchainTestBase.DescribeFcuInclusionListMismatch(ForkchoiceResponse(reported), _serializer.Deserialize<TestEngineNewPayloadsJson>(json), fcuVersion: 5);
+
+    // A release that dropped the field would leave the rule uncovered with every test still green, so the
+    // FOCIL lane gates on how many checks actually ran.
+    [TestCase("{}", ExpectedResult = 0, TestName = "Silent fixture is not counted")]
+    [TestCase("""{"newPayloadVersion": "6"}""", ExpectedResult = 0, TestName = "Pre-EIP-7805 fixture is not counted")]
+    [TestCase("""{"inclusionListSatisfied": true}""", ExpectedResult = 1, TestName = "Inherited expectation is counted")]
+    [TestCase("""{"forkchoiceUpdatedInclusionListSatisfied": null}""", ExpectedResult = 1, TestName = "Absent-field expectation is counted")]
+    public long Only_the_checks_that_run_are_counted(string json)
+    {
+        long before = BlockchainTestBase.FcuInclusionListAssertionCount;
+        BlockchainTestBase.DescribeFcuInclusionListMismatch(ForkchoiceResponse(true), _serializer.Deserialize<TestEngineNewPayloadsJson>(json), fcuVersion: 5);
+        return BlockchainTestBase.FcuInclusionListAssertionCount - before;
+    }
+
+    private static ResultWrapper<ForkchoiceUpdatedV2Result> ForkchoiceResponse(bool? inclusionListSatisfied) =>
+        ResultWrapper<ForkchoiceUpdatedV2Result>.Success(new ForkchoiceUpdatedV2Result
+        {
+            PayloadStatus = new PayloadStatusV2 { Status = PayloadStatus.Valid, InclusionListSatisfied = inclusionListSatisfied }
+        });
 }

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -490,6 +490,11 @@ public abstract class BlockchainTestBase
 
                 if (expectWitness)
                 {
+                    // The witness result has no PayloadStatusV2, so a payload-side expectation would be
+                    // skipped silently; the fork-choice update below still carries one.
+                    Assert.That(enginePayload.InclusionListSatisfied, Is.Null,
+                        $"engine_newPayloadWithWitnessV{newPayloadVersion} cannot report inclusionListSatisfied, which this fixture states");
+
                     using NewPayloadWithWitnessV1Result witnessResult = GetWitnessResult(npResponse, newPayloadVersion);
                     PayloadStatusV1 payloadStatus = new() { Status = witnessResult.Status, ValidationError = witnessResult.ValidationError, LatestValidHash = witnessResult.LatestValidHash };
                     AssertPayloadStatus(payloadStatus, validationError, newPayloadVersion);
@@ -632,10 +637,11 @@ public abstract class BlockchainTestBase
     /// </summary>
     /// <remarks>
     /// Counts every expectation it checks in <see cref="FcuInclusionListAssertionCount"/>, so a run can tell
-    /// the rule holding apart from the fixtures having stopped stating it. A response that is not of the V5
-    /// shape reads as an absent field, so a boolean expectation answered by an older fork-choice version
-    /// fails; a null expectation cannot tell that apart from V5 answering null, which is harmless while every
-    /// fixture stating one runs against V5.
+    /// the rule holding apart from the fixtures having stopped stating it. A fork-choice version that cannot
+    /// carry the field is a mismatch in its own right rather than an absent field, so it can neither satisfy
+    /// an expectation nor pass a null one vacuously while still counting as a check that ran. The reported
+    /// payload status is named too: an FCU answering SYNCING also reports no compliance, and that is a
+    /// different failure from the head being VALID and disagreeing.
     /// </remarks>
     internal static string? DescribeFcuInclusionListMismatch(JsonRpcResponse response, TestEngineNewPayloadsJson enginePayload, int fcuVersion)
     {
@@ -643,13 +649,14 @@ public abstract class BlockchainTestBase
 
         Interlocked.Increment(ref _fcuInclusionListAssertions);
 
-        bool? actual = (response as IResultWrapper)?.Data is ForkchoiceUpdatedV2Result result
-            ? result.PayloadStatus.InclusionListSatisfied
-            : null;
+        if ((response as IResultWrapper)?.Data is not ForkchoiceUpdatedV2Result result)
+            return $"engine_forkchoiceUpdatedV{fcuVersion} answered with {((response as IResultWrapper)?.Data ?? response).GetType().Name}, which cannot report inclusionListSatisfied, expected {expected?.ToString() ?? "null"}";
+
+        bool? actual = result.PayloadStatus.InclusionListSatisfied;
 
         return actual == expected
             ? null
-            : $"engine_forkchoiceUpdatedV{fcuVersion} reported inclusionListSatisfied={actual?.ToString() ?? "null"}, expected {expected?.ToString() ?? "null"}";
+            : $"engine_forkchoiceUpdatedV{fcuVersion} returned {result.PayloadStatus.Status} and reported inclusionListSatisfied={actual?.ToString() ?? "null"}, expected {expected?.ToString() ?? "null"}";
     }
 
     private static void AssertFcuInclusionListSatisfied(JsonRpcResponse response, TestEngineNewPayloadsJson enginePayload, int fcuVersion) =>

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -56,6 +56,19 @@ public abstract class BlockchainTestBase
     private static readonly ILogger _logger = _logManager.GetClassLogger<BlockchainTestBase>();
     private const int _genesisProcessingTimeoutMs = 30000;
 
+    private static long _fcuInclusionListAssertions;
+
+    /// <summary>
+    /// How many fork-choice responses have had their <c>inclusionListSatisfied</c> asserted in this process
+    /// (EIP-7805), counted across every test run so far.
+    /// </summary>
+    /// <remarks>
+    /// A fixture that states no expectation leaves the response unasserted, so a fixture release that stopped
+    /// stating one would return this rule to zero coverage with the lane still green. A run that is supposed
+    /// to cover the rule gates on this being non-zero — see nethtest's <c>--minFcuInclusionListAssertions</c>.
+    /// </remarks>
+    public static long FcuInclusionListAssertionCount => Volatile.Read(ref _fcuInclusionListAssertions);
+
     /// <summary>
     /// Override to force parallel or sequential BAL execution in tests.
     /// Null means use the default config value.
@@ -496,7 +509,9 @@ public abstract class BlockchainTestBase
                             CompareWitnesses(blockHash, enginePayload.ExecutionWitness!, witnessResult.ExecutionWitness, witnessDifferences);
                         }
 
-                        AssertRpcSuccess(await SendFcu(rpcService, rpcContext, fcuVersion, blockHash.ToString()));
+                        JsonRpcResponse fcuResponse = await SendFcu(rpcService, rpcContext, fcuVersion, blockHash.ToString());
+                        AssertRpcSuccess(fcuResponse);
+                        AssertFcuInclusionListSatisfied(fcuResponse, enginePayload, fcuVersion);
                     }
                 }
                 else
@@ -612,24 +627,33 @@ public abstract class BlockchainTestBase
     }
 
     /// <summary>
-    /// Asserts the inclusion-list compliance reported by the fork-choice update that follows a payload,
-    /// when the fixture states an expectation for it (EIP-7805).
+    /// Describes why the inclusion-list compliance reported by the fork-choice update that follows a payload
+    /// contradicts the fixture (EIP-7805), or null when it matches or the fixture states no expectation.
     /// </summary>
     /// <remarks>
-    /// A response that is not of the V5 shape reads as an absent field rather than an error: answering a
-    /// fixture that expects a value with an older fork-choice version is itself the failure.
+    /// Counts every expectation it checks in <see cref="FcuInclusionListAssertionCount"/>, so a run can tell
+    /// the rule holding apart from the fixtures having stopped stating it. A response that is not of the V5
+    /// shape reads as an absent field, so a boolean expectation answered by an older fork-choice version
+    /// fails; a null expectation cannot tell that apart from V5 answering null, which is harmless while every
+    /// fixture stating one runs against V5.
     /// </remarks>
-    private static void AssertFcuInclusionListSatisfied(JsonRpcResponse response, TestEngineNewPayloadsJson enginePayload, int fcuVersion)
+    internal static string? DescribeFcuInclusionListMismatch(JsonRpcResponse response, TestEngineNewPayloadsJson enginePayload, int fcuVersion)
     {
-        if (!JsonToEthereumTest.TryParseForkchoiceInclusionListSatisfied(enginePayload, out bool? expected)) return;
+        if (!JsonToEthereumTest.TryParseForkchoiceInclusionListSatisfied(enginePayload, out bool? expected)) return null;
+
+        Interlocked.Increment(ref _fcuInclusionListAssertions);
 
         bool? actual = (response as IResultWrapper)?.Data is ForkchoiceUpdatedV2Result result
             ? result.PayloadStatus.InclusionListSatisfied
             : null;
 
-        Assert.That(actual, Is.EqualTo(expected),
-            $"engine_forkchoiceUpdatedV{fcuVersion} reported inclusionListSatisfied={actual?.ToString() ?? "null"}, expected {expected?.ToString() ?? "null"}");
+        return actual == expected
+            ? null
+            : $"engine_forkchoiceUpdatedV{fcuVersion} reported inclusionListSatisfied={actual?.ToString() ?? "null"}, expected {expected?.ToString() ?? "null"}";
     }
+
+    private static void AssertFcuInclusionListSatisfied(JsonRpcResponse response, TestEngineNewPayloadsJson enginePayload, int fcuVersion) =>
+        Assert.That(DescribeFcuInclusionListMismatch(response, enginePayload, fcuVersion), Is.Null);
 
     private static void AssertValidationError(string? actualError, string expectedError, int payloadVersion)
     {

--- a/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
+++ b/src/Nethermind/Ethereum.Test.Base/BlockchainTestBase.cs
@@ -511,7 +511,9 @@ public abstract class BlockchainTestBase
                     if (payloadStatus.Status is PayloadStatus.Valid or PayloadStatus.InclusionListUnsatisfied)
                     {
                         string blockHash = enginePayload.Params[0].GetProperty("blockHash").GetString()!;
-                        AssertRpcSuccess(await SendFcu(rpcService, rpcContext, fcuVersion, blockHash));
+                        JsonRpcResponse fcuResponse = await SendFcu(rpcService, rpcContext, fcuVersion, blockHash);
+                        AssertRpcSuccess(fcuResponse);
+                        AssertFcuInclusionListSatisfied(fcuResponse, enginePayload, fcuVersion);
                     }
                 }
             }
@@ -607,6 +609,26 @@ public abstract class BlockchainTestBase
 
         if (expectedValidationError is not null)
             AssertValidationError(payloadStatus.ValidationError, expectedValidationError, payloadVersion);
+    }
+
+    /// <summary>
+    /// Asserts the inclusion-list compliance reported by the fork-choice update that follows a payload,
+    /// when the fixture states an expectation for it (EIP-7805).
+    /// </summary>
+    /// <remarks>
+    /// A response that is not of the V5 shape reads as an absent field rather than an error: answering a
+    /// fixture that expects a value with an older fork-choice version is itself the failure.
+    /// </remarks>
+    private static void AssertFcuInclusionListSatisfied(JsonRpcResponse response, TestEngineNewPayloadsJson enginePayload, int fcuVersion)
+    {
+        if (!JsonToEthereumTest.TryParseForkchoiceInclusionListSatisfied(enginePayload, out bool? expected)) return;
+
+        bool? actual = (response as IResultWrapper)?.Data is ForkchoiceUpdatedV2Result result
+            ? result.PayloadStatus.InclusionListSatisfied
+            : null;
+
+        Assert.That(actual, Is.EqualTo(expected),
+            $"engine_forkchoiceUpdatedV{fcuVersion} reported inclusionListSatisfied={actual?.ToString() ?? "null"}, expected {expected?.ToString() ?? "null"}");
     }
 
     private static void AssertValidationError(string? actualError, string expectedError, int payloadVersion)

--- a/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
+++ b/src/Nethermind/Ethereum.Test.Base/JsonToEthereumTest.cs
@@ -119,6 +119,38 @@ namespace Ethereum.Test.Base
         }
 
         /// <summary>
+        /// Parses the <c>inclusionListSatisfied</c> an engine fixture expects on the fork-choice update
+        /// that follows the payload (EIP-7805).
+        /// </summary>
+        /// <param name="engineNewPayload">The fixture's engine payload entry.</param>
+        /// <param name="expected">The expected value, null meaning the field must be absent.</param>
+        /// <returns>False when the fixture states no expectation at all, leaving the response unasserted.</returns>
+        /// <remarks>
+        /// When only <c>inclusionListSatisfied</c> is given, execution-apis <c>bogota.md</c> pins the
+        /// fork-choice answer: the head was just deemed VALID by <c>engine_newPayloadV6</c>, so the
+        /// compliance answer determined there must be repeated.
+        /// </remarks>
+        /// <exception cref="FormatException">The override is neither a boolean nor null.</exception>
+        public static bool TryParseForkchoiceInclusionListSatisfied(TestEngineNewPayloadsJson engineNewPayload, out bool? expected)
+        {
+            JsonElement stated = engineNewPayload.ForkchoiceUpdatedInclusionListSatisfied;
+            if (stated.ValueKind == JsonValueKind.Undefined)
+            {
+                expected = engineNewPayload.InclusionListSatisfied;
+                return expected is not null;
+            }
+
+            expected = stated.ValueKind switch
+            {
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Null => null,
+                _ => throw new FormatException($"Invalid forkchoiceUpdatedInclusionListSatisfied: '{stated.GetRawText()}'")
+            };
+            return true;
+        }
+
+        /// <summary>
         /// Parses the JSON-RPC error code an engine fixture expects <c>engine_newPayloadV*</c> to
         /// answer with, or null when it expects the payload to be validated.
         /// </summary>

--- a/src/Nethermind/Ethereum.Test.Base/TestEngineNewPayloadsJson.cs
+++ b/src/Nethermind/Ethereum.Test.Base/TestEngineNewPayloadsJson.cs
@@ -14,6 +14,16 @@ namespace Ethereum.Test.Base
         // EIP-7805: expected PayloadStatusV2.inclusionListSatisfied; only meaningful for a VALID payload.
         public bool? InclusionListSatisfied { get; set; }
 
+        /// <summary>
+        /// The <c>inclusionListSatisfied</c> the fixture expects on the fork-choice update that follows the
+        /// payload, overriding the value inherited from <see cref="InclusionListSatisfied"/>.
+        /// </summary>
+        /// <remarks>
+        /// A JSON <c>null</c> asserts the field is absent, which an omitted property cannot express — hence
+        /// <see cref="JsonElement"/> (<c>Undefined</c> when the fixture is silent) rather than <c>bool?</c>.
+        /// </remarks>
+        public JsonElement ForkchoiceUpdatedInclusionListSatisfied { get; set; }
+
         public ExecutionWitnessJson? ExecutionWitness { get; set; }
         public bool? ExecutionWitnessMutated { get; set; }
 

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -158,6 +158,16 @@ internal class Program
         bool? parallelExecution = parseResult.GetValue(Options.ParallelExecution);
         bool? batchRead = parseResult.GetValue(Options.BatchRead);
 
+        int minFcuInclusionListAssertions = parseResult.GetValue(Options.MinFcuInclusionListAssertions);
+        if (minFcuInclusionListAssertions > 0 && !isEngineTest)
+        {
+            // No other mode drives engine_forkchoiceUpdated, so the count could only ever be zero and the
+            // coverage report below would blame the fixtures for a misuse of the option.
+            Console.Error.WriteLine("--minFcuInclusionListAssertions applies only to --engineTest.");
+            Console.Error.Flush();
+            return 1;
+        }
+
         if (parseResult.GetValue(Options.TrieDb))
         {
             Environment.SetEnvironmentVariable("TEST_USE_TRIE", "1");
@@ -217,7 +227,6 @@ internal class Program
 
         if (parseResult.GetValue(Options.Wait)) Console.ReadLine();
 
-        int minFcuInclusionListAssertions = parseResult.GetValue(Options.MinFcuInclusionListAssertions);
         if (minFcuInclusionListAssertions > 0)
         {
             // stdout carries the JSON results, and FAIL/EXCEPTION are per-test markers the CI summary counts.

--- a/src/Nethermind/Nethermind.Test.Runner/Program.cs
+++ b/src/Nethermind/Nethermind.Test.Runner/Program.cs
@@ -85,6 +85,9 @@ internal class Program
 
         public static Option<bool?> BatchRead { get; } =
             new("--batchRead") { Description = "Force BAL batch-read prewarming on or off; when omitted, the client config default is used. [Only for Blockchain/Engine Test]" };
+
+        public static Option<int> MinFcuInclusionListAssertions { get; } =
+            new("--minFcuInclusionListAssertions") { Description = "Fail the run unless the EIP-7805 inclusion-list expectation was asserted on at least this many engine_forkchoiceUpdated responses. Guards a FOCIL run against fixtures that stop stating the expectation, which would pass vacuously. [Only for Engine Test]" };
     }
 
     private static readonly IJsonSerializer _serializer = new EthereumJsonSerializer();
@@ -114,6 +117,7 @@ internal class Program
             Options.TrieDb,
             Options.ParallelExecution,
             Options.BatchRead,
+            Options.MinFcuInclusionListAssertions,
         ];
         rootCommand.SetAction(Run);
 
@@ -212,6 +216,22 @@ internal class Program
         }
 
         if (parseResult.GetValue(Options.Wait)) Console.ReadLine();
+
+        int minFcuInclusionListAssertions = parseResult.GetValue(Options.MinFcuInclusionListAssertions);
+        if (minFcuInclusionListAssertions > 0)
+        {
+            // stdout carries the JSON results, and FAIL/EXCEPTION are per-test markers the CI summary counts.
+            // Reported even when it passes, so coverage collapsing is visible before it reaches zero.
+            long asserted = BlockchainTestBase.FcuInclusionListAssertionCount;
+            Console.Error.WriteLine($"engine_forkchoiceUpdated inclusionListSatisfied asserted {asserted} time(s), required at least {minFcuInclusionListAssertions}");
+            Console.Error.Flush();
+            if (asserted < minFcuInclusionListAssertions)
+            {
+                Console.Error.WriteLine("\x1b[31mCOVERAGE GAP\x1b[0m the fixtures state no inclusion-list expectation, so this run does not cover the EIP-7805 fork-choice rule.");
+                Console.Error.Flush();
+                return 1;
+            }
+        }
 
         return 0;
     }


### PR DESCRIPTION
## Changes

The EEST harness asserted EIP-7805 `inclusionListSatisfied` on the `engine_newPayloadV6` response only. The follow-up `engine_forkchoiceUpdatedV5` was checked for RPC success and nothing else, so the fork-choice side of the rule had no fixture coverage at all.

- `BlockchainTestBase` now reads `payloadStatus.inclusionListSatisfied` off the fork-choice response and asserts it.
- The expectation is inherited from the payload's own `inclusionListSatisfied`. `execution-apis` `bogota.md` pins it for the flow the harness drives: the head was just deemed `VALID` by `engine_newPayloadV6`, so its compliance answer must be repeated.
- `TestEngineNewPayloadsJson` gains an optional `forkchoiceUpdatedInclusionListSatisfied` override for fixtures whose fork-choice expectation differs from the payload's — including an explicit `null`, which an omitted property cannot express.
- The `engine_newPayloadWithWitnessV*` branch asserted nothing on its fork-choice response either; it now runs the same assertion.

A fixture that states no `inclusionListSatisfied` leaves the fork-choice response unasserted, which keeps older fixture sets working — and is also the way this coverage could be lost again without anything turning red. So the harness counts the checks that actually run, and nethtest gains `--minFcuInclusionListAssertions`, which fails the run when that count falls below the given number. The workflow passes `1` for `focilTest` only, and only when no explicit `filter` input narrows the run; every other lane is unaffected, and the count is logged on success too, so a collapse is visible before it reaches zero.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [x] Other: test-harness conformance coverage

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`tests-focil-devnet@v0.2.0`, `blockchain_tests_engine/for_bogota`:

- `bogota/eip7805_focil`: 54/55 pass; the one failure is `test_block_with_failing_included_il_tx_is_valid[...scenario_creation_address_collision]`, already in the lane's `KNOWN_FAILURES`.
- A chunk of the full corpus with the lane's filter applied: 2494/2494 pass, 1959 fork-choice assertions fired.
- `Ethereum.Basic.Test` 60/60, `Nethermind.Merge.Plugin.Test` `EngineModuleTests` 946/946.

Backwards compatibility, by census rather than by inference — a green run over fixtures that all state the field says nothing about fixtures that do not:

| corpus | fixture files | test cases | `engineNewPayloads` entries | mention `inclusionListSatisfied` |
|---|---|---|---|---|
| `tests-glamsterdam-devnet@v8.1.4` `blockchain_tests_engine` | 11,030 | 80,369 | 99,264 | **0** |
| `tests-focil-devnet@v0.2.0` `blockchain_tests_engine/for_bogota` | 3,108 | 26,689 | 32,776 | **all** |

The denominator depends on how an engine fixture is filtered and an independent count of the same release differed; the zero is what carries the argument, and it is zero however the corpus is scoped. So no fixture outside the FOCIL release reaches the new assertion at all. Within the FOCIL release, 27,260 of the 32,776 entries reach it; the other 5,516 state `true` but expect the payload to be rejected, and the existing `VALID`-only guard skips them. A slice of `for_amsterdam` engine fixtures run without the new option is unchanged: 716/716 pass.

Positive control for the tripwire — one variable, the presence of the field in the fixtures:

| run | fixtures | tests | exit | log |
|---|---|---|---|---|
| green | `bogota/eip7805_focil` as shipped | 54/54 pass | 0 | `asserted 55 time(s), required at least 1` |
| red | same, with the field removed from all 56 entries | 54/54 pass | 1 | `asserted 0 time(s)` + `COVERAGE GAP` |

The stripped run is exactly the failure mode this guards: every test still passes and nothing about the rule is being checked. The tripwire is the only thing that separates the two.

Positive control for the assertion itself: inverting the value returned by `ForkchoiceUpdatedWithInclusionList` turned the FOCIL directory from 54/55 to 0/55, with 54 failures attributed to the new assertion — 33 in the `true` direction and 21 in the `false` direction. The break was then reverted.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

**This covers the cached-answer path only, and must not be read as evidence for anything else.**

The harness always hands a processable block its full inclusion list, so every case it produces lands on `VALID` or `INCLUSION_LIST_UNSATISFIED` and the fork-choice update always finds the answer retained from `engine_newPayloadV6`. The retain-and-recompute branch — where the head's `newPayloadV6` went unanswered (`SYNCING`/`ACCEPTED`) and the fork-choice update has to validate during the call — is never reached.

Reaching it needs a fixture that leaves a head's `newPayloadV6` unanswered and then fork-choice-updates to it, which is a fixture-shape question for `execution-spec-tests`, not something to synthesise in the harness. Out of scope here.

Concretely: a green run of this harness is **not** conformance evidence for the recomputation path that draft #13385 adds. Treating local green as evidence about a path it never exercised is exactly the conflation that led to an earlier PR being opened and retracted on a wrong premise.

### Known limitation

The `engine_newPayloadWithWitnessV*` branch now asserts the fork-choice response, but still not the payload response: `NewPayloadWithWitnessV1Result` carries no `inclusionListSatisfied` field, so covering that side means changing the engine API result type rather than the harness. Nothing exercises it today — no engine fixture in either release carries an `executionWitness` (0 of 11,030 and 0 of 3,108) — so this is recorded rather than fixed.

