### PR TITLE
EIP-8141: keep a pooled frame tx's reservations when its storage write throws

### DIFF
--- a/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
+++ b/src/Nethermind/Nethermind.Core.Test/Encoding/FrameTxReceiptDecoderTests.cs
@@ -705,50 +705,55 @@ public class FrameTxReceiptDecoderTests
         }
     }
 
-    // The payload defines only failure, success and skipped. An out-of-range byte round-trips, so the decoder is
-    // the only place it can be caught before AggregateStatus folds it to failure and RPC surfaces it raw.
+    /// <summary>The payload defines only failure, success and skipped, and the decoder is where a peer's
+    /// out-of-range byte is caught before AggregateStatus folds it to failure and RPC surfaces it raw.</summary>
+    /// <remarks>The write paths refuse those values first, so they are spliced into encoded bytes instead. Only
+    /// single-byte statuses are spliced, leaving the enclosing lengths intact; the two-byte <see cref="byte.MaxValue"/>
+    /// is pinned on the write side by <see cref="Encode_FrameStatusOutsideThePayloadValues_IsRefused"/>.</remarks>
     [TestCase(TxFrameReceipt.StatusFailure, false)]
     [TestCase(TxFrameReceipt.StatusSuccess, false)]
     [TestCase(TxFrameReceipt.StatusSkipped, false)]
     [TestCase((byte)3, true)]
-    [TestCase(byte.MaxValue, true)]
+    [TestCase((byte)0x7f, true)]
     public void MessageDecode_FrameStatusOutsideThePayloadValues_Throws(byte status, bool rejected)
     {
-        TxReceipt receipt = CreateReceipt(new TxFrameReceipt(status, 21_000, 0, []));
+        if (!rejected)
+        {
+            Assert.That(DecodeMessage(CreateReceipt(new TxFrameReceipt(status, 21_000, 0, []))).FrameReceipts![0].Status,
+                Is.EqualTo(status));
+            return;
+        }
 
-        if (rejected)
-        {
-            Assert.That(() => DecodeMessage(receipt), Throws.InstanceOf<RlpException>());
-        }
-        else
-        {
-            Assert.That(DecodeMessage(receipt).FrameReceipts![0].Status, Is.EqualTo(status));
-        }
+        byte[] encoded = EncodeMessage(CreateReceipt(new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, [])));
+        encoded[FirstFrameStatusOffset(encoded)] = status;
+
+        Assert.That(() => DecodeMessage(encoded), Throws.InstanceOf<RlpException>());
     }
 
     // The log ceiling is derived from a whole transaction's gas, so the frames share one budget; spent per frame
-    // it would admit MaxFrames times the emissions it stands for.
+    // it would admit MaxFrames times the emissions it stands for. Encoded before the ceiling is lowered, or the
+    // write path's own guard would refuse the over-budget receipt and the decoder would never see it.
     [TestCase(0, false, TestName = "MessageDecode_FrameLogsAtTheReceiptBudget_IsAccepted")]
     [TestCase(1, true, TestName = "MessageDecode_FrameLogsOverTheReceiptBudget_Throws")]
     public void MessageDecode_FrameLogBudgetIsSpentPerReceiptNotPerFrame(int excess, bool rejected)
     {
-        RlpLimit.InitMaxBlockGas(EightLogBlockGas);
-
-        int maxReceiptLogs = RlpLimit.ReceiptLogs.Limit;
-        int firstFrameLogs = maxReceiptLogs / 2;
-        int secondFrameLogs = maxReceiptLogs - firstFrameLogs + excess;
+        int firstFrameLogs = EightLogBlockGasLimit / 2;
+        int secondFrameLogs = EightLogBlockGasLimit - firstFrameLogs + excess;
         // Each frame stays under the ceiling on its own, so only their sum can trip the guard.
-        TxReceipt receipt = CreateReceipt(
+        byte[] encoded = EncodeMessage(CreateReceipt(
             new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, RepeatedLogs(firstFrameLogs)),
-            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, RepeatedLogs(secondFrameLogs)));
+            new TxFrameReceipt(TxFrameReceipt.StatusSuccess, 21_000, 0, RepeatedLogs(secondFrameLogs))));
+
+        RlpLimit.InitMaxBlockGas(EightLogBlockGas);
+        Assert.That(RlpLimit.ReceiptLogs.Limit, Is.EqualTo(EightLogBlockGasLimit), "the ceiling the frames are sized against");
 
         if (rejected)
         {
-            Assert.That(() => DecodeMessage(receipt), Throws.InstanceOf<RlpException>());
+            Assert.That(() => DecodeMessage(encoded), Throws.InstanceOf<RlpException>());
         }
         else
         {
-            Assert.That(DecodeMessage(receipt).Logs, Has.Length.EqualTo(maxReceiptLogs));
+            Assert.That(DecodeMessage(encoded).Logs, Has.Length.EqualTo(EightLogBlockGasLimit));
         }
     }
 
@@ -765,6 +770,22 @@ public class FrameTxReceiptDecoderTests
         RlpLimit.InitMaxBlockGas(EightLogBlockGas);
 
         Assert.That(() => DecodeMessage(encoded), Throws.InstanceOf<RlpException>());
+    }
+
+    /// <summary>Where the first frame's status byte sits in an encoded receipt message.</summary>
+    /// <remarks>Walks the wrapper, the type byte and the payload fields the decoder reads before the status,
+    /// so a layout change moves this with it rather than silently patching the wrong byte.</remarks>
+    private static int FirstFrameStatusOffset(byte[] encoded)
+    {
+        RlpReader reader = new(encoded);
+        reader.SkipLength();
+        reader.SkipBytes(1);
+        reader.ReadSequenceLength();
+        reader.SkipItem();
+        reader.SkipItem();
+        reader.ReadSequenceLength();
+        reader.ReadSequenceLength();
+        return reader.Position;
     }
 
     private static TxReceipt DecodeMessage(TxReceipt receipt) => DecodeMessage(EncodeMessage(receipt));

--- a/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
+++ b/src/Nethermind/Nethermind.TxPool.Test/TxPoolTests.Blobs.cs
@@ -4868,6 +4868,47 @@ namespace Nethermind.TxPool.Test
             }
         }
 
+        // EIP-8141: the persistent blob pool takes the light record before it writes the body, so a throwing
+        // storage leaves the record pooled. The reservations are the pooled record's from that point on, and
+        // releasing them on the way out would free a slot the record still holds.
+        [Test]
+        public async Task Blob_carrying_frame_tx_pooled_by_a_throwing_storage_write_keeps_its_reservations()
+        {
+            TxPoolConfig txPoolConfig = new() { BlobsSupport = BlobsSupportMode.StorageWithReorgs };
+            ThrowingBlobTxStorage blobTxStorage = new();
+            _txPool = CreatePool(txPoolConfig, GetBogotaSpecProvider(), txStorage: blobTxStorage);
+            EnsureSenderBalance(TestItem.PrivateKeyA.Address, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.PrivateKeyB.Address, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.PrivateKeyC.Address, UInt256.MaxValue);
+            EnsureSenderBalance(TestItem.AddressD, UInt256.MaxValue);
+            _stateProvider.InsertCode([0x60, 0x00], TestItem.AddressD);
+
+            Transaction Sponsored(PrivateKey sender) =>
+                BuildBlobFrameTx(nonce: 0, blobCount: 1, withSidecar: true, paymaster: TestItem.AddressD, sender: sender);
+
+            Transaction pooled = Sponsored(TestItem.PrivateKeyA);
+            blobTxStorage.ThrowOnAdd = true;
+            Assert.That(() => _txPool.SubmitTx(pooled, TxHandlingOptions.None), Throws.InstanceOf<InvalidOperationException>());
+            blobTxStorage.ThrowOnAdd = false;
+
+            Assert.That(_txPool.GetPendingBlobTransactionsCount(), Is.EqualTo(1), "the failed write leaves the record pooled");
+
+            // The ledgers are only checked against pool membership on a head change.
+            await RaiseBlockAddedToMainAndWaitForNewHead(Build.A.Block.WithNumber(1).TestObject);
+
+            AcceptTxResult whilePooled = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyB), TxHandlingOptions.None);
+
+            _txPool.RemoveTransaction(pooled.Hash);
+            AcceptTxResult afterRemoval = _txPool.SubmitTx(Sponsored(TestItem.PrivateKeyC), TxHandlingOptions.None);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(whilePooled, Is.EqualTo(AcceptTxResult.NonCanonicalPaymasterLimitReached),
+                    "the pooled record still holds its sponsor's slot");
+                Assert.That(afterRemoval, Is.EqualTo(AcceptTxResult.Accepted), "and frees it once, on removal");
+            }
+        }
+
         // EIP-8141: the cap is summed over the pending set, so a record that survived a restart has to keep
         // holding its sponsor's slot, and to free it on removal.
         [Test]
@@ -5572,6 +5613,41 @@ namespace Nethermind.TxPool.Test
             };
             tx.Hash = tx.CalculateHash();
             return tx;
+        }
+
+        /// <summary>A blob tx storage whose body write can be made to fail, standing in for a disk error.</summary>
+        /// <remarks>A decorator rather than a subclass: the pool reaches the write through the interface, and
+        /// deliberately not an <see cref="IAtomicBlobTxStorage"/>, so a fresh insert takes the plain add path.</remarks>
+        private sealed class ThrowingBlobTxStorage : IBlobTxStorage
+        {
+            private readonly BlobTxStorage _inner = new();
+
+            public bool ThrowOnAdd { get; set; }
+
+            public void Add(Transaction transaction)
+            {
+                if (ThrowOnAdd) throw new InvalidOperationException("blob tx storage write failed");
+
+                _inner.Add(transaction);
+            }
+
+            public bool TryGet(in ValueHash256 hash, Address sender, in UInt256 timestamp, out Transaction transaction) =>
+                _inner.TryGet(hash, sender, timestamp, out transaction);
+
+            public int TryGetMany(TxLookupKey[] keys, int count, Transaction[] results) =>
+                _inner.TryGetMany(keys, count, results);
+
+            public IEnumerable<LightTransaction> GetAll() => _inner.GetAll();
+
+            public void Delete(in ValueHash256 hash, in UInt256 timestamp) => _inner.Delete(hash, timestamp);
+
+            public bool TryGetBlobTransactionsFromBlock(ulong blockNumber, out Transaction[] blockBlobTransactions) =>
+                _inner.TryGetBlobTransactionsFromBlock(blockNumber, out blockBlobTransactions);
+
+            public void AddBlobTransactionsFromBlock(ulong blockNumber, in ArrayPoolListRef<Transaction> blockBlobTransactions) =>
+                _inner.AddBlobTransactionsFromBlock(blockNumber, in blockBlobTransactions);
+
+            public void DeleteBlobTransactionsFromBlock(ulong blockNumber) => _inner.DeleteBlobTransactionsFromBlock(blockNumber);
         }
     }
 }

--- a/src/Nethermind/Nethermind.TxPool/TxPool.cs
+++ b/src/Nethermind/Nethermind.TxPool/TxPool.cs
@@ -1500,12 +1500,12 @@ namespace Nethermind.TxPool
 
             // EIP-8141: a successful insert hands the payer exposure and paymaster slot to the pool,
             // released on Removed. Every other exit, a throw included, must release them here or they leak.
+            TxDistinctSortedPool relevantPool = (tx.CarriesBlobs ? _blobTransactions : _transactions);
             bool reservationSettled = false;
             try
             {
                 bool eip1559Enabled = headSpec.IsEip1559Enabled;
                 UInt256 effectiveGasPrice = tx.CalculateEffectiveGasPrice(eip1559Enabled, _headInfo.CurrentBaseFee);
-                TxDistinctSortedPool relevantPool = (tx.CarriesBlobs ? _blobTransactions : _transactions);
 
                 relevantPool.TryGetBucketsWorstValue(tx.SenderAddress!, out Transaction? worstTx);
                 tx.GasBottleneck = (worstTx is null || effectiveGasPrice <= worstTx.GasBottleneck)
@@ -1515,7 +1515,6 @@ namespace Nethermind.TxPool
                 bool inserted = relevantPool.TryInsert(tx.Hash!, tx, out Transaction? removed);
                 // The reservation is now the pool's, or was already released by a self-eviction Removed.
                 reservationSettled = true;
-                state.PaymasterReserved = false;
 
                 if (!inserted)
                 {
@@ -1569,13 +1568,22 @@ namespace Nethermind.TxPool
                 Metrics.BlobTransactionCount = _blobTransactions.Count;
                 return AcceptTxResult.Accepted;
             }
+            catch
+            {
+                // The insert can take the record and then throw — the persistent blob pool writes the body
+                // inside it — and the reservations are then the pooled record's, released on its Removed.
+                reservationSettled |= relevantPool.ContainsKey(tx.Hash!.ValueHash256);
+                throw;
+            }
             finally
             {
                 if (!reservationSettled)
                 {
                     ReleaseFrameTxReservations(tx);
-                    state.PaymasterReserved = false;
                 }
+
+                // Settled either way by here, so the caller's own release must not run again.
+                state.PaymasterReserved = false;
             }
         }
 


### PR DESCRIPTION
Addresses two review threads on #12526 that were missed in an earlier round.

## Changes

**[P2] `TxPool.AddCore` released reservations a pooled record still held.**
`PersistentBlobTxDistinctSortedPool.InsertCore` inserts the light record before
`PersistInsertedBlobTransaction` writes the body, so a throwing `ITxStorage.Add`
propagates out of `TryInsert` with the record already in the pool. `reservationSettled`
was still `false`, so the `finally` released the payer exposure and the paymaster slot
while the transaction stayed pending: the sponsor's slot was free for a sibling for as
long as the record lived, and the later `Removed` released a second time (clamped by
`PendingPaymasterCache.Decrement`, so the damage is the early release, not a negative
count). The eviction-retry ledger is unaffected — it is staged and dropped on the pool's
own `Inserted`/`Removed`, so it already tracks membership.

- Settle ownership by pool membership in a `catch`, so every exit path releases the
  reservations exactly once, whether or not the insert took the record.
- Clear `state.PaymasterReserved` unconditionally in the `finally`. That is the contract
  the caller's own `finally` already documents ("AddCore clears the flag once the pool
  owns it or has released it itself"), and it removes the second place the flag was set.
- Regression test: a throwing blob storage, then assertions that the record is pooled,
  that its sponsor's slot is still held against a sibling, and that removal frees it once.

**[P3] Two frame-receipt "decoder rejection" tests stopped in the encoder.**
`DecodeMessage(receipt)` encodes first, and `FrameReceiptRlp.GuardEncodable` refused both
malformed shapes before the decoder was reached. Both tests passed with the corresponding
decoder guards removed. `FrameReceiptRlp`'s guards are deliberately write-side only, so
the fix feeds the decoder bytes the write path would never produce:

- `MessageDecode_FrameStatusOutsideThePayloadValues_Throws` encodes a valid status and
  splices the out-of-range byte in. Only single-byte statuses are spliced, so the enclosing
  RLP lengths stay intact; the two-byte `byte.MaxValue` is already pinned on the write side
  by `Encode_FrameStatusOutsideThePayloadValues_IsRefused`, so the decode case uses `0x7f`.
- `MessageDecode_FrameLogBudgetIsSpentPerReceiptNotPerFrame` encodes the multi-frame logs
  before lowering the configured block gas, mirroring the neighbouring
  `MessageDecode_FrameLogCount_IsBoundedByTheConfiguredBlockGas`.

Both were verified to discriminate: with `GuardFrameStatus` and the per-receipt `totalLogs`
accumulation removed from `FrameReceiptRlp.DecodePayload`, all 8 `MessageDecode` cases
passed before the change and exactly the 3 repaired negative cases fail after it.

## Types of changes

#### What types of changes does your code introduce?

- [x] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [ ] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other: _Description_

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

`Nethermind.TxPool.Test`, `Nethermind.Core.Test` and `Nethermind.Blockchain.Test` run green
in both release and checked (`-p:DefineConstants=TRACE;DEBUG`) configurations. The checked
config is where the reservation leak shows through the `#if DEBUG` ledger symmetry check:
reverting the `catch` terminates the run with
`Paymaster cap ledger holds 0 paymasters, but 1 are pooled.` from
`AssertFrameTxBookkeeping`, while release fails the cap assertion in the new test.

The pinned on-disk receipt sizes in `FrameTxReceiptDecoderTests` (435 compact / 701
non-compact) are unchanged.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
