### PR TITLE
perf: stream receipt commitments during execution

### DIFF
--- a/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/BlockProcessorTests.cs
@@ -31,6 +31,8 @@ using Nethermind.Specs;
 using Nethermind.Specs.Forks;
 using Nethermind.Evm.State;
 using Nethermind.State;
+using Nethermind.State.Proofs;
+using Nethermind.Serialization.Rlp;
 using Nethermind.TxPool;
 using NSubstitute;
 using NUnit.Framework;
@@ -54,6 +56,76 @@ namespace Nethermind.Blockchain.Test;
 [Parallelizable(ParallelScope.All)]
 public class BlockProcessorTests
 {
+    [Test]
+    public async Task ReceiptStream_WhenCompleted_MatchesBatchCommitments([Values(0, 1, 64, 129)] int count)
+    {
+        TxReceipt[] receipts = new TxReceipt[count];
+        for (int i = 0; i < count; i++)
+        {
+            receipts[i] = Build.A.Receipt.WithAllFieldsFilled.WithGasUsedTotal((ulong)(i + 1) * 21_000)
+                .WithTxType((TxType)(i % 5)).WithStatusCode((byte)(i % 2))
+                .WithLogs(new LogEntry(TestItem.AddressA, [(byte)i], [TestItem.KeccakA])).TestObject;
+        }
+        Hash256 expectedRoot = ReceiptsRootCalculator.Instance.GetReceiptsRoot(receipts, Prague.Instance, null);
+        Bloom expectedBloom = new();
+        foreach (TxReceipt receipt in receipts)
+        {
+            expectedBloom.Accumulate(receipt.Bloom);
+            receipt.Bloom = null;
+        }
+        using BlockProcessor.ReceiptCommitmentStream stream = new(
+            new ReceiptTrie.StreamingRoot(Prague.Instance, count, new ReceiptMessageDecoder()),
+            count, CancellationToken.None, LimboLogs.Instance.GetClassLogger<BlockProcessor>());
+
+        foreach (TxReceipt receipt in receipts) stream.Add(receipt);
+        stream.CompleteAdding();
+        (Bloom bloom, Hash256 root) = await stream.Result;
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(root, Is.EqualTo(expectedRoot), "streaming must preserve receipt commitments");
+            Assert.That(bloom, Is.EqualTo(expectedBloom), "streaming must preserve block blooms");
+        }
+    }
+
+    [Test]
+    public void ReceiptStream_WhenIncomplete_RejectsCompletion()
+    {
+        using BlockProcessor.ReceiptCommitmentStream stream = new(
+            new ReceiptTrie.StreamingRoot(Prague.Instance, 1, new ReceiptMessageDecoder()),
+            1, CancellationToken.None, LimboLogs.Instance.GetClassLogger<BlockProcessor>());
+
+        stream.CompleteAdding();
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await stream.Result,
+            "an incomplete stream must fail rather than publish a partial commitment");
+    }
+
+    [Test]
+    public void ReceiptStream_WhenCancelled_RejectsPublication()
+    {
+        using CancellationTokenSource cancellation = new();
+        cancellation.Cancel();
+        using BlockProcessor.ReceiptCommitmentStream stream = new(
+            new ReceiptTrie.StreamingRoot(Prague.Instance, 1, new ReceiptMessageDecoder()),
+            1, cancellation.Token, LimboLogs.Instance.GetClassLogger<BlockProcessor>());
+
+        Assert.That(() => stream.Add(Build.A.Receipt.WithAllFieldsFilled.TestObject), Throws.InstanceOf<OperationCanceledException>(),
+            "cancelled execution must not publish receipts");
+    }
+
+    [Test]
+    public void ReceiptStream_WhenDisposedWithoutCompletion_JoinsWorker()
+    {
+        BlockProcessor.ReceiptCommitmentStream stream = new(
+            new ReceiptTrie.StreamingRoot(Prague.Instance, 1, new ReceiptMessageDecoder()),
+            1, CancellationToken.None, LimboLogs.Instance.GetClassLogger<BlockProcessor>());
+
+        stream.Dispose();
+
+        Assert.That(stream.Result.IsCompleted, Is.True, "disposal must finish the worker before the block scope can be reused");
+    }
+
     [Test]
     public void Read_coverage_validates_system_slices_and_preserves_read_budget(
         [Values] bool omitRead, [Values] bool revertWrite, [ValueSource(nameof(ReadCoverageBlockCounts))] int blockCount)
@@ -165,25 +237,42 @@ public class BlockProcessorTests
     }
 
     [Test]
-    public async Task Block_processing_preserves_receipt_logs_without_a_log_tracer()
+    public async Task Block_processing_preserves_receipt_logs_without_a_log_tracer([Values(1, 64, 129)] int receiptCount)
     {
         using BasicTestBlockchain chain = await BasicTestBlockchain.Create(builder => builder
             .AddSingleton<ISpecProvider>(new TestSpecProvider(Prague.Instance) { AllowTestChainOverride = false }));
-        Transaction tx = Build.A.Transaction.WithTo(null)
-            .WithCode(Prepare.EvmCode.Log(32, 0, [TestItem.KeccakA]).STOP().Done)
-            .WithGasLimit(100_000).SignedAndResolved(TestItem.PrivateKeyB).TestObject;
-
-        Block block = await chain.AddBlock(tx);
-
-        TxReceipt[] receipts = chain.ReceiptStorage.Get(block);
-        Assert.That(receipts, Has.Length.EqualTo(1));
-        Assert.That(receipts[0].Logs, Has.Length.EqualTo(1));
-        using (Assert.EnterMultipleScope())
+        for (int blockIndex = 0; blockIndex < 2; blockIndex++)
         {
-            Assert.That(receipts[0].StatusCode, Is.EqualTo(StatusCode.Success));
-            Assert.That(receipts[0].Logs[0].Topics, Is.EqualTo(new[] { TestItem.KeccakA }));
-            Assert.That(receipts[0].Bloom, Is.Not.EqualTo(Bloom.Empty));
-            Assert.That(block.Header.Bloom, Is.Not.EqualTo(Bloom.Empty));
+            Transaction[] transactions = new Transaction[receiptCount];
+            for (int i = 0; i < transactions.Length; i++)
+            {
+                transactions[i] = Build.A.Transaction.WithTo(null).WithNonce((ulong)(blockIndex * receiptCount + i))
+                    .WithCode(Prepare.EvmCode.Log(32, 0, [TestItem.KeccakA]).STOP().Done)
+                    .WithGasLimit(100_000).SignedAndResolved(TestItem.PrivateKeyB).TestObject;
+            }
+
+            Block block = await chain.AddBlock(transactions);
+            TxReceipt[] receipts = chain.ReceiptStorage.Get(block);
+            Assert.That(receipts, Has.Length.EqualTo(receiptCount), "every executed transaction must retain a receipt");
+            using TrackingCappedArrayPool pool = new();
+            ReceiptTrie trie = new(Prague.Instance, receipts, new ReceiptMessageDecoder(), pool, canBeParallel: false);
+            Bloom expectedBloom = new();
+            foreach (TxReceipt receipt in receipts)
+            {
+                Assert.That(receipt.Logs, Has.Length.EqualTo(1), "streaming must not consume receipt logs");
+                expectedBloom.Accumulate(new Bloom(receipt.Logs));
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(receipt.StatusCode, Is.EqualTo(StatusCode.Success));
+                    Assert.That(receipt.Logs[0].Topics, Is.EqualTo(new[] { TestItem.KeccakA }));
+                    Assert.That(receipt.Bloom, Is.Not.EqualTo(Bloom.Empty));
+                }
+            }
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(block.Header.ReceiptsRoot, Is.EqualTo(trie.RootHash), "the mutable trie is the commitment oracle");
+                Assert.That(block.Header.Bloom, Is.EqualTo(expectedBloom), "block bloom must include every finalized receipt");
+            }
         }
     }
 

--- a/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
+++ b/src/Nethermind/Nethermind.Blockchain.Test/Proofs/ReceiptTrieTests.cs
@@ -104,12 +104,37 @@ public class ReceiptTrieTests
         using (Assert.EnterMultipleScope())
         {
             Assert.That(actual, Is.EqualTo(expected));
+            if (decoder is ReceiptMessageDecoder messageDecoder)
+            {
+                using ReceiptTrie.StreamingRoot streaming = new(spec, receipts.Length, messageDecoder);
+                foreach (TxReceipt receipt in receipts) streaming.Add(receipt);
+                Assert.That(streaming.Complete(), Is.EqualTo(expected), "incremental leaves must preserve the mutable trie root");
+            }
             if (receipts.Length > 0)
             {
                 byte[][] proof = ReceiptTrie.CalculateReceiptProofs(spec, receipts, receipts.Length / 2, decoder);
                 Assert.That(Keccak.Compute(proof[0]), Is.EqualTo(actual), "proof root must match the streamed root");
             }
         }
+    }
+
+    [Test]
+    public void StreamingRoot_WhenReceiptsAreMissing_RejectsCompletion()
+    {
+        using ReceiptTrie.StreamingRoot streaming = new(Osaka.Instance, 2, _decoder);
+        streaming.Add(Build.A.Receipt.WithAllFieldsFilled.TestObject);
+
+        Assert.That(() => streaming.Complete(), Throws.InvalidOperationException,
+            "a partial receipt stream must never produce a block commitment");
+    }
+
+    [Test]
+    public void StreamingRoot_WhenReceiptsExceedBlockCount_RejectsAppend()
+    {
+        using ReceiptTrie.StreamingRoot streaming = new(Osaka.Instance, 0, _decoder);
+
+        Assert.That(() => streaming.Add(Build.A.Receipt.WithAllFieldsFilled.TestObject), Throws.InvalidOperationException,
+            "the block transaction count bounds receipt storage");
     }
 
     [Test, MaxTime(Timeout.MaxTestTime)]

--- a/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRootCalculator.cs
+++ b/src/Nethermind/Nethermind.Blockchain/Receipts/ReceiptsRootCalculator.cs
@@ -15,6 +15,11 @@ public class ReceiptsRootCalculator : IReceiptsRootCalculator
     private static readonly IRlpDecoder<TxReceipt> _decoder = Rlp.GetDecoderOrThrow<TxReceipt>(RlpDecoderKey.Trie);
     private static readonly ReceiptMessageDecoder _skipStateDecoder = new(skipStateAndStatus: true);
 
+    /// <summary>Creates a streaming calculator when no alternate receipt encoding is required.</summary>
+    public ReceiptTrie.StreamingRoot? CreateStreamingRoot(IReceiptSpec spec, int receiptCount)
+        => spec.ValidateReceipts && _decoder is ReceiptMessageDecoder decoder
+            ? new ReceiptTrie.StreamingRoot(spec, receiptCount, decoder) : null;
+
     public Hash256 GetReceiptsRoot(TxReceipt[] receipts, IReceiptSpec spec, Hash256? suggestedRoot)
     {
         Hash256 receiptsRoot = ReceiptTrie.CalculateRoot(spec, receipts, _decoder);

--- a/src/Nethermind/Nethermind.Consensus/Nethermind.Consensus.csproj
+++ b/src/Nethermind/Nethermind.Consensus/Nethermind.Consensus.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Nethermind.Blockchain.Test" />
     <PackageReference Include="Collections.Pooled" />
   </ItemGroup>
 

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.BlockValidationTransactionsExecutor.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -36,6 +37,10 @@ public partial class BlockProcessor
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext) => transactionProcessor.SetBlockExecutionContext(in blockExecutionContext);
 
         public TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer, CancellationToken token)
+            => ProcessTransactions(block, processingOptions, receiptsTracer, token, null);
+
+        internal TxReceipt[] ProcessTransactions(Block block, ProcessingOptions processingOptions, BlockReceiptsTracer receiptsTracer,
+            CancellationToken token, Action<TxReceipt>? receiptProcessed)
         {
             Metrics.ResetBlockStats();
             SetupTxTimingMetrics(block);
@@ -52,6 +57,8 @@ public partial class BlockProcessor
                 {
                     ThrowInvalidBlockForGasLimit(block);
                 }
+
+                receiptProcessed?.Invoke(receiptsTracer.TxReceipts[i]);
             }
 
             Metrics.SeedBlockGasPriceIfEmpty(block.Header.BaseFeePerGas);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ParallelBlockValidationTransactionsExecutor.cs
@@ -39,6 +39,10 @@ public partial class BlockProcessor
         private TxExecutionSortKey[] _txExecutionSortKeys = [];
         private int _pooledSlotsInUse;
 
+        internal BlockValidationTransactionsExecutor? ReceiptStreamingExecutor =>
+            !balManager.Enabled && inner.GetType() == typeof(BlockValidationTransactionsExecutor)
+                ? (BlockValidationTransactionsExecutor)inner : null;
+
         public void SetBlockExecutionContext(in BlockExecutionContext blockExecutionContext)
         {
             balManager.SetBlockExecutionContext(blockExecutionContext);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ReceiptCommitmentStream.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.ReceiptCommitmentStream.cs
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Metric;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.Tracing;
+using Nethermind.Logging;
+using Nethermind.State.Proofs;
+
+namespace Nethermind.Consensus.Processing;
+
+public partial class BlockProcessor
+{
+    private partial ReceiptCommitmentStream? CreateReceiptStream(Block block, IBlockTracer tracer,
+        ProcessingOptions options, IReleaseSpec spec, CancellationToken token, out BlockValidationTransactionsExecutor? executor);
+
+    internal sealed class ReceiptCommitmentStream : IDisposable
+    {
+        private readonly Channel<TxReceipt> _receipts;
+        private readonly CancellationTokenSource _cancellation;
+        private readonly ReceiptTrie.StreamingRoot _root;
+        private readonly int _receiptCount;
+        private readonly ILogger _logger;
+        private int _published;
+
+        public ReceiptCommitmentStream(ReceiptTrie.StreamingRoot root,
+            int receiptCount, CancellationToken token, ILogger logger)
+        {
+            _root = root;
+            _receiptCount = receiptCount;
+            _logger = logger;
+            _cancellation = CancellationTokenSource.CreateLinkedTokenSource(token);
+            _receipts = Channel.CreateUnbounded<TxReceipt>(new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = true,
+                AllowSynchronousContinuations = false
+            });
+            Result = Task.Run(ConsumeAsync);
+        }
+
+        public Task<(Bloom BlockBloom, Hash256 ReceiptsRoot)> Result { get; }
+
+        public void Add(TxReceipt receipt)
+        {
+            _cancellation.Token.ThrowIfCancellationRequested();
+            if (Result.IsFaulted) Result.GetAwaiter().GetResult();
+            if (_published == _receiptCount) throw new InvalidOperationException("Too many receipts for the block.");
+            // Only the standard sequential executor publishes, after all synchronous receipt observers return.
+            if (!_receipts.Writer.TryWrite(receipt)) throw new InvalidOperationException("Receipt stream is closed.");
+            _published++;
+        }
+
+        public void CompleteAdding() => _receipts.Writer.TryComplete();
+
+        private async Task<(Bloom, Hash256)> ConsumeAsync()
+        {
+            using (_root)
+            {
+                Bloom bloom = new();
+                await foreach (TxReceipt receipt in _receipts.Reader.ReadAllAsync(_cancellation.Token))
+                {
+                    _cancellation.Token.ThrowIfCancellationRequested();
+                    using (MetricsTimer<BloomsTimeSink> _ = new())
+                    {
+                        receipt.CalculateBloom();
+                        bloom.Accumulate(receipt.Bloom);
+                    }
+                    using (MetricsTimer<ReceiptsRootTimeSink> _ = new())
+                    {
+                        _root.Add(receipt);
+                    }
+                }
+
+                _cancellation.Token.ThrowIfCancellationRequested();
+                using (MetricsTimer<ReceiptsRootTimeSink> _ = new())
+                {
+                    return (bloom, _root.Complete());
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            _cancellation.Cancel();
+            _receipts.Writer.TryComplete();
+            try
+            {
+                Result.GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception exception) when (Result.IsFaulted)
+            {
+                _logger.DebugError("Receipt commitment worker failed.", exception);
+            }
+            finally
+            {
+                _cancellation.Dispose();
+            }
+        }
+    }
+}

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.cs
@@ -163,7 +163,12 @@ public partial class BlockProcessor(
         _systemContractHandler.ApplyBlockhashStateChanges(header, spec);
         CommitState(spec);
 
-        TxReceipt[] receipts = _blockTransactionsExecutor.ProcessTransactions(block, options, ReceiptsTracer, token);
+        using ReceiptCommitmentStream? receiptStream = CreateReceiptStream(block, blockTracer, options, spec, token,
+            out BlockValidationTransactionsExecutor? streamingExecutor);
+        TxReceipt[] receipts = receiptStream is null
+            ? _blockTransactionsExecutor.ProcessTransactions(block, options, ReceiptsTracer, token)
+            : streamingExecutor!.ProcessTransactions(block, options, ReceiptsTracer, token, receiptStream.Add);
+        receiptStream?.CompleteAdding();
 
         // Signal that transactions are done — subscribers can cancel background work (e.g. prewarmer)
         // to free the thread pool for blooms, receipts root, state root parallel work below
@@ -176,8 +181,8 @@ public partial class BlockProcessor(
             header.BlobGasUsed = BlobGasCalculator.CalculateBlobGas(block.Transactions);
         }
 
-        Task<(Bloom BlockBloom, Hash256 ReceiptsRoot)>? bloomsAndReceiptsRootTask = null;
-        if (ShouldCalculateReceiptsInBackground(receipts))
+        Task<(Bloom BlockBloom, Hash256 ReceiptsRoot)>? bloomsAndReceiptsRootTask = receiptStream?.Result;
+        if (receiptStream is null && ShouldCalculateReceiptsInBackground(receipts))
         {
             bloomsAndReceiptsRootTask = Task.Run(() =>
             {
@@ -185,7 +190,7 @@ public partial class BlockProcessor(
                 return (AccumulateBlockBloom(receipts), CalculateReceiptsRoot(receipts, spec, block));
             });
         }
-        else
+        else if (receiptStream is null)
         {
             CalculateBlooms(receipts);
             header.ReceiptsRoot = CalculateReceiptsRoot(receipts, spec, block);

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.std.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.std.cs
@@ -2,11 +2,18 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Nethermind.Blockchain;
+using Nethermind.Blockchain.Receipts;
+using Nethermind.Blockchain.Tracing;
 using Nethermind.Core;
+using Nethermind.Core.Cpu;
+using Nethermind.Core.Specs;
 using Nethermind.Evm.State;
+using Nethermind.Evm.Tracing;
 using Nethermind.Int256;
 using Nethermind.Specs.Forks;
+using Nethermind.State.Proofs;
 
 namespace Nethermind.Consensus.Processing;
 
@@ -14,6 +21,27 @@ public partial class BlockProcessor
 {
     private const int BackgroundReceiptCountThreshold = 16;
     private const int BackgroundLogCountThreshold = 64;
+    private const int StreamingReceiptCountThreshold = 64;
+
+    private partial ReceiptCommitmentStream? CreateReceiptStream(Block block, IBlockTracer tracer,
+        ProcessingOptions options, IReleaseSpec spec, CancellationToken token, out BlockValidationTransactionsExecutor? executor)
+    {
+        executor = null;
+        if (RuntimeInformation.IsSingleProcessor || block.Transactions.Length < StreamingReceiptCountThreshold
+            || GetType() != typeof(BlockProcessor)
+            || ReceiptsTracer.GetType() != typeof(BlockReceiptsTracer) || tracer != NullBlockTracer.Instance
+            || options.ContainsFlag(ProcessingOptions.NoValidation) || _balManager.Enabled)
+            return null;
+
+        executor = _blockTransactionsExecutor.GetType() == typeof(BlockValidationTransactionsExecutor)
+            ? (BlockValidationTransactionsExecutor)_blockTransactionsExecutor
+            : _blockTransactionsExecutor.GetType() == typeof(ParallelBlockValidationTransactionsExecutor)
+                ? ((ParallelBlockValidationTransactionsExecutor)_blockTransactionsExecutor).ReceiptStreamingExecutor : null;
+        if (executor is null) return null;
+
+        ReceiptTrie.StreamingRoot? root = ReceiptsRootCalculator.Instance.CreateStreamingRoot(spec, block.Transactions.Length);
+        return root is null ? null : new ReceiptCommitmentStream(root, block.Transactions.Length, token, _logger);
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static partial bool ShouldCalculateReceiptsInBackground(TxReceipt[] receipts) =>

--- a/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.zkevm.cs
+++ b/src/Nethermind/Nethermind.Consensus/Processing/BlockProcessor.zkevm.cs
@@ -2,12 +2,22 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Nethermind.Core;
+using Nethermind.Core.Specs;
+using Nethermind.Evm.Tracing;
 
 namespace Nethermind.Consensus.Processing;
 
 public partial class BlockProcessor
 {
+    private partial ReceiptCommitmentStream? CreateReceiptStream(Block block, IBlockTracer tracer,
+        ProcessingOptions options, IReleaseSpec spec, CancellationToken token, out BlockValidationTransactionsExecutor? executor)
+    {
+        executor = null;
+        return null;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static partial bool ShouldCalculateReceiptsInBackground(TxReceipt[] receipts) => false;
 

--- a/src/Nethermind/Nethermind.State/Proofs/IndexedTrieRoot.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/IndexedTrieRoot.cs
@@ -38,7 +38,8 @@ internal static class IndexedTrieRoot
         private readonly ReadOnlySpan<NodeReference> _leaves = leaves;
 
         public Hash256 Calculate(bool canBeParallel = true)
-            => _items.IsEmpty ? Keccak.EmptyTreeHash
+            => !_leaves.IsEmpty ? CalculateSequential()
+                : _items.IsEmpty ? Keccak.EmptyTreeHash
                 : !canBeParallel || RuntimeInformation.IsSingleProcessor || _items.Length <= MinItemsForParallelRootHash
                 ? CalculateSequential()
                 : CalculateParallel();
@@ -58,11 +59,7 @@ internal static class IndexedTrieRoot
                     int end = start + Math.Min(LeafBatchSize, inputs.Count - start);
                     for (int position = start; position < end; position++)
                     {
-                        Key key = calculator.GetKey(position);
-                        int depth = position == 0 ? 0 : CommonPrefix(key, calculator.GetKey(position - 1), 0);
-                        if (position + 1 < inputs.Count)
-                            depth = Math.Max(depth, CommonPrefix(key, calculator.GetKey(position + 1), 0));
-                        references[position] = calculator.Leaf(key, depth + 1, inputs[calculator.GetIndex(position)]);
+                        references[position] = calculator.CalculateLeafAtPosition(position, inputs[calculator.GetIndex(position)]);
                     }
                 });
             }
@@ -75,8 +72,27 @@ internal static class IndexedTrieRoot
 
         private Hash256 CalculateSequential()
         {
-            NodeReference root = Build(0, _items.Length, 0);
+            NodeReference root = Build(0, Count, 0);
             return root.Length == 32 ? new Hash256(root.Value) : Keccak.Compute(root.Value.Bytes[..root.Length]);
+        }
+
+        private int Count => _leaves.IsEmpty ? _items.Length : _leaves.Length;
+
+        internal int GetPosition(int index)
+            => index == 0 ? Math.Min(Count - 1, 127) : index <= 127 ? index - 1 : index;
+
+        internal NodeReference CalculateLeaf(int index, T item)
+            => CalculateLeafAtPosition(GetPosition(index), item);
+
+        private NodeReference CalculateLeafAtPosition(int position, T item)
+        {
+            Key key = GetKey(position);
+            if (Count == 1) return Leaf(key, 0, item);
+
+            int depth = position == 0 ? 0 : CommonPrefix(key, GetKey(position - 1), 0);
+            if (position + 1 < Count)
+                depth = Math.Max(depth, CommonPrefix(key, GetKey(position + 1), 0));
+            return Leaf(key, depth + 1, item);
         }
 
         [SkipLocalsInit]
@@ -170,7 +186,7 @@ internal static class IndexedTrieRoot
 
         private int GetIndex(int position)
         {
-            int zeroPosition = Math.Min(_items.Length - 1, 127);
+            int zeroPosition = Math.Min(Count - 1, 127);
             return position < zeroPosition ? position + 1 : position == zeroPosition ? 0 : position;
         }
 

--- a/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.StreamingRoot.cs
+++ b/src/Nethermind/Nethermind.State/Proofs/ReceiptTrie.StreamingRoot.cs
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Demerzel Solutions Limited
+// SPDX-License-Identifier: LGPL-3.0-only
+
+using System;
+using Nethermind.Core;
+using Nethermind.Core.Collections;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Specs;
+using Nethermind.Serialization.Rlp;
+
+namespace Nethermind.State.Proofs;
+
+public sealed partial class ReceiptTrie
+{
+    /// <summary>Hashes finalized receipts in transaction order, retaining only their trie leaf references.</summary>
+    public sealed class StreamingRoot : IDisposable
+    {
+        private readonly ArrayPoolList<IndexedTrieRoot.NodeReference> _leaves;
+        private readonly ReceiptEncoder _encoder;
+        private int _count;
+        private bool _disposed;
+
+        public StreamingRoot(IReceiptSpec spec, int receiptCount, ReceiptMessageDecoder decoder)
+        {
+            ArgumentNullException.ThrowIfNull(spec);
+            ArgumentNullException.ThrowIfNull(decoder);
+            ArgumentOutOfRangeException.ThrowIfNegative(receiptCount);
+            _leaves = new(receiptCount, receiptCount);
+            _encoder = new(decoder, (spec.IsEip658Enabled ? RlpBehaviors.Eip658Receipts : RlpBehaviors.None)
+                | RlpBehaviors.SkipTypedWrapping);
+        }
+
+        /// <summary>Appends the next receipt. Its bloom and cumulative gas must already be final.</summary>
+        public void Add(TxReceipt receipt)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_count == _leaves.Count) throw new InvalidOperationException("Too many receipts for the block.");
+            IndexedTrieRoot.Calculator<TxReceipt, ReceiptEncoder> calculator = new([], _encoder, _leaves.AsSpan());
+            _leaves[calculator.GetPosition(_count)] = calculator.CalculateLeaf(_count, receipt);
+            _count++;
+        }
+
+        /// <summary>Returns the root only after every receipt has been appended.</summary>
+        public Hash256 Complete()
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (_count != _leaves.Count) throw new InvalidOperationException("Incomplete receipt stream.");
+            return new IndexedTrieRoot.Calculator<TxReceipt, ReceiptEncoder>([], _encoder, _leaves.AsSpan()).Calculate(false);
+        }
+
+        public void Dispose()
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _leaves.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- Overlap receipt bloom calculation and receipt-trie leaf hashing with sequential block validation.
- Publish receipts after transaction processing and synchronous observers finish; finalize the existing indexed trie after execution.
- Enable only for standard validated blocks with at least 64 transactions on multicore hosts. Retain the existing path for custom tracers/executors, block production, BAL, and unsupported receipt decoders.
- Cancel and join the worker before the processing scope is released.
- Add root-equivalence, receipt-boundary, cancellation, and consecutive-block coverage.

## Types of changes

- [x] Optimization

## Testing

#### Requires testing

- [x] Yes

#### If yes, did you write tests?

- [x] Yes

#### Notes on testing

| Verification | Status |
|---|---|
| Consensus Release build | Passed, zero warnings/errors |
| Blockchain.Test Release build | Passed, zero warnings/errors |
| Whitespace and diff checks | Passed |
| Test execution | Pending CI; not run locally |
| Block-processing performance A/B | Pending; no measured speedup claimed |

## Documentation

#### Requires documentation update

- [x] No

#### Requires explanation in Release Notes

- [x] No

## Remarks

Draft pending correctness tests and matched block-processing A/B measurements. No database-format or RPC behavior changes are intended.
