### PR TITLE
fix(core): stop ElapsedMicroseconds overflowing on long-running stopwatches

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/StopwatchExtensionsTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/StopwatchExtensionsTests.cs
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System.Diagnostics;
+using System.Threading;
+using Nethermind.Core.Extensions;
+using NUnit.Framework;
+
+namespace Nethermind.Core.Test;
+
+[TestFixture]
+public class StopwatchExtensionsTests
+{
+    // On Linux, Stopwatch.Frequency is 1_000_000_000 (nanosecond ticks), so `ticks * 1_000_000`
+    // overflows long once ticks exceeds ~9.22e12 (~2h33m of elapsed time).
+    [TestCase(10_000_000_000_000L, 1_000_000_000L, 10_000_000_000L)] // ~2h46m of 1GHz ticks: overflows the naive `ticks * 1_000_000` formula
+    [TestCase(long.MaxValue, 1_000_000_000L, 9_223_372_036_854_775L)] // largest possible tick count: the naive formula wraps clean through zero here
+    [TestCase(123_456_789L, 10_000_000L, 12_345_678L)] // Windows-style 10MHz QPC frequency, non-multiple ticks
+    [TestCase(1_500L, 1_000_000_000L, 1L)] // sub-microsecond precision truncates rather than rounds
+    [TestCase(0L, 1_000_000_000L, 0L)] // zero elapsed ticks
+    public void ToMicroseconds_computes_elapsed_microseconds_without_overflow(long ticks, long frequency, long expected) =>
+        Assert.That(StopwatchExtensions.ToMicroseconds(ticks, frequency), Is.EqualTo(expected));
+
+    [Test]
+    public void ElapsedMicroseconds_matches_stopwatch_elapsed()
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+        Thread.Sleep(5);
+        stopwatch.Stop();
+
+        long microseconds = stopwatch.ElapsedMicroseconds();
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(microseconds, Is.GreaterThanOrEqualTo(0));
+            Assert.That((double)microseconds, Is.EqualTo(stopwatch.Elapsed.TotalMicroseconds).Within(1));
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Core/Extensions/StopwatchExtensions.cs
+++ b/src/Nethermind/Nethermind.Core/Extensions/StopwatchExtensions.cs
@@ -7,6 +7,17 @@ namespace Nethermind.Core.Extensions
 {
     public static class StopwatchExtensions
     {
-        public static long ElapsedMicroseconds(this Stopwatch stopwatch) => stopwatch.ElapsedTicks * 1000000 / Stopwatch.Frequency;
+        public static long ElapsedMicroseconds(this Stopwatch stopwatch) => ToMicroseconds(stopwatch.ElapsedTicks, Stopwatch.Frequency);
+
+        /// <remarks>
+        /// Splitting <paramref name="ticks"/> into a whole-second part and a sub-second remainder keeps
+        /// every intermediate value within <see langword="long"/> range, unlike
+        /// <c>ticks * 1000000 / frequency</c>, which overflows once <paramref name="ticks"/> exceeds
+        /// roughly <see langword="long"/>.MaxValue / 1000000 (about 2h33m at the 1GHz
+        /// <see cref="Stopwatch.Frequency"/> on Linux). The result is exact for any
+        /// <paramref name="frequency"/> of at least 1MHz; below that, the microsecond count no longer
+        /// fits in a <see langword="long"/>.
+        /// </remarks>
+        internal static long ToMicroseconds(long ticks, long frequency) => ticks / frequency * 1000000 + ticks % frequency * 1000000 / frequency;
     }
 }


### PR DESCRIPTION
Fixes #6847

## Changes

### What

`StopwatchExtensions.ElapsedMicroseconds` computed `ElapsedTicks * 1000000 / Stopwatch.Frequency`. On Linux `Stopwatch.Frequency` is 1,000,000,000, so the product overflows `long` once `ElapsedTicks` exceeds `long.MaxValue / 1000000` = 9,223,372,036,854 ticks — 2 h 33 min 43 s of elapsed time — and wraps negative.

The conversion moves into an internal pure helper, `ToMicroseconds(long ticks, long frequency)`, that splits ticks into whole seconds and a sub-second remainder before scaling: `ticks / frequency * 1000000 + ticks % frequency * 1000000 / frequency`. Every intermediate stays within `long`, the result is exact for any frequency of at least 1 MHz, and it is bit-identical to the old expression below the overflow threshold. The public `ElapsedMicroseconds` signature is unchanged.

### Why this shows up as negative slot times

`ProcessingStats._runStopwatch` is started once and never reset, so `RunMicroseconds` drops by 18,446,744 ms (2^64 / 1e9 µs) each time the product crosses the sign boundary — that is the negative `slot ... ms` value reported in the issue — and `BlockStatistics.SlotMs` carries it through to the monitoring data feed.

### Implementation note

The helper is `internal` rather than `private` because a sealed `Stopwatch` cannot be made to report 10^13 ticks in a unit test — exercising the overflow region needs calling the conversion directly. `Nethermind.Core` already exposes internals to `Nethermind.Core.Test` via `InternalsVisibleTo`.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

New `Nethermind.Core.Test/StopwatchExtensionsTests.cs`.

`ToMicroseconds_computes_elapsed_microseconds_without_overflow` runs five `[TestCase]` rows: the first overflow region at 1 GHz, `long.MaxValue` ticks at 1 GHz, 10 MHz with a remainder, sub-microsecond truncation, and zero. The two overflow rows fail on the old expression (`-8446744073` and `0` respectively) and pass on the fix.

`ElapsedMicroseconds_matches_stopwatch_elapsed` covers the extension-to-helper wiring against a stopped stopwatch, within 1 µs.

`dotnet test src/Nethermind/Nethermind.Core.Test/Nethermind.Core.Test.csproj -c release -- --filter "FullyQualifiedName~StopwatchExtensionsTests"` passes; the full `Nethermind.Core.Test` project also passes — 6386 succeeded, 108 skipped, 0 failed. `dotnet format whitespace src/Nethermind/ --folder --verify-no-changes` is clean.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No

## Remarks

Issue #5995 is an older duplicate of the same symptom (negative slot times in the monitoring feed); not added as a second `Fixes` keyword since GitHub only closes the first issue reference in a PR.

Two adjacent notes, to save reviewers a look:

- `src/Nethermind/Nethermind.Blockchain.Test.Runner/PerfStateTest.cs:50` computes `1_000_000_000L * ElapsedTicks / Frequency` and wraps after about 9.2 s at 1 GHz, but its stopwatch is restarted per state test and it only feeds a developer console print, not node output; left out on purpose to keep this change inside `Nethermind.Core`.
- `BlockchainProcessor`'s other `ElapsedMicroseconds` call site uses a per-block restarted stopwatch, so it never reached the overflow; it picks up the new arithmetic with no behaviour change.

