### PR TITLE
perf: memoize the per-contract read and the SSTORE originals probe

### DIFF
--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -237,7 +237,10 @@ public class StorageProviderTests(bool useFlat)
         Assert.That(provider.GetOriginal(cell).ToArray(), Is.EqualTo(_values[1]), "original for the new transaction");
     }
 
-    /// <summary>A write must be visible to the next read even when that slot was just read.</summary>
+    /// <summary>A write to a just-read slot must win over the read memo.</summary>
+    /// <remarks>The written cell is answered by the journal before <c>LoadFromTree</c> is reached, so this
+    /// pins the ordering invariant the memo's safety rests on (journal first) rather than the memo itself —
+    /// it passes with the memo deleted, and would fail only if that order were ever inverted.</remarks>
     [Test]
     public void Write_after_read_is_not_answered_from_the_read_memo()
     {

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -669,6 +669,40 @@ public class StorageProviderTests(bool useFlat)
         Assert.That(provider.Get(nonAccessedStorageCell).ToArray(), Is.EqualTo(StorageTree.ZeroBytes));
     }
 
+    /// <summary>The originals-probe memo must not answer across caching rounds.</summary>
+    /// <remarks>tx1 memoizes (cell, v1) while writing v2; after commit the next transaction's original for
+    /// the same cell is v2. A memo without the round in its key silently returns v1, which mis-meters every
+    /// EIP-2200 SSTORE of tx2 without failing anything.</remarks>
+    [Test]
+    public void Get_original_after_commit_is_the_new_rounds_original()
+    {
+        using Context ctx = new(useFlat, setInitialState: false);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell cell = new(ctx.Address1, (UInt256)1);
+
+        BlockHeader baseBlock;
+        using (provider.BeginScope(IWorldState.PreGenesis))
+        {
+            provider.CreateAccount(ctx.Address1, 1);
+            provider.Set(in cell, _values[1]);
+            provider.Commit(Frontier.Instance);
+            provider.CommitTree(0);
+            baseBlock = Build.A.BlockHeader.WithStateRoot(provider.StateRoot).TestObject;
+        }
+
+        using (provider.BeginScope(baseBlock))
+        {
+            provider.Get(in cell);
+            provider.Set(in cell, _values[2]);
+            Assert.That(provider.GetOriginal(in cell).ToArray(), Is.EqualTo(_values[1]), "tx1 original is the committed value");
+
+            provider.Commit(Frontier.Instance);
+
+            provider.Get(in cell);
+            Assert.That(provider.GetOriginal(in cell).ToArray(), Is.EqualTo(_values[2]), "tx2 original is tx1's write");
+        }
+    }
+
     // Rolling a storage clear back drops originals first captured under the clear, so anything caching a probe
     // of them has to let go: after the rollback the cell recaptures the block value, and only a stale cache can
     // still answer with the zero the clear planted.

--- a/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
+++ b/src/Nethermind/Nethermind.State.Test/StorageProviderTests.cs
@@ -207,6 +207,55 @@ public class StorageProviderTests(bool useFlat)
         Assert.That(provider.Get(new StorageCell(ctx.Address1, 1)).ToArray(), Is.EqualTo(_values[1]));
     }
 
+    /// <summary>A read-only transaction must not let its memo suppress the next transaction's capture.</summary>
+    /// <remarks>
+    /// Reads are answered from a memo of the last slot read, keyed partly on the originals round. A
+    /// transaction that only reads writes no change, so nothing else drops that memo at commit — without the
+    /// round in the key the next transaction would never record an original, and <c>GetOriginal</c> is what
+    /// SSTORE meters against.
+    /// </remarks>
+    [Test]
+    public void Read_only_transaction_does_not_suppress_the_next_original()
+    {
+        using Context ctx = new(useFlat);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell cell = new(ctx.Address1, 1);
+
+        provider.Set(cell, _values[1]);
+        provider.Commit(Frontier.Instance);
+
+        // A transaction that only reads: the second read is served from the memo, and committing it
+        // changes nothing, so nothing invalidates that memo.
+        provider.TakeSnapshot(newTransactionStart: true);
+        Assert.That(provider.Get(cell).ToArray(), Is.EqualTo(_values[1]));
+        Assert.That(provider.Get(cell).ToArray(), Is.EqualTo(_values[1]));
+        provider.Commit(Frontier.Instance);
+
+        // The next transaction must still capture its own original for the slot.
+        provider.TakeSnapshot(newTransactionStart: true);
+        Assert.That(provider.Get(cell).ToArray(), Is.EqualTo(_values[1]));
+        Assert.That(provider.GetOriginal(cell).ToArray(), Is.EqualTo(_values[1]), "original for the new transaction");
+    }
+
+    /// <summary>A write must be visible to the next read even when that slot was just read.</summary>
+    [Test]
+    public void Write_after_read_is_not_answered_from_the_read_memo()
+    {
+        using Context ctx = new(useFlat);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell cell = new(ctx.Address1, 1);
+
+        provider.Set(cell, _values[1]);
+        provider.Commit(Frontier.Instance);
+
+        Assert.That(provider.Get(cell).ToArray(), Is.EqualTo(_values[1]));
+        Assert.That(provider.Get(cell).ToArray(), Is.EqualTo(_values[1]));
+
+        provider.Set(cell, _values[3]);
+
+        Assert.That(provider.Get(cell).ToArray(), Is.EqualTo(_values[3]), "the write must win over the memo");
+    }
+
     [Test]
     public void Original_value_tracks_transaction_start_across_stacked_writes()
     {
@@ -618,6 +667,42 @@ public class StorageProviderTests(bool useFlat)
         provider.ClearStorage(TestItem.AddressA);
         Assert.That(provider.Get(accessedStorageCell).ToArray(), Is.EqualTo(StorageTree.ZeroBytes));
         Assert.That(provider.Get(nonAccessedStorageCell).ToArray(), Is.EqualTo(StorageTree.ZeroBytes));
+    }
+
+    // Rolling a storage clear back drops originals first captured under the clear, so anything caching a probe
+    // of them has to let go: after the rollback the cell recaptures the block value, and only a stale cache can
+    // still answer with the zero the clear planted.
+    [Test]
+    public void Rolling_back_a_storage_clear_forgets_originals_captured_under_the_clear()
+    {
+        using Context ctx = new(useFlat, setInitialState: false);
+        WorldState provider = BuildStorageProvider(ctx);
+        StorageCell cell = new(TestItem.AddressA, 1);
+
+        BlockHeader baseBlock;
+        using (provider.BeginScope(IWorldState.PreGenesis))
+        {
+            provider.CreateAccount(TestItem.AddressA, 1);
+            provider.Set(cell, _values[1]);
+            provider.Commit(Frontier.Instance);
+            provider.CommitTree(0);
+            baseBlock = Build.A.BlockHeader.WithStateRoot(provider.StateRoot).TestObject;
+        }
+
+        using (provider.BeginScope(baseBlock))
+        {
+            Snapshot snapshot = provider.TakeSnapshot();
+            provider.ClearStorage(TestItem.AddressA);
+
+            provider.Get(cell);
+            Assert.That(provider.GetOriginal(cell).ToArray(), Is.EqualTo(StorageTree.ZeroBytes),
+                "precondition: the first capture happens under the clear");
+
+            provider.Restore(snapshot);
+
+            provider.Get(cell);
+            Assert.That(provider.GetOriginal(cell).ToArray(), Is.EqualTo(_values[1]));
+        }
     }
 
     // A batch that drops what it held stops accepting storage writes, so every clear the write-back issues has to be

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -987,11 +987,12 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         /// </remarks>
         public ReadOnlySpan<byte> LoadFromTree(in StorageCell storageCell)
         {
-            if (_lastReadRound == Provider._originalsRound && _lastReadIndex.Equals(storageCell.Index))
+            PersistentStorageProvider provider = Provider;
+            if (_lastReadRound == provider._originalsRound && _lastReadIndex.Equals(storageCell.Index))
             {
                 // Still a served repeat read: keep DbMetrics.StorageTreeCache (and the per-block
                 // processing stats built on it) counting the workload it always counted.
-                Provider._metrics.IncrementStorageTreeCache();
+                provider._metrics.IncrementStorageTreeCache();
                 return _lastReadValue;
             }
 
@@ -1007,7 +1008,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 Provider._metrics.IncrementStorageTreeCache();
             }
 
-            PersistentStorageProvider provider = Provider;
             uint round = provider._originalsRound;
             if (valueChange.CapturedRound != round)
             {

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -832,6 +832,14 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         public int EstimatedChanges => BlockChange.EstimatedSize;
 
+        private UInt256 _lastReadIndex;
+        private byte[]? _lastReadValue;
+        private uint _lastReadRound;
+        private bool _hasLastRead;
+
+        /// <summary>Drops the memo of the last slot read, for anything that can change what a read returns.</summary>
+        private void ForgetLastRead() => _hasLastRead = false;
+
         private PersistentStorageProvider Provider =>
             _provider ?? throw new InvalidOperationException("A returned storage state cannot be used.");
 
@@ -898,6 +906,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             {
                 // Slight optimization that skips the tree
                 BlockChange.ClearAndSetMissingAsDefault();
+                ForgetLastRead();
             }
         }
 
@@ -905,6 +914,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         {
             EnsureStorageTree();
             _wasCleared = true;
+            ForgetLastRead();
             BlockChange.ClearAndSetMissingAsDefault();
         }
 
@@ -913,10 +923,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             EnsureStorageTree();
             // Stays set if the clear is reverted: a cache then drops slots it could have kept, never keeps stale ones.
             _wasCleared = true;
+            ForgetLastRead();
             return BlockChange.ClearRevertibly();
         }
 
-        public void RestoreClear(DefaultableDictionary.ClearSnapshot snapshot) => BlockChange.Restore(snapshot);
+        public void RestoreClear(DefaultableDictionary.ClearSnapshot snapshot)
+        {
+            ForgetLastRead();
+            BlockChange.Restore(snapshot);
+        }
 
         public void Return()
         {
@@ -924,6 +939,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             _provider = null;
             _backend = null;
             _wasWritten = false;
+            ForgetLastRead();
             _hadStorageBeforeBlock = false;
             _storageRootSeen = false;
             _wasCleared = false;
@@ -935,6 +951,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
 
         public void SaveChange(StorageCell storageCell, byte[] value)
         {
+            ForgetLastRead();
             _wasWritten = true;
             ref StorageChangeTrace valueChanges = ref BlockChange.GetValueRefOrAddDefault(storageCell.Index, out bool exists);
             if (!exists)
@@ -950,8 +967,19 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             _backend.HintSet(storageCell.Index, value);
         }
 
+        /// <remarks>
+        /// A loop over one slot lands here every iteration with the same index. Written cells never reach
+        /// this method — the journal answers those first — so a value here cannot change under us while the
+        /// round holds, and the round is part of the key so the first read of each round still captures its
+        /// original. Everything that can rewrite <c>BlockChange</c> drops the memo.
+        /// </remarks>
         public ReadOnlySpan<byte> LoadFromTree(in StorageCell storageCell)
         {
+            if (_hasLastRead && _lastReadRound == Provider._originalsRound && _lastReadIndex.Equals(storageCell.Index))
+            {
+                return _lastReadValue;
+            }
+
             ref StorageChangeTrace valueChange = ref BlockChange.GetValueRefOrAddDefault(storageCell.Index, out bool exists);
             if (!exists)
             {
@@ -971,6 +999,11 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
                 provider.CaptureOriginalValue(storageCell, valueChange.After);
                 valueChange = valueChange.WithCapturedRound(round);
             }
+
+            _lastReadIndex = storageCell.Index;
+            _lastReadValue = valueChange.After;
+            _lastReadRound = round;
+            _hasLastRead = true;
 
             return valueChange.After;
         }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -48,14 +48,21 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     // Zero means never captured, which is what a default BlockChange entry carries.
     private uint _originalsRound = 1;
 
-    /// <summary>Memoizes the last <see cref="_originalValues"/> probe.</summary>
-    /// <remarks>An SSTORE probes the same cell its preceding read just captured. Keyed on the originals
-    /// round because <see cref="EndOriginalsRound"/> is the only routine clearing the map, and it always
-    /// bumps the round; within a round the map only grows, except in <see cref="RestoreStorageClear"/>,
-    /// which forgets the memo explicitly. Round 0 is never issued, so it doubles as "no memo".</remarks>
+    // These three fields memoize the last _originalValues probe: an SSTORE probes the same cell its
+    // preceding read just captured. Keyed on the originals round because EndOriginalsRound is the only
+    // routine clearing the map, and it always bumps the round; within a round the map only grows, except
+    // in RestoreStorageClear, which calls ForgetLastOriginal. Round 0 is never issued, so it doubles as
+    // "no memo".
     private StorageCell _lastOriginalCell;
     private byte[]? _lastOriginalValue;
     private uint _lastOriginalRound;
+
+    /// <summary>Drops the originals-probe memo and releases the value it pinned.</summary>
+    private void ForgetLastOriginal()
+    {
+        _lastOriginalRound = 0;
+        _lastOriginalValue = null;
+    }
 
     private void EndOriginalsRound()
     {
@@ -672,7 +679,7 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             throw new InvalidOperationException($"Expected storage clear journal entry {lastIndex}, got {journalIndex}");
         }
 
-        _lastOriginalRound = 0;
+        ForgetLastOriginal();
 
         StorageClearChange change = _storageClearJournal[journalIndex];
         _storageClearJournal.RemoveAt(journalIndex);
@@ -835,10 +842,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         private UInt256 _lastReadIndex;
         private byte[]? _lastReadValue;
         private uint _lastReadRound;
-        private bool _hasLastRead;
 
         /// <summary>Drops the memo of the last slot read, for anything that can change what a read returns.</summary>
-        private void ForgetLastRead() => _hasLastRead = false;
+        /// <remarks>Round 0 is never issued, so it is the "no memo" sentinel — same convention as the
+        /// provider-level originals memo. Nulling the value keeps a pooled instance from pinning the array.</remarks>
+        private void ForgetLastRead()
+        {
+            _lastReadRound = 0;
+            _lastReadValue = null;
+        }
 
         private PersistentStorageProvider Provider =>
             _provider ?? throw new InvalidOperationException("A returned storage state cannot be used.");
@@ -975,8 +987,11 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         /// </remarks>
         public ReadOnlySpan<byte> LoadFromTree(in StorageCell storageCell)
         {
-            if (_hasLastRead && _lastReadRound == Provider._originalsRound && _lastReadIndex.Equals(storageCell.Index))
+            if (_lastReadRound == Provider._originalsRound && _lastReadIndex.Equals(storageCell.Index))
             {
+                // Still a served repeat read: keep DbMetrics.StorageTreeCache (and the per-block
+                // processing stats built on it) counting the workload it always counted.
+                Provider._metrics.IncrementStorageTreeCache();
                 return _lastReadValue;
             }
 
@@ -1003,7 +1018,6 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
             _lastReadIndex = storageCell.Index;
             _lastReadValue = valueChange.After;
             _lastReadRound = round;
-            _hasLastRead = true;
 
             return valueChange.After;
         }

--- a/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
+++ b/src/Nethermind/Nethermind.State/PersistentStorageProvider.cs
@@ -48,6 +48,15 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     // Zero means never captured, which is what a default BlockChange entry carries.
     private uint _originalsRound = 1;
 
+    /// <summary>Memoizes the last <see cref="_originalValues"/> probe.</summary>
+    /// <remarks>An SSTORE probes the same cell its preceding read just captured. Keyed on the originals
+    /// round because <see cref="EndOriginalsRound"/> is the only routine clearing the map, and it always
+    /// bumps the round; within a round the map only grows, except in <see cref="RestoreStorageClear"/>,
+    /// which forgets the memo explicitly. Round 0 is never issued, so it doubles as "no memo".</remarks>
+    private StorageCell _lastOriginalCell;
+    private byte[]? _lastOriginalValue;
+    private uint _lastOriginalRound;
+
     private void EndOriginalsRound()
     {
         _originalValues.ClearAndTrim();
@@ -116,9 +125,21 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
     /// <returns></returns>
     public ReadOnlySpan<byte> GetOriginal(in StorageCell storageCell)
     {
-        if (!_originalValues.TryGetValue(storageCell, out byte[]? value))
+        byte[]? value;
+        if (_lastOriginalRound == _originalsRound && _lastOriginalCell.Equals(in storageCell))
         {
-            throw new InvalidOperationException("Get original should only be called after get within the same caching round");
+            value = _lastOriginalValue;
+        }
+        else
+        {
+            if (!_originalValues.TryGetValue(storageCell, out value))
+            {
+                throw new InvalidOperationException("Get original should only be called after get within the same caching round");
+            }
+
+            _lastOriginalCell = storageCell;
+            _lastOriginalValue = value;
+            _lastOriginalRound = _originalsRound;
         }
 
         if (_intraBlockCache.TryGetValue(storageCell, out HeadChange head))
@@ -650,6 +671,8 @@ internal sealed partial class PersistentStorageProvider(StateProvider stateProvi
         {
             throw new InvalidOperationException($"Expected storage clear journal entry {lastIndex}, got {journalIndex}");
         }
+
+        _lastOriginalRound = 0;
 
         StorageClearChange change = _storageClearJournal[journalIndex];
         _storageClearJournal.RemoveAt(journalIndex);


### PR DESCRIPTION
## Changes

Split out of the original #13414: the storage-provider read memos. **Sequencing note: this is the
slice that overlaps #13420** (storage values as UInt256) — it conflicts textually in
`PersistentStorageProvider` and its arithmetic should be re-measured on the UInt256 code if #13420
lands first; the sibling EVM-side PR carries no such overlap.

- `PerContractState` remembers the last slot it read. With the warm-access check memoized (sibling
  PR), this was what a warm `SLOAD` had left. Written cells never reach this path — the journal
  answers those first — so a value here cannot change while the originals round holds; the round is
  part of the key, so the first read of each round still captures its original.
- `GetOriginal` remembers the last `_originalValues` probe. An SSTORE probes the originals map for
  the exact cell its own preceding read just captured, and ablating that probe takes a warm dirty
  SSTORE from ~37 ns to ~10 ns. Keyed on the same originals round; the one routine that rewrites
  captured originals mid-round, `RestoreStorageClear`, forgets it explicitly.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

- `Read_only_transaction_does_not_suppress_the_next_original` — without the round in the key this
  **fails** with "Get original should only be called after get within the same caching round".
- `Write_after_read_is_not_answered_from_the_read_memo` — a write to a just-read slot must win.
- `Rolling_back_a_storage_clear_forgets_originals_captured_under_the_clear` — the one way the
  originals map is rewritten mid-round. **Verified to fail** without the invalidation in
  `RestoreStorageClear`. (EIP-2200 nuance: the original under a clear is the tx-start value; the
  divergent case is a cell first captured after the clear.)

`Nethermind.State.Test` 1,700 passed / 0 failed on the split branch. On the combined original branch:
`Ethereum.Legacy.Blockchain.Test` 101,673 and `Ethereum.Legacy.VM.Test` 4,376 — 0 failures.

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Measured with the sibling PRs applied (`Sload_SameKey` / `Sstore_DirtyTransitions` scenarios), quiet
machine, interleaved: the read memo takes a warm SLOAD iteration from 60.5/56.8 ns (warm-access memo
alone) to **25.9/26.1 ns**; the `GetOriginal` memo takes a warm dirty SSTORE from 39.7 to 35.2 ns
(**-11%**, lower in all three paired rounds). On Amsterdam the `GetOriginal` memo is deliberately
inert: `BlockAccessListBasedWorldState.GetOriginal` overrides the provider and answers from the BAL
overlay — measured, and the overlay-side equivalent was implemented, measured as noise, and dropped.
