### PR TITLE
fix(logging): stop Init.LogRules bypassing Seq.MinLevel

### DIFF
--- a/src/Nethermind/Nethermind.Logging.NLog.Test/NLogManagerTests.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog.Test/NLogManagerTests.cs
@@ -1,11 +1,16 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using NLog;
 using NLog.Config;
+using NLog.Targets;
+using NLog.Targets.Wrappers;
 using NUnit.Framework;
+using Level = NLog.LogLevel;
 
 namespace Nethermind.Logging.NLog.Test
 {
@@ -50,20 +55,165 @@ namespace Nethermind.Logging.NLog.Test
         [Test]
         public void Create_removes_overwritten_rules()
         {
-            _ = new NLogManager("test", null, "*:Error");
-            Assert.That(LogManager.Configuration.LoggingRules, Has.Count.EqualTo(1));
+            // Reload the linked NLog.config into a fresh configuration so this test's outcome
+            // does not depend on rule mutations left behind by other tests in this fixture.
+            string configPath = Path.Combine(AppContext.BaseDirectory, "NLog.config");
+            LogManager.Configuration = new XmlLoggingConfiguration(configPath);
 
-            LoggingRule rule = LogManager.Configuration.LoggingRules.Single();
+            using (new NLogManager("test", null, "*:Error")) { }
+
+            // The shipped catch-all rule writing to seq survives alongside the synthesised "*" rule;
+            // every other shipped rule matches "*" and is overridden.
+            Assert.That(LogManager.Configuration.LoggingRules, Has.Count.EqualTo(2));
+
+            LoggingRule seqRule = LogManager.Configuration.LoggingRules.Single(r => r.Targets.Any(t => t.Name == "seq"));
+            LoggingRule synthesisedRule = LogManager.Configuration.LoggingRules.Single(r => r != seqRule);
+
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(rule.LoggerNamePattern, Is.EqualTo("*"));
-                Assert.That(rule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Trace), Is.False);
-                Assert.That(rule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Debug), Is.False);
-                Assert.That(rule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Info), Is.False);
-                Assert.That(rule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Warn), Is.False);
-                Assert.That(rule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Error), Is.True);
-                Assert.That(rule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Fatal), Is.True);
+                Assert.That(seqRule.LoggerNamePattern, Is.EqualTo("*"));
+                Assert.That(seqRule.Targets.Select(t => t.Name), Is.EqualTo(new[] { "seq" }));
+
+                Assert.That(synthesisedRule.LoggerNamePattern, Is.EqualTo("*"));
+                Assert.That(synthesisedRule.Targets.Select(t => t.Name), Does.Not.Contain("seq"));
+                Assert.That(synthesisedRule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Trace), Is.False);
+                Assert.That(synthesisedRule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Debug), Is.False);
+                Assert.That(synthesisedRule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Info), Is.False);
+                Assert.That(synthesisedRule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Warn), Is.False);
+                Assert.That(synthesisedRule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Error), Is.True);
+                Assert.That(synthesisedRule.IsLoggingEnabledForLevel(global::NLog.LogLevel.Fatal), Is.True);
             }
+        }
+
+        [Test]
+        public void Log_rules_do_not_write_to_seq_target()
+        {
+            // Reload the linked NLog.config into a fresh configuration so this test's outcome
+            // does not depend on rule mutations left behind by other tests in this fixture.
+            string configPath = Path.Combine(AppContext.BaseDirectory, "NLog.config");
+            LogManager.Configuration = new XmlLoggingConfiguration(configPath);
+
+            using (new NLogManager("test", null, "Synchronization.*:Trace"))
+            {
+                LoggingRule rule = LogManager.Configuration.LoggingRules.Single(r => r.LoggerNamePattern == "Synchronization.*");
+                string[] targetNames = rule.Targets.Select(t => t.Name).ToArray();
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(targetNames, Does.Not.Contain("seq"));
+                    Assert.That(targetNames, Does.Contain("file-async"));
+                    Assert.That(targetNames, Does.Contain("auto-colored-console-async"));
+                }
+            }
+        }
+
+        private static LoggingConfiguration ConfigurationWith(params LoggingRule[] rules)
+        {
+            LoggingConfiguration configuration = new();
+            foreach (LoggingRule rule in rules)
+            {
+                configuration.LoggingRules.Add(rule);
+            }
+
+            return configuration;
+        }
+
+        [TestCase("*:Warn", false, TestName = "Seq_writing_rules_survive_Init_LogRules(catch_all_override)")]
+        [TestCase("Network.*:Trace", true, TestName = "Seq_writing_rules_survive_Init_LogRules(overlapping_namespace_override)")]
+        public void Seq_writing_rules_survive_Init_LogRules(string logRules, bool fileRuleSurvives)
+        {
+            MemoryTarget seq = new() { Name = "seq" };
+            MemoryTarget file = new() { Name = "file" };
+            LoggingRule seqCatchAll = new("*", Level.Trace, Level.Fatal, seq);
+            LoggingRule seqNetwork = new("Network.*", Level.Trace, Level.Fatal, seq);
+            LoggingRule fileCatchAll = new("*", Level.Trace, Level.Fatal, file);
+            LogManager.Configuration = ConfigurationWith(seqCatchAll, seqNetwork, fileCatchAll);
+
+            using (new NLogManager("test", null, logRules))
+            {
+                IList<LoggingRule> rules = LogManager.Configuration.LoggingRules;
+                // Identified by pattern and by not writing to seq, rather than "not one of the known
+                // pre-set rules": other fixtures in this class leave undisposed NLogManager instances
+                // subscribed to LogManager.ConfigurationChanged, which can inject unrelated rules into
+                // this configuration too.
+                string expectedPattern = logRules.Split(':')[0];
+                LoggingRule synthesised = rules.Single(r => r.LoggerNamePattern == expectedPattern && r.Targets.All(t => t.Name != "seq"));
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(rules, Does.Contain(seqCatchAll));
+                    Assert.That(rules, Does.Contain(seqNetwork));
+                    Assert.That(seqCatchAll.Targets.Select(t => t.Name), Is.EqualTo(new[] { "seq" }));
+                    Assert.That(seqNetwork.Targets.Select(t => t.Name), Is.EqualTo(new[] { "seq" }));
+                    Assert.That(seqCatchAll.IsLoggingEnabledForLevel(Level.Trace), Is.True);
+                    Assert.That(seqNetwork.IsLoggingEnabledForLevel(Level.Trace), Is.True);
+                    Assert.That(synthesised.Targets.Select(t => t.Name), Does.Not.Contain("seq"));
+                    Assert.That(rules.Contains(fileCatchAll), Is.EqualTo(fileRuleSurvives));
+                }
+            }
+        }
+
+        [Test]
+        public void Group_target_containing_seq_is_excluded_when_walked()
+        {
+            MemoryTarget seq = new() { Name = "seq" };
+            MemoryTarget file = new() { Name = "file" };
+            SplitGroupTarget all = new() { Name = "all" };
+            all.Targets.Add(seq);
+            all.Targets.Add(file);
+            LoggingRule ruleAll = new("*", Level.Trace, Level.Fatal, all);
+            LoggingRule ruleFile = new("*", Level.Trace, Level.Fatal, file);
+            LogManager.Configuration = ConfigurationWith(ruleAll, ruleFile);
+
+            using (new NLogManager("test", null, "Synchronization.*:Trace"))
+            {
+                LoggingRule synthesised = LogManager.Configuration.LoggingRules.Single(r => r.LoggerNamePattern == "Synchronization.*");
+                string[] targetNames = synthesised.Targets.Select(t => t.Name).ToArray();
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(targetNames, Does.Not.Contain("all"));
+                    Assert.That(targetNames, Does.Not.Contain("seq"));
+                    Assert.That(targetNames, Does.Contain("file"));
+                }
+            }
+        }
+
+        [Test]
+        public void Rule_reaching_seq_through_a_group_is_not_overridden_by_Init_LogRules()
+        {
+            MemoryTarget seq = new() { Name = "seq" };
+            MemoryTarget file = new() { Name = "file" };
+            SplitGroupTarget all = new() { Name = "all" };
+            all.Targets.Add(seq);
+            all.Targets.Add(file);
+            LoggingRule networkAll = new("Network.*", Level.Trace, Level.Fatal, all);
+            LoggingRule fileCatchAll = new("*", Level.Trace, Level.Fatal, file);
+            LogManager.Configuration = ConfigurationWith(networkAll, fileCatchAll);
+
+            using (new NLogManager("test", null, "Network.*:Warn"))
+            {
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(LogManager.Configuration.LoggingRules, Does.Contain(networkAll));
+                    Assert.That(networkAll.IsLoggingEnabledForLevel(Level.Trace), Is.True);
+                }
+            }
+        }
+
+        [Test]
+        public void No_rule_synthesised_when_every_target_reaches_seq()
+        {
+            MemoryTarget seq = new() { Name = "seq" };
+            LoggingRule seqCatchAll = new("*", Level.Trace, Level.Fatal, seq);
+            LogManager.Configuration = ConfigurationWith(seqCatchAll);
+
+            Assert.DoesNotThrow(() =>
+            {
+                using (new NLogManager("test", null, "Synchronization.*:Trace")) { }
+            });
+
+            Assert.That(LogManager.Configuration.LoggingRules.Any(r => r.LoggerNamePattern == "Synchronization.*"), Is.False);
         }
     }
 }

--- a/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
+++ b/src/Nethermind/Nethermind.Logging.NLog/NLogManager.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using NLog;
 using NLog.Config;
 using NLog.Targets;
+using NLog.Targets.Wrappers;
 using Level = NLog.LogLevel;
 
 namespace Nethermind.Logging.NLog;
@@ -18,6 +19,7 @@ public class NLogManager : ILogManager, IDisposable
 {
     private const string DefaultFileTargetName = "file-async_wrapped";
     private const string DefaultFolder = "logs";
+    private const string SeqTargetName = "seq";
 
     /// <summary>
     /// The constructor to use when the configuration is not yet initialized.
@@ -90,6 +92,11 @@ public class NLogManager : ILogManager, IDisposable
             lock (configurationLoggingRules)
             {
                 Target[] targets = GetTargets(configurationLoggingRules);
+                if (targets.Length == 0)
+                {
+                    return;
+                }
+
                 IEnumerable<LoggingRule> loggingRules = ParseRules(logRules, targets);
                 foreach (LoggingRule loggingRule in loggingRules)
                 {
@@ -100,15 +107,30 @@ public class NLogManager : ILogManager, IDisposable
         }
     }
 
+    /// <remarks>
+    /// Excludes anything that reaches the seq target: its floor is <c>Seq.MinLevel</c>, which the runner's
+    /// <c>NLogConfigurator</c> applies only to a catch-all ("*") rule whose target is named <c>seq</c> so that
+    /// <c>NLog.config</c> can still opt a single namespace into seq with an explicit <c>writeTo="seq"</c> rule
+    /// (#4835). A rule synthesised from <c>Init.LogRules</c> that fanned out to seq would bypass that floor
+    /// (#6911), and removing a seq-writing rule as "overridden" would leave seq with no rule at all.
+    /// </remarks>
     private static Target[] GetTargets(IList<LoggingRule> configurationLoggingRules) =>
-        configurationLoggingRules.SelectMany(static r => r.Targets).Distinct().ToArray();
+        configurationLoggingRules.SelectMany(static r => r.Targets).Where(static t => !WritesToSeq(t)).Distinct().ToArray();
 
+    /// <remarks>
+    /// Never removes a rule that writes to seq, for the same reason <see cref="GetTargets"/> excludes it from
+    /// the targets a synthesised rule can use — dropping it as "overridden" would leave seq with no rule at all.
+    /// A surviving rule keeps its own levels and targets, so <c>Init.LogRules</c> cannot raise or lower a
+    /// namespace that <c>NLog.config</c> already routes to seq, directly or through a group such as <c>all</c>,
+    /// and a <c>final="true"</c> rule of that shape suppresses the synthesised rule entirely. That matches the
+    /// node's behaviour with no <c>Init.LogRules</c> set: for those namespaces the config file is authoritative.
+    /// </remarks>
     private static void RemoveOverriddenRules(IList<LoggingRule> configurationLoggingRules, LoggingRule loggingRule)
     {
         string regexPattern = $"^{loggingRule.LoggerNamePattern.Replace(".", "\\.").Replace("*", ".*")}$";
         for (int j = 0; j < configurationLoggingRules.Count;)
         {
-            if (Regex.IsMatch(configurationLoggingRules[j].LoggerNamePattern, regexPattern))
+            if (Regex.IsMatch(configurationLoggingRules[j].LoggerNamePattern, regexPattern) && !configurationLoggingRules[j].Targets.Any(WritesToSeq))
             {
                 configurationLoggingRules.RemoveAt(j);
             }
@@ -118,6 +140,14 @@ public class NLogManager : ILogManager, IDisposable
             }
         }
     }
+
+    private static bool WritesToSeq(Target target) =>
+        target.Name == SeqTargetName || target switch
+        {
+            WrapperTargetBase wrapper => wrapper.WrappedTarget is not null && WritesToSeq(wrapper.WrappedTarget),
+            CompoundTargetBase compound => compound.Targets.Any(WritesToSeq),
+            _ => false
+        };
 
     private static IEnumerable<LoggingRule> ParseRules(string logRules, Target[] targets)
     {


### PR DESCRIPTION
Fixes #6911

## Changes

### What

`Init.LogRules` synthesises one rule per pattern, and `NLogManager` fanned that rule across every target found in the current configuration, including `seq`. `Seq.MinLevel` is applied by the runner's `NLogConfigurator` only to the catch-all `*` rule whose target is named `seq` — deliberately, since PR #4835, so `NLog.config` can route one namespace to Seq with an explicit `writeTo="seq"` rule, as documented in the config's commented samples. So `--log=DEBUG --Seq.MinLevel=Info --Init.LogRules=Synchronization.*:Trace` shipped Trace and Debug from `Synchronization.*` to Seq. Reproduced against the real Runner assemblies in `Program.cs` order.

The fix: a rule synthesised from `Init.LogRules` now neither writes to `seq` nor removes a rule that writes to `seq`. `GetTargets` filters synthesised targets through a `WritesToSeq` check, and `RemoveOverriddenRules` skips any existing rule for which that check is true. If no non-seq target remains, no rule is synthesised at all, instead of indexing an empty target array — and that case is now reported through NLog's internal logger, so an operator whose `Init.LogRules` had no effect can see why.

Two consequences worth stating plainly:

1. `Init.LogRules` no longer routes a raised namespace to Seq. `Seq.MinLevel` is the floor for the Seq target unless `NLog.config` opts a namespace in with `writeTo="seq"`.
2. `Init.LogRules` no longer deletes a config rule that routes a namespace to Seq, directly or through a group such as `all`. That rule keeps its own levels and targets, and a `final="true"` rule of that shape now suppresses the synthesised rule on the levels it covers itself. Both match what the node does with no `Init.LogRules` set. Previously, `Init.LogRules=*:Warn` collapsed everything into one rule that `Seq.MinLevel` then raised to Info on file and console too, and delivered every event twice through the `all` group; that is gone.

### Targets reached only through a group

`GetTargets` doesn't just drop a group target such as `all` whole because it reaches `seq` — it descends into the group and keeps the members that don't. Excluding the group wholesale meant a configuration whose only route to console and file was that group ignored `Init.LogRules` entirely, which is worse than the bug this PR fixes: it's a straight regression against current behaviour, not just a level that leaks to Seq. A wrapper in the chain (e.g. a buffering wrapper) is unwrapped only to look for a group behind it — its contents are never yielded, since targets inside a wrapper chain are unnamed and yielding them would slip past the `seq` name check and reopen #6911.

On the shipped `NLog.config` this descent is a no-op: the `all → all_wrapped → {console, seq, file}` members are reference-equal to the targets the shipped catch-all rules already name, so `Distinct()` collapses them, and no live rule in the shipped config actually uses `writeTo="all"` — every such line sits in the commented sample block. Descent only matters for an operator who replaces the three shipped catch-all rules with a single `*` rule targeting `all`.

That shape has one caveat, documented on `GetTargets`: unless the group rule is `final="true"`, its own delivery and the synthesised rule's both reach the group's non-seq members, so a level they share is written twice (seq is unaffected, since the synthesised rule excludes it either way). Suppressing the duplication in code was considered and rejected — inserting the synthesised rule ahead of the group rule with `Final=true` would also block the group's own seq delivery for that namespace, reopening the inverse of #6911. `final="true"` on the group rule is the fix on the operator's side.

### Why not a smaller-looking fix

- Raising the synthesised rule's own level to `Seq.MinLevel` instead of excluding `seq` would destroy the level the operator asked for on file and console too (measured).
- Relaxing the runner's guard to cover every rule that writes to `seq`, or adding a hard filter directly on the `seq` target, both kill the PR #4835 `writeTo="seq"` routing that this fix is careful to preserve (measured).

### Implementation note

`WritesToSeq` is a private recursive helper, not a name check, because the shipped `all` group target is `AsyncTargetWrapper → SplitGroup → seq` — a target can reach `seq` through a wrapper (e.g. a buffering wrapper) or through a compound/group target, and a plain name comparison would miss both. It walks `WrapperTargetBase.WrappedTarget` and `CompoundTargetBase.Targets` recursively until it finds `seq` or runs out of targets, tracking the targets it has already visited so a target cycle assembled in code (NLog itself drops one declared in XML) can't overflow the stack.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

Six more tests added in `Nethermind.Logging.NLog.Test/NLogManagerTests.cs` (16 in the project now):

- `Log_rules_do_not_write_to_seq_target` — against the real linked `NLog.config`, a synthesised rule never targets `seq`.
- `Seq_writing_rules_survive_Init_LogRules` — two cases, a catch-all `*:Warn` and an overlapping `Network.*:Trace`, confirming existing rules that write to `seq` are neither removed nor altered.
- `Group_target_containing_seq_is_excluded_when_walked` — a target reaching `seq` only through a `SplitGroupTarget` is still excluded from a synthesised rule.
- `Rule_reaching_seq_through_a_group_is_not_overridden_by_Init_LogRules` — the group-routed rule survives `RemoveOverriddenRules`.
- `No_rule_synthesised_when_every_target_reaches_seq` — no rule is synthesised, and nothing throws, when every existing target reaches `seq`.
- `Init_LogRules_that_cannot_be_applied_are_reported` — that case now writes a warning through `InternalLogger` naming the discarded pattern.
- `Wrapper_target_around_seq_is_excluded_from_Init_LogRules` — a wrapper around `seq` is excluded while a sibling target is kept, covering the wrapper branch of the walk directly.
- `Target_graph_with_a_cycle_is_walked_once` — a group target that contains itself is walked without overflowing the stack.
- `Init_LogRules_reach_the_non_seq_members_of_a_group_target` — with a `final="true"` rule to a group as the only route to `seq` and `file`, real log output confirms `file` gets the raised level and `seq` doesn't.
- `Non_final_group_rule_writes_shared_levels_twice` — same setup without `final`, pinning the documented double-delivery on the shared level.
- `Group_target_of_the_shipped_config_contributes_no_target_of_its_own` — descending into the shipped `all` target adds no target beyond the two the catch-all rules already name, and no duplicate.
- `Create_removes_overwritten_rules` — updated to assert the shipped `*` → `seq` rule survives alongside the synthesised rule.

The first cut's production changes were each reverted one at a time to confirm the tests actually pin them: removing the `RemoveOverriddenRules` condition fails 4 tests, reducing `WritesToSeq` to a plain name check fails 2, and dropping the empty-targets guard fails 1 with an `IndexOutOfRangeException`. The later additions each have a test that exercises exactly the behaviour they add: `Init_LogRules_reach_the_non_seq_members_of_a_group_target` and `Non_final_group_rule_writes_shared_levels_twice` exist only because of the group descent, `Target_graph_with_a_cycle_is_walked_once` only because of the visited-set guard, and `Init_LogRules_that_cannot_be_applied_are_reported` only because of the `InternalLogger.Warn` call.

`dotnet test src/Nethermind/Nethermind.Logging.NLog.Test/Nethermind.Logging.NLog.Test.csproj -c release` — 16/16 passing. `Nethermind.Runner.Test`'s `NLogConfiguratorTests` — 18/18 passing, unaffected. `Nethermind.Runner` builds. `dotnet format whitespace src/Nethermind/ --folder --verify-no-changes` is clean.

End-to-end, a driver calling the real `NLogConfigurator.ConfigureLogLevels`, `new NLogManager(...)`, and `NLogConfigurator.ConfigureSeqBufferTarget` in the same order `Program.cs` calls them, against the shipped `NLog.config` with a memory target spliced into `seq`, confirmed: Seq receives only Info and above from `Synchronization.*` while file and console still receive Trace; an explicit `Network.*` `writeTo="seq"` rule still delivers Trace to Seq; and a configuration whose only rules reach `seq` starts without throwing.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [x] Yes
- [ ] No

`Init.LogRules` no longer routes a namespace to Seq and no longer overrides config rules that do; `Seq.MinLevel` is the floor for the Seq target. To send a namespace's Trace to Seq, use an explicit `writeTo="seq"` rule in `NLog.config`.

## Remarks

Adjacent, pre-existing issues, deliberately left out of this fix and each worth its own issue:

- After an `NLog.config` autoReload, only `NLogManager` re-applies its rules on `ConfigurationChanged`, so both `--log` and `Seq.MinLevel` are lost at that point (measured).
- `NLogConfigurator.ConfigureSeqBufferTarget` (~:195) and `ConfigureLogLevels` (~:244) still test `ruleTarget.Name == "seq"` directly, rather than walking wrappers and groups the way this PR's `WritesToSeq` does, so a `*` rule that reaches `seq` only through the `all` group escapes the Seq floor with or without this change. The codebase now carries two different definitions of "reaches seq" that would need a shared, cross-project helper to unify — left alone here since it touches a different project (`Nethermind.Runner`) for behaviour this PR doesn't otherwise change.
- `NLogConfigurator` disposes every `SeqTarget` immediately after configuring it, which looks suspicious; it was not exercised by this change.
