### PR TITLE
EIP-8141: return every call frame the callTracer still owns

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -36,7 +36,6 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
 
     private EvmExceptionType? _error;
     private ulong _remainingGas;
-    private bool _resultBuilt = false;
 
     public NativeCallTracer(
         Transaction? tx,
@@ -75,7 +74,6 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
         }
 
         result.TxHash = _txHash;
-        _resultBuilt = true;
 
         return result;
     }
@@ -83,12 +81,9 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
     public override void Dispose()
     {
         base.Dispose();
-        for (int i = _resultBuilt ? 1 : 0; i < _callStack.Count; i++)
-        {
-            _callStack[i].Dispose();
-        }
 
-        _callStack.Dispose();
+        // BuildResult already removed the frame it handed to the trace, so everything still here is ours.
+        _callStack.DisposeRecursive();
     }
 
     public override void ReportAction(ulong gas, UInt256 value, Address from, Address to, ReadOnlyMemory<byte> input, ExecutionType callType, bool isPrecompileCall = false)

--- a/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Tracing/GethStyle/Custom/Native/Call/NativeCallTracer.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
-using System.Diagnostics;
 using System.Text.Json;
 using Nethermind.Core;
 using Nethermind.Core.Collections;
@@ -60,8 +59,6 @@ public sealed class NativeCallTracer : GethLikeNativeTxTracer
     public override GethLikeTxTrace BuildResult()
     {
         GethLikeTxTrace result = base.BuildResult();
-
-        Debug.Assert(_callStack.Count <= 1, $"Unexpected frames on call stack, expected at most one master frame, found {_callStack.Count} frames.");
 
         if (_callStack.Count is not 0)
         {

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.IO;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using Nethermind.Core;
+using Nethermind.Core.Collections;
 using Nethermind.Core.Extensions;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test;
@@ -682,6 +684,63 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
         Assert.That(
             () => tracer.ReportLog(new LogEntry(TestItem.AddressA, [], [])),
             Throws.Nothing);
+    }
+
+    [Test]
+    public void Test_CallTrace_EveryTopLevelFrame_IsReturnedToThePool()
+    {
+#if DEBUG
+        // BuildResult asserts a single root, which aborts a checked build before reaching the disposal below.
+        Assert.Ignore("more than one root trips BuildResult's single-root Debug.Assert in a checked build");
+#endif
+        Transaction tx = Build.A.Transaction.WithGasLimit(100000).TestObject;
+        NativeCallTracer tracer = new(tx, CancunSpec, GetGethTraceOptions(null));
+
+        // Two top-level invocations, which is what a transaction running more than one frame produces:
+        // each frame enters at depth 0, so each leaves its own root on the call stack.
+        ReportTopLevelInvocation(tracer, TestItem.AddressB);
+        ReportTopLevelInvocation(tracer, TestItem.AddressC);
+
+        NativeCallTracerCallFrame[] roots = TopLevelFramesOf(tracer);
+        Assert.That(roots, Has.Length.EqualTo(2), "both top-level invocations should be on the call stack");
+
+        tracer.MarkAsSuccess(TestItem.AddressB, new GasConsumed(21000, 21000), [], []);
+        GethLikeTxTrace trace = tracer.BuildResult();
+        tracer.Dispose();
+        trace.Dispose();
+
+        using (Assert.EnterMultipleScope())
+        {
+            for (int i = 0; i < roots.Length; i++)
+            {
+                Assert.That(IsReturnedToPool(roots[i]), Is.True, $"top-level frame {i} never returned its pooled buffers");
+            }
+        }
+    }
+
+    private static void ReportTopLevelInvocation(NativeCallTracer tracer, Address to)
+    {
+        tracer.ReportAction(50000, 1, TestItem.AddressA, to, ReadOnlyMemory<byte>.Empty, ExecutionType.CALL);
+        tracer.ReportActionEnd(40000ul, ReadOnlyMemory<byte>.Empty);
+    }
+
+    private static NativeCallTracerCallFrame[] TopLevelFramesOf(NativeCallTracer tracer) =>
+        ((ArrayPoolList<NativeCallTracerCallFrame>)typeof(NativeCallTracer)
+            .GetField("_callStack", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(tracer)!).AsSpan().ToArray();
+
+    /// <summary>Reports whether a call frame's rented buffers went back to the pool, which is what disposing it does.</summary>
+    private static bool IsReturnedToPool(NativeCallTracerCallFrame callFrame)
+    {
+        try
+        {
+            _ = callFrame.Calls.AsSpan().Length;
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
     }
 
     private static GethLikeTxTrace TraceAmsterdamTopCall(bool withSubFrame)

--- a/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
+++ b/src/Nethermind/Nethermind.Evm.Test/Tracing/GethLikeCallTracerTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System;
+using System.Buffers;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -29,6 +31,8 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
 {
     private static readonly JsonSerializerOptions SerializerOptions = new(EthereumJsonSerializer.JsonOptionsIndented) { NewLine = "\n" };
     private static readonly IReleaseSpec CancunSpec = MainnetSpecProvider.Instance.GetSpec(MainnetSpecProvider.CancunActivation);
+    // ArrayPoolList only returns a rental when its capacity is non-zero.
+    private const int ProbeBufferCapacity = 32;
     internal const string? WithLog = """{"withLog":true}""";
     internal const string? OnlyTopCall = """{"onlyTopCall":true}""";
     internal const string? WithLogAndOnlyTopCall = """{"withLog":true,"onlyTopCall":true}""";
@@ -689,10 +693,8 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
     [Test]
     public void Test_CallTrace_EveryTopLevelFrame_IsReturnedToThePool()
     {
-#if DEBUG
-        // BuildResult asserts a single root, which aborts a checked build before reaching the disposal below.
-        Assert.Ignore("more than one root trips BuildResult's single-root Debug.Assert in a checked build");
-#endif
+        // A plain transaction, deliberately: only a root BuildResult leaves behind can be skipped, and a
+        // frame transaction's roots are folded into the one synthetic root the trace takes ownership of.
         Transaction tx = Build.A.Transaction.WithGasLimit(100000).TestObject;
         NativeCallTracer tracer = new(tx, CancunSpec, GetGethTraceOptions(null));
 
@@ -706,6 +708,13 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
 
         tracer.MarkAsSuccess(TestItem.AddressB, new GasConsumed(21000, 21000), [], []);
         GethLikeTxTrace trace = tracer.BuildResult();
+
+        TrackingPool[] pools = new TrackingPool[roots.Length];
+        for (int i = 0; i < roots.Length; i++)
+        {
+            pools[i] = AttachRentalProbe(roots[i]);
+        }
+
         tracer.Dispose();
         trace.Dispose();
 
@@ -713,7 +722,7 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
         {
             for (int i = 0; i < roots.Length; i++)
             {
-                Assert.That(IsReturnedToPool(roots[i]), Is.True, $"top-level frame {i} never returned its pooled buffers");
+                Assert.That(pools[i].Returned, Has.Count.EqualTo(1), $"top-level frame {i} never returned its pooled buffers");
             }
         }
     }
@@ -729,18 +738,25 @@ public class GethLikeCallTracerTests : VirtualMachineTestsBase
             .GetField("_callStack", BindingFlags.Instance | BindingFlags.NonPublic)!
             .GetValue(tracer)!).AsSpan().ToArray();
 
-    /// <summary>Reports whether a call frame's rented buffers went back to the pool, which is what disposing it does.</summary>
-    private static bool IsReturnedToPool(NativeCallTracerCallFrame callFrame)
+    /// <summary>Gives a call frame a buffer rented from a pool of its own, so that whether the frame was
+    /// disposed can be read off that pool rather than inferred from the frame.</summary>
+    /// <returns>The pool, which receives the rental back when the frame is disposed.</returns>
+    /// <remarks>The frame's own buffers come from the shared pool and it exposes no seam to swap that, so the
+    /// probe is attached through <see cref="NativeCallTracerCallFrame.Output"/>. Disposing a frame disposes
+    /// every buffer it holds, so a returned rental here means the whole frame went back.</remarks>
+    private static TrackingPool AttachRentalProbe(NativeCallTracerCallFrame callFrame)
     {
-        try
-        {
-            _ = callFrame.Calls.AsSpan().Length;
-            return false;
-        }
-        catch (ObjectDisposedException)
-        {
-            return true;
-        }
+        TrackingPool pool = new();
+        callFrame.Output?.Dispose();
+        callFrame.Output = new ArrayPoolList<byte>(pool, ProbeBufferCapacity);
+        return pool;
+    }
+
+    private sealed class TrackingPool : ArrayPool<byte>
+    {
+        public List<byte[]> Returned { get; } = [];
+        public override byte[] Rent(int minimumLength) => new byte[minimumLength];
+        public override void Return(byte[] array, bool clearArray = false) => Returned.Add(array);
     }
 
     private static GethLikeTxTrace TraceAmsterdamTopCall(bool withSubFrame)


### PR DESCRIPTION
## Changes

Addresses the **disposal skew** raised in the `NativeCallTracer` review thread on #12526. The
representation half of that thread — every frame after the first missing from the result, the
`Debug.Assert`, and the transaction-wide gas landing on the first frame — is #13399's; this is the
pooling-lifetime half, which survives that fix untouched.

`BuildResult` hands one call frame to the trace and removes it from `_callStack`, so after it runs
nothing on the stack has been given away. `Dispose` nevertheless started its loop at index
`_resultBuilt ? 1 : 0`. Once `RemoveAt(0)` has shifted everything down, index 0 holds a frame the
tracer still owns, and skipping it means its pooled `Input`, `Calls` and `Logs` buffers are never
returned to the pool — churn rather than a leak, since the arrays stay GC-reclaimable, but the
rentals are lost.

The fix removes the index arithmetic and the `_resultBuilt` field that existed only to feed it:
everything the stack still holds belongs to the tracer, so `Dispose` returns all of it. The skew
becomes unreachable by construction rather than by argument — there is no longer a rule about which
frames `Dispose` may skip that a later change could quietly invalidate.

### On the `Debug.Assert`

Now that this branch has merged #13399, `CollapseFrameRoots()` runs immediately above the stack's use
in `BuildResult` and leaves a frame transaction with exactly one root, while a plain transaction
pushes exactly one depth-0 root. No production path reaches that line with two roots:
`BlockTracerBase.StartNewTxTrace` builds a fresh tracer per transaction, so no stack carries across.
The unqualified `Debug.Assert(_callStack.Count <= 1, ...)` therefore no longer guards against a live
crash — the only state that trips it is the one the regression test below builds by hand.

Rather than drop it, it is narrowed to the claim #13399 actually makes:

```csharp
// CollapseFrameRoots folds a frame transaction's per-frame roots into one synthetic root.
Debug.Assert(!_isFrameTx || _callStack.Count <= 1, $"Expected one collapsed root, found {_callStack.Count} frames.");
```

This still keeps the collapse checked — forcing a frame transaction to reach `BuildResult` with a
second depth-0 root after `MarkAsSuccess` has already collapsed aborts a checked build with
`Expected one collapsed root, found 2 frames.` — while leaving the disposal test, which uses a plain
transaction deliberately, able to run in both configurations.

## Testing

`Test_CallTrace_EveryTopLevelFrame_IsReturnedToThePool` drives the tracer through two top-level
invocations, captures the roots, then disposes both the trace and the tracer and asserts that every
root returned its rented buffers. The probe is a rental the test hands each root from a pool it owns,
so the assertion is a rent/return balance rather than a read of incidental `ArrayPoolList` behaviour.
Reverting only the `Dispose` change fails it — `top-level frame 1 never returned its pooled buffers` —
in release and in a checked build alike, and it passes with the fix in both.

A plain transaction is used deliberately: only a root `BuildResult` leaves behind can be skipped, and
#13399 folds a frame transaction's roots into one synthetic root that the trace then owns, which
would make the probe pass whatever `Dispose` does.

- [x] `Nethermind.Blockchain.Test`, `Nethermind.Evm.Test`, `Nethermind.JsonRpc.Test` and
      `Nethermind.JsonRpc.TraceStore.Test` pass in release and in a checked build
- [x] Builds with 0 warnings; lint gate clean and positive-controlled

## Types of changes

- [x] Bug fix (a non-breaking change that fixes an issue)

## Documentation

- [x] Requires documentation update: **no**
