### PR TITLE
perf: memoize the warm-access check, settle EXTCODEHASH with one account read

### DIFF
--- a/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
@@ -45,7 +45,7 @@ public class CodeInfoRepositoryTests
         Address address = Address.FromNumber((UInt256)(ulong)number);
         CodeInfo expected = new(Substitute.For<IPrecompile>());
 
-        IPrecompileProvider provider = NoPrecompiles();
+        IPrecompileProvider provider = Substitute.For<IPrecompileProvider>();
         provider.GetPrecompiles().Returns(new Dictionary<AddressAsKey, CodeInfo>
         {
             [Address.FromNumber(UInt256.One)] = new(Substitute.For<IPrecompile>()),

--- a/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/CodeInfoRepositoryTests.cs
@@ -45,7 +45,7 @@ public class CodeInfoRepositoryTests
         Address address = Address.FromNumber((UInt256)(ulong)number);
         CodeInfo expected = new(Substitute.For<IPrecompile>());
 
-        IPrecompileProvider provider = Substitute.For<IPrecompileProvider>();
+        IPrecompileProvider provider = NoPrecompiles();
         provider.GetPrecompiles().Returns(new Dictionary<AddressAsKey, CodeInfo>
         {
             [Address.FromNumber(UInt256.One)] = new(Substitute.For<IPrecompile>()),
@@ -58,6 +58,71 @@ public class CodeInfoRepositoryTests
         CodeInfoRepository repository = new(Substitute.For<IWorldState>(), provider);
 
         Assert.That(repository.GetCachedCodeInfo(address, false, spec, out _), Is.SameAs(expected));
+    }
+
+    private static IPrecompileProvider NoPrecompiles()
+    {
+        IPrecompileProvider provider = Substitute.For<IPrecompileProvider>();
+        provider.GetPrecompiles().Returns(FrozenDictionary<AddressAsKey, CodeInfo>.Empty);
+        return provider;
+    }
+
+    /// <summary>Replacing an account's code must be visible immediately, not answered from the memo.</summary>
+    /// <remarks>
+    /// <see cref="CacheCodeInfoRepository"/> remembers the code it last resolved so a repeated query skips
+    /// the shared cache's probe. The memo is keyed on the code hash, which is re-read from the world state
+    /// on every call, so a changed or reverted deployment misses it — this pins that, since a stale hit
+    /// would run the wrong bytecode.
+    /// </remarks>
+    [Test]
+    public void Changed_code_is_not_answered_from_the_last_resolved_code()
+    {
+        byte[] first = [(byte)Instruction.STOP];
+        byte[] second = [(byte)Instruction.JUMPDEST, (byte)Instruction.STOP];
+
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        CacheCodeInfoRepository repository = new(stateProvider, NoPrecompiles(), new StaticCodeCache(64));
+
+        stateProvider.CreateAccount(TestItem.AddressA, 0);
+        stateProvider.InsertCode(TestItem.AddressA, first, _releaseSpec);
+
+        // Resolve twice so the second answer is the one the memo serves.
+        Assert.That(repository.GetCachedCodeInfo(TestItem.AddressA, false, _releaseSpec, out _).CodeSpan.ToArray(), Is.EqualTo(first));
+        Assert.That(repository.GetCachedCodeInfo(TestItem.AddressA, false, _releaseSpec, out _).CodeSpan.ToArray(), Is.EqualTo(first));
+
+        stateProvider.InsertCode(TestItem.AddressA, second, _releaseSpec);
+
+        Assert.That(repository.GetCachedCodeInfo(TestItem.AddressA, false, _releaseSpec, out _).CodeSpan.ToArray(), Is.EqualTo(second));
+    }
+
+    /// <summary>Two accounts sharing a code hash share its body; a different one must not be confused.</summary>
+    [Test]
+    public void Different_accounts_resolve_their_own_code()
+    {
+        byte[] shared = [(byte)Instruction.STOP];
+        byte[] other = [(byte)Instruction.JUMPDEST, (byte)Instruction.STOP];
+
+        IWorldState stateProvider = TestWorldStateFactory.CreateForTest();
+        using IDisposable scope = stateProvider.BeginScope(IWorldState.PreGenesis);
+        CacheCodeInfoRepository repository = new(stateProvider, NoPrecompiles(), new StaticCodeCache(64));
+
+        foreach (Address address in (Address[])[TestItem.AddressA, TestItem.AddressB, TestItem.AddressC])
+        {
+            stateProvider.CreateAccount(address, 0);
+        }
+
+        stateProvider.InsertCode(TestItem.AddressA, shared, _releaseSpec);
+        stateProvider.InsertCode(TestItem.AddressB, shared, _releaseSpec);
+        stateProvider.InsertCode(TestItem.AddressC, other, _releaseSpec);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(repository.GetCachedCodeInfo(TestItem.AddressA, false, _releaseSpec, out _).CodeSpan.ToArray(), Is.EqualTo(shared));
+            Assert.That(repository.GetCachedCodeInfo(TestItem.AddressC, false, _releaseSpec, out _).CodeSpan.ToArray(), Is.EqualTo(other));
+            Assert.That(repository.GetCachedCodeInfo(TestItem.AddressB, false, _releaseSpec, out _).CodeSpan.ToArray(), Is.EqualTo(shared));
+            Assert.That(repository.GetCachedCodeInfo(TestItem.AddressC, false, _releaseSpec, out _).CodeSpan.ToArray(), Is.EqualTo(other));
+        }
     }
 
     [Test]

--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -16,6 +16,53 @@ namespace Nethermind.Evm.Test;
 
 public class EthereumGasPolicyTests
 {
+    /// <summary>A cell warmed after a snapshot must read cold again once that snapshot is restored.</summary>
+    /// <remarks>
+    /// <see cref="StackAccessTracker.IsCold(in StorageCell)"/> remembers the last cell it found warm, so a
+    /// repeated read answers without probing the set. Only a restore or the pooled reset can take a cell
+    /// back out, and this pins that the memo is dropped there — were it not, a reverted warm-up would keep
+    /// reporting warm and the next access would be charged warm gas instead of cold.
+    /// </remarks>
+    [Test]
+    public void Reverted_warm_up_is_cold_again()
+    {
+        StorageCell cell = new(TestItem.AddressA, UInt256.One);
+        StorageCell other = new(TestItem.AddressB, UInt256.One);
+        using StackAccessTracker tracker = new();
+
+        tracker.TakeSnapshot();
+        tracker.WarmUp(in cell);
+
+        // Read it twice: the second read is the one served from the memo.
+        Assert.That(tracker.IsCold(in cell), Is.False);
+        Assert.That(tracker.IsCold(in cell), Is.False);
+
+        tracker.Restore();
+
+        Assert.That(tracker.IsCold(in cell), Is.True, "the warm-up was reverted");
+        Assert.That(tracker.IsCold(in other), Is.True);
+    }
+
+    /// <summary>The memo must answer for the cell it remembers, not for a different one.</summary>
+    [Test]
+    public void Warm_cell_does_not_make_other_cells_warm()
+    {
+        StorageCell warm = new(TestItem.AddressA, UInt256.One);
+        StorageCell sameAddressOtherSlot = new(TestItem.AddressA, new UInt256(2));
+        StorageCell otherAddressSameSlot = new(TestItem.AddressB, UInt256.One);
+        using StackAccessTracker tracker = new();
+
+        tracker.WarmUp(in warm);
+        Assert.That(tracker.IsCold(in warm), Is.False);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(tracker.IsCold(in sameAddressOtherSlot), Is.True);
+            Assert.That(tracker.IsCold(in otherAddressSameSlot), Is.True);
+            Assert.That(tracker.IsCold(in warm), Is.False, "still warm after the misses");
+        }
+    }
+
     [Test]
     public void Memory_cost_preserves_preexpanded_range_and_full_width_validation(
         [Values(0UL, 1UL, 31UL, 32UL, 33UL, ulong.MaxValue)] ulong offset,

--- a/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/EthereumGasPolicyTests.cs
@@ -43,6 +43,25 @@ public class EthereumGasPolicyTests
         Assert.That(tracker.IsCold(in other), Is.True);
     }
 
+    /// <summary>Returning a tracker to the pool must drop the remembered warm cell, or the next rental
+    /// serves a cold cell as warm across a transaction boundary — a genuinely cold SLOAD charged 100
+    /// instead of 2100.</summary>
+    /// <remarks>The pool's localCapacity is 1, so a same-thread dispose-then-rent reuses the one state
+    /// deterministically; this pins the Clear() -> ForgetWarm() path that Restore()'s test does not.</remarks>
+    [Test]
+    public void Pooled_reset_drops_the_remembered_cell()
+    {
+        StorageCell cell = new(TestItem.AddressA, UInt256.One);
+        using (StackAccessTracker first = new())
+        {
+            first.WarmUp(in cell);
+            Assert.That(first.IsCold(in cell), Is.False, "sets the memo");
+        }
+
+        using StackAccessTracker second = new();
+        Assert.That(second.IsCold(in cell), Is.True, "a pooled reset must forget the warm cell");
+    }
+
     /// <summary>The memo must answer for the cell it remembers, not for a different one.</summary>
     [Test]
     public void Warm_cell_does_not_make_other_cells_warm()

--- a/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
@@ -27,8 +27,9 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
     /// <summary>The code most recently resolved, so a repeat skips the shared cache's probe.</summary>
     /// <remarks>
     /// A single reference is self-validating: <see cref="StaticCodeCache"/> assigns <c>CodeHash</c> when it
-    /// stores, so matching against the hash re-read from the world state costs no allocation and cannot
-    /// tear. Anything that changes an account's code — including a reverted deployment — produces a
+    /// stores, so matching against the hash re-read from the world state costs no allocation, and a stale
+    /// read can only miss (a partially-written hash has no keccak preimage), never answer with the wrong
+    /// body. Anything that changes an account's code — including a reverted deployment — produces a
     /// different hash and misses; there is nothing to invalidate. Under <c>NoopCodeCache</c> (witness
     /// generation, stateless execution) the hash stays default and the memo never fires, which is exactly
     /// the every-lookup-through-the-world-state behaviour that mode requires.

--- a/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
@@ -24,11 +24,32 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
         _inner = new CodeInfoRepository(worldState, precompileProvider, GetOrCacheCodeInfo);
     }
 
+    /// <summary>The code most recently resolved, so a repeat skips the shared cache's probe.</summary>
+    /// <remarks>
+    /// Held as one immutable reference so a racing reader sees a matched hash and body or neither, never a
+    /// torn pair. The hash is re-read from the world state on every call, so anything that changes an
+    /// account's code — including a reverted deployment — produces a different hash and misses the memo;
+    /// there is nothing to invalidate.
+    /// </remarks>
+    private sealed class ResolvedCode(in ValueHash256 codeHash, CodeInfo codeInfo)
+    {
+        public readonly ValueHash256 CodeHash = codeHash;
+        public readonly CodeInfo CodeInfo = codeInfo;
+    }
+
+    private ResolvedCode? _lastResolved;
+
     private CodeInfo GetOrCacheCodeInfo(Address address, ValueHash256 codeHash, IReleaseSpec spec)
     {
         if (codeHash == ValueKeccak.OfAnEmptyString)
         {
             return CodeInfo.Empty;
+        }
+
+        ResolvedCode? lastResolved = _lastResolved;
+        if (lastResolved is not null && lastResolved.CodeHash == codeHash)
+        {
+            return lastResolved.CodeInfo;
         }
 
         CodeInfo? cachedCodeInfo = _codeCache.Get(in codeHash);
@@ -42,6 +63,7 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
             Metrics.IncrementCodeDbCache();
         }
 
+        _lastResolved = new ResolvedCode(in codeHash, cachedCodeInfo);
         return cachedCodeInfo;
     }
 

--- a/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
+++ b/src/Nethermind/Nethermind.Evm/CacheCodeInfoRepository.cs
@@ -26,18 +26,14 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
 
     /// <summary>The code most recently resolved, so a repeat skips the shared cache's probe.</summary>
     /// <remarks>
-    /// Held as one immutable reference so a racing reader sees a matched hash and body or neither, never a
-    /// torn pair. The hash is re-read from the world state on every call, so anything that changes an
-    /// account's code — including a reverted deployment — produces a different hash and misses the memo;
-    /// there is nothing to invalidate.
+    /// A single reference is self-validating: <see cref="StaticCodeCache"/> assigns <c>CodeHash</c> when it
+    /// stores, so matching against the hash re-read from the world state costs no allocation and cannot
+    /// tear. Anything that changes an account's code — including a reverted deployment — produces a
+    /// different hash and misses; there is nothing to invalidate. Under <c>NoopCodeCache</c> (witness
+    /// generation, stateless execution) the hash stays default and the memo never fires, which is exactly
+    /// the every-lookup-through-the-world-state behaviour that mode requires.
     /// </remarks>
-    private sealed class ResolvedCode(in ValueHash256 codeHash, CodeInfo codeInfo)
-    {
-        public readonly ValueHash256 CodeHash = codeHash;
-        public readonly CodeInfo CodeInfo = codeInfo;
-    }
-
-    private ResolvedCode? _lastResolved;
+    private CodeInfo? _lastResolved;
 
     private CodeInfo GetOrCacheCodeInfo(Address address, ValueHash256 codeHash, IReleaseSpec spec)
     {
@@ -46,10 +42,12 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
             return CodeInfo.Empty;
         }
 
-        ResolvedCode? lastResolved = _lastResolved;
+        CodeInfo? lastResolved = _lastResolved;
         if (lastResolved is not null && lastResolved.CodeHash == codeHash)
         {
-            return lastResolved.CodeInfo;
+            // A memo hit is a cache hit: keep cache.code.hits and the cached-contracts-used stats counting.
+            Metrics.IncrementCodeDbCache();
+            return lastResolved;
         }
 
         CodeInfo? cachedCodeInfo = _codeCache.Get(in codeHash);
@@ -63,7 +61,7 @@ public class CacheCodeInfoRepository : ICodeInfoRepository
             Metrics.IncrementCodeDbCache();
         }
 
-        _lastResolved = new ResolvedCode(in codeHash, cachedCodeInfo);
+        _lastResolved = cachedCodeInfo;
         return cachedCodeInfo;
     }
 

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -54,7 +54,9 @@ public sealed partial class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     public IPrecompile? Precompile { get; }
 
     private readonly JumpDestinationAnalyzer? _analyzer;
-    public ValueHash256 CodeHash { get; set; }
+    /// <remarks>Written only by <see cref="StaticCodeCache"/> on insert; <c>CacheCodeInfoRepository</c>'s
+    /// last-resolved memo validates a hit against it, so the write must stay confined to the cache.</remarks>
+    public ValueHash256 CodeHash { get; internal set; }
 
     /// <summary>
     /// Returns <c>true</c> when this instance represents non-executable empty bytecode.

--- a/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
+++ b/src/Nethermind/Nethermind.Evm/CodeAnalysis/CodeInfo.cs
@@ -54,8 +54,12 @@ public sealed partial class CodeInfo : IThreadPoolWorkItem, IEquatable<CodeInfo>
     public IPrecompile? Precompile { get; }
 
     private readonly JumpDestinationAnalyzer? _analyzer;
+    /// <summary>The keccak of the code, assigned when the cache stores this instance.</summary>
     /// <remarks>Written only by <see cref="StaticCodeCache"/> on insert; <c>CacheCodeInfoRepository</c>'s
-    /// last-resolved memo validates a hit against it, so the write must stay confined to the cache.</remarks>
+    /// last-resolved memo validates a hit against it, so the write must stay confined to the cache. An
+    /// instance that never passed through <c>ICodeCache.Set</c> — a precompile, <see cref="Empty"/>, or
+    /// anything resolved under <c>NoopCodeCache</c> — therefore reports <c>default</c> rather than its
+    /// own hash.</remarks>
     public ValueHash256 CodeHash { get; internal set; }
 
     /// <summary>

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -633,7 +633,7 @@ public static partial class EvmInstructions
         // The dead check is three more reads — balance, nonce, and the same code hash again — and EIP-1052
         // only needs them to tell an empty account (push zero) from a codeless live one (push the empty hash).
         ValueHash256 hash = state.GetCodeHash(address);
-        if (hash != Keccak.OfAnEmptyString.ValueHash256)
+        if (hash != ValueKeccak.OfAnEmptyString)
         {
             return stack.Push32Bytes<TTracingInst, OnFlag>(in hash);
         }

--- a/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
+++ b/src/Nethermind/Nethermind.Evm/Instructions/EvmInstructions.Environment.cs
@@ -628,13 +628,19 @@ public static partial class EvmInstructions
         if (!TSpec.TryConsumeAccountAccessGas<TGasPolicy>(ref gas, spec, in vm.VmState.AccessTracker, vm.IsTracingAccess, address)) goto OutOfGas;
 
         IWorldState state = vm.WorldState;
-        // For dead accounts, the specification requires pushing zero.
-        if (state.IsDeadAccount(address))
-        {
-            return stack.PushZero<TTracingInst, OnFlag>();
-        }
+
+        // An account with code cannot be dead, so reading its hash first settles both questions at once.
+        // The dead check is three more reads — balance, nonce, and the same code hash again — and EIP-1052
+        // only needs them to tell an empty account (push zero) from a codeless live one (push the empty hash).
         ValueHash256 hash = state.GetCodeHash(address);
-        return stack.Push32Bytes<TTracingInst, OnFlag>(in hash);
+        if (hash != Keccak.OfAnEmptyString.ValueHash256)
+        {
+            return stack.Push32Bytes<TTracingInst, OnFlag>(in hash);
+        }
+
+        return state.IsDeadAccount(address)
+            ? stack.PushZero<TTracingInst, OnFlag>()
+            : stack.Push32Bytes<TTracingInst, OnFlag>(in hash);
         // Jump forward to be unpredicted by the branch predictor.
     OutOfGas:
         return EvmExceptionType.OutOfGas;

--- a/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
+++ b/src/Nethermind/Nethermind.Evm/StackAccessTracker.cs
@@ -30,7 +30,24 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
 
     public readonly bool IsCold(Address? address) => address is null || !_trackingState.AccessedAddresses.Contains(address);
 
-    public readonly bool IsCold(in StorageCell storageCell) => !_trackingState.AccessedStorageCells.Contains(storageCell);
+    /// <remarks>
+    /// A loop reading one slot asks this of the same cell every iteration, and the set probe costs about as
+    /// much as the storage read that follows it. Remembering the last cell found warm answers the repeat
+    /// from an inlined compare. Only <see cref="Restore"/> and the pooled reset can take a cell back out of
+    /// the set, and both forget it; adding never invalidates, so a remembered cell cannot go stale warm.
+    /// </remarks>
+    public readonly bool IsCold(in StorageCell storageCell)
+    {
+        if (_trackingState.IsKnownWarm(in storageCell)) return false;
+
+        if (_trackingState.AccessedStorageCells.Contains(storageCell))
+        {
+            _trackingState.RememberWarm(in storageCell);
+            return false;
+        }
+
+        return true;
+    }
 
     public readonly bool WarmUp(Address address)
         => _trackingState.AccessedAddresses.Add(address);
@@ -73,6 +90,7 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
         {
             _trackingState.AccessedAddresses.Restore(_addressesSnapshots);
             _trackingState.AccessedStorageCells.Restore(_storageKeysSnapshots);
+            _trackingState.ForgetWarm();
         }
         _trackingState.DestroyList.Restore(_destroyListSnapshots);
         _trackingState.Logs.Restore(_logsSnapshots);
@@ -109,8 +127,22 @@ public struct StackAccessTracker(bool isTracingAccess) : IDisposable
         public JournalSet<Address> DestroyList { get; } = new(Address.EqualityComparer);
         public HashSet<AddressAsKey> CreateList { get; } = new(AddressAsKey.EqualityComparer);
 
+        private StorageCell _lastWarmCell;
+        private bool _hasLastWarmCell;
+
+        public bool IsKnownWarm(in StorageCell storageCell) => _hasLastWarmCell && _lastWarmCell.Equals(in storageCell);
+
+        public void RememberWarm(in StorageCell storageCell)
+        {
+            _lastWarmCell = storageCell;
+            _hasLastWarmCell = true;
+        }
+
+        public void ForgetWarm() => _hasLastWarmCell = false;
+
         private void Clear()
         {
+            ForgetWarm();
             AccessedAddresses.Clear();
             AccessedStorageCells.Clear();
             Logs.Clear();


### PR DESCRIPTION
## Changes

Split out of the original #13414 (per review scheduling around #13420): this PR carries only the
EVM-side pieces, which do not overlap #13420's storage-value rewrite. Siblings: the benchmark scenarios are #13421 and the storage-provider memos are #13422.

- `StackAccessTracker.IsCold(in StorageCell)` remembers the last cell it found warm and answers a
  repeat from an inlined compare. A loop reading one slot asks the identical question every iteration
  and paid the full `HashSet<StorageCell>` probe each time — about as much as the storage read it
  precedes. Adding to the set never invalidates the memo (a warm cell stays warm); the only operations
  that take a cell back out are `Restore` and the pooled `Clear`, and both forget it.
- `EXTCODEHASH` settles with **one account read instead of four**. It asked whether the account was
  dead before reading the code hash, and that check is itself three reads — balance, nonce, and the
  same hash again. An account with code cannot be dead, so reading the hash first answers both; the
  EIP-1052 dead check remains for the empty-hash case only.
- Tests for the last-resolved-code memo in `CacheCodeInfoRepository` (the memo itself is already on
  master via #13311): a changed deployment must not be answered from the memo, and two accounts
  sharing a code hash resolve their own code.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `Reverted_warm_up_is_cold_again` — warm a cell after a snapshot, read it twice so the second read is
  served by the memo, restore, and assert it reads cold again. **Verified to fail** when the
  invalidation is removed from `Restore`.
- `Changed_code_is_not_answered_from_the_last_resolved_code` and
  `Different_accounts_resolve_their_own_code` — both **fail** if the memo stops comparing the hash.

`Nethermind.Evm.Test` 12,462 passed / 0 failed on the split branch.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Measured on `BlockProcessingBenchmark.Sload_SameKey` (scenarios in the sibling PR), base and branch
interleaved: the warm-access memo alone takes a warm `SLOAD` iteration from 80.6/79.8 ns to
60.5/56.8 ns (**-27%**); `EXTCODEHASH` (Amsterdam) 42.1/46.2 -> 28.9/28.8 ns (**-35%**). The further
drop to ~26 ns comes from the storage-provider read memo in the sibling PR.

The same memo on the address side was measured and dropped: a warm `BALANCE` costs only ~19 ns after
loop overhead, and the memo moved it within noise (27.0/25.4 -> 25.5/36.9 ns).
