### PR TITLE
Avoid unused gas-price rejection messages during transaction selection

### DIFF
--- a/src/Nethermind/Nethermind.Consensus/Transactions/MinGasPriceTxFilter.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/MinGasPriceTxFilter.cs
@@ -14,6 +14,8 @@ namespace Nethermind.Consensus.Transactions;
 /// After 1559: EffectivePriorityFeePerGas = transaction.EffectiveGasPrice - BaseFee.</summary>
 public class MinGasPriceTxFilter(IBlocksConfig blocksConfig) : IMinGasPriceTxFilter
 {
+    internal bool IncludeRejectionMessage { get; init; } = true;
+
     public AcceptTxResult IsAllowed(Transaction tx, BlockHeader parentHeader, IReleaseSpec currentSpec)
         => IsAllowed(tx, parentHeader, blocksConfig.MinGasPrice, currentSpec);
 
@@ -30,7 +32,9 @@ public class MinGasPriceTxFilter(IBlocksConfig blocksConfig) : IMinGasPriceTxFil
         bool allowed = premiumPerGas >= minGasPriceFloor;
         return allowed
             ? AcceptTxResult.Accepted
-            : AcceptTxResult.FeeTooLow.WithMessage(
-                $"EffectivePriorityFeePerGas too low {premiumPerGas} < {minGasPriceFloor}, BaseFee: {baseFeePerGas}");
+            : IncludeRejectionMessage
+                ? AcceptTxResult.FeeTooLow.WithMessage(
+                    $"EffectivePriorityFeePerGas too low {premiumPerGas} < {minGasPriceFloor}, BaseFee: {baseFeePerGas}")
+                : AcceptTxResult.FeeTooLow;
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Transactions/MinGasPriceTxFilter.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/MinGasPriceTxFilter.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System.Runtime.CompilerServices;
 using Nethermind.Config;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
@@ -14,6 +15,9 @@ namespace Nethermind.Consensus.Transactions;
 /// After 1559: EffectivePriorityFeePerGas = transaction.EffectiveGasPrice - BaseFee.</summary>
 public class MinGasPriceTxFilter(IBlocksConfig blocksConfig) : IMinGasPriceTxFilter
 {
+    /// <summary>Whether rejected results include detailed gas-price information.</summary>
+    /// <remarks>Disabled by the standard selection pipeline, which discards the message.
+    /// Enabled by default to preserve tx-pool admission diagnostics returned to RPC callers.</remarks>
     internal bool IncludeRejectionMessage { get; init; } = true;
 
     public AcceptTxResult IsAllowed(Transaction tx, BlockHeader parentHeader, IReleaseSpec currentSpec)
@@ -33,8 +37,12 @@ public class MinGasPriceTxFilter(IBlocksConfig blocksConfig) : IMinGasPriceTxFil
         return allowed
             ? AcceptTxResult.Accepted
             : IncludeRejectionMessage
-                ? AcceptTxResult.FeeTooLow.WithMessage(
-                    $"EffectivePriorityFeePerGas too low {premiumPerGas} < {minGasPriceFloor}, BaseFee: {baseFeePerGas}")
+                ? Rejected(premiumPerGas, minGasPriceFloor, baseFeePerGas)
                 : AcceptTxResult.FeeTooLow;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static AcceptTxResult Rejected(in UInt256 premiumPerGas, in UInt256 minGasPriceFloor, in UInt256 baseFeePerGas) =>
+            AcceptTxResult.FeeTooLow.WithMessage(
+                $"EffectivePriorityFeePerGas too low {premiumPerGas} < {minGasPriceFloor}, BaseFee: {baseFeePerGas}");
     }
 }

--- a/src/Nethermind/Nethermind.Consensus/Transactions/TxFilterPipelineBuilder.cs
+++ b/src/Nethermind/Nethermind.Consensus/Transactions/TxFilterPipelineBuilder.cs
@@ -25,7 +25,7 @@ namespace Nethermind.Consensus.Transactions
 
         public TxFilterPipelineBuilder WithMinGasPriceFilter(IBlocksConfig blocksConfig)
         {
-            _filterPipeline.AddTxFilter(new MinGasPriceTxFilter(blocksConfig));
+            _filterPipeline.AddTxFilter(new MinGasPriceTxFilter(blocksConfig) { IncludeRejectionMessage = false });
             return this;
         }
 

--- a/src/Nethermind/Nethermind.Mining.Test/MinGasPriceTests.cs
+++ b/src/Nethermind/Nethermind.Mining.Test/MinGasPriceTests.cs
@@ -39,7 +39,7 @@ namespace Nethermind.Mining.Test
         }
 
         [Test]
-        public void Selection_does_not_allocate_for_gas_price_filter([Values(0, 1, 2)] int gasPrice)
+        public void Pipeline_does_not_allocate_for_gas_price_filter([Values(0, 1, 2)] int gasPrice)
         {
             ITxFilterPipeline pipeline = new TxFilterPipelineBuilder(NullLogManager.Instance)
                 .WithMinGasPriceFilter(new BlocksConfig { MinGasPrice = 1 })

--- a/src/Nethermind/Nethermind.Mining.Test/MinGasPriceTests.cs
+++ b/src/Nethermind/Nethermind.Mining.Test/MinGasPriceTests.cs
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Demerzel Solutions Limited
 // SPDX-License-Identifier: LGPL-3.0-only
 
+using System;
 using Nethermind.Config;
 using Nethermind.Consensus.Transactions;
 using Nethermind.Core;
 using Nethermind.Core.Specs;
 using Nethermind.Core.Test.Builders;
 using Nethermind.Int256;
+using Nethermind.Logging;
 using Nethermind.Specs;
 using Nethermind.TxPool;
 using NSubstitute;
@@ -17,6 +19,54 @@ namespace Nethermind.Mining.Test
     [TestFixture]
     public class MinGasPriceTests
     {
+        [Test]
+        public void Rejection_preserves_detailed_message([Values] bool customFloor)
+        {
+            MinGasPriceTxFilter filter = new(new BlocksConfig { MinGasPrice = 2 });
+            Transaction tx = Build.A.Transaction.WithGasPrice(1).TestObject;
+            IReleaseSpec spec = new ReleaseSpec { IsEip1559Enabled = false };
+
+            AcceptTxResult result = customFloor
+                ? filter.IsAllowed(tx, null, 3, spec)
+                : filter.IsAllowed(tx, null!, spec);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result, Is.EqualTo(AcceptTxResult.FeeTooLow));
+                Assert.That(result.ToString(), Is.EqualTo(
+                    $"{AcceptTxResult.FeeTooLow}, EffectivePriorityFeePerGas too low 1 < {(customFloor ? 3 : 2)}, BaseFee: 0"));
+            }
+        }
+
+        [Test]
+        public void Selection_does_not_allocate_for_gas_price_filter([Values(0, 1, 2)] int gasPrice)
+        {
+            ITxFilterPipeline pipeline = new TxFilterPipelineBuilder(NullLogManager.Instance)
+                .WithMinGasPriceFilter(new BlocksConfig { MinGasPrice = 1 })
+                .Build;
+            Transaction tx = Build.A.Transaction.WithGasPrice((UInt256)gasPrice).TestObject;
+            IReleaseSpec spec = new ReleaseSpec { IsEip1559Enabled = false };
+
+            for (int i = 0; i < 100; i++)
+            {
+                pipeline.Execute(tx, null!, spec);
+            }
+
+            bool accepted = true;
+            long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            for (int i = 0; i < 1000; i++)
+            {
+                accepted &= pipeline.Execute(tx, null!, spec);
+            }
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(accepted, Is.EqualTo(gasPrice >= 1));
+                Assert.That(allocated, Is.Zero);
+            }
+        }
+
         [TestCase(0L, 0L, true)]
         [TestCase(1L, 0L, false)]
         [TestCase(1L, 1L, true)]


### PR DESCRIPTION
## Changes

<img width="581" height="446" alt="image" src="https://github.com/user-attachments/assets/29fe9069-c89e-4be1-b13f-d850061d59c1" />


- Skip minimum-gas-price rejection message formatting in filters created by `TxFilterPipelineBuilder.WithMinGasPriceFilter`. Block selection and speculative prewarming discard the result's message, so repeatedly rejecting underpriced transactions otherwise allocates unused strings.
- Keep detailed messages enabled by default for existing callers, including AuRa transaction admission and contract fallbacks, preserving RPC send-transaction error details. No public API changes.
- Add regression coverage for allocation-free selection and exact rejection messages with configured and custom gas-price floors.

## Types of changes

#### What types of changes does your code introduce?

- [ ] Bugfix (a non-breaking change that fixes an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a change that causes existing functionality not to work as expected)
- [x] Optimization
- [ ] Refactoring
- [ ] Documentation update
- [ ] Build-related changes
- [ ] Other

## Testing

#### Requires testing

- [x] Yes
- [ ] No

#### If yes, did you write tests?

- [x] Yes
- [ ] No

#### Notes on testing

- `MinGasPriceTests`: 19 passed in Release, including zero managed allocations over 1,000 selection calls for each tested fee level and preservation of detailed rejection messages.
- `MinGasPriceContractTxFilterTests`: 4 passed in Release.
- Scoped `dotnet format whitespace --verify-no-changes` and `git diff --check` passed.

## Documentation

#### Requires documentation update

- [ ] Yes
- [x] No

#### Requires explanation in Release Notes

- [ ] Yes
- [x] No
